### PR TITLE
Use scoped lock inside mac-specific XrdSysSemaphore implementation to avoid deadlock on thread cancellation

### DIFF
--- a/src/XrdSys/XrdSysPthread.cc
+++ b/src/XrdSys/XrdSysPthread.cc
@@ -223,7 +223,7 @@ void XrdSysSemaphore::Wait()
 // Wait until the sempahore value is positive. This will not be starvation
 // free is the OS implements an unfair mutex;
 //
-   semVar.Lock();
+   XrdSysCondVarHelper scopedLock(&semVar);
    if (semVal < 1 || semWait)
       while(semVal < 1)
            {semWait++;
@@ -234,7 +234,6 @@ void XrdSysSemaphore::Wait()
 // Decrement the semaphore value and return
 //
    semVal--;
-   semVar.UnLock();
 }
 #endif
  


### PR DESCRIPTION
If a thread is waiting inside XrdSysCondVar::Wait and the thread is cancelled, the mutex is not released, therefore causing deadlock when other threads attempt to lock it.

The simple fix is to use a scoped lock to ensure the mutex is unlocked in the destructor if the thread is cancelled.
