### PR TITLE
Fix compilation on Solaris 11

### DIFF
--- a/src/XrdSys/XrdSysPlatform.hh
+++ b/src/XrdSys/XrdSysPlatform.hh
@@ -65,6 +65,7 @@
 #ifdef __solaris__
 #define posix_memalign(memp, algn, sz) \
         ((*memp = memalign(algn, sz)) ? 0 : ENOMEM)
+#define __USE_LEGACY_PROTOTYPES__ 1
 #endif
 
 #if defined(__linux__) || defined(__APPLE__) || defined(__FreeBSD__)


### PR DESCRIPTION
Solaris 11 defines a different DIR structure by default than Solaris 10. The `__USE_LEGACY_PROTOTYPES__` variable, if defined, makes Solaris 11 use the Solaris 10 structure. So we define it in `XrdSysPlatform.hh`.
