### PR TITLE
Use cleanup handler in mac-specific semaphore implementation to allow it...

### DIFF
--- a/src/XrdSys/XrdSysPthread.hh
+++ b/src/XrdSys/XrdSysPthread.hh
@@ -311,6 +311,8 @@ public:
 
        void Wait();
 
+static void CleanUp(void *semVar);
+
   XrdSysSemaphore(int semval=1,const char *cid=0) : semVar(0, cid)
                                   {semVal = semval; semWait = 0;}
  ~XrdSysSemaphore() {}


### PR DESCRIPTION
...s condition variable to be unlocked on thread cancellation
