### PR TITLE
[XrdApps] Add --mkpath option in XrdCpConfig

### DIFF
--- a/src/XrdApps/XrdCpConfig.cc
+++ b/src/XrdApps/XrdCpConfig.cc
@@ -81,7 +81,7 @@ static XrdSysError  eDest(&Logger, "");
 
 XrdSysError  *XrdCpConfig::Log = &XrdCpConfiguration::eDest;
   
-const char   *XrdCpConfig::opLetters = ":C:d:D:fFhHI:NPrRsS:t:T:vVX:y:";
+const char   *XrdCpConfig::opLetters = ":C:d:D:fFhHI:NpPrRsS:t:T:vVX:y:";
 
 struct option XrdCpConfig::opVec[] =         // For getopt_long()
      {
@@ -96,6 +96,7 @@ struct option XrdCpConfig::opVec[] =         // For getopt_long()
       {OPT_TYPE "posc",      0, 0, XrdCpConfig::OpPosc},
       {OPT_TYPE "proxy",     1, 0, XrdCpConfig::OpProxy},
       {OPT_TYPE "recursive", 0, 0, XrdCpConfig::OpRecurse},
+      {OPT_TYPE "mkpath",    0, 0, XrdCpConfig::OpMkPath},
       {OPT_TYPE "retry",     1, 0, XrdCpConfig::OpRetry},
       {OPT_TYPE "server",    0, 0, XrdCpConfig::OpServer},
       {OPT_TYPE "silent",    0, 0, XrdCpConfig::OpSilent},
@@ -233,6 +234,8 @@ do{while(optind < Argc && Legacy(optind)) {}
           case OpRecurse:  OpSpec |= DoRecurse;
                            break;
           case OpRecursv:  OpSpec |= DoRecurse;
+                           break;
+          case OpMkPath:   OpSpec |= DoMkPath;
                            break;
           case OpRetry:    OpSpec |= DoRetry;
                            if (!a2i(optarg, &Retry, 0, -1)) Usage(22);

--- a/src/XrdApps/XrdCpConfig.hh
+++ b/src/XrdApps/XrdCpConfig.hh
@@ -121,6 +121,9 @@ static const int    OpRecurse  =  'r';
 static const int    OpRecursv  =  'R';
 static const int    DoRecurse  =  0x00000800; // -r | --recursive | -R {legacy}
 
+static const int    OpMkPath   =  'p';
+static const int    DoMkPath   =  0x00200000; // -p | --mkpath
+
 static const int    OpRetry    =  't';
 static const int    DoRetry    =  0x00001000; // --coerce
 


### PR DESCRIPTION
When implemented by a copy command, this could allow `mkdir -p` like behaviour when copying to a local target. This could then also be used to aid a recursive remote to local copy.
