### PR TITLE
Missing myFile initialization in XrdXrootdProtocol::Reset

### DIFF
--- a/src/XrdXrootd/XrdXrootdProtocol.cc
+++ b/src/XrdXrootd/XrdXrootdProtocol.cc
@@ -711,6 +711,7 @@ void XrdXrootdProtocol::Reset()
    myIOLen            = 0;
    myStalls           = 0;
    myAioReq           = 0;
+   myFile             = 0;
    numReads           = 0;
    numReadP           = 0;
    numReadV           = 0;


### PR DESCRIPTION
Using the Justin imposter we managed to track down the crash related to write requests on not open files. When a redirector (as in the case of EOS) can redirect and serve files protocol objects get recycled and the 'myFile' pointer is not reset to 0 in a recycled object. This leads to a SEGV in the WriteNone logic.
