### PR TITLE
Add a cmake option for disabling usage of atomics.

### DIFF
--- a/cmake/XRootDSystemCheck.cmake
+++ b/cmake/XRootDSystemCheck.cmake
@@ -118,4 +118,8 @@ check_cxx_source_runs(
   }
 "
 HAVE_ATOMICS )
-compiler_define_if_found( HAVE_ATOMICS HAVE_ATOMICS )
+option(EnableAtomicsIfPresent "EnableAtomicsIfPresent" ON)
+if ( EnableAtomicsIfPresent )
+  compiler_define_if_found( HAVE_ATOMICS HAVE_ATOMICS )
+endif ()
+


### PR DESCRIPTION
Without this, if a platform has atomics support detected, there isn't
any simple way for a developer to disable them for debugging purposes.
