### PR TITLE
Adjusting the listing behavior strictly following the protocol docs

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1349,10 +1349,11 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
             }
 
-            int l = 0;
+
             if (endp) {
-              l = strlen(endp);
-              startp = endp + l + 2;
+                char *pp = (char *)strchr((const char *)endp, '\n');
+                if (pp) startp = pp+1;
+                else break;
             } else break;
 
           }


### PR DESCRIPTION
Little fix that makes html listing work again after the \0 disappeared from the response
