### PR TITLE
Fix for XrdOssReloc int overflow bug

### DIFF
--- a/src/XrdOss/XrdOssReloc.cc
+++ b/src/XrdOss/XrdOssReloc.cc
@@ -107,6 +107,7 @@ int XrdOssSys::Reloc(const char *tident, const char *path,
    pendFiles PF(pbuff, tbuff);
    XrdOssCache::allocInfo aInfo(path, pbuff, sizeof(pbuff));
    int rc, lblen, datfd, Pure = (anchor && !strcmp(anchor, "."));
+   off_t rc_c;
    struct stat buf;
 
 // Generate the actual local path for this file.
@@ -144,7 +145,7 @@ int XrdOssSys::Reloc(const char *tident, const char *path,
 // Copy the original file to the new location. Copy() always closes the fd.
 //
    PF.datfd = -1;
-   if ((rc = XrdOssCopy::Copy(local_path, pbuff, datfd)) < 0) return rc;
+   if ((rc_c = XrdOssCopy::Copy(local_path, pbuff, datfd)) < 0) return (int)rc_c;
 
 // If the file is to be merely copied, substitute the desired destination
 //


### PR DESCRIPTION
I've recently hit this bug while converting old xrootd spaces to new format. It's been described in Savannah (https://savannah.cern.ch/bugs/?96364) quite a while ago but is still not fixed in xrootd 3.3.6
Basically, any file greater than 2G cannot be converted, moreover conversion stops when such a file is encountered and the only way to continue is to manually move the file out of the space.
