### PR TITLE
Improve error message in Say()

### DIFF
--- a/src/XrdCl/XrdClLog.cc
+++ b/src/XrdCl/XrdClLog.cc
@@ -114,7 +114,9 @@ namespace XrdCl
 
       if( ret < 0 )
       {
-        pOutput->Write( "Error while processing a log message" );
+        snprintf( buffer, size, "Error while processing a log message \"%s\" \n", format);
+        pOutput->Write(buffer);
+        delete [] buffer;
         return;
       }
       else if( ret < size )


### PR DESCRIPTION
Print new line at the end of an error message and info about the format when vsnprinf fails. 

Without new line the error message is confusing. E.g.the Dump msg in this example looks like it had an error, but it was the previous message that failed.

Error while processing a log message[2014-03-24 12:01:44.586263 -0700][Dump ][App ] Prefetch::ReadInBlocks ram = 0 file block = 1
