### PR TITLE
Bugfix: avoid double free of the async bio on connection shutdown

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1396,12 +1396,6 @@ void XrdHttpProtocol::Cleanup() {
     myBuff = 0;
   }
 
-
-  if (sbio) {
-    TRACE(DEBUG, " Freeing sbio");
-    BIO_free(sbio);
-    }
-
   if (ssl) {
     if (SSL_shutdown(ssl) != 1) {
       TRACE(ALL, " SSL_shutdown failed");


### PR DESCRIPTION
Inserted bug... sorry... :-)
