### PR TITLE
Fix 100% CPU usage in XrdSysCondVar::WaitMS

### DIFF
--- a/src/XrdSys/XrdSysPthread.cc
+++ b/src/XrdSys/XrdSysPthread.cc
@@ -149,8 +149,7 @@ int XrdSysCondVar::WaitMS(int msec)
 
 // Now wait for the condition or timeout
 //
-   do {retc = pthread_cond_timedwait(&cvar, &cmut, &tval);}
-   while (retc && (retc != ETIMEDOUT));
+   retc = pthread_cond_timedwait(&cvar, &cmut, &tval);
 
    if (relMutex) UnLock();
    return retc == ETIMEDOUT;


### PR DESCRIPTION
It is possible  XrdSysCondVar::WaitMS() burns all CPU if abstime is invalid. The pthread_cond_timedwait exit with EINVAL in this case.

To reproduce the bug change line https://github.com/xrootd/xrootd/blob/master/src/XrdSys/XrdSysPthread.cc#L141 to:
tval.tv_sec  = tnow.tv_sec  +  sec -1;
