### PR TITLE
[XrdCl] Improve matching of 'exit' and 'quit' commands for xrdfs

### DIFF
--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -1670,7 +1670,7 @@ int ExecuteInteractive( const URL &url )
   {
     char *linebuf = 0;
     linebuf = readline( BuildPrompt( ex->GetEnv(), url ).c_str() );
-    if( !linebuf || !strcmp( linebuf, "exit" ) || !strcmp( linebuf, "quit" ) )
+    if( !linebuf || !strncmp( linebuf, "exit", 4 ) || !strncmp( linebuf, "quit", 4 ) )
     {
       std::cout << "Goodbye." << std::endl << std::endl;
       break;


### PR DESCRIPTION
This is just a minor convenience fix as I type most of the times "exit " - note the space at the end and I get : [ERROR] Command not found. More generally, maybe there should be some trimming of white-spaces around the commands issued.
