### PR TITLE
Unable to load plugin OFS lib

### DIFF
--- a/src/XrdOfs/XrdOfsConfig.cc
+++ b/src/XrdOfs/XrdOfsConfig.cc
@@ -135,10 +135,10 @@ int XrdOfs::Configure(XrdSysError &Eroute, XrdOucEnv *EnvInfo) {
 
 // Establish the network interface that the caller must provide
 //
-   if (!EnvInfo || !(myIF = (XrdNetIF *)EnvInfo->GetPtr("XrdNetIF*")))
-      {Eroute.Emsg("Finder", "Network i/f undefined; unable to self-locate.");
-       NoGo = 1;
-      }
+   if (EnvInfo && !(myIF = (XrdNetIF *)EnvInfo->GetPtr("XrdNetIF*")))
+   {Eroute.Emsg("Finder", "Network i/f undefined; unable to self-locate.");
+     NoGo = 1;
+   }
 
 // Preset all variables with common defaults
 //


### PR DESCRIPTION
While trying to load the OFS plugin for the fst nodes in EOS, I get the following error:

++++++ File system initialization started.
141103 09:46:41 8806 FstOfs_Finder: Network i/f undefined; unable to self-locate.

This comes from the fact that my OFS Configure method is called with a 0 EnvInfo parameter since when loading the library in XrdXrootdConfig.cc:294 the function is called like this:
      osFS = XrdXrootdloadFileSystem(&eDest, osFS, FSLib[1], pi->ConfigFN);

Therefore the EnvInfo is not passed but it's set later on (4 lines below) using: osFS->EnvInfo(&myEnv); 

But when the call is done in XrdXrootdloadFileSystem, I also need to call the Configure on my OFS plugin and I don't have then EnvInfo object. And setting it later does not help me at this point, since I don't have another opportunity to call the ofs Configure method. 

Therefore, I believe either the XrdSfsGetFileSystem signature should be modified to pass the EnvInfo object or you can first pass the EnvInfo object to XrdXrootdloadFileSystem and then after calling XrdSfsGetFileSystem set it for the new ofs object and also call the Configure method - so that I am not forced to call it myself in the XrdSfsGetFileSystem.

It's a bit twisted, but feel free to aske me further questions if it's not clear ... 

Thanks,
Elvin
