### PR TITLE
Fix const-ness of secEnv call.

### DIFF
--- a/src/XrdOuc/XrdOucEnv.hh
+++ b/src/XrdOuc/XrdOucEnv.hh
@@ -99,7 +99,7 @@ static bool  Import( const char *var, long  &val );
 
 // secEnv() returns the security environment; which may be a null pointer.
 //
-inline const XrdSecEntity *secEnv() {return secEntity;}
+inline const XrdSecEntity *secEnv() const {return secEntity;}
 
 // Use the constructor to define the initial variable settings. The passed
 // string is duplicated and the copy can be retrieved using Env().


### PR DESCRIPTION
This allows us to access the security environment given a const XrdOucEnv reference.

Does not affect ABI / API.
