### PR TITLE
New entry in proxy  setopt configuration

### DIFF
--- a/src/XrdPss/XrdPssConfig.cc
+++ b/src/XrdPss/XrdPssConfig.cc
@@ -941,6 +941,7 @@ int XrdPssSys::xsopt(XrdSysError *Eroute, XrdOucStream &Config)
          {"ConnectTimeout",             "ConnectionWindow"},    // Default  120
          {"DataServerConn_ttl",         ""},
          {"DebugLevel",                 "*"},                   // Default   -1
+         {"DebugMask",                 "*"},                    // Default   -1
          {"DfltTcpWindowSize",          0},
          {"LBServerConn_ttl",           ""},
          {"ParStreamsPerPhyConn",       "SubStreamsPerChannel"},// Default    1


### PR DESCRIPTION
Add new entry for DebugMask. This is used in file caching proxy to have an ability to select message type.
An alternative is to export  XRD_LOGMASK in environment.
