### PR TITLE
Fix ppc compilation

### DIFF
--- a/src/Xrd/XrdConfig.hh
+++ b/src/Xrd/XrdConfig.hh
@@ -117,6 +117,6 @@ int                 AdminMode;
 int                 repInt;
 char                repOpts;
 char                ppNet;
-char                coreV;
+signed char         coreV;
 };
 #endif


### PR DESCRIPTION
/builddir/build/BUILD/xrootd-4.1.0/src/Xrd/XrdConfig.cc: In member function 'int XrdConfig::setFDL()':
/builddir/build/BUILD/xrootd-4.1.0/src/Xrd/XrdConfig.cc:831:17: error: comparison is always true due to limited range of data type [-Werror=type-limits]
    if (coreV >= 0)
