### PR TITLE
XrdFileCache:  fix bug in setting cached file path

### DIFF
--- a/src/XrdFileCache/XrdFileCache.cc
+++ b/src/XrdFileCache/XrdFileCache.cc
@@ -21,6 +21,7 @@
 #include <sys/statvfs.h>
 
 #include "XrdCl/XrdClConstants.hh"
+#include "XrdCl/XrdClURL.hh"
 #include "XrdSys/XrdSysPthread.hh"
 #include "XrdOss/XrdOss.hh"
 #include "XrdOuc/XrdOucEnv.hh"
@@ -99,23 +100,10 @@ void Cache::Detach(XrdOucCacheIO* io)
 //______________________________________________________________________________
 
 
-bool Cache::getFilePathFromURL(const char* url, std::string &result) const
+void Cache::getFilePathFromURL(const char* iUrl, std::string &result) const
 {
-   std::string path = url;
-   size_t split_loc = path.rfind("//");
-
-   if (split_loc == path.npos)
-      return false;
-
-   size_t kloc = path.rfind("?");
-
-   if (kloc == path.npos)
-      return false;
-
-   result = Factory::GetInstance().RefConfiguration().m_cache_dir;
-   result += path.substr(split_loc+1,kloc-split_loc-1);
-
-   return true;
+   XrdCl::URL url(iUrl);
+   result = Factory::GetInstance().RefConfiguration().m_cache_dir + url.GetPath();
 }
 
 //______________________________________________________________________________

--- a/src/XrdFileCache/XrdFileCache.hh
+++ b/src/XrdFileCache/XrdFileCache.hh
@@ -90,7 +90,7 @@ namespace XrdFileCache
          void Detach(XrdOucCacheIO *);
 
          //! Transfor URL to path on local disk.
-         bool getFilePathFromURL(const char* url, std::string& res) const;
+         void getFilePathFromURL(const char* url, std::string& res) const;
 
          //! Short log alias.
          XrdCl::Log* clLog() const { return XrdCl::DefaultEnv::GetLog(); }


### PR DESCRIPTION
Files failed to be cached if proxy server is configured  to stage files.
I assumed CGI parameter will be always appended by XrdPssFile::Open which is not true in the case above.

In this commit I fixed the problem by using XrdCl::URL util.
