### PR TITLE
XrdCl: Delete URL pointer if it was previously allocated to avoid leak i...

### DIFF
--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -305,6 +305,13 @@ namespace XrdCl
     // Check if the parameters are valid
     //--------------------------------------------------------------------------
     Log *log = DefaultEnv::GetLog();
+
+    if (pFileUrl)
+    {
+      delete pFileUrl;
+      pFileUrl = 0;
+    }
+
     pFileUrl = new URL( url );
     if( !pFileUrl->IsValid() )
     {


### PR DESCRIPTION
...n case

```
   the same file object is used in a loop to open and close files.
```
