### PR TITLE
XrdSys: Delete channel object before returning

### DIFF
--- a/src/XrdSys/XrdSysIOEvents.cc
+++ b/src/XrdSys/XrdSysIOEvents.cc
@@ -289,7 +289,8 @@ void XrdSys::IOEvents::Channel::Delete()
    chMutex.Lock();
    if (!chPollXQ || chPollXQ == &pollErr1)
       {chMutex.UnLock();
-       return;
+        delete this;
+        return;
       }
 
 // Disable and remove ourselves from all queues


### PR DESCRIPTION

Is there any particular reason why the channel object is not deleted in this case?
According to valgrind this is a leak ...

Thanks,
Elvin