### PR TITLE
XrdHTTP thread looping after partial chunk requests: critical bugfix. 

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -882,6 +882,7 @@ int XrdHttpReq::ProcessHTTPReq() {
 	      }
 	      else {
 		TRACE(ALL, " No more bytes to send.");
+		reset();
 		return 1;
 	      }
 	    }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1584,11 +1584,11 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                             (char *) "123456");
 
                     TRACEI(REQ, "Sending multipart: " << rwOps[rwOpDone].bytestart << "-" << rwOps[rwOpDone].byteend);
-                    prot->SendData((char *) s.c_str(), s.size());
+                    if (prot->SendData((char *) s.c_str(), s.size())) return -1;
                   }
 
                   // Send all the data we have
-                  prot->SendData(p + sizeof (readahead_list), len);
+                  if (prot->SendData(p + sizeof (readahead_list), len)) return -1;
 
                   // If we sent all the data relative to the current original chunk request
                   // then pass to the next chunk, otherwise wait for more data
@@ -1606,12 +1606,12 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
               if (rwOpDone == rwOps.size()) {
                 string s = buildPartialHdrEnd((char *) "123456");
-                prot->SendData((char *) s.c_str(), s.size());
+                if (prot->SendData((char *) s.c_str(), s.size())) return -1;
               }
 
             } else
               for (int i = 0; i < iovN; i++) {
-		if (prot->SendData((char *) iovP[i].iov_base, iovP[i].iov_len)) return 1;
+		if (prot->SendData((char *) iovP[i].iov_base, iovP[i].iov_len)) return -1;
 		writtenbytes += iovP[i].iov_len;
               }
               

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -878,12 +878,12 @@ int XrdHttpReq::ProcessHTTPReq() {
             if (l <= 0) {
 	      if (l < 0) {
 		TRACE(ALL, " Data sizes mismatch.");
+		return -1;
 	      }
 	      else {
 		TRACE(ALL, " No more bytes to send.");
+		return 1;
 	      }
-	      
-	      return -1;
 	    }
 	    
 	    


### PR DESCRIPTION
The nightly HC tests that include XrdHTTP degraded mid-December 2014 after upgrading to
Xrootd/XrdHTTP from EPEL-test in our stable testbed. Before it was running a head from October.

The symptom is thread looping after partial chunk requests under certain circumstances.
The consequence is the performance degrading to almost zero due to cpu consumption.

This pull request fixes this
