### PR TITLE
Propagate remove call from Posix to Cache layer

### DIFF
--- a/src/XrdOuc/XrdOucCache.hh
+++ b/src/XrdOuc/XrdOucCache.hh
@@ -394,14 +394,22 @@ Debug        = 0x0003; // Produce some debug messages (levels 0, 1, 2, or 3)
 virtual
 XrdOucCache   *Create(Parms &Params, XrdOucCacheIO::aprParms *aprP=0) = 0;
 
-virtual
-int            Unlink(const char* /*path*/) { return 0; }    
 
+// Propagate  Unlink client request from posix layer to cache.
 virtual
-int            Rmdir(const char* /*path*/) { return 0; }      
+int           Unlink(const char* /*path*/) { return 0; }    
 
+// Propagate  Rmdir client request from posix layer to cache.
 virtual
-int            Rename(const char* /*path*/, const char* /*newPath*/) { return 0; }                
+int           Rmdir(const char* /*path*/) { return 0; }      
+
+// Propagate  Rename client request from posix layer to cache.
+virtual
+int           Rename(const char* /*path*/, const char* /*newPath*/) { return 0; }                
+
+// Propagate  Truncate client request from posix layer to cache.
+virtual
+int           Truncate(const char* /*path*/, off_t /*size*/) { return 0; }    
 
 /* The following holds statistics for the cache itself. It is updated as
    associated cacheIO objects are deleted and their statistics are added.

--- a/src/XrdOuc/XrdOucCache.hh
+++ b/src/XrdOuc/XrdOucCache.hh
@@ -394,6 +394,15 @@ Debug        = 0x0003; // Produce some debug messages (levels 0, 1, 2, or 3)
 virtual
 XrdOucCache   *Create(Parms &Params, XrdOucCacheIO::aprParms *aprP=0) = 0;
 
+virtual
+int            Unlink(const char* /*path*/) { return 0; }    
+
+virtual
+int            Rmdir(const char* /*path*/) { return 0; }      
+
+virtual
+int            Rename(const char* /*path*/, const char* /*newPath*/) { return 0; }                
+
 /* The following holds statistics for the cache itself. It is updated as
    associated cacheIO objects are deleted and their statistics are added.
 */

--- a/src/XrdPosix/XrdPosixXrootd.cc
+++ b/src/XrdPosix/XrdPosixXrootd.cc
@@ -984,8 +984,14 @@ int XrdPosixXrootd::Truncate(const char *path, off_t Size)
 
 // Issue the truncate
 //
-   return XrdPosixMap::Result(admin.Xrd.Truncate(admin.Url.GetPathWithParams(),
-                                                 tSize));
+  std::string urlp = admin.Url.GetPathWithParams();
+  int res = XrdPosixMap::Result(admin.Xrd.Truncate(urlp,tSize));
+
+  if (!res && myCache) {
+     myCache->Truncate(urlp.c_str(), tSize);
+  }
+
+  return res;
 }
 
 /******************************************************************************/

--- a/src/XrdPosix/XrdPosixXrootd.cc
+++ b/src/XrdPosix/XrdPosixXrootd.cc
@@ -745,8 +745,13 @@ int XrdPosixXrootd::Rename(const char *oldpath, const char *newpath)
 
 // Issue the rename
 //
-   return XrdPosixMap::Result(admin.Xrd.Mv(admin.Url.GetPathWithParams(),
-                                           newUrl.GetPathWithParams()));
+  std::string urlp    = admin.Url.GetPathWithParams();
+  std::string nurlp   = newUrl.GetPathWithParams();
+  int res = XrdPosixMap::Result(admin.Xrd.Mv(urlp, nurlp));
+  if (!res && myCache)
+     myCache->Rename(urlp.c_str(), nurlp.c_str());
+
+  return res;
 }
 
 /******************************************************************************/
@@ -780,7 +785,12 @@ int XrdPosixXrootd::Rmdir(const char *path)
 
 // Issue the rmdir
 //
-   return XrdPosixMap::Result(admin.Xrd.RmDir(admin.Url.GetPathWithParams()));
+   std::string urlp = admin.Url.GetPathWithParams();
+   int res = XrdPosixMap::Result(admin.Xrd.RmDir(urlp));
+   if (!res && myCache)
+      myCache->Rmdir(urlp.c_str());
+
+   return res;
 }
 
 /******************************************************************************/
@@ -992,7 +1002,12 @@ int XrdPosixXrootd::Unlink(const char *path)
 
 // Issue the UnLink
 //
-   return XrdPosixMap::Result(admin.Xrd.Rm(admin.Url.GetPathWithParams()));
+  std::string urlp = admin.Url.GetPathWithParams();
+  int res = XrdPosixMap::Result(admin.Xrd.Rm(urlp));
+  if (!res && myCache)
+     myCache->Unlink(urlp.c_str());
+
+  return res;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
With this change method Unlink, Rmdir, Rename, and Truncate are propagated to cache from posix layer.

The request for this change was formed in #180.