### PR TITLE
XrdFileCache:: fix crash in cache purge 

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -29,6 +29,7 @@
 #include "XrdSys/XrdSysError.hh"
 #include "XrdSys/XrdSysLogger.hh"
 #include "XrdOuc/XrdOucEnv.hh"
+#include "XrdOss/XrdOssCache.hh"
 #include "XrdOuc/XrdOucPinLoader.hh"
 #include "XrdOuc/XrdOucStream.hh"
 #include "XrdOuc/XrdOuca2x.hh"
@@ -244,7 +245,11 @@ bool Factory::Config(XrdSysLogger *logger, const char *config_filename, const ch
 
    if (retval)
    {
-      if (ofsCfg->Load(XrdOfsConfigPI::theOssLib)) ofsCfg->Plugin(m_output_fs);
+      if (ofsCfg->Load(XrdOfsConfigPI::theOssLib))  {
+          ofsCfg->Plugin(m_output_fs);
+          XrdOssCache_FS* ocfs = XrdOssCache::Find("public");
+          ocfs->Add(m_configuration.m_cache_dir.c_str());
+      }
       else
       {
          clLog()->Error(XrdCl::AppMsg, "Factory::Config() Unable to create an OSS object");
@@ -423,24 +428,25 @@ void Factory::CacheDirCleanup()
 
    XrdOss* oss =  Factory::GetInstance().GetOss();
    XrdOssDF* dh = oss->newDir(m_configuration.m_username.c_str());
+   XrdOssVSInfo sP;
+
    while (1)
    {
       // get amount of space to erase
       long long bytesToRemove = 0;
-      struct statvfs fsstat;
-      if(statvfs(m_configuration.m_cache_dir.c_str(), &fsstat) < 0 )
+      if( oss->StatVS(&sP, "public", 1) < 0 )
       {
-         clLog()->Error(XrdCl::AppMsg, "Factory::CacheDirCleanup() can't get statvfs for dir [%s] \n", m_configuration.m_cache_dir.c_str());
+         clLog()->Error(XrdCl::AppMsg, "Factory::CacheDirCleanup() can't get statvs for dir [%s] \n", m_configuration.m_cache_dir.c_str());
          exit(1);
       }
       else
       {
-         float oc = 1 - float(fsstat.f_bfree)/fsstat.f_blocks;
+         float oc = 1 - float(sP.Free)/(sP.Total);
          clLog()->Debug(XrdCl::AppMsg, "Factory::CacheDirCleanup() occupates disk space == %f", oc);
          if (oc > m_configuration.m_hwm)
          {
             long long bytesToRemoveLong = static_cast<long long> ((oc - m_configuration.m_lwm) * static_cast<float>(s_diskSpacePrecisionFactor));
-            bytesToRemove = (fsstat.f_bsize * fsstat.f_blocks * bytesToRemoveLong) / s_diskSpacePrecisionFactor;
+            bytesToRemove = (sP.Total * bytesToRemoveLong) / s_diskSpacePrecisionFactor;
             clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() need space for  %lld bytes", bytesToRemove);
          }
       }
@@ -494,17 +500,17 @@ bool Factory::CheckFileForDiskSpace(const char* path, long long fsize)
         inQueue += i->second;
 
 
-    long long availableSpace = 0;;
-    struct statvfs fsstat;
+    XrdOssVSInfo sP;
+    long long availableSpace = 0;
 
-    if(statvfs(m_configuration.m_cache_dir.c_str(), &fsstat) < 0 ) {
+    if(m_output_fs->StatVS(&sP, "public", 1) < 0 ) {
         clLog()->Error(XrdCl::AppMsg, "Factory:::CheckFileForDiskSpace can't get statvfs for dir [%s] \n", m_configuration.m_cache_dir.c_str());
         exit(1);
     }
-    float oc = 1 - float(fsstat.f_bfree)/fsstat.f_blocks;
+    float oc = 1 - float(sP.Free)/sP.Total;
     long long availableSpaceLong =  static_cast<long long>((m_configuration.m_hwm -oc)* static_cast<float>(s_diskSpacePrecisionFactor));
     if (oc < m_configuration.m_hwm) {
-        availableSpace = (fsstat.f_bsize * fsstat.f_blocks * availableSpaceLong) / s_diskSpacePrecisionFactor;
+        availableSpace = (sP.Free * availableSpaceLong) / s_diskSpacePrecisionFactor;
 
         if (availableSpace > fsize) {
             m_filesInQueue[path] = fsize;

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -366,16 +366,16 @@ bool Factory::ConfigParameters(std::string part, XrdOucStream& config )
 //______________________________________________________________________________
 
 
-void FillFileMapRecurse( XrdOssDF* df, const std::string& path, std::map<std::string, time_t>& fcmap)
+void FillFileMapRecurse( XrdOssDF* iOssDF, const std::string& path, std::map<std::string, time_t>& fcmap)
 {
    char buff[256];
    XrdOucEnv env;
    int rdr;
-   const size_t InfoExtLen = sizeof(XrdFileCache::Info::m_infoExtension);  // cached var
+   const size_t InfoExtLen = strlen(XrdFileCache::Info::m_infoExtension);  // cached var
    XrdCl::Log *log = XrdCl::DefaultEnv::GetLog();
 
    Factory& factory = Factory::GetInstance();
-   while ( (rdr = df->Readdir(&buff[0], 256)) >= 0)
+   while ( (rdr = iOssDF->Readdir(&buff[0], 256)) >= 0)
    {
       // printf("readdir [%s]\n", buff);
       std::string np = path + "/" + std::string(buff);
@@ -413,7 +413,7 @@ void FillFileMapRecurse( XrdOssDF* df, const std::string& path, std::map<std::st
          }
 
          delete dh; dh = 0;
-         delete df; df = 0;
+         delete fh; fh = 0;
       }
    }
 }

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -158,7 +158,7 @@ bool Info::GetLatestDetachTime(time_t& t, XrdOssDF* fp) const
    {
       AStat stat;
       long long off = GetHeaderSize() + sizeof(int) + (m_accessCnt-1)*sizeof(AStat);
-      int res = fp->Read(&stat, off, sizeof(AStat));
+      res = fp->Read(&stat, off, sizeof(AStat));
       if (res == sizeof(AStat))
       {
          t = stat.DetachTime;


### PR DESCRIPTION
The PR contains two commits:
- fix crash in purge of file cache 
- replace statvs with XrdOssSys::StatVS to use XrdOssSys consistently for all output file operations