### PR TITLE
free() dnarray only when necessary

### DIFF
--- a/src/XrdFfs/XrdFfsXrootdfs.cc
+++ b/src/XrdFfs/XrdFfsXrootdfs.cc
@@ -303,7 +303,7 @@ static int xrootdfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     char rootpath[MAXROOTURLLEN];
 
     XrdFfsMisc_xrd_secsss_register(fuse_get_context()->uid, fuse_get_context()->gid, 0);
-/* 
+/*
    if CNS server is not defined, there is no way to list files in a directory
    because we don't know the data nodes
 */
@@ -317,7 +317,7 @@ static int xrootdfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
         dp = XrdFfsPosix_opendir(rootpath);
         if (dp == NULL)
             return -errno;
-                                                                                                                                               
+
         while ((de = XrdFfsPosix_readdir(dp)) != NULL)
         {
 /*
@@ -335,20 +335,21 @@ static int xrootdfs_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
     else  /* if there is no CNS, try collect dirents from all known data servers. */
     {
          int i, n;
-         char **dnarray;
+         char **dnarray = NULL;
 
          n = XrdFfsPosix_readdirall(xrootdfs.rdr, path, &dnarray, fuse_get_context()->uid);
 
          for (i = 0; i < n; i++)
              if (filler(buf, dnarray[i], NULL, 0)) break;
 
-/* 
-  this loop should not be merged with the above loop because all members of 
+/*
+  this loop should not be merged with the above loop because all members of
   dnarray[] should be freed, or there will be memory leak.
  */
-         for (i = 0; i < n; i++) 
+         for (i = 0; i < n; i++)
              free(dnarray[i]);
-         free(dnarray); 
+         if (dnarray != NULL)
+             free(dnarray);
 
          return -errno;
     }


### PR DESCRIPTION
xrootdfs attempts to free() an uninitialized pointer when redirector returns an empty list of data nodes. This patch is supposed to fix that.