### PR TITLE
pfc: Leave cachedir empty by the default.

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFactory.hh
+++ b/src/XrdFileCache/XrdFileCacheFactory.hh
@@ -46,7 +46,6 @@ namespace XrdFileCache
    {
       Configuration() :
          m_hdfsmode(false),
-         m_cache_dir("/var/tmp/xrootd-file-cache"),
          m_username("nobody"),
          m_lwm(0.95),
          m_hwm(0.9),


### PR DESCRIPTION
For a test I substitute pfc.cacehdir with oss.localroot parameter in configuration:

#pfc.cachedir /foo/home/alja/xrd/data1
oss.localroot /foo/home/alja/xrd/data1