### PR TITLE
[pfc] Use fsync for cache consistency

### DIFF
--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -129,7 +129,6 @@ void Info::AppendIOStat(const Stats* caches, XrdOssDF* fp)
 {
    clLog()->Info(XrdCl::AppMsg, "Info:::AppendIOStat()");
 
-
    int flr = XrdOucSxeq::Serialize(fp->getFD(), 0);
    if (flr) clLog()->Error(XrdCl::AppMsg, "AppendIOStat() lock failed \n");
 
@@ -145,7 +144,7 @@ void Info::AppendIOStat(const Stats* caches, XrdOssDF* fp)
    as.BytesMissed = caches->m_BytesMissed;
 
    flr = XrdOucSxeq::Release(fp->getFD());
-   if (flr) clLog()->Error(XrdCl::AppMsg, "AppendStat() un-lock failed \n");
+   if (flr) clLog()->Error(XrdCl::AppMsg, "AppenIOStat() un-lock failed \n");
 
    long long ws = fp->Write(&as, off, sizeof(AStat));
    if ( ws != sizeof(AStat)) { assert(0); }

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -159,10 +159,10 @@ bool Info::GetLatestDetachTime(time_t& t, XrdOssDF* fp) const
    if (flr) clLog()->Error(XrdCl::AppMsg, "Info::GetLatestAttachTime() lock failed \n");
    if (m_accessCnt)
    {
-      AStat stat;
-      long long off = GetHeaderSize() + sizeof(int) + (m_accessCnt-1)*sizeof(AStat);
-      res = fp->Read(&stat, off, sizeof(AStat));
-      if (res == sizeof(AStat))
+      AStat     stat;
+      long long off      = GetHeaderSize() + sizeof(int) + (m_accessCnt-1)*sizeof(AStat);
+      ssize_t   read_res = fp->Read(&stat, off, sizeof(AStat));
+      if (read_res == sizeof(AStat))
       {
          t = stat.DetachTime;
          res = true;

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -42,7 +42,7 @@ using namespace XrdFileCache;
 Info::Info() :
    m_version(0),
    m_bufferSize(0),
-   m_sizeInBits(0), m_buff(0),
+   m_sizeInBits(0), m_buff_fetched(0), m_buff_write_called(0),
    m_accessCnt(0),
    m_complete(false)
 {
@@ -51,7 +51,8 @@ Info::Info() :
 
 Info::~Info()
 {
-   if (m_buff) free(m_buff);
+   if (m_buff_fetched) free(m_buff_fetched);
+   if (m_buff_write_called) free(m_buff_write_called);
 }
 
 //______________________________________________________________________________
@@ -60,8 +61,10 @@ Info::~Info()
 void Info::ResizeBits(int s)
 {
    m_sizeInBits = s;
-   m_buff = (unsigned char*)malloc(GetSizeInBytes());
-   memset(m_buff, 0, GetSizeInBytes());
+   m_buff_fetched = (unsigned char*)malloc(GetSizeInBytes());
+   m_buff_write_called = (unsigned char*)malloc(GetSizeInBytes());
+   memset(m_buff_fetched, 0, GetSizeInBytes());
+   memset(m_buff_write_called, 0, GetSizeInBytes());
 }
 
 //______________________________________________________________________________
@@ -81,7 +84,8 @@ int Info::Read(XrdOssDF* fp)
    off += fp->Read(&sb, off, sizeof(int));
    ResizeBits(sb);
 
-   off += fp->Read(m_buff, off, GetSizeInBytes());
+   off += fp->Read(m_buff_fetched, off, GetSizeInBytes());
+   off += fp->Read(m_buff_write_called, off, GetSizeInBytes());
    m_complete = IsAnythingEmptyInRng(0, sb-1) ? false : true;
 
    assert (off = GetHeaderSize());
@@ -112,7 +116,7 @@ void Info::WriteHeader(XrdOssDF* fp)
 
    int nb = GetSizeInBits();
    off += fp->Write(&nb, off, sizeof(int));
-   off += fp->Write(m_buff, off, GetSizeInBytes());
+   off += fp->Write(m_buff_write_called, off, GetSizeInBytes());
 
    flr = XrdOucSxeq::Release(fp->getFD());
    if (flr) clLog()->Error(XrdCl::AppMsg, "WriteHeader() un-lock failed \n");

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -62,7 +62,8 @@ namespace XrdFileCache
          //!
          //! @param i block index
          //---------------------------------------------------------------------
-         void SetBit(int i);
+         void SetBitWriteCalled(int i);
+         void SetBitFetched(int i);
 
          //---------------------------------------------------------------------
          //! \brief Reserve buffer for fileSize/bufferSize bytes
@@ -155,7 +156,8 @@ namespace XrdFileCache
          int            m_version;    //!< info version
          long long      m_bufferSize; //!< prefetch buffer size
          int            m_sizeInBits; //!< number of file blocks
-         unsigned char *m_buff;       //!< download state vector
+         unsigned char *m_buff_fetched;       //!< download state vector
+         unsigned char *m_buff_write_called;  //!< disk written state vector
          int            m_accessCnt;  //!< number of written AStat structs
          bool           m_complete;   //!< cached
    };
@@ -166,7 +168,7 @@ namespace XrdFileCache
       assert(cn < GetSizeInBytes());
 
       int off = i - cn*8;
-      return (m_buff[cn] & cfiBIT(off)) == cfiBIT(off);
+      return (m_buff_fetched[cn] & cfiBIT(off)) == cfiBIT(off);
    }
 
    inline int Info::GetSizeInBytes() const
@@ -197,13 +199,22 @@ namespace XrdFileCache
       m_complete = !IsAnythingEmptyInRng(0, m_sizeInBits-1);
    }
 
-   inline void Info::SetBit(int i)
+   inline void Info::SetBitWriteCalled(int i)
    {
       int cn = i/8;
       assert(cn < GetSizeInBytes());
 
       int off = i - cn*8;
-      m_buff[cn] |= cfiBIT(off);
+      m_buff_write_called[cn] |= cfiBIT(off);
+   }
+
+   inline void Info::SetBitFetched(int i)
+   {
+      int cn = i/8;
+      assert(cn < GetSizeInBytes());
+
+      int off = i - cn*8;
+      m_buff_fetched[cn] |= cfiBIT(off);
    }
 
    inline long long Info::GetBufferSize() const

--- a/src/XrdFileCache/XrdFileCachePrefetch.cc
+++ b/src/XrdFileCache/XrdFileCachePrefetch.cc
@@ -162,7 +162,6 @@ Prefetch::~Prefetch()
    }
    if (m_infoFile)
    {
-      RecordDownloadInfo();
       clLog()->Info(XrdCl::AppMsg, "Prefetch::~Prefetch close info file");
 
       m_infoFile->Close();
@@ -286,9 +285,6 @@ Prefetch::Run()
       delete task;
 
       numReadBlocks++;
-      //      if (numReadBlocks % 100 == 0)
-      //  RecordDownloadInfo();
-
    }  // loop tasks
 
 
@@ -296,7 +292,6 @@ Prefetch::Run()
 
 
    m_cfi.CheckComplete();
-   //   RecordDownloadInfo();
 
    m_stateCond.Lock();
    m_stopped = true;
@@ -911,15 +906,6 @@ Prefetch::Read(char *buff, off_t off, size_t size)
    }
 }
 
-//______________________________________________________________________________
-void Prefetch::RecordDownloadInfo()
-{
-   /*
-   clLog()->Debug(XrdCl::AppMsg, "Prefetch record Info file %s", lPath());
-   m_cfi.WriteHeader(m_infoFile);
-   m_nfoFile->Fsync();
-   */
-}
 
 //______________________________________________________________________________
 void Prefetch::AppendIOStatToFileInfo()

--- a/src/XrdFileCache/XrdFileCachePrefetch.cc
+++ b/src/XrdFileCache/XrdFileCachePrefetch.cc
@@ -181,14 +181,14 @@ const char* Prefetch::lPath() const
 bool Prefetch::Open()
 {
    // clLog()->Debug(XrdCl::AppMsg, "Prefetch::Open() open file for disk cache %s", lPath());
-   XrdOss  &m_output_fs =  *Factory::GetInstance().GetOss();
+   XrdOss  &output_fs =  *Factory::GetInstance().GetOss();
    // Create the data file itself.
    XrdOucEnv myEnv;
-   m_output_fs.Create(Factory::GetInstance().RefConfiguration().m_username.c_str(), m_temp_filename.c_str(), 0600, myEnv, XRDOSS_mkpath);
-   m_output = m_output_fs.newFile(Factory::GetInstance().RefConfiguration().m_username.c_str());
+   output_fs.Create(Factory::GetInstance().RefConfiguration().m_username.c_str(), m_temp_filename.c_str(), 0644, myEnv, XRDOSS_mkpath);
+   m_output = output_fs.newFile(Factory::GetInstance().RefConfiguration().m_username.c_str());
    if (m_output)
    {
-      int res = m_output->Open(m_temp_filename.c_str(), O_RDWR, 0600, myEnv);
+      int res = m_output->Open(m_temp_filename.c_str(), O_RDWR, 0644, myEnv);
       if ( res < 0)
       {
          clLog()->Error(XrdCl::AppMsg, "Prefetch::Open() can't get data-FD for %s %s", m_temp_filename.c_str(), lPath());
@@ -205,12 +205,12 @@ bool Prefetch::Open()
 
    // Create the info file
    std::string ifn = m_temp_filename + Info::m_infoExtension;
-   m_output_fs.Create(Factory::GetInstance().RefConfiguration().m_username.c_str(), ifn.c_str(), 0600, myEnv, XRDOSS_mkpath);
-   m_infoFile = m_output_fs.newFile(Factory::GetInstance().RefConfiguration().m_username.c_str());
+   output_fs.Create(Factory::GetInstance().RefConfiguration().m_username.c_str(), ifn.c_str(), 0644, myEnv, XRDOSS_mkpath);
+   m_infoFile = output_fs.newFile(Factory::GetInstance().RefConfiguration().m_username.c_str());
    if (m_infoFile)
    {
 
-      int res = m_infoFile->Open(ifn.c_str(), O_RDWR, 0600, myEnv);
+      int res = m_infoFile->Open(ifn.c_str(), O_RDWR, 0644, myEnv);
       if ( res < 0 )
       {
          clLog()->Error(XrdCl::AppMsg, "Prefetch::Open() can't get info-FD %s  %s", ifn.c_str(), lPath());
@@ -232,7 +232,6 @@ bool Prefetch::Open()
       int ss = (m_fileSize -1)/m_cfi.GetBufferSize() + 1;
       //      clLog()->Info(XrdCl::AppMsg, "Creating new file info with size %lld. Reserve space for %d blocks %s", m_fileSize,  ss, lPath());
       m_cfi.ResizeBits(ss);
-      RecordDownloadInfo();
    }
    else
    {

--- a/src/XrdFileCache/XrdFileCachePrefetch.cc
+++ b/src/XrdFileCache/XrdFileCachePrefetch.cc
@@ -553,7 +553,7 @@ Prefetch::WriteBlockToDisk(int ramIdx, size_t size)
 //______________________________________________________________________________
 void Prefetch::Sync()
 { 
-   clLog()->Info(XrdCl::AppMsg, "Prefetch sync %s", lPath());
+   clLog()->Dump(XrdCl::AppMsg, "Prefetch sync %s", lPath());
    m_syncStatusMutex.Lock();
    m_in_sync = true;
    m_syncStatusMutex.UnLock();
@@ -561,7 +561,6 @@ void Prefetch::Sync()
    m_output->Fsync();
    m_infoFile->Fsync();
 
-   clLog()->Info(XrdCl::AppMsg, "Prefetch sync done for data and info file %s", lPath());
    m_syncStatusMutex.Lock();
    m_in_sync = false;
    m_cfi.WriteHeader(m_infoFile);
@@ -570,9 +569,7 @@ void Prefetch::Sync()
       m_cfi.SetBitWriteCalled(*i);
    m_write_called_while_in_sync.clear();
 
-
-
-   clLog()->Info(XrdCl::AppMsg, "Prefetch sync left %d",  m_non_flushed_cnt);
+   clLog()->Dump(XrdCl::AppMsg, "Prefetch sync left %d",  m_non_flushed_cnt);
 
    m_syncStatusMutex.UnLock();
 }

--- a/src/XrdFileCache/XrdFileCachePrefetch.hh
+++ b/src/XrdFileCache/XrdFileCachePrefetch.hh
@@ -26,7 +26,9 @@
 #include "XrdFileCacheInfo.hh"
 #include "XrdFileCacheStats.hh"
 
+class XrdJob;
 class XrdOucIOVec;
+
 namespace XrdCl
 {
    class Log;
@@ -179,18 +181,19 @@ namespace XrdFileCache
          bool            m_stopped;   //!< prefetch is stopped
          XrdSysCondVar   m_stateCond; //!< state condition variable
 
-         XrdSysMutex      m_downloadStatusMutex; //!< mutex locking access to m_cfi object
+         XrdSysMutex       m_downloadStatusMutex; //!< mutex locking access to m_cfi object
 
          std::deque<Task*> m_tasks_queue;  //!< download queue
          XrdSysCondVar     m_queueCond;    //!< m_tasks_queue condition variable
 
-         Stats            m_stats;      //!< cache statistics, used in IO detach
+         Stats             m_stats;      //!< cache statistics, used in IO detach
 
          // fsync
-         XrdSysMutex      m_syncStatusMutex; //!< mutex locking fsync status
-         std::vector<int> m_write_called_while_in_sync;
-         int              m_non_flushed_cnt;
-         bool             m_in_sync;
+         XrdSysMutex       m_syncStatusMutex; //!< mutex locking fsync status
+         XrdJob           *m_syncer;
+         std::vector<int>  m_writes_during_sync;
+         int               m_non_flushed_cnt;
+         bool              m_in_sync;
    };
 }
 #endif

--- a/src/XrdFileCache/XrdFileCachePrefetch.hh
+++ b/src/XrdFileCache/XrdFileCachePrefetch.hh
@@ -143,9 +143,6 @@ namespace XrdFileCache
          //! Open file handle for data file and info file on local disk.
          bool Open();
 
-         //! Write download state into cinfo file.
-         void RecordDownloadInfo();
-
          //! Short log alias.
          XrdCl::Log* clLog() const { return XrdCl::DefaultEnv::GetLog(); }
 

--- a/src/XrdFileCache/XrdFileCachePrefetch.hh
+++ b/src/XrdFileCache/XrdFileCachePrefetch.hh
@@ -82,6 +82,12 @@ namespace XrdFileCache
          //----------------------------------------------------------------------
          bool InitiateClose();
 
+         //----------------------------------------------------------------------
+         //! Sync file cache inf o and output data with disk
+         //----------------------------------------------------------------------
+         void Sync();
+
+
       protected:
          //! Read from disk, RAM, task, or client.
          ssize_t Read(char * buff, off_t offset, size_t size);
@@ -157,7 +163,7 @@ namespace XrdFileCache
 
          //! Log path
          const char* lPath() const;
-
+          
          RAM             m_ram;            //!< in memory cache
 
          XrdOssDF       *m_output;         //!< file handle for data file on disk
@@ -182,6 +188,12 @@ namespace XrdFileCache
          XrdSysCondVar     m_queueCond;    //!< m_tasks_queue condition variable
 
          Stats            m_stats;      //!< cache statistics, used in IO detach
+
+         // fsync
+         XrdSysMutex      m_syncStatusMutex; //!< mutex locking fsync status
+         std::vector<int> m_write_called_while_in_sync;
+         int              m_non_flushed_cnt;
+         bool             m_in_sync;
    };
 }
 #endif


### PR DESCRIPTION
- Use fsync before writing out cinfo file to make sure state file is consistent with data file contents on disk in case of forced shutdown.
- Use 0644 for cached files.
