### PR TITLE
XrdCl: Fix xrdcp progress bar displaying a trasfer speed of 0 for small ...

### DIFF
--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -138,6 +138,8 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
       uint64_t speed = 0;
       if( now-d.started )
         speed = d.bytesProcessed/(now-d.started);
+      else
+        speed = d.bytesProcessed;
 
       std::string bar;
       int prog = 0;


### PR DESCRIPTION
...files/fast trasfers since the time resolution is in seconds.

Avoid situations like these:
[273.2kB/273.2kB][100%][==================================================][273.2kB/s] 
[177.8kB/177.8kB][100%][==================================================][0B/s] 
[375.3kB/375.3kB][100%][==================================================][375.3kB/s] 
[473.1kB/473.1kB][100%][==================================================][473.1kB/s] 
[809.3kB/809.3kB][100%][==================================================][0B/s] 
[451.5kB/451.5kB][100%][==================================================][451.5kB/s] 
[410.1kB/410.1kB][100%][==================================================][0B/s]  