### PR TITLE
Pfc:: set owner of cached files same as the process owner

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFactory.hh
+++ b/src/XrdFileCache/XrdFileCacheFactory.hh
@@ -46,7 +46,6 @@ namespace XrdFileCache
    {
       Configuration() :
          m_hdfsmode(false),
-         m_username("nobody"),
          m_lwm(0.95),
          m_hwm(0.9),
          m_bufferSize(1024*1024),


### PR DESCRIPTION
By the default owner of the cached files is the same as the process owner.