### PR TITLE
Compatibility code for different versions of Ceph

### DIFF
--- a/src/XrdCeph.cmake
+++ b/src/XrdCeph.cmake
@@ -15,6 +15,11 @@ add_library(
   SHARED
   XrdCeph/XrdCephPosix.cc     XrdCeph/XrdCephPosix.hh )
 
+# needed during the transition between ceph giant and ceph hammer
+# for object listing API
+set_property(SOURCE XrdCeph/XrdCephPosix.cc
+             PROPERTY COMPILE_FLAGS " -Wno-deprecated-declarations")
+
 target_link_libraries(
   XrdCephPosix
   ${RADOS_LIBS} )


### PR DESCRIPTION
The interface concerning object listing has changed in Ceph between giant and hammer releases.
This commit allows to compile against both by keeping the old interface and disabling the deprecation warnings