### PR TITLE
pfc: write meta data info after its initialization

### DIFF
--- a/src/XrdFileCache/XrdFileCachePrefetch.cc
+++ b/src/XrdFileCache/XrdFileCachePrefetch.cc
@@ -265,6 +265,7 @@ bool Prefetch::Open()
       int ss = (m_fileSize -1)/m_cfi.GetBufferSize() + 1;
       //      clLog()->Info(XrdCl::AppMsg, "Creating new file info with size %lld. Reserve space for %d blocks %s", m_fileSize,  ss, lPath());
       m_cfi.ResizeBits(ss);
+      m_cfi.WriteHeader(m_infoFile);
    }
    else
    {


### PR DESCRIPTION
This is a bugfix in a meta-data file manifested in case where the file is only opened in proxy, but not read.