### PR TITLE
New xrdpfc_print command line tool to display XrdFileCache meta data

### DIFF
--- a/docs/man/pfc_print.8
+++ b/docs/man/pfc_print.8
@@ -1,0 +1,54 @@
+.TH pfc_print 8 "__VERSION__"
+.SH NAME
+pfc_print - print content of ProxyFileCache meta data
+.SH SYNOPSIS
+.nf
+
+\fBpfc_print\fR [\fIoptions\fR] \fRpath\fR
+
+\fIoptions\fR: [\fB--config\fR \fIargs\fR] [\fB--verbose\fR] [\fB--help\fR]
+
+.fi
+.br
+.ad l
+.SH DESCRIPTION
+The \fBpfc_print\fR prints status of downloaded file blocks and access statistics of cached files
+.SH OPTIONS
+
+\fB-c\fR | \fB--config\fR
+.RS 5
+xrootd configuration file. Used to load non-default file system (directive ofs.osslib) and prefix for the location of cached files (directive oss.localroot)
+
+.RE
+\fB-v\fR | \fB--verbose\fR
+.RS 5
+prints additional info for each downloaded file block
+
+.RE
+\fB-h\fR | \fB--help\fR
+.RS 5
+displays usage information.
+
+.RE
+
+
+.RE
+.SH OPERANDS
+\fRpath\fR
+.RS 5
+Path to a file or directory for which the information is to be printed. Path can be relative or absoulte. If the path begins with root:/ the path is assumed to be a LFN and gets translated via the standard OSS rules (in the least, it gets prefixed by the oss.localroot). In this case --config option is mandatory.
+
+.RE
+
+.SH NOTES
+Documentation for all components associated with \fBpfc_print\fR can be found at
+http://xrootd.org/docs.html
+.SH DIAGNOSTICS
+Errors yield an error message and a non-zero exit status.
+.SH LICENSE
+License terms can be displayed by typing "\fBxrootd -H\fR".
+.SH SUPPORT LEVEL
+The \fBpfc_print\fR command is supported by the xrootd collaboration.
+Contact information can be found at
+.ce
+http://xrootd.org/contact.html

--- a/docs/man/xrdpfc_print.8
+++ b/docs/man/xrdpfc_print.8
@@ -1,10 +1,10 @@
-.TH pfc_print 8 "__VERSION__"
+.TH xrdpfc_print 8 "__VERSION__"
 .SH NAME
-pfc_print - print content of ProxyFileCache meta data
+xrdpfc_print - print content of ProxyFileCache meta data
 .SH SYNOPSIS
 .nf
 
-\fBpfc_print\fR [\fIoptions\fR] \fRpath\fR
+\fBxrdpfc_print\fR [\fIoptions\fR] \fRpath\fR
 
 \fIoptions\fR: [\fB--config\fR \fIargs\fR] [\fB--verbose\fR] [\fB--help\fR]
 
@@ -12,7 +12,7 @@ pfc_print - print content of ProxyFileCache meta data
 .br
 .ad l
 .SH DESCRIPTION
-The \fBpfc_print\fR prints status of downloaded file blocks and access statistics of cached files
+The \fBxrdpfc_print\fR prints status of downloaded file blocks and access statistics of cached files
 .SH OPTIONS
 
 \fB-c\fR | \fB--config\fR
@@ -41,14 +41,14 @@ Path to a file or directory for which the information is to be printed. Path can
 .RE
 
 .SH NOTES
-Documentation for all components associated with \fBpfc_print\fR can be found at
+Documentation for all components associated with \fBxrdpfc_print\fR can be found at
 http://xrootd.org/docs.html
 .SH DIAGNOSTICS
 Errors yield an error message and a non-zero exit status.
 .SH LICENSE
 License terms can be displayed by typing "\fBxrootd -H\fR".
 .SH SUPPORT LEVEL
-The \fBpfc_print\fR command is supported by the xrootd collaboration.
+The \fBxrdpfc_print\fR command is supported by the xrootd collaboration.
 Contact information can be found at
 .ce
 http://xrootd.org/contact.html

--- a/src/XrdFileCache.cmake
+++ b/src/XrdFileCache.cmake
@@ -39,8 +39,28 @@ set_target_properties(
   LINK_INTERFACE_LIBRARIES "" )
 
 #-------------------------------------------------------------------------------
+# pfc_print
+#-------------------------------------------------------------------------------
+add_executable(
+  pfc_print
+  XrdFileCache/XrdFileCachePrint.hh  XrdFileCache/XrdFileCachePrint.cc
+  XrdFileCache/XrdFileCacheInfo.hh  XrdFileCache/XrdFileCacheInfo.cc)
+
+target_link_libraries(
+  pfc_print
+  XrdServer
+  XrdCl
+  XrdUtils )
+
+#-------------------------------------------------------------------------------
 # Install
 #-------------------------------------------------------------------------------
+
 install(
   TARGETS ${LIB_XRD_FILECACHE}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
+
+
+install(
+  TARGETS pfc_print
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )

--- a/src/XrdFileCache.cmake
+++ b/src/XrdFileCache.cmake
@@ -39,15 +39,15 @@ set_target_properties(
   LINK_INTERFACE_LIBRARIES "" )
 
 #-------------------------------------------------------------------------------
-# pfc_print
+# xrdpfc_print
 #-------------------------------------------------------------------------------
 add_executable(
-  pfc_print
+  xrdpfc_print
   XrdFileCache/XrdFileCachePrint.hh  XrdFileCache/XrdFileCachePrint.cc
   XrdFileCache/XrdFileCacheInfo.hh  XrdFileCache/XrdFileCacheInfo.cc)
 
 target_link_libraries(
-  pfc_print
+  xrdpfc_print
   XrdServer
   XrdCl
   XrdUtils )
@@ -62,5 +62,5 @@ install(
 
 
 install(
-  TARGETS pfc_print
+  TARGETS xrdpfc_print
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -441,7 +441,7 @@ void FillFileMapRecurse( XrdOssDF* iOssDF, const std::string& path, FPurgeState&
          if (fname_len > InfoExtLen && strncmp(&buff[fname_len - InfoExtLen ], XrdFileCache::Info::m_infoExtension, InfoExtLen) == 0)
          {
             fh->Open((np).c_str(),O_RDONLY, 0600, env);
-            Info cinfo;
+            Info cinfo(factory.RefConfiguration().m_bufferSize);
             time_t accessTime;
             cinfo.Read(fh);
             if (cinfo.GetLatestDetachTime(accessTime, fh))

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -29,9 +29,6 @@
 #include "XrdCl/XrdClConstants.hh"
 #include "XrdFileCacheInfo.hh"
 #include "XrdFileCache.hh"
-//#include "XrdFileCacheFactory.hh"
-//#include "XrdFileCacheStats.hh"
-
 
 const char* XrdFileCache::Info::m_infoExtension = ".cinfo";
 

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -59,7 +59,7 @@ namespace XrdFileCache
          //------------------------------------------------------------------------
          //! Constructor.
          //------------------------------------------------------------------------
-         Info();
+         Info(long long bufferSize);
 
          //------------------------------------------------------------------------
          //! Destructor.
@@ -103,7 +103,7 @@ namespace XrdFileCache
          //---------------------------------------------------------------------
          //! Append access time, and cache statistics
          //---------------------------------------------------------------------
-         void AppendIOStat(const Stats* stat, XrdOssDF* fp);
+         void AppendIOStat(AStat& stat, XrdOssDF* fp);
 
          //---------------------------------------------------------------------
          //! Check download status in given block range

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -47,6 +47,15 @@ namespace XrdFileCache
          static unsigned char cfiBIT(int n) { return 1 << n; }
 
       public:
+         // !Access statistics
+         struct AStat
+         {
+            time_t    DetachTime;  //! close time
+            long long BytesDisk;   //! read from disk
+            long long BytesRam;    //! read from ram
+            long long BytesMissed; //! read remote client
+         };
+
          //------------------------------------------------------------------------
          //! Constructor.
          //------------------------------------------------------------------------
@@ -62,8 +71,13 @@ namespace XrdFileCache
          //!
          //! @param i block index
          //---------------------------------------------------------------------
-         void SetBitWriteCalled(int i);
          void SetBitFetched(int i);
+
+         //! \brief Mark block as disk written
+         //!
+         //! @param i block index
+         //---------------------------------------------------------------------
+         void SetBitWriteCalled(int i);
 
          //---------------------------------------------------------------------
          //! \brief Reserve buffer for fileSize/bufferSize bytes
@@ -141,22 +155,26 @@ namespace XrdFileCache
          //---------------------------------------------------------------------
          void CheckComplete();
 
+         //---------------------------------------------------------------------
+         //! Get number of accesses
+         //---------------------------------------------------------------------
+         int GetAccessCnt() { return  m_accessCnt; }
+
+         //---------------------------------------------------------------------
+         //! Get version
+         //---------------------------------------------------------------------
+         int GetVersion() { return  m_version; }
+
+
          const static char* m_infoExtension;
 
-      private:
+      protected:
 
          XrdCl::Log* clLog() const { return XrdCl::DefaultEnv::GetLog(); }
 
          //---------------------------------------------------------------------
          //! Cache statistics and time of access.
          //---------------------------------------------------------------------
-         struct AStat
-         {
-            time_t    DetachTime;
-            long long BytesDisk;
-            long long BytesRam;
-            long long BytesMissed;
-         };
 
          int            m_version;    //!< info version
          long long      m_bufferSize; //!< prefetch buffer size

--- a/src/XrdFileCache/XrdFileCachePrefetch.cc
+++ b/src/XrdFileCache/XrdFileCachePrefetch.cc
@@ -265,6 +265,7 @@ bool Prefetch::Open()
       int ss = (m_fileSize -1)/m_cfi.GetBufferSize() + 1;
       //      clLog()->Info(XrdCl::AppMsg, "Creating new file info with size %lld. Reserve space for %d blocks %s", m_fileSize,  ss, lPath());
       m_cfi.ResizeBits(ss);
+      m_cfi.WriteHeader(m_infoFile);
    }
    else
    {

--- a/src/XrdFileCache/XrdFileCachePrefetch.cc
+++ b/src/XrdFileCache/XrdFileCachePrefetch.cc
@@ -82,6 +82,7 @@ Prefetch::RAM::~RAM()
 Prefetch::Prefetch(XrdOucCacheIO &inputIO, std::string& disk_file_path, long long iOffset, long long iFileSize) :
    m_output(NULL),
    m_infoFile(NULL),
+   m_cfi(Factory::GetInstance().RefConfiguration().m_bufferSize),
    m_input(inputIO),
    m_temp_filename(disk_file_path),
    m_offset(iOffset),
@@ -962,7 +963,12 @@ void Prefetch::AppendIOStatToFileInfo()
    m_downloadStatusMutex.Lock();
    if (m_infoFile)
    {
-      m_cfi.AppendIOStat(&m_stats, (XrdOssDF*)m_infoFile);
+      Info::AStat as;
+      as.DetachTime  = time(0);
+      as.BytesDisk   = m_stats.m_BytesDisk;
+      as.BytesRam    = m_stats.m_BytesRam;
+      as.BytesMissed = m_stats.m_BytesMissed;
+      m_cfi.AppendIOStat(as, (XrdOssDF*)m_infoFile);
    }
    else
    {

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -10,107 +10,183 @@
 #include "XrdFileCacheInfo.hh"
 #include "XrdOss/XrdOss.hh"
 
-static const char* usage = "Usage: pfc_print [-c config_file] [-v] path\n\n";
 
-using namespace XrdFileCache;
+namespace XrdFileCache {
+class Print {
+public:
+   Print(XrdOss* oss, bool v, const char* path):m_oss(oss), m_verbose(v), m_ossUser("nobody"){
+      // check if file ends with .cinfo
+      if (isInfoFile(path)) {
+         printFile(std::string(path));
+      }
+      else {
+         XrdOssDF* dh = m_oss->newDir(m_ossUser);
+         if ( dh->Opendir(path, m_env)  >= 0 ) {
+            printDir(dh, path);
+         }
+      }
 
-void printFile(XrdOssDF* fh, bool verbose) 
-{
-   Info cfi;
-   long long off = cfi.Read(fh);
+   }
+   ~Print(){};
 
-   std::vector<Info::AStat> statv;
-   statv.resize(cfi.GetAccessCnt());
-   for (int i = 0; i <cfi.GetAccessCnt(); ++i )
-   {
-      off += fh->Read(&statv[1], off, sizeof(Info::AStat));
+private:
+   XrdOss* m_oss;
+   bool    m_verbose;
+   const char* m_ossUser;
+XrdOucEnv m_env;
+
+   bool isInfoFile(const char* path) {
+      if (strncmp(&path[strlen(path)-6], ".cinfo", 6))
+         return false;
+      return true;
    }
 
-   int cntd = 0;
-   for (int i = 0; i < cfi.GetSizeInBits(); ++i) if (cfi.TestBit(i)) cntd++;
+
+   void printFile(const std::string& path) 
+   { 
+      printf("printing %s ...\n", path.c_str());
+      XrdOssDF* fh = m_oss->newFile(m_ossUser);
+      fh->Open((path).c_str(),O_RDONLY, 0600, m_env);
+      Info cfi;
+      long long off = cfi.Read(fh);
+
+      std::vector<Info::AStat> statv;
+
+      printf("Numaccess %d \n", cfi.GetAccessCnt());
+      for (int i = 0; i <cfi.GetAccessCnt(); ++i ) {
+         Info::AStat a;
+         fh->Read(&a, off , sizeof(Info::AStat));
+         statv.push_back(a);
+      }
+
+      int cntd = 0;
+      for (int i = 0; i < cfi.GetSizeInBits(); ++i) if (cfi.TestBit(i)) cntd++;
 
 
-   printf("version == %d, bufferSize %lld nBlocks %d nDownlaoded %d %s\n",cfi.GetVersion(), cfi.GetBufferSize(), cfi.GetSizeInBits() , cntd, (cfi.GetSizeInBits() == cntd) ? " complete" :"");
+      printf("version == %d, bufferSize %lld nBlocks %d nDownlaoded %d %s\n",cfi.GetVersion(), cfi.GetBufferSize(), cfi.GetSizeInBits() , cntd, (cfi.GetSizeInBits() == cntd) ? " complete" :"");
 
-   if (verbose) {
-      printf("printing %d blocks: \n", cfi.GetSizeInBits());
-      for (int i = 0; i < cfi.GetSizeInBits(); ++i)
-         printf("%c ", cfi.TestBit(i) ? 'x':'.');
+      if (m_verbose) {
+         printf("printing %d blocks: \n", cfi.GetSizeInBits());
+         for (int i = 0; i < cfi.GetSizeInBits(); ++i)
+            printf("%c ", cfi.TestBit(i) ? 'x':'.');
+         printf("\n");
+      }
+
+      for (int i=0; i < cfi.GetAccessCnt(); ++i)
+      {
+         printf("access %d >> ", i);
+         Info::AStat& a = statv[i];
+         char s[1000];
+         struct tm * p = localtime(&a.DetachTime);
+         strftime(s, 1000, "%c", p);
+         printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", "test", a.BytesDisk, a.BytesRam, a.BytesMissed);
+      }
+
+      delete fh;
       printf("\n");
    }
 
-   for (int i=0; i < cfi.GetAccessCnt(); ++i)
+   void printDir(XrdOssDF* iOssDF, const std::string& path) 
    {
-      printf("access %d >> ", i);
-      Info::AStat& a = statv[i];
-      char s[1000];
-      struct tm * p = localtime(&a.DetachTime);
-      strftime(s, 1000, "%c", p);
-      printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", s, a.BytesDisk, a.BytesRam, a.BytesMissed);
+      // printf("---------> print dir %s \n", path.c_str());
+      char buff[256];
+      int rdr;
+      while ( (rdr = iOssDF->Readdir(&buff[0], 256)) >= 0)
+      {
+         if (strncmp("..", &buff[0], 2) && strncmp(".", &buff[0], 1)) {
+
+            if (strlen(buff) == 0) {
+               break; // end of readdir
+            }
+            std::string np = path + "/" + std::string(&buff[0]);
+            if (isInfoFile(buff))
+            {
+               printFile(np);
+            }
+            else {
+               XrdOssDF* dh = m_oss->newDir(m_ossUser);
+               if (dh->Opendir(np.c_str(), m_env) >= 0) {
+                  printDir(dh, np);
+               }
+               delete dh; dh = 0;
+            }
+         }
+      }
    }
-}
+
+};
+
+
+   }
+
+
+
+//______________________________________________________________________________
+
 
 int main(int argc, char *argv[])
-{
-    bool verbose = false;
-    const char* infoFP = "/data1/store/user/alja/data.root.cinfo";
-    const char* cfgn = 0;
+{ 
+
+   static const char* usage = "Usage: pfc_print [-c config_file] [-v] path\n\n";
+
+
+   bool verbose = false;
+   const char* cfgn = 0;
   
-    XrdOucEnv myEnv;
-    int efs = open("/dev/null",O_RDWR, 0);
-    XrdSysLogger log(efs);
-    XrdSysError err(&log, "print");
-    XrdOucStream Config(&err, getenv("XRDINSTANCE"), &myEnv, "=====> ");
-    XrdOucArgs Spec(&err, "pfc_print: ",    "", 
-                    "verbose",        1, "v",
-                    "config",       1, "c",
-                    (const char *)0);
+   XrdOucEnv myEnv;
+   int efs = open("/dev/null",O_RDWR, 0); XrdSysLogger log(efs);
+
+   XrdSysError err(&log, "print");
+   XrdOucStream Config(&err, getenv("XRDINSTANCE"), &myEnv, "=====> ");
+   XrdOucArgs Spec(&err, "pfc_print: ",    "", 
+                   "verbose",        1, "v",
+                   "config",       1, "c",
+                   (const char *)0);
 
 
-    Spec.Set(argc-1, &argv[1]);
-    char theOpt;
+   Spec.Set(argc-1, &argv[1]);
+   char theOpt;
 
-    while((theOpt = Spec.getopt()) != (char)-1)
-    {
-        switch(theOpt)
-        {
-        case 'c': {
-           cfgn = Spec.getarg();
-           // if (cfgn) printf("config ... %s\n", cfgn);
-           break;
-        }
-        case 'v': {
+   while((theOpt = Spec.getopt()) != (char)-1)
+   {
+      switch(theOpt)
+      {
+         case 'c': {
+            cfgn = Spec.getarg();
+            // if (cfgn) printf("config ... %s\n", cfgn);
+            break;
+         }
+         case 'v': {
             // printf("set verbose argval  !\n");
             verbose = true;
             break;
-        }
-        default: {
-           // printf("invalid option %c \n", theOpt);
-           printf("%s", usage);
-           exit(1);
-        }
-        }
-    }
+         }
+         default: {
+            // printf("invalid option %c \n", theOpt);
+            printf("%s", usage);
+            exit(1);
+         }
+      }
+   }
 
-    infoFP = Spec.getarg();
-    if (!infoFP) {
-       printf("%s", usage);
-       exit(1);
-    }
+   XrdOss *oss; 
+   XrdOfsConfigPI *ofsCfg = XrdOfsConfigPI::New(cfgn,&Config,&err);
+   bool ossSucc = ofsCfg->Load(XrdOfsConfigPI::theOssLib);
+   if (!ossSucc) {
+      printf("can't load oss\n");
+      exit(1);
+   }
+   ofsCfg->Plugin(oss);
 
-    XrdOss *oss; 
-    XrdOfsConfigPI *ofsCfg = XrdOfsConfigPI::New(cfgn,&Config,&err);
-    bool ossSucc = ofsCfg->Load(XrdOfsConfigPI::theOssLib);
-    if (!ossSucc) {
-       printf("can't load oss\n");
-       exit(1);
-    }
-    ofsCfg->Plugin(oss);
 
-    XrdOssDF* fh = oss->newFile("user");
-    fh->Open(infoFP, O_RDWR, 0644, myEnv);
-    printFile(fh, verbose);
-    fh->Close();
+   const char* path = Spec.getarg();
+   if (!path) {
+      printf("%s", usage);
+      exit(1);
+   }
+   std::cerr << "START !!!!\n";
+
+   XrdFileCache::Print p(oss, verbose, path);
 }
 
 

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -1,0 +1,22 @@
+int main(int argc, char *argv[])
+{
+   XrdOucEnv myEnv;
+   XrdOucStream Config(&m_log, getenv("XRDINSTANCE"), &myEnv, "=====> ");
+
+   // Obtain plugin configurator
+   XrdOfsConfigPI *ofsCfg = XrdOfsConfigPI::New(config_filename,&Config,&m_log,
+                                                &XrdVERSIONINFOVAR(XrdOucGetCache));
+
+   if (ofsCfg->Load(XrdOfsConfigPI::theOssLib)) 
+      ofsCfg->Plugin(m_output_fs);
+
+
+   int resc =   output_fs.Create(Factory::GetInstance().RefConfiguration().m_username.c_str(), m_temp_filename.c_str(), 0644, myEnv, XRDOSS_mkpath);
+
+   m_output = output_fs.newFile(Factory::GetInstance().RefConfiguration().m_username.c_str());
+   int res = m_output->Open(m_temp_filename.c_str(), O_RDWR, 0644, myEnv);
+
+    XrdFileCacheInfo cfi;
+    cfi.Read(m_infoFile);
+    printf("Info is complete %d\n", cfi.IsComplete());
+}

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
    }
 
    // append oss.localroot if path starts with 'root://'
-   if (!strncmp(&path[0], "root://", 7)) {
+   if (!strncmp(&path[0], "root:/", 6)) {
       if (Config.FDNum() < 0) {
          printf("Configuration file not specified.\n");
          exit(1);
@@ -202,8 +202,7 @@ int main(int argc, char *argv[])
          if (!strncmp(var,"oss.localroot", strlen("oss.localroot")))
          {
             std::string tmp = Config.GetWord();
-            tmp += "/";
-            tmp += &path[7];
+            tmp += &path[6];
             // printf("Absolute path %s \n", tmp.c_str());  
             XrdFileCache::Print p(oss, verbose, tmp.c_str());
          }

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -1,22 +1,116 @@
+#include <iostream>
+#include <fcntl.h>
+#include <vector>
+
+#include "XrdOuc/XrdOucEnv.hh"
+#include "XrdOuc/XrdOucStream.hh"
+#include "XrdOuc/XrdOucArgs.hh"
+#include "XrdOfs/XrdOfsConfigPI.hh"
+#include "XrdSys/XrdSysLogger.hh"
+#include "XrdFileCacheInfo.hh"
+#include "XrdOss/XrdOss.hh"
+
+static const char* usage = "Usage: pfc_print [-c config_file] [-v] path\n\n";
+
+using namespace XrdFileCache;
+
+void printFile(XrdOssDF* fh, bool verbose) 
+{
+   Info cfi;
+   long long off = cfi.Read(fh);
+
+   std::vector<Info::AStat> statv;
+   statv.resize(cfi.GetAccessCnt());
+   for (int i = 0; i <cfi.GetAccessCnt(); ++i )
+   {
+      off += fh->Read(&statv[1], off, sizeof(Info::AStat));
+   }
+
+   int cntd = 0;
+   for (int i = 0; i < cfi.GetSizeInBits(); ++i) if (cfi.TestBit(i)) cntd++;
+
+
+   printf("version == %d, bufferSize %lld nBlocks %d nDownlaoded %d %s\n",cfi.GetVersion(), cfi.GetBufferSize(), cfi.GetSizeInBits() , cntd, (cfi.GetSizeInBits() == cntd) ? " complete" :"");
+
+   if (verbose) {
+      printf("printing %d blocks: \n", cfi.GetSizeInBits());
+      for (int i = 0; i < cfi.GetSizeInBits(); ++i)
+         printf("%c ", cfi.TestBit(i) ? 'x':'.');
+      printf("\n");
+   }
+
+   for (int i=0; i < cfi.GetAccessCnt(); ++i)
+   {
+      printf("access %d >> ", i);
+      Info::AStat& a = statv[i];
+      char s[1000];
+      struct tm * p = localtime(&a.DetachTime);
+      strftime(s, 1000, "%c", p);
+      printf("[%s], bytesDisk=%lld, bytesRAM=%lld, bytesMissed=%lld\n", s, a.BytesDisk, a.BytesRam, a.BytesMissed);
+   }
+}
+
 int main(int argc, char *argv[])
 {
-   XrdOucEnv myEnv;
-   XrdOucStream Config(&m_log, getenv("XRDINSTANCE"), &myEnv, "=====> ");
+    bool verbose = false;
+    const char* infoFP = "/data1/store/user/alja/data.root.cinfo";
+    const char* cfgn = 0;
+  
+    XrdOucEnv myEnv;
+    int efs = open("/dev/null",O_RDWR, 0);
+    XrdSysLogger log(efs);
+    XrdSysError err(&log, "print");
+    XrdOucStream Config(&err, getenv("XRDINSTANCE"), &myEnv, "=====> ");
+    XrdOucArgs Spec(&err, "pfc_print: ",    "", 
+                    "verbose",        1, "v",
+                    "config",       1, "c",
+                    (const char *)0);
 
-   // Obtain plugin configurator
-   XrdOfsConfigPI *ofsCfg = XrdOfsConfigPI::New(config_filename,&Config,&m_log,
-                                                &XrdVERSIONINFOVAR(XrdOucGetCache));
 
-   if (ofsCfg->Load(XrdOfsConfigPI::theOssLib)) 
-      ofsCfg->Plugin(m_output_fs);
+    Spec.Set(argc-1, &argv[1]);
+    char theOpt;
 
+    while((theOpt = Spec.getopt()) != (char)-1)
+    {
+        switch(theOpt)
+        {
+        case 'c': {
+           cfgn = Spec.getarg();
+           // if (cfgn) printf("config ... %s\n", cfgn);
+           break;
+        }
+        case 'v': {
+            // printf("set verbose argval  !\n");
+            verbose = true;
+            break;
+        }
+        default: {
+           // printf("invalid option %c \n", theOpt);
+           printf("%s", usage);
+           exit(1);
+        }
+        }
+    }
 
-   int resc =   output_fs.Create(Factory::GetInstance().RefConfiguration().m_username.c_str(), m_temp_filename.c_str(), 0644, myEnv, XRDOSS_mkpath);
+    infoFP = Spec.getarg();
+    if (!infoFP) {
+       printf("%s", usage);
+       exit(1);
+    }
 
-   m_output = output_fs.newFile(Factory::GetInstance().RefConfiguration().m_username.c_str());
-   int res = m_output->Open(m_temp_filename.c_str(), O_RDWR, 0644, myEnv);
+    XrdOss *oss; 
+    XrdOfsConfigPI *ofsCfg = XrdOfsConfigPI::New(cfgn,&Config,&err);
+    bool ossSucc = ofsCfg->Load(XrdOfsConfigPI::theOssLib);
+    if (!ossSucc) {
+       printf("can't load oss\n");
+       exit(1);
+    }
+    ofsCfg->Plugin(oss);
 
-    XrdFileCacheInfo cfi;
-    cfi.Read(m_infoFile);
-    printf("Info is complete %d\n", cfi.IsComplete());
+    XrdOssDF* fh = oss->newFile("user");
+    fh->Open(infoFP, O_RDWR, 0644, myEnv);
+    printFile(fh, verbose);
+    fh->Close();
 }
+
+

--- a/src/XrdFileCache/XrdFileCachePrint.hh
+++ b/src/XrdFileCache/XrdFileCachePrint.hh
@@ -1,0 +1,54 @@
+//----------------------------------------------------------------------------------
+// Copyright (c) 2014 by Board of Trustees of the Leland Stanford, Jr., University
+// Author: Alja Mrak-Tadel
+//----------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//----------------------------------------------------------------------------------
+
+#include "XrdOuc/XrdOucEnv.hh"
+
+class XrdOss;
+class XrdOssDF;
+
+namespace XrdFileCache
+{
+class Print {
+public:
+   //------------------------------------------------------------------------
+   //! Constructor.
+   //------------------------------------------------------------------------
+   Print(XrdOss* oss, bool v, const char* path);
+
+private:
+   XrdOss*     m_oss;      //! file system
+   XrdOucEnv   m_env;      //! env used by file system
+   bool        m_verbose;  //! print each block
+   const char* m_ossUser;  //! file system user
+
+   //---------------------------------------------------------------------
+   //! Check file ends with *.cinfo suffix
+   //---------------------------------------------------------------------
+   bool isInfoFile(const char* path);
+
+   //---------------------------------------------------------------------
+   //! Print information in meta-data file
+   //---------------------------------------------------------------------
+   void printFile(const std::string& path);
+
+   //---------------------------------------------------------------------
+   //! Print information in meta-data file recursivly
+   //---------------------------------------------------------------------
+   void printDir(XrdOssDF* iOssDF, const std::string& path);
+};
+}


### PR DESCRIPTION
This is a new tool which prints XrdFileCache binary meta data.

Usage: **xrdpfc_print** [-c config_file] [-v] path

More information is in xrdpfc_print man page. 