### PR TITLE
Fix narrowing conversion error on RHEL7 ppc64

### DIFF
--- a/src/XrdCms/XrdCmsLogin.cc
+++ b/src/XrdCms/XrdCmsLogin.cc
@@ -272,7 +272,7 @@ int XrdCmsLogin::SendErrorBL(XrdLink *Link)
   
 int XrdCmsLogin::SendErrorBL(XrdLink *Link, char *rbuff, int rblen)
 {
-  CmsRRHdr Rsp = {0, kYR_try, CmsTryRequest::kYR_permtop, htons(rblen)};
+  CmsRRHdr Rsp = {0, kYR_try, CmsTryRequest::kYR_permtop, htons((unsigned short int)rblen)};
   struct iovec iov[2] = {{(char *)&Rsp, sizeof(Rsp)},
                                 {rbuff, static_cast<size_t>(rblen)}};
   char msgbuff[2048];


### PR DESCRIPTION
Fix for compilation error on RHEL7 ppc64:

error: narrowing conversion of 'rblen' from 'int' to 'kXR_unt16 {aka short unsigned int}' inside { } is ill-formed in C++11
