### PR TITLE
TPC: Fix deadlock in case of error in the TPC authentication

### DIFF
--- a/src/XrdOfs/XrdOfsTPCAuth.cc
+++ b/src/XrdOfs/XrdOfsTPCAuth.cc
@@ -98,7 +98,10 @@ int XrdOfsTPCAuth::Add(XrdOfsTPC::Facts &Args)
 // Set the copy authorization information
 //
    if ((eMsg = Info.Set(Args.Key, Buff, Args.Lfn, Args.Dst)))
-      return Fatal(Args, eMsg, EINVAL);
+   {
+     authMutex.UnLock();
+     return Fatal(Args, eMsg, EINVAL);
+   }
 
 // Add this to queue
 //


### PR DESCRIPTION
In case the address resolution fails then the authMutex is never
released and all subsequent TPC transfers will deadlock. Seen in
in the XRootD plugin in CASTOR with the following signature:
150706 19:25:54 10128 castor2ofs_TPC: alienmas.60723:19@aliendb9
Unable to open ....; Name or service not known

Example of deadlocked threads:

Thread 31 (Thread 0x7f1b7369c700 (LWP 10128)):
#0  0x000000369f40e264 in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x000000369f409508 in _L_lock_854 () from /lib64/libpthread.so.0
#2  0x000000369f4093d7 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x00000036a046ccf8 in XrdOfsTPCAuth::Del() () from /usr/lib64/libXrdServer.so.2
#4  0x00000036a045f252 in XrdOfsFile::close() () from /usr/lib64/libXrdServer.so.2
#5  0x00007f1b72a11d1e in XrdxCastor2OfsFile::close() () from /usr/lib64/libxrdxcastor2ofs.so.2.1
#6  0x00000036a0458451 in XrdXrootdProtocol::do_Close() () from /usr/lib64/libXrdServer.so.2
#7  0x00000036a105d909 in XrdLink::DoIt() () from /usr/lib64/libXrdUtils.so.2
#8  0x00000036a1060dc5 in XrdScheduler::Run() () from /usr/lib64/libXrdUtils.so.2
#9  0x00000036a1060fb9 in XrdStartWorking(void*) () from /usr/lib64/libXrdUtils.so.2
#10 0x00000036a1025f9f in XrdSysThread_Xeq () from /usr/lib64/libXrdUtils.so.2
#11 0x000000369f4079d1 in start_thread () from /lib64/libpthread.so.0
#12 0x000000369f0e88fd in clone () from /lib64/libc.so.6

Thread 30 (Thread 0x7f1b7359b700 (LWP 10129)):
#0  0x000000369f40e264 in __lll_lock_wait () from /lib64/libpthread.so.0
#1  0x000000369f409508 in _L_lock_854 () from /lib64/libpthread.so.0
#2  0x000000369f4093d7 in pthread_mutex_lock () from /lib64/libpthread.so.0
#3  0x00000036a046d2cd in XrdOfsTPCAuth::Add(XrdOfsTPC::Facts&) () from /usr/lib64/libXrdServer.so.2
#4  0x00000036a046c9b0 in XrdOfsTPC::Authorize(XrdOfsTPC**, XrdOfsTPC::Facts&, int) () from /usr/lib64/libXrdServer.so.2
#5  0x00000036a045d64c in XrdOfsFile::open(char const*, int, unsigned int, XrdSecEntity const*, char const*) () from /usr/lib64/libXrdServer.so.2
#6  0x00007f1b72a10e69 in XrdxCastor2OfsFile::open(char const*, int, unsigned int, XrdSecEntity const*, char const*) () from /usr/lib64/libxrdxcastor2ofs.so.2.1
#7  0x00000036a045528c in XrdXrootdProtocol::do_Open() () from /usr/lib64/libXrdServer.so.2
#8  0x00000036a105d909 in XrdLink::DoIt() () from /usr/lib64/libXrdUtils.so.2
#9  0x00000036a1060dc5 in XrdScheduler::Run() () from /usr/lib64/libXrdUtils.so.2
#10 0x00000036a1060fb9 in XrdStartWorking(void*) () from /usr/lib64/libXrdUtils.so.2
#11 0x00000036a1025f9f in XrdSysThread_Xeq () from /usr/lib64/libXrdUtils.so.2
#12 0x000000369f4079d1 in start_thread () from /lib64/libpthread.so.0
#13 0x000000369f0e88fd in clone () from /lib64/libc.so.6