### PR TITLE
XrdCl: Fix race condition in PostMaster initialization

### DIFF
--- a/src/XrdCl/XrdClDefaultEnv.cc
+++ b/src/XrdCl/XrdClDefaultEnv.cc
@@ -314,27 +314,32 @@ namespace XrdCl
     if( unlikely(!sPostMaster) )
     {
       XrdSysMutexHelper scopedLock( sInitMutex );
+
       if( sPostMaster )
         return sPostMaster;
-      sPostMaster = new PostMaster();
 
-      if( !sPostMaster->Initialize() )
+      PostMaster* post_master = new PostMaster();
+
+      if( !post_master->Initialize() )
       {
-        delete sPostMaster;
-        sPostMaster = 0;
+        delete post_master;
+        post_master = 0;
         return 0;
       }
 
-      if( !sPostMaster->Start() )
+      if( !post_master->Start() )
       {
-        sPostMaster->Finalize();
-        delete sPostMaster;
-        sPostMaster = 0;
+        post_master->Finalize();
+        delete post_master;
+        post_master = 0;
         return 0;
       }
-      sForkHandler->RegisterPostMaster( sPostMaster );
-      sPostMaster->GetTaskManager()->RegisterTask( sFileTimer, time(0), false );
+
+      sForkHandler->RegisterPostMaster( post_master );
+      post_master->GetTaskManager()->RegisterTask( sFileTimer, time(0), false );
+      sPostMaster = post_master;
     }
+
     return sPostMaster;
   }
 
@@ -547,7 +552,6 @@ namespace XrdCl
     sPlugInManager->ProcessEnvironmentSettings();
     sForkHandler->RegisterFileTimer( sFileTimer );
 
-
     //--------------------------------------------------------------------------
     // MacOSX library loading is completely moronic. We cannot dlopen a library
     // from a thread other than a main thread, so we-pre dlopen all the
@@ -723,9 +727,6 @@ extern "C"
   //----------------------------------------------------------------------------
   static void prepare()
   {
-    //--------------------------------------------------------------------------
-    // Prepare
-    //--------------------------------------------------------------------------
     using namespace XrdCl;
     Log         *log         = DefaultEnv::GetLog();
     Env         *env         = DefaultEnv::GetEnv();
@@ -749,9 +750,6 @@ extern "C"
   //----------------------------------------------------------------------------
   static void parent()
   {
-    //--------------------------------------------------------------------------
-    // Prepare
-    //--------------------------------------------------------------------------
     using namespace XrdCl;
     Log         *log         = DefaultEnv::GetLog();
     Env         *env         = DefaultEnv::GetEnv();
@@ -778,9 +776,6 @@ extern "C"
   //----------------------------------------------------------------------------
   static void child()
   {
-    //--------------------------------------------------------------------------
-    // Prepare
-    //--------------------------------------------------------------------------
     using namespace XrdCl;
     DefaultEnv::ReInitializeLogging();
     Log         *log         = DefaultEnv::GetLog();

--- a/src/XrdCl/XrdClPostMaster.cc
+++ b/src/XrdCl/XrdClPostMaster.cc
@@ -66,9 +66,12 @@ namespace XrdCl
     env->GetString( "PollerPreference", pollerPref );
 
     pPoller = PollerFactory::CreatePoller( pollerPref );
+
     if( !pPoller )
       return false;
+
     bool st = pPoller->Initialize();
+
     if( !st )
     {
       delete pPoller;
@@ -76,7 +79,6 @@ namespace XrdCl
     }
 
     pJobManager->Initialize();
-
     pInitialized = true;
     return true;
   }
@@ -93,12 +95,12 @@ namespace XrdCl
       return true;
 
     pInitialized = false;
-
     pJobManager->Finalize();
-
     ChannelMap::iterator it;
+
     for( it = pChannelMap.begin(); it != pChannelMap.end(); ++it )
       delete it->second;
+
     pChannelMap.clear();
     return pPoller->Finalize();
   }
@@ -126,6 +128,7 @@ namespace XrdCl
       pTaskManager->Stop();
       return false;
     }
+
     return true;
   }
 
@@ -162,8 +165,6 @@ namespace XrdCl
                            bool       stateful,
                            time_t     expires )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
 
     if( !channel )
@@ -181,8 +182,6 @@ namespace XrdCl
                            bool                  stateful,
                            time_t                expires )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
 
     if( !channel )
@@ -199,8 +198,6 @@ namespace XrdCl
                               MessageFilter  *filter,
                               time_t          expires )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
 
     if( !channel )
@@ -216,10 +213,7 @@ namespace XrdCl
                               IncomingMsgHandler *handler,
                               time_t              expires )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
-
 
     if( !channel )
       return Status( stError, errNotSupported );
@@ -234,8 +228,6 @@ namespace XrdCl
                                      uint16_t   query,
                                      AnyObject &result )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
 
     if( !channel )
@@ -250,8 +242,6 @@ namespace XrdCl
   Status PostMaster::RegisterEventHandler( const URL           &url,
                                            ChannelEventHandler *handler )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
 
     if( !channel )
@@ -267,8 +257,6 @@ namespace XrdCl
   Status PostMaster::RemoveEventHandler( const URL           &url,
                                        ChannelEventHandler *handler )
   {
-    if( !pInitialized )
-      return Status( stFatal, errUninitialized );
     Channel *channel = GetChannel( url );
 
     if( !channel )
@@ -286,6 +274,7 @@ namespace XrdCl
     XrdSysMutexHelper scopedLock( pChannelMapMutex );
     Channel *channel = 0;
     ChannelMap::iterator it = pChannelMap.find( url.GetHostId() );
+
     if( it == pChannelMap.end() )
     {
       TransportManager *trManager = DefaultEnv::GetTransportManager();


### PR DESCRIPTION
In case several threads start doing transfers in parallel some can
fail with the following error: [FATAL] Initialization error
because the post master object is created but not initialized.

This only happens in the beginning when the PostMaster is not set up. The initial idea was probably to make the GetPostMaster code as efficient as possible by not taking the lock on the most frequent case. But this leads to a situation where a thread creates the sPostMaster object but does not get to initialize it, and another thread picks it up as the object exists and tries to use it.