### PR TITLE
XrdCl: Use std::atomic when possible for the PostMaster pointer

### DIFF
--- a/src/XrdCl/XrdClDefaultEnv.hh
+++ b/src/XrdCl/XrdClDefaultEnv.hh
@@ -21,6 +21,7 @@
 
 #include "XrdSys/XrdSysPthread.hh"
 #include "XrdCl/XrdClEnv.hh"
+#include "XrdSys/XrdSysAtomics.hh"
 
 class XrdOucPinLoader;
 
@@ -160,7 +161,6 @@ namespace XrdCl
 
       static XrdSysMutex        sInitMutex;
       static Env               *sEnv;
-      static PostMaster        *sPostMaster;
       static Log               *sLog;
       static ForkHandler       *sForkHandler;
       static FileTimer         *sFileTimer;
@@ -170,6 +170,7 @@ namespace XrdCl
       static CheckSumManager   *sCheckSumManager;
       static TransportManager  *sTransportManager;
       static PlugInManager     *sPlugInManager;
+      static CPP_ATOMIC_TYPE(PostMaster*) sPostMaster;
   };
 }
 


### PR DESCRIPTION
Hi all, 

I've created this pull request which deals with the atomicity of the sPostMaster pointer. This is only enforced when compiled with c++11 support. Let me know if this is acceptable for you or if you want the __sync_fetch* approach. The reason for this is that on x86_64 architectures this approach has no performance penalty for the load operation.

For example the following code:
```c++
#include <atomic>

std::atomic<int> a;
void val_set(int v) { a = v; }
int val_get() { return a; }
```
yields the following assembler code on x86_64 for the two functions:

```asm
Z7val_seti:
        .cfi_startproc
        movl    %edi, a(%rip)
        mfence
        ret
        .cfi_endproc

_Z7val_getv:
        .cfi_startproc
        movl    a(%rip), %eax
        ret
        .cfi_endproc
```

Therefore the get operation is no different on the atomic variable than on the non-atomic one.

For an ARM architecture, the the issue is totally different. The assembler code for the same functions is:

```asm
Z7val_seti:
        @ args = 0, pretend = 0, frame = 0
        @ frame_needed = 0, uses_anonymous_args = 0
        stmfd   sp!, {r4, r5, r6, lr}
        mov     r5, r0
        ldr     r4, .L2
        mov     r0, r4
        bl      __atomic_flag_for_address
        mov     r1, #5
        mov     r6, r0
        bl      __atomic_flag_wait_explicit
        mov     r0, r6
        mov     r1, #5
        str     r5, [r4, #0]
        ldmfd   sp!, {r4, r5, r6, lr}
        b       atomic_flag_clear_explicit

_Z7val_getv:
        @ args = 0, pretend = 0, frame = 0
        @ frame_needed = 0, uses_anonymous_args = 0
        stmfd   sp!, {r3, r4, r5, lr}
        ldr     r4, .L5
        mov     r0, r4
        bl      __atomic_flag_for_address
        mov     r1, #5
        mov     r5, r0
        bl      __atomic_flag_wait_explicit
        ldr     r4, [r4, #0]
        mov     r0, r5
        mov     r1, #5
        bl      atomic_flag_clear_explicit
        mov     r0, r4
        ldmfd   sp!, {r3, r4, r5, pc}
```

Therefore, the trade-off is that when you compile for ARM it will be a bit slower and you need to use c++11 which I assume is already the case for the CMSSW where c++11 is omnipresent. 
Let me know your thoughts on this and if everything is fine, I will merge it tomorrow.

Cheers,
Elvin