### PR TITLE
add MANIFEST.in for python bindings

### DIFF
--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.rst
+recursive-include tests *
+recursive-include examples *
+recursive-include docs *
+recursive-include src *
+recursive-include libs *


### PR DESCRIPTION
* Requested by @esindril (see [original PR to xrootd-python](https://github.com/xrootd/xrootd-python/pull/12).
* Adds a MANIFEST.in file for the python bindings.
* Is not by itself sufficient to generate a python source distribution:
  * The `setup.py` file generated via `setup.py.in` and `cmake` looks for XrootD libraries and resources within the XrootD source directory -- assuming they can be found wherever they were found on the system on which the `setup.py` file was generated. This is not portable.