### PR TITLE
Use correct snprintf sizeof variable

### DIFF
--- a/src/XrdSsi/XrdSsiFileReq.cc
+++ b/src/XrdSsi/XrdSsiFileReq.cc
@@ -139,7 +139,7 @@ XrdSsiFileReq *XrdSsiFileReq::Alloc(XrdOucErrInfo *eiP,
        nP->sessP  = sP;
        nP->cbInfo = eiP;
        nP->reqID = rnum;
-       snprintf(nP->rID, sizeof(rID), "%d:", rnum);
+       snprintf(nP->rID, sizeof(nP->rID), "%d:", rnum);
       }
 
 // Return the pointer


### PR DESCRIPTION
Clang reports a problem with the variable being used to calculate the
size of the string buffer in XrdSsiFileReq::Alloc -

    XrdSsiFileReq.cc:142:33: error: invalid use of member 'rID' in static member

The fix is to use sizeof() on the same variable that is receiving the string.

With this change xrootd compiles this branch on OS X with clang. This is important as this branch is already in use at LSST.