### PR TITLE
pfc: add possibility to specify disk usage parameters in .. G, T units using XrdOuca2x::a2sz()

### DIFF
--- a/src/XrdFileCache/README
+++ b/src/XrdFileCache/README
@@ -119,7 +119,7 @@ pfc.nread: number of in memory cached blocks reserved for read tasks
 pfc.nprefetch: number of in memory cached blocks reserved for prefetch tasks
 
 pfc.diskusage <lwm fraction> <hwm fraction>: high / low watermarks for disk cache
-purge operation (default 0.7 and 0.9)
+purge operation (default 0.9 and 0.95)
 
 pfc.user <username>: username used by XrdOss plugin
 

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -334,12 +334,12 @@ bool Factory::ConfigParameters(std::string part, XrdOucStream& config )
             {
                float lwmf = ::atof(minV.c_str());
                float hwmf = ::atof(maxV.c_str());
-               if (hwmf) {
+               if (lwmf && hwmf) {
                   m_configuration.m_diskUsageLWM = sP.Total * lwmf;
                   m_configuration.m_diskUsageHWM = sP.Total * hwmf;
                }
                else {
-                  m_log.Emsg("Factory::ConfigParameters() error parsing parameter", maxV.c_str());
+                  m_log.Emsg("Factory::ConfigParameters() error parsing diskusage parameters ", minV.c_str(), maxV.c_str());
                }
             }
          }

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -325,7 +325,7 @@ bool Factory::ConfigParameters(std::string part, XrdOucStream& config )
          {
             if (::isalpha(*(minV.rbegin())) && ::isalpha(*(minV.rbegin()))) {
                if ( XrdOuca2x::a2sz(m_log, "Error getting disk usage low watermark",  minV.c_str(), &m_configuration.m_diskUsageLWM, 0, sP.Total) 
-                 && XrdOuca2x::a2sz(m_log, "Error getting disk usage high watermark", maxV.c_str(), &m_configuration.m_diskUsageHWM, 0, sP.Total))
+                 || XrdOuca2x::a2sz(m_log, "Error getting disk usage high watermark", maxV.c_str(), &m_configuration.m_diskUsageHWM, 0, sP.Total))
                {
                   return false;
                }

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -258,7 +258,7 @@ bool Factory::Config(XrdSysLogger *logger, const char *config_filename, const ch
       if (m_output_fs->StatVS(&sP, "public", 1) >= 0) {
          m_configuration.m_diskUsageLWM = 0.90 * sP.Total;
          m_configuration.m_diskUsageHWM = 0.95 * sP.Total;
-         clLog()->Debug(XrdCl::AppMsg, "Default disk usage [%lld, %lld]",  sP.Total, m_configuration.m_diskUsageLWM, m_configuration.m_diskUsageHWM);
+         clLog()->Debug(XrdCl::AppMsg, "Default disk usage [%lld, %lld]", m_configuration.m_diskUsageLWM, m_configuration.m_diskUsageHWM);
       }
    }
 

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -332,15 +332,21 @@ bool Factory::ConfigParameters(std::string part, XrdOucStream& config )
             }
             else 
             {
-               float lwmf = ::atof(minV.c_str());
-               float hwmf = ::atof(maxV.c_str());
-               if (lwmf && hwmf) {
-                  m_configuration.m_diskUsageLWM = sP.Total * lwmf;
-                  m_configuration.m_diskUsageHWM = sP.Total * hwmf;
+               char* eP;
+               errno = 0;
+               float lwmf = strtod(minV.c_str(), &eP);
+               if (errno || eP == minV.c_str()) {
+                    m_log.Emsg("Factory::ConfigParameters() error parsing diskusage parameter ", minV.c_str());
+                    return false;
                }
-               else {
-                  m_log.Emsg("Factory::ConfigParameters() error parsing diskusage parameters ", minV.c_str(), maxV.c_str());
+               float hwmf = strtod(maxV.c_str(), &eP);
+               if (errno || eP == maxV.c_str()) {
+                  m_log.Emsg("Factory::ConfigParameters() error parsing diskusage parameter ", maxV.c_str());
+                  return false;
                }
+
+               m_configuration.m_diskUsageLWM = sP.Total * lwmf;
+               m_configuration.m_diskUsageHWM = sP.Total * hwmf;
             }
          }
       }

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -46,9 +46,6 @@
 
 
 using namespace XrdFileCache;
-namespace {
-static long long s_diskSpacePrecisionFactor = 10000000;
-}
 
 XrdVERSIONINFO(XrdOucGetCache, XrdFileCache);
 
@@ -212,6 +209,20 @@ bool Factory::Config(XrdSysLogger *logger, const char *config_filename, const ch
                                                 &XrdVERSIONINFOVAR(XrdOucGetCache));
    if (!ofsCfg) return false;
 
+
+   if (ofsCfg->Load(XrdOfsConfigPI::theOssLib))  {
+      ofsCfg->Plugin(m_output_fs);
+      XrdOssCache_FS* ocfs = XrdOssCache::Find("public");
+      ocfs->Add(m_configuration.m_cache_dir.c_str());
+   }
+   else
+   {
+      clLog()->Error(XrdCl::AppMsg, "Factory::Config() Unable to create an OSS object");
+      m_output_fs = 0;
+      return false;
+   }
+
+
    // Actual parsing of the config file.
    bool retval = true;
    char *var;
@@ -240,23 +251,19 @@ bool Factory::Config(XrdSysLogger *logger, const char *config_filename, const ch
    }
 
    Config.Close();
-
+   // sets default value for disk usage
+   if (m_configuration.m_diskUsageLWM < 0 || m_configuration.m_diskUsageHWM < 0)
+   {
+      XrdOssVSInfo sP;
+      if (m_output_fs->StatVS(&sP, "public", 1) >= 0) {
+         m_configuration.m_diskUsageLWM = 0.90 * sP.Total;
+         m_configuration.m_diskUsageHWM = 0.95 * sP.Total;
+         clLog()->Debug(XrdCl::AppMsg, "Default disk usage [%lld, %lld]",  sP.Total, m_configuration.m_diskUsageLWM, m_configuration.m_diskUsageHWM);
+      }
+   }
 
    if (retval)
    {
-      if (ofsCfg->Load(XrdOfsConfigPI::theOssLib))  {
-          ofsCfg->Plugin(m_output_fs);
-          XrdOssCache_FS* ocfs = XrdOssCache::Find("public");
-          ocfs->Add(m_configuration.m_cache_dir.c_str());
-      }
-      else
-      {
-         clLog()->Error(XrdCl::AppMsg, "Factory::Config() Unable to create an OSS object");
-         retval = false;
-         m_output_fs = 0;
-      }
-
-  
       int loff = 0;
       char buff[2048];
       loff = snprintf(buff, sizeof(buff), "result\n"
@@ -312,14 +319,17 @@ bool Factory::ConfigParameters(std::string part, XrdOucStream& config )
    {
       const char* minV = config.GetWord();
       if (minV) {
-         m_configuration.m_lwm = ::atof(minV);
+         float lwmf = ::atof(minV);
          const char* maxV = config.GetWord();
          if (maxV) {
-            m_configuration.m_hwm = ::atof(maxV);
+            float hwmf = ::atof(maxV);
+            XrdOssVSInfo sP;
+            if (m_output_fs->StatVS(&sP, "public", 1) >= 0)
+            {
+               m_configuration.m_diskUsageLWM = sP.Total * lwmf;
+               m_configuration.m_diskUsageHWM = sP.Total * hwmf;
+            }
          }
-      }
-      else {
-         clLog()->Error(XrdCl::AppMsg, "Factory::ConfigParameters() pss.diskUsage min max value not specified");
       }
    }
    else if  ( part == "blocksize" )
@@ -488,12 +498,11 @@ void Factory::CacheDirCleanup()
       }
       else
       {
-         float oc = 1 - float(sP.Free)/(sP.Total);
-         clLog()->Debug(XrdCl::AppMsg, "Factory::CacheDirCleanup() occupates disk space == %f", oc);
-         if (oc > m_configuration.m_hwm)
+         long long ausage = sP.Total - sP.Free;
+         clLog()->Debug(XrdCl::AppMsg, "Factory::CacheDirCleanup() occupates disk space == %lld", ausage);
+         if (ausage > m_configuration.m_diskUsageHWM)
          {
-            long long bytesToRemoveLong = static_cast<long long> ((oc - m_configuration.m_lwm) * static_cast<float>(s_diskSpacePrecisionFactor));
-            bytesToRemove = (sP.Total * bytesToRemoveLong) / s_diskSpacePrecisionFactor;
+            bytesToRemove = ausage - m_configuration.m_diskUsageLWM;
             clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() need space for  %lld bytes", bytesToRemove);
          }
       }

--- a/src/XrdFileCache/XrdFileCacheFactory.hh
+++ b/src/XrdFileCache/XrdFileCacheFactory.hh
@@ -46,8 +46,8 @@ namespace XrdFileCache
    {
       Configuration() :
          m_hdfsmode(false),
-         m_lwm(0.95),
-         m_hwm(0.9),
+         m_diskUsageLWM(-1),
+         m_diskUsageHWM(-1),
          m_bufferSize(1024*1024),
 	 m_NRamBuffersRead(8),
 	 m_NRamBuffersPrefetch(1),
@@ -57,8 +57,8 @@ namespace XrdFileCache
       std::string m_cache_dir;        //!< path of disk cache
       std::string m_username;         //!< username passed to oss plugin
 
-      float m_lwm;                    //!< cache purge low water mark
-      float m_hwm;                    //!< cache purge high water mark
+      long long m_diskUsageLWM;       //!< cache purge low water mark
+      long long m_diskUsageHWM;       //!< cache purge high water mark
 
       long long m_bufferSize;         //!< prefetch buffer size, default 1MB
       int  m_NRamBuffersRead;         //!< number of read in-memory cache blocks


### PR DESCRIPTION
This feature was requested by Hinori Ito and Lincoln Bryant.

The parameter can be now specified absolute or relative. For example:
pfc.diskuage 1.5T 10T
pfc.diskuage 0.7 0.95