### PR TITLE
Fix a couple small issues caught by gcc 4.9.2

### DIFF
--- a/src/XrdSsi/XrdSsiFile.cc
+++ b/src/XrdSsi/XrdSsiFile.cc
@@ -27,6 +27,7 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
+#include <cstddef>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -211,7 +212,7 @@ bool XrdSsiFile::AttnInfo(XrdOucErrInfo &eInfo, const XrdSsiRespInfo *respP,
 // Initialize the response
 //
    attnResp = (AttnResp *)mBuff;
-   memset(attnResp, 0, sizeof(attnResp));
+   memset(attnResp, 0, sizeof(AttnResp));
    attnResp->aHdr.pfxLen = htons(sizeof(XrdSsiRRInfoAttn));
 
 // Fill out iovec to point to our header


### PR DESCRIPTION
- Add missing #include <cstddef>
- Fix inadvertent sizeof pointer instead of sizeof pointee