### PR TITLE
Fix several issues with cache purging

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -421,7 +421,7 @@ public:
 
    map_t fmap;
 
-   void checkFile (time_t iTime, const char* iPath,  int iNByte)
+   void checkFile (time_t iTime, const char* iPath,  long long iNByte)
    {
       if (nByteAccum < nByteReq || iTime < fmap.rbegin()->first)
       {

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -403,42 +403,46 @@ bool Factory::ConfigParameters(std::string part, XrdOucStream& config )
 //______________________________________________________________________________
 //namespace {
 
-class FPurgeState {
+class FPurgeState
+{
 public:
-   struct FS {
+   struct FS
+   {
       std::string path;
-      int nBlck;
+      long long   nByte;
 
-      FS(const char* p, int n) : path(p), nBlck(n) {}
+      FS(const char* p, int n) : path(p), nByte(n) {}
    };
 
    typedef std::multimap<time_t, FS> map_t;
    typedef map_t::iterator map_i;
 
-   FPurgeState(long long iNBlckReq) : nBlckReq(iNBlckReq), nBlckAccum(0) {}
+   FPurgeState(long long iNByteReq) : nByteReq(iNByteReq), nByteAccum(0) {}
 
    map_t fmap;
 
-   void checkFile (time_t iTime, const char* iPath,  int iNBlck) 
+   void checkFile (time_t iTime, const char* iPath,  int iNByte)
    {
-      if ( (nBlckAccum <  nBlckReq ) || (iTime < fmap.rbegin()->first) ) {
-         fmap.insert(std::pair<const time_t, FS> (iTime, FS(iPath, iNBlck)));
-         nBlckAccum += iNBlck;
+      if (nByteAccum < nByteReq || iTime < fmap.rbegin()->first)
+      {
+         fmap.insert(std::pair<const time_t, FS> (iTime, FS(iPath, iNByte)));
+         nByteAccum += iNByte;
 
          // remove newest files from map if necessary
-         while (nBlckAccum > nBlckReq) {
+         while (nByteAccum > nByteReq)
+         {
             time_t nt = fmap.begin()->first;
             std::pair<map_i, map_i> ret = fmap.equal_range(nt); 
             for (map_i it2 = ret.first; it2 != ret.second; ++it2)
-               nBlckAccum -= it2->second.nBlck;
+               nByteAccum -= it2->second.nByte;
 	    fmap.erase(ret.first, ret.second);
          }
       }
    }
 
-   private:
-      long long nBlckReq;
-      long long nBlckAccum;
+private:
+   long long nByteReq;
+   long long nByteAccum;
 };
 
 
@@ -453,12 +457,12 @@ void FillFileMapRecurse( XrdOssDF* iOssDF, const std::string& path, FPurgeState&
    XrdCl::Log *log = XrdCl::DefaultEnv::GetLog();
 
    Factory& factory = Factory::GetInstance();
-   while ( (rdr = iOssDF->Readdir(&buff[0], 256)) >= 0)
+   while ((rdr = iOssDF->Readdir(&buff[0], 256)) >= 0)
    {
       // printf("readdir [%s]\n", buff);
       std::string np = path + "/" + std::string(buff);
       size_t fname_len = strlen(&buff[0]);
-      if (fname_len == 0  )
+      if (fname_len == 0)
       {
          // std::cout << "Finish read dir.[" << np <<"] Break loop \n";
          break;
@@ -471,21 +475,23 @@ void FillFileMapRecurse( XrdOssDF* iOssDF, const std::string& path, FPurgeState&
 
          if (fname_len > InfoExtLen && strncmp(&buff[fname_len - InfoExtLen ], XrdFileCache::Info::m_infoExtension, InfoExtLen) == 0)
          {
-            fh->Open((np).c_str(),O_RDONLY, 0600, env);
+            // XXXX MT - shouldn't we also check if it is currently opened?
+
+            fh->Open(np.c_str(), O_RDONLY, 0600, env);
             Info cinfo(factory.RefConfiguration().m_bufferSize);
             time_t accessTime;
             cinfo.Read(fh);
             if (cinfo.GetLatestDetachTime(accessTime, fh))
             {
                log->Debug(XrdCl::AppMsg, "FillFileMapRecurse() checking %s accessTime %d ", buff, (int)accessTime);
-               purgeState.checkFile(accessTime, np.c_str(), cinfo.GetNDownloadedBlocks());
+               purgeState.checkFile(accessTime, np.c_str(), cinfo.GetNDownloadedBytes());
             }
             else
             {
                log->Warning(XrdCl::AppMsg, "FillFileMapRecurse() could not get access time for %s \n", np.c_str());
             }
          }
-         else if ( dh->Opendir(np.c_str(), env)  >= 0 )
+         else if (dh->Opendir(np.c_str(), env) >= 0)
          {
             FillFileMapRecurse(dh, np, purgeState);
          }
@@ -511,7 +517,7 @@ void Factory::CacheDirCleanup()
    {
       // get amount of space to erase
       long long bytesToRemove = 0;
-      if( oss->StatVS(&sP, "public", 1) < 0 )
+      if (oss->StatVS(&sP, "public", 1) < 0)
       {
          clLog()->Error(XrdCl::AppMsg, "Factory::CacheDirCleanup() can't get statvs for dir [%s] \n", m_configuration.m_cache_dir.c_str());
          exit(1);
@@ -519,7 +525,7 @@ void Factory::CacheDirCleanup()
       else
       {
          long long ausage = sP.Total - sP.Free;
-         clLog()->Debug(XrdCl::AppMsg, "Factory::CacheDirCleanup() occupates disk space == %lld", ausage);
+         clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() occupates disk space == %lld", ausage);
          if (ausage > m_configuration.m_diskUsageHWM)
          {
             bytesToRemove = ausage - m_configuration.m_diskUsageLWM;
@@ -529,33 +535,37 @@ void Factory::CacheDirCleanup()
 
       if (bytesToRemove > 0)
       {
-        // make a sorted map of file patch by access time
+         // make a sorted map of file patch by access time
          XrdOssDF* dh = oss->newDir(m_configuration.m_username.c_str());
          if (dh->Opendir(m_configuration.m_cache_dir.c_str(), env) >= 0)
          {
-            long long nReq = (long long) ((bytesToRemove*1.4)/m_configuration.m_bufferSize); // check more that required
-            FPurgeState purgeState(nReq);
+            FPurgeState purgeState(bytesToRemove * 5 / 4); // prepare 20% more volume than required
+
             FillFileMapRecurse(dh, m_configuration.m_cache_dir, purgeState);
 
             // loop over map and remove files with highest value of access time
             for (FPurgeState::map_i it = purgeState.fmap.begin(); it != purgeState.fmap.end(); ++it)
             {
+               // XXXX MT - shouldn't we re-check if the file is currently opened?
+
                std::string path = it->second.path;
                // remove info file
                if (oss->Stat(path.c_str(), &fstat) == XrdOssOK)
                {
                   bytesToRemove -= fstat.st_size;
                   oss->Unlink(path.c_str());
-                  clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() removed %s size %lld ", path.c_str(), fstat.st_size);
+                  clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() removed %s size %lld",
+                                                path.c_str(), fstat.st_size);
                }
 
                // remove data file
                path = path.substr(0, path.size() - strlen(XrdFileCache::Info::m_infoExtension));
                if (oss->Stat(path.c_str(), &fstat) == XrdOssOK)
                {
-                  bytesToRemove -= fstat.st_size;
+                  bytesToRemove -= it->second.nByte;
                   oss->Unlink(path.c_str());
-                  clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() removed %s size %lld ", path.c_str(), fstat.st_size);
+                  clLog()->Info(XrdCl::AppMsg, "Factory::CacheDirCleanup() removed %s bytes %lld, stat_size %lld",
+                                                path.c_str(), it->second.nByte, fstat.st_size);
                }
 
                if (bytesToRemove <= 0)
@@ -565,6 +575,7 @@ void Factory::CacheDirCleanup()
 	 dh->Close();
 	 delete dh; dh =0;
       }
+
       sleep(sleept);
    }
 }

--- a/src/XrdFileCache/XrdFileCacheFactory.cc
+++ b/src/XrdFileCache/XrdFileCacheFactory.cc
@@ -411,7 +411,7 @@ public:
       std::string path;
       long long   nByte;
 
-      FS(const char* p, int n) : path(p), nByte(n) {}
+      FS(const char* p, long long n) : path(p), nByte(n) {}
    };
 
    typedef std::multimap<time_t, FS> map_t;
@@ -488,8 +488,7 @@ void FillFileMapRecurse( XrdOssDF* iOssDF, const std::string& path, FPurgeState&
             }
             else
             {
-               // XXXX MT - get a lot of those ... use time from stat?
-               // Or just remove them?
+               // cinfo file does not contain any known accesses, use stat.mtime instead.
 
                log->Info(XrdCl::AppMsg, "FillFileMapRecurse() could not get access time for %s, trying stat.\n", np.c_str());
 
@@ -506,6 +505,8 @@ void FillFileMapRecurse( XrdOssDF* iOssDF, const std::string& path, FPurgeState&
                }
                else
                {
+                  // This really shouldn't happen ... but if it does remove cinfo and the data file right away.
+
                   log->Warning(XrdCl::AppMsg, "FillFileMapRecurse() could not get access time for %s. Purging directly.\n",
                                np.c_str());
 

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -151,6 +151,11 @@ namespace XrdFileCache
          int GetNDownloadedBlocks() const;
 
          //---------------------------------------------------------------------
+         //! Get number of downloaded bytes
+         //---------------------------------------------------------------------
+         long long GetNDownloadedBytes() const;
+
+         //---------------------------------------------------------------------
          //! Update complete status
          //---------------------------------------------------------------------
          void CheckComplete();
@@ -202,6 +207,11 @@ namespace XrdFileCache
          if (TestBit(i)) cntd++;
 
       return cntd;
+   }
+
+   inline long long Info::GetNDownloadedBytes() const
+   {
+      return m_bufferSize * GetNDownloadedBlocks();
    }
 
    inline int Info::GetSizeInBytes() const


### PR DESCRIPTION
* use bytes instead of blocks when planning purge operation;
* fallback to stat.mtime when access time can not be determined from cinfo file.
