### PR TITLE
Fix deadlock due to lock inversion in python bindings.

### DIFF
--- a/bindings/python/src/AsyncResponseHandler.hh
+++ b/bindings/python/src/AsyncResponseHandler.hh
@@ -57,6 +57,11 @@ namespace PyXRootD
                                     XrdCl::AnyObject *response,
                                     XrdCl::HostList *hostList )
       {
+        // If we get called while the program's exit handlers are being called,
+        // then calls to PyGILState_Ensure() deadlock.  Py_IsInitialized() is
+        // not thread-safe but we appear to be lacking in alternates.
+        if (!Py_IsInitialized()) {return;}
+
         //----------------------------------------------------------------------
         // Ensure we hold the Global Interpreter Lock
         //----------------------------------------------------------------------
@@ -164,6 +169,11 @@ namespace PyXRootD
       void HandleResponse( XrdCl::XRootDStatus *status,
                            XrdCl::AnyObject *response )
       {
+        // If we get called while the program's exit handlers are being called,
+        // then calls to PyGILState_Ensure() deadlock.  Py_IsInitialized() is
+        // not thread-safe but we appear to be lacking in alternates.
+        if (!Py_IsInitialized()) {return;}
+
         //----------------------------------------------------------------------
         // Ensure we hold the Global Interpreter Lock
         //----------------------------------------------------------------------

--- a/bindings/python/src/PyXRootDFile.cc
+++ b/bindings/python/src/PyXRootDFile.cc
@@ -58,7 +58,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->file->Open( url, flags, mode, timeout );
+      async( status = self->file->Open( url, flags, mode, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -89,7 +89,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->file->Close( timeout );
+      async( status = self->file->Close( timeout ) )
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -123,7 +123,7 @@ namespace PyXRootD
 
     else {
       XrdCl::StatInfo *response = 0;
-      status = self->file->Stat( force, response, timeout );
+      async( status = self->file->Stat( force, response, timeout ) );
       pyresponse = ConvertType<XrdCl::StatInfo>( response );
       delete response;
     }
@@ -176,7 +176,7 @@ namespace PyXRootD
 
     if (!size) {
       XrdCl::StatInfo *info = 0;
-      XrdCl::XRootDStatus status = self->file->Stat(true, info, timeout);
+      async( XrdCl::XRootDStatus status = self->file->Stat(true, info, timeout) );
       size = info->GetSize();
       if (info) delete info;
     }
@@ -194,7 +194,7 @@ namespace PyXRootD
 
     else {
       uint32_t bytesRead;
-      status = self->file->Read( offset, size, buffer, bytesRead, timeout );
+      async( status = self->file->Read( offset, size, buffer, bytesRead, timeout ) );
       pyresponse = Py_BuildValue( "s#", buffer, bytesRead );
       delete[] buffer;
     }
@@ -466,7 +466,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->file->Write( offset, size, buffer, timeout );
+      async( status = self->file->Write( offset, size, buffer, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -498,7 +498,7 @@ namespace PyXRootD
       async( status = self->file->Sync( handler, timeout ) );
     }
     else {
-      status = self->file->Sync( timeout );
+      async( status = self->file->Sync( timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -545,7 +545,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->file->Truncate( size, timeout );
+      async( status = self->file->Truncate( size, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -620,7 +620,7 @@ namespace PyXRootD
     }
     else {
       XrdCl::VectorReadInfo *info = 0;
-      status = self->file->VectorRead( chunks, 0, info, timeout );
+      async( status = self->file->VectorRead( chunks, 0, info, timeout ) );
       pyresponse = ConvertType<XrdCl::VectorReadInfo>( info );
       delete info;
     }
@@ -664,7 +664,7 @@ namespace PyXRootD
 
     else {
       XrdCl::Buffer *response = 0;
-      status = self->file->Fcntl( arg, response, timeout );
+      async( status = self->file->Fcntl( arg, response, timeout ) );
       pyresponse = ConvertType<XrdCl::Buffer>( response );
       delete response;
     }
@@ -704,7 +704,7 @@ namespace PyXRootD
 
     else {
       XrdCl::Buffer *response = 0;
-      status = self->file->Visa( response, timeout );
+      async( status = self->file->Visa( response, timeout ) );
       pyresponse = ConvertType<XrdCl::Buffer>( response );
       delete response;
     }

--- a/bindings/python/src/PyXRootDFileSystem.cc
+++ b/bindings/python/src/PyXRootDFileSystem.cc
@@ -89,7 +89,7 @@ namespace PyXRootD
 
     else {
       XrdCl::LocationInfo *response = 0;
-      status = self->filesystem->Locate( path, flags, response, timeout );
+      async( status = self->filesystem->Locate( path, flags, response, timeout ) );
       pyresponse = ConvertType<XrdCl::LocationInfo>( response );
       delete response;
     }
@@ -127,7 +127,7 @@ namespace PyXRootD
 
     else {
       XrdCl::LocationInfo *response = 0;
-      status = self->filesystem->DeepLocate( path, flags, response, timeout );
+      async( status = self->filesystem->DeepLocate( path, flags, response, timeout ) );
       pyresponse = ConvertType<XrdCl::LocationInfo>( response );
       delete response;
     }
@@ -164,7 +164,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->Mv( source, dest, timeout );
+      async( status = self->filesystem->Mv( source, dest, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -202,7 +202,7 @@ namespace PyXRootD
 
     else {
       XrdCl::Buffer *response = 0;
-      status = self->filesystem->Query( queryCode, argbuffer, response, timeout );
+      async( status = self->filesystem->Query( queryCode, argbuffer, response, timeout ) );
       pyresponse = ConvertType<XrdCl::Buffer>( response );
       delete response;
     }
@@ -238,7 +238,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->Truncate( path, size, timeout );
+      async( status = self->filesystem->Truncate( path, size, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -270,7 +270,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->Rm( path, timeout );
+      async( status = self->filesystem->Rm( path, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -305,7 +305,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->MkDir( path, flags, mode, timeout );
+      async( status = self->filesystem->MkDir( path, flags, mode, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -337,7 +337,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->RmDir( path, timeout );
+      async( status = self->filesystem->RmDir( path, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -370,7 +370,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->ChMod( path, mode, timeout );
+      async( status = self->filesystem->ChMod( path, mode, timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -401,7 +401,7 @@ namespace PyXRootD
     }
 
     else {
-      status = self->filesystem->Ping( timeout );
+      async( status = self->filesystem->Ping( timeout ) );
     }
 
     pystatus = ConvertType<XrdCl::XRootDStatus>( &status );
@@ -434,7 +434,7 @@ namespace PyXRootD
 
     else {
       XrdCl::StatInfo *response = 0;
-      status = self->filesystem->Stat( path, response, timeout );
+      async( status = self->filesystem->Stat( path, response, timeout ) );
       pyresponse = ConvertType<XrdCl::StatInfo>( response );
       delete response;
     }
@@ -470,7 +470,7 @@ namespace PyXRootD
 
     else {
       XrdCl::StatInfoVFS *response = 0;
-      status = self->filesystem->StatVFS( path, response, timeout );
+      async( status = self->filesystem->StatVFS( path, response, timeout ) );
       pyresponse = ConvertType<XrdCl::StatInfoVFS>( response );
       delete response;
     }
@@ -505,7 +505,7 @@ namespace PyXRootD
 
     else {
       XrdCl::ProtocolInfo *response = 0;
-      status = self->filesystem->Protocol( response, timeout );
+      async( status = self->filesystem->Protocol( response, timeout ) );
       pyresponse = ConvertType<XrdCl::ProtocolInfo>( response );
       delete response;
     }
@@ -543,7 +543,7 @@ namespace PyXRootD
 
     else {
       XrdCl::DirectoryList *list = 0;
-      status = self->filesystem->DirList( path, flags, list, timeout );
+      async( status = self->filesystem->DirList( path, flags, list, timeout ) );
       pyresponse = ConvertType<XrdCl::DirectoryList>( list );
       delete list;
     }
@@ -579,7 +579,7 @@ namespace PyXRootD
 
     else {
       XrdCl::Buffer *response = 0;
-      status = self->filesystem->SendInfo( info, response, timeout );
+      async( status = self->filesystem->SendInfo( info, response, timeout ) );
       pyresponse = ConvertType<XrdCl::Buffer>( response );
       delete response;
     }
@@ -637,8 +637,8 @@ namespace PyXRootD
 
     else {
       XrdCl::Buffer *response = 0;
-      status = self->filesystem->Prepare( files, flags, priority, response,
-                                          timeout );
+      async( status = self->filesystem->Prepare( files, flags, priority, response,
+                                          timeout ) );
       pyresponse = ConvertType<XrdCl::Buffer>( response );
       delete response;
     }


### PR DESCRIPTION
When synchronous operations are performed, the python GIL should be
dropped using the `async` macro.  Otherwise, the following deadlock
can occur:
a) A python thread, holding the GIL, may call out to a XrdCl::File
   object, which takes an XRootD-related lock.
b) A XrdCl callback thread, holding an XRootD-related lock, tries
   to invoke a python callback and tries to acquire the GIL.

Since the python GIL is not needed to invoke an XrdCl operation,
this patch drops it for case (a), avoiding the deadlock.