### PR TITLE
Don't throw exceptions in destructors

### DIFF
--- a/src/XrdSys/XrdSysPthread.hh
+++ b/src/XrdSys/XrdSysPthread.hh
@@ -119,9 +119,9 @@ inline void UnLock() {if (cnd) {cnd->UnLock(); cnd = 0;}}
                  {if (CndVar) CndVar->Lock();
                   cnd = CndVar;
                  }
-            XrdSysCondVarHelper(XrdSysCondVar &CndVar) {
-	         CndVar.Lock();
-		 cnd = &CndVar;
+            XrdSysCondVarHelper(XrdSysCondVar &CndVar)
+                 {CndVar.Lock();
+                  cnd = &CndVar;
                  }
 
            ~XrdSysCondVarHelper() {if (cnd) UnLock();}
@@ -204,9 +204,9 @@ inline void UnLock() {if (mtx) {mtx->UnLock(); mtx = 0;}}
                  {if (mutex) mutex->Lock();
                   mtx = mutex;
                  }
-            XrdSysMutexHelper(XrdSysMutex &mutex) {
-	         mutex.Lock();
-		 mtx = &mutex;
+            XrdSysMutexHelper(XrdSysMutex &mutex)
+                 {mutex.Lock();
+                  mtx = &mutex;
                  }
 
            ~XrdSysMutexHelper() {if (mtx) UnLock();}
@@ -350,11 +350,11 @@ inline void Wait() {while (sem_wait(&h_semaphore))
 
   XrdSysSemaphore(int semval=1, const char * =0)
                                {if (sem_init(&h_semaphore, 0, semval))
-				   {throw "sem_init() failed";}
+                                   {throw "sem_init() failed";}
                                }
  ~XrdSysSemaphore() {if (sem_destroy(&h_semaphore))
-                       {throw "sem_destroy() failed";}
-                   }
+                        {/* throw "sem_destroy() failed"; */}
+                    }
 
 private:
 

--- a/src/XrdSys/XrdSysPthread.hh
+++ b/src/XrdSys/XrdSysPthread.hh
@@ -353,7 +353,7 @@ inline void Wait() {while (sem_wait(&h_semaphore))
                                    {throw "sem_init() failed";}
                                }
  ~XrdSysSemaphore() {if (sem_destroy(&h_semaphore))
-                        {/* throw "sem_destroy() failed"; */}
+                        {abort();}
                     }
 
 private:

--- a/src/XrdSys/XrdSysXSLock.cc
+++ b/src/XrdSys/XrdSysXSLock.cc
@@ -43,7 +43,7 @@ XrdSysXSLock::~XrdSysXSLock()
    LockContext.Lock();
    if (cur_count || shr_wait || exc_wait)
       {LockContext.UnLock();
-	/* throw "XSLock_delete: Lock object is still active."; */
+       abort();
       }
    LockContext.UnLock();
 }

--- a/src/XrdSys/XrdSysXSLock.cc
+++ b/src/XrdSys/XrdSysXSLock.cc
@@ -43,7 +43,7 @@ XrdSysXSLock::~XrdSysXSLock()
    LockContext.Lock();
    if (cur_count || shr_wait || exc_wait)
       {LockContext.UnLock();
-       throw "XSLock_delete: Lock object is still active.";
+	/* throw "XSLock_delete: Lock object is still active."; */
       }
    LockContext.UnLock();
 }


### PR DESCRIPTION
Throwing exceptions in a destructor causes warnings with gcc 6, and since -Werror is used this becomes an error:

XrdSys/XrdSysPthread.hh: In destructor 'XrdSysSemaphore::~XrdSysSemaphore()':
XrdSys/XrdSysPthread.hh:356:31: error: throw will always call terminate() [-Werror=terminate]
XrdSys/XrdSysPthread.hh:356:31: note: in C++11 destructors default to noexcept

There are two destructors in the code that does this. This pull request comments out these lines of code.
