### PR TITLE
With GSI auth, free Entity variable before replacing it from the cache

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -1948,6 +1948,7 @@ int XrdSecProtocolgsi::Authenticate(XrdSecCredentials *cred,
          } else {
             // Fetch a copy of the saved entity
             int slen = 0;
+            FreeEntity(&Entity);
             CopyEntity((XrdSecEntity *) cent->buf1.buf, &Entity, &slen);
             // Notify
             DEBUG("Got Entity from cacheAuthzFun ("<<slen<<" bytes)");


### PR DESCRIPTION
We recently enabled GSI authentication with xrootd 4.2.3. It appears each GSI authentication causes about 6kB of memory to be leaked.

Toward the beginning of XrdSecProtocolgsi::Authenticate(), memory may be
allocated for the Entity with strdup():
https://github.com/xrootd/xrootd/blob/a76eccc1f2/src/XrdSecgsi/XrdSecProtocolgsi.cc#L1873

Later in the same function, the Entity may be replaced with an entry from the
cache:
https://github.com/xrootd/xrootd/blob/a76eccc1f2/src/XrdSecgsi/XrdSecProtocolgsi.cc#L1951

However, the memory allocated with strdup() is not free()d. This patch calls FreeEntity()
before replacing Entity with a copy from the cache.

Regards,
John

valgrind output for the largest lost block after 20 GSI authentications (xrootd 4.2.3):
```
==10420== 120,760 bytes in 20 blocks are definitely lost in loss record 2,541 of 2,543
==10420==    at 0x4A06A2E: malloc (vg_replace_malloc.c:270)
==10420==    by 0x324EE80EC1: strdup (in /lib64/libc-2.12.so)
==10420==    by 0x66E717F: XrdSecProtocolgsi::Authenticate(XrdSecBuffer*, XrdSecBuffer**, XrdOucErrInfo*) (XrdSecProtocolgsi.cc:1873)
==10420==    by 0x4C67959: XrdXrootdProtocol::do_Auth() (XrdXrootdXeq.cc:155)
==10420==    by 0x4F37148: XrdLink::DoIt() (XrdLink.cc:397)
==10420==    by 0x4F3A624: XrdScheduler::Run() (XrdScheduler.cc:333)
==10420==    by 0x4F3A818: XrdStartWorking(void*) (XrdScheduler.cc:85)
==10420==    by 0x4EFF3AE: XrdSysThread_Xeq (XrdSysPthread.cc:86)
==10420==    by 0x324F607AA0: start_thread (in /lib64/libpthread-2.12.so)
==10420==    by 0x324EEE893C: clone (in /lib64/libc-2.12.so)
```