### PR TITLE
XtdHTTP: work around compilation issues in platforms with old versions of OpenSSL

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1321,7 +1321,21 @@ int XrdHttpProtocol::InitSecurity() {
   OpenSSL_add_all_digests();
 
   const SSL_METHOD *meth;
+  
+#ifdef TLS1_2_VERSION
   meth = TLSv1_2_method();
+  eDest.Say(" Using TLS 1.2");
+#elif TLS1_1_VERSION
+  eDest.Say(" Using deprecated TLS version 1.1.")
+  meth = TLSv1_1_method();
+#elif TLS1_VERSION
+  eDest.Say(" Using deprecated TLS version 1.")
+  meth = TLSv1_method();
+#else
+  eDest.Say(" warning: TLS is not available, falling back to SSL23 (deprecated).")
+  meth = SSLv23_method();
+#endif
+  
   sslctx = SSL_CTX_new((SSL_METHOD *)meth);
   //SSL_CTX_set_min_proto_version(sslctx, TLS1_2_VERSION);
   SSL_CTX_set_session_cache_mode(sslctx, SSL_SESS_CACHE_SERVER);

--- a/src/XrdHttp/xrootd-http.cf
+++ b/src/XrdHttp/xrootd-http.cf
@@ -7,15 +7,15 @@
 
 
 if exec xrootd
-   xrd.protocol XrdHttp /usr/local/lib/libXrdHttp.so
+   xrd.protocol XrdHttp /usr/local/lib/libXrdHttp-4.so
 fi
 
 http.cert /etc/grid-security/hostcert.pem
 http.key /etc/grid-security/hostkey.pem
 http.cadir /etc/grid-security/certificates
-http.secretkey CHANGEME
+#http.secretkey CHANGEME
 #http.gridmap /etc/grid-security/mapfile
-#http.secxtractor /usr/lib64/libXrdHttpVOMS.so
+#http.secxtractor /usr/lib64/libXrdHttpVOMS-4.so
 #http.selfhttps2http yes
 
 # As an example of preloading files, let's preload in memory
@@ -29,7 +29,7 @@ http.secretkey CHANGEME
 # Usual basic xrd stuff
 #
 all.role server
-all.manager pcitgt02.cern.ch:1213
+all.manager pcitsdcfab.cern.ch:1213
 all.export /
 oss.localroot /tmp/xrdroot
 


### PR DESCRIPTION
namely SLC5, rawhide and some flavors of MacOS