### PR TITLE
pfc-V2: Set RAM usage required parameter

### DIFF
--- a/src/XrdFileCache/README
+++ b/src/XrdFileCache/README
@@ -114,12 +114,11 @@ CONFIGURATION
 
 pfc.blocksize: prefetch buffer size, default 1M
 
-pfc.nread: number of in memory cached blocks reserved for read tasks
+pfc.ram [bytes[g]]: maximum allowed RAM usage for caching proxy 
 
-pfc.nprefetch: number of in memory cached blocks reserved for prefetch tasks
+pfc.prefetch <n>: prefetch level, default is 10. Value zero disables prefetching.
 
-pfc.diskusage <lwm fraction> <hwm fraction>: high / low watermarks for disk cache
-purge operation (default 0.9 and 0.95)
+pfc.diskusage <low> <hig> diskusage boundaries, can be specified relative in percantage or in g or T bytes
 
 pfc.user <username>: username used by XrdOss plugin
 
@@ -135,7 +134,7 @@ Examples
 a) Enable proxy file prefetching:
 pps.cachelib libXrdFileCache.so
 pfc.localroot  /data/xrd-file-cache
-pfc.nprefetch 1
+pfc.ram 5g
 
 
 b) enable file block mode, with block size 64 MB:

--- a/src/XrdFileCache/XrdFileCache.hh
+++ b/src/XrdFileCache/XrdFileCache.hh
@@ -52,7 +52,7 @@ namespace XrdFileCache
          m_diskUsageLWM(-1),
          m_diskUsageHWM(-1),
          m_bufferSize(1024*1024),
-    	 m_RamAbsAvailable(8*1024*1024),
+    	 m_RamAbsAvailable(0),
     	 m_NRamBuffers(-1),
          m_prefetch_max_blocks(10),
          m_hdfsbsize(128*1024*1024) {}

--- a/src/XrdFileCache/XrdFileCache.hh
+++ b/src/XrdFileCache/XrdFileCache.hh
@@ -67,7 +67,6 @@ namespace XrdFileCache
       long long m_bufferSize;         //!< prefetch buffer size, default 1MB
       long long m_RamAbsAvailable;     //!< available from configuration
       int       m_NRamBuffers;        //!< number of total in-memory cache blocks, cached
-      bool      m_prefetch;           //!< prefetch enable state        
       size_t    m_prefetch_max_blocks;//!< maximum number of blocks to prefetch per file
 
       long long m_hdfsbsize;          //!< used with m_hdfsmode, default 128MB

--- a/src/XrdFileCache/XrdFileCacheConfiguration.cc
+++ b/src/XrdFileCache/XrdFileCacheConfiguration.cc
@@ -152,7 +152,13 @@ bool Cache::Config(XrdSysLogger *logger, const char *config_filename, const char
    }
 
    // get number of available RAM blocks after process configuration
+   if (m_configuration.m_RamAbsAvailable == 0 )
+   {
+         m_log.Emsg("Error", "RAM usage not specified. Please set pfc.ram value in configuration file.");
+         return false;
+   }
    m_configuration.m_NRamBuffers = static_cast<int>(m_configuration.m_RamAbsAvailable/ m_configuration.m_bufferSize);
+
    if (retval)
    {
       int loff = 0;

--- a/src/XrdFileCache/XrdFileCacheConfiguration.cc
+++ b/src/XrdFileCache/XrdFileCacheConfiguration.cc
@@ -196,7 +196,6 @@ bool Cache::Config(XrdSysLogger *logger, const char *config_filename, const char
 
 bool Cache::ConfigParameters(std::string part, XrdOucStream& config )
 {   
-   printf("part %s \n", part.c_str());
    XrdSysError err(0, "");
    if ( part == "user" )
    {
@@ -251,7 +250,7 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config )
          return false;
       }
    }
-   else if (part == "prefetch_max_blocks" )
+   else if (part == "prefetch" )
    {
        const char* params =  config.GetWord();
        if (params) {

--- a/src/XrdFileCache/XrdFileCacheConfiguration.cc
+++ b/src/XrdFileCache/XrdFileCacheConfiguration.cc
@@ -159,10 +159,10 @@ bool Cache::Config(XrdSysLogger *logger, const char *config_filename, const char
       char buff[2048];
       loff = snprintf(buff, sizeof(buff), "result\n"
                "\tpfc.blocksize %lld\n"
-               "\tpfc.prefetch %d\n"
+               "\tpfc.prefetch %ld\n"
                "\tpfc.nramblocks %d\n\n",
                m_configuration.m_bufferSize,
-               m_configuration.m_prefetch, // AMT not sure what parsing should be
+               m_configuration.m_prefetch_max_blocks, // AMT not sure what parsing should be
                m_configuration.m_NRamBuffers );
 
       if (m_configuration.m_hdfsmode)


### PR DESCRIPTION
Two changes in thos PR:
* pfc.ram a required parameter
* specifiy prefetch level as pfc.prefetch <n>
* update readme