### PR TITLE
pfc-V2: Fix crash File destructor

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFile.cc
+++ b/src/XrdFileCache/XrdFileCacheFile.cc
@@ -184,7 +184,7 @@ bool File::InitiateClose()
       {
          // file is not active when block map is empty and sync is done
          XrdSysMutexHelper _lck(&m_syncStatusMutex);
-         if (m_in_sync) {
+         if (m_in_sync == false) {
             delete m_syncer; 
             m_syncer = NULL;
             return false;


### PR DESCRIPTION
From the stack trace looked like Sync() function was called from the scheduler at the time the object was partially destroyed.
With this change, the Sync is waited to be executed (indirectly checked by ioActive call).