### PR TITLE
Use cmake to determine the existence of openssl funcs. Ignore the openssl constants

### DIFF
--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -38,3 +38,19 @@ else()
 
   mark_as_advanced( OPENSSL_INCLUDE_DIR OPENSSL_LIBRARIES )
 endif()
+
+
+#-------------------------------------------------------------------------------
+# Check for the TLS support in the OpenSSL version that is available
+#-------------------------------------------------------------------------------
+
+set ( CMAKE_REQUIRED_LIBRARIES ${OPENSSL_LIBRARIES} )
+
+check_function_exists(TLSv1_2_method HAVE_TLS12)
+compiler_define_if_found(HAVE_TLS12 HAVE_TLS12)
+
+check_function_exists(TLSv1_1_method HAVE_TLS11)
+compiler_define_if_found(HAVE_TLS11 HAVE_TLS11)
+
+check_function_exists(TLSv1_method HAVE_TLS1)
+compiler_define_if_found(HAVE_TLS1 HAVE_TLS1)

--- a/cmake/XRootDSystemCheck.cmake
+++ b/cmake/XRootDSystemCheck.cmake
@@ -125,3 +125,5 @@ if ( EnableAtomicsIfPresent )
   compiler_define_if_found( HAVE_ATOMICS HAVE_ATOMICS )
 endif ()
 
+
+

--- a/src/XrdHttp.cmake
+++ b/src/XrdHttp.cmake
@@ -14,7 +14,7 @@ if( BUILD_HTTP )
   # The XrdHttp library
   #-----------------------------------------------------------------------------
   include_directories( ${OPENSSL_INCLUDE_DIR} )
-
+  
   add_library(
     ${LIB_XRD_HTTP}
     MODULE

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1332,7 +1332,7 @@ int XrdHttpProtocol::InitSecurity() {
   eDest.Say(" Using deprecated TLS version 1.");
   meth = TLSv1_method();
 #else
-  eDest.Say(" warning: TLS is not available, falling back to SSL23 (deprecated).")
+  eDest.Say(" warning: TLS is not available, falling back to SSL23 (deprecated).");
   meth = SSLv23_method();
 #endif
   

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1322,14 +1322,14 @@ int XrdHttpProtocol::InitSecurity() {
 
   const SSL_METHOD *meth;
   
-#ifdef TLS1_2_VERSION
+#ifdef HAVE_TLS12
   meth = TLSv1_2_method();
   eDest.Say(" Using TLS 1.2");
-#elif TLS1_1_VERSION
-  eDest.Say(" Using deprecated TLS version 1.1.")
+#elif defined (HAVE_TLS11)
+  eDest.Say(" Using deprecated TLS version 1.1.");
   meth = TLSv1_1_method();
-#elif TLS1_VERSION
-  eDest.Say(" Using deprecated TLS version 1.")
+#elif defined (HAVE_TLS1)
+  eDest.Say(" Using deprecated TLS version 1.");
   meth = TLSv1_method();
 #else
   eDest.Say(" warning: TLS is not available, falling back to SSL23 (deprecated).")

--- a/src/XrdHttp/xrootd-http.cf
+++ b/src/XrdHttp/xrootd-http.cf
@@ -29,7 +29,7 @@ http.cadir /etc/grid-security/certificates
 # Usual basic xrd stuff
 #
 all.role server
-all.manager pcitsdcfab.cern.ch:1213
+all.manager <your_manager_host>:1213
 all.export /
 oss.localroot /tmp/xrdroot
 


### PR DESCRIPTION
This version of the openssl method detection works for me on slc5 and rawhide.