### PR TITLE
Stopping the service if already stop should be succesfull now

### DIFF
--- a/packaging/rhel/xrootd.functions
+++ b/packaging/rhel/xrootd.functions
@@ -139,10 +139,15 @@ function stopDaemon()
 {
   echo -n "Shutting down xrootd ($1, $5): "
   PIDFILE="/var/run/xrootd/$1-$5.pid"
-  killproc -p $PIDFILE $1
-  RETVAL=$?
+  if [ -e $PIDFILE ]; then
+    killproc -p $PIDFILE $1
+    RETVAL=$?
+    echo
+    return $RETVAL
+  fi
+  echo -n "$1-$5 not running"
   echo
-  return $RETVAL
+  return 0
 }
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
According to Fedora packaging guidelines stopping an already stopped service should be considered succesful see:

http://fedoraproject.org/wiki/EPEL:SysVInitScript#Exit_Codes_for_non-Status_Actions

Now an already stopped service returns 0:

```
[1448] root@uclhctest /etc/init.d# service xrootd stop
Shutting down xrootd (xrootd, rdr): xrootd-rdr not running
Shutting down xrootd (xrootd, srv): xrootd-srv not running
Shutting down xrootd (xrootd, atlas_proxy): xrootd-atlas_proxy not running
Shutting down xrootd (xrootd, cms_proxy): xrootd-cms_proxy not running
[1448] root@uclhctest /etc/init.d# echo $?
0
```
