### PR TITLE
Set max open files limit to 65k for systemd services

### DIFF
--- a/packaging/common/cmsd@.service
+++ b/packaging/common/cmsd@.service
@@ -13,6 +13,7 @@ Type=simple
 Restart=on-abort
 RestartSec=0
 KillMode=control-group
+LimitNOFILE=65536
 
 [Install]
 RequiredBy=multi-user.target

--- a/packaging/common/frm_purged@.service
+++ b/packaging/common/frm_purged@.service
@@ -13,6 +13,7 @@ Type=simple
 Restart=on-abort
 RestartSec=0
 KillMode=control-group
+LimitNOFILE=65536
 
 [Install]
 RequiredBy=multi-user.target

--- a/packaging/common/frm_xfrd@.service
+++ b/packaging/common/frm_xfrd@.service
@@ -13,6 +13,7 @@ Type=simple
 Restart=on-abort
 RestartSec=0
 KillMode=control-group
+LimitNOFILE=65536
 
 [Install]
 RequiredBy=multi-user.target

--- a/packaging/common/xrootd@.service
+++ b/packaging/common/xrootd@.service
@@ -13,6 +13,7 @@ Type=simple
 Restart=on-abort
 RestartSec=0
 KillMode=control-group
+LimitNOFILE=65536
 
 [Install]
 RequiredBy=multi-user.target


### PR DESCRIPTION
@zvada noted that max open files is not being set in RHEL7 for the xrootd service.

This request updates the systemd config, increasing the limits to 65k to match the RHEL6 init script.
https://github.com/xrootd/xrootd/blob/c786d75c00/packaging/rhel/xrootd.functions#L108