### PR TITLE
pfc-V2 Save and print access statistics in bytes

### DIFF
--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.cc
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.cc
@@ -157,11 +157,6 @@ XrdOucCacheIO *IOEntireFile::Detach()
    return io;
 }
 
-void IOEntireFile::Read (XrdOucCacheIOCB &iocb, char *buff, long long offs, int rlen)
-{
-   iocb.Done(IOEntireFile::Read(buff, offs, rlen));
-}
-
 int IOEntireFile::Read (char *buff, long long off, int size)
 {
    TRACEIO(Dump, "IOEntireFile::Read() "<< this << " off: " << off << " size: " << size );

--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
@@ -62,19 +62,6 @@ namespace XrdFileCache
          virtual int Read(char *Buffer, long long Offset, int Length);
 
          //---------------------------------------------------------------------
-         //! Asynchronous read.
-         //!
-         //! @param callback
-         //! @param Buffer
-         //! @param Offset
-         //! @param Length
-         //!
-         //! @return number of bytes read
-         //---------------------------------------------------------------------
-         virtual void Read (XrdOucCacheIOCB &iocb, char *buff, long long offs, int rlen);
-
-
-         //---------------------------------------------------------------------
          //! Pass ReadV request to the corresponding File object.
          //!
          //! @param readV

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -44,9 +44,7 @@ IOFileBlock::IOFileBlock(XrdOucCacheIO2 *io, XrdOucCacheStats &statsGlobal, Cach
 //______________________________________________________________________________
 XrdOucCacheIO* IOFileBlock::Detach()
 {
-    TRACEIO(Info, "IOFileBlock::Detach() " );
-    XrdOucCacheIO * io = GetInput();
-
+   XrdOucCacheIO * io = GetInput();
 
    for (std::map<int, File*>::iterator it = m_blocks.begin(); it != m_blocks.end(); ++it)
    {

--- a/src/XrdFileCache/XrdFileCacheVRead.cc
+++ b/src/XrdFileCache/XrdFileCacheVRead.cc
@@ -125,7 +125,10 @@ int File::ReadV (const XrdOucIOVec *readV, int n)
       if (direct_handler->m_errno == 0)
       {
          for (std::vector<XrdOucIOVec>::iterator i = chunkVec.begin(); i != chunkVec.end(); ++i)
+         {
             bytesRead += i->size;
+            m_stats.m_BytesMissed += i->size;
+         }  
       }
       else
       {
@@ -234,6 +237,7 @@ int File::VReadFromDisk(const XrdOucIOVec *readV, int n, ReadVBlockListDisk& blo
          int rs = m_output->Read(readV[chunkIdx].data + off,  blockIdx*m_cfi.GetBufferSize() + blk_off - m_offset, size);
          if (rs >=0 ) {
             bytes_read += rs;
+            m_stats.m_BytesDisk += rs;
          }
          else {
             // ofs read should set the errno
@@ -295,6 +299,7 @@ int File::VReadProcessBlocks(const XrdOucIOVec *readV, int n,
                overlap(block_idx, m_cfi.GetBufferSize(), readV[*chunkIt].offset, readV[*chunkIt].size, off, blk_off, size);
                memcpy(readV[*chunkIt].data + off,  &(bi->block->m_buff[blk_off]), size);
                bytes_read += size;
+               m_stats.m_BytesRam += size;
             }
          }
          else {


### PR DESCRIPTION
Previously access statistics was saved in block units. Now it is saved with exact number of bytes read from disk, directly from client and from ram.