### PR TITLE
Package xrdacctest in xrootd-server RPM.

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -596,6 +596,7 @@ fi
 %{_bindir}/xrdmapc
 %{_bindir}/xrootd
 %{_bindir}/xrdpfc_print
+%{_bindir}/xrdacctest
 %{_mandir}/man8/cmsd.8*
 %{_mandir}/man8/cns_ssi.8*
 %{_mandir}/man8/frm_admin.8*

--- a/src/XrdApps.cmake
+++ b/src/XrdApps.cmake
@@ -126,7 +126,7 @@ target_link_libraries(
 # Install
 #-------------------------------------------------------------------------------
 install(
-  TARGETS xrdadler32 cconfig mpxstats wait41 xrdcp-old XrdAppUtils xrdmapc
+  TARGETS xrdadler32 cconfig mpxstats wait41 xrdcp-old XrdAppUtils xrdmapc xrdacctest
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 


### PR DESCRIPTION
The xrdacctest programme is available in the source but is not currently packaged. At Rutherford Appleton Laboratory, we would like to use the xrdacctest with the GridFTP Ceph plugin and so would like it packaged. This change accomplishes just that.