### PR TITLE
Update name of ceph development package in spec file.

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -62,7 +62,7 @@ BuildRequires: cppunit-devel
 %endif
 
 %if %{?_with_ceph:1}%{!?_with_ceph:0}
-BuildRequires: ceph-devel
+BuildRequires: ceph-devel-compat
 %endif
 
 BuildRequires:	doxygen


### PR DESCRIPTION
Since the 'hammer' release of ceph, the package "ceph-devel" no longer exists, having been replaced by the meta package "ceph-devel-compat". This change updates the spec file accordingly.
