### PR TITLE
XrdUtils library is needed for libXrdSsi on OS X

### DIFF
--- a/src/XrdPlugins.cmake
+++ b/src/XrdPlugins.cmake
@@ -120,6 +120,7 @@ add_library(
 target_link_libraries(
   ${LIB_XRD_SSI}
   XrdSsiLib
+  XrdUtils
   XrdServer )
 
 set_target_properties(


### PR DESCRIPTION
Without this the build fails on a Mac because of unresolved symbols.