### PR TITLE
PSS: Add url prefix functionality to the PSS plugin

### DIFF
--- a/src/XrdPss/XrdPss.cc
+++ b/src/XrdPss/XrdPss.cc
@@ -130,7 +130,7 @@ XrdOss *XrdOssGetStorageSystem(XrdOss       *native_oss,
 XrdPssSys::XrdPssSys() : LocalRoot(0), N2NLib(0), N2NParms(0), theN2N(0),
                          DirFlags(0), cPath(0), cParm(0),
                          myVersion(&XrdVERSIONINFOVAR(XrdOssGetStorageSystem)),
-                         TraceLvl(0) {}
+			 TraceLvl(0) {}
 
 /******************************************************************************/
 /*                                  i n i t                                   */
@@ -1056,6 +1056,13 @@ char *XrdPssSys::P2OUT(int &retc,  char *pbuff, int pblen,
 // Create the new path
 //
    n = snprintf(pbuff,pblen,"root://%s%s/%s%s%s",theID,hBuff,path,Quest,Cgi);
+
+// If an url prefix is set then append it to the current url
+//
+   if (sUrlPrefix && strlen(sUrlPrefix)) {
+     n = snprintf(pbuff, pblen, "%sroot://%s/%s%s%s", sUrlPrefix,
+		  hBuff, path, Quest, Cgi);
+   }
 
 // Make sure the path will fit
 //

--- a/src/XrdPss/XrdPss.hh
+++ b/src/XrdPss/XrdPss.hh
@@ -184,6 +184,7 @@ static char         allRm;
 static char         allTrunc;
 
 static char         cfgDone;   // Configuration completed
+static char        *sUrlPrefix; // URL prefix
 
          XrdPssSys();
 virtual ~XrdPssSys() {}
@@ -199,6 +200,7 @@ char              *cPath;    // -> Cache path
 char              *cParm;    // -> Cache parameters
 XrdVersionInfo    *myVersion;// -> Compilation version
 int                TraceLvl; // Tracing options
+
 
 int    buildHdr();
 int    Configure(const char *);
@@ -220,5 +222,6 @@ int    xorig(XrdSysError *errp,   XrdOucStream &Config);
 int    xsopt(XrdSysError *Eroute, XrdOucStream &Config);
 int    xtrac(XrdSysError *Eroute, XrdOucStream &Config);
 int    xnml (XrdSysError *Eroute, XrdOucStream &Config);
+int    xurlp(XrdSysError *Eroute, XrdOucStream& Config);
 };
 #endif


### PR DESCRIPTION
The administrator can specify the following configuration directive
for a PSS plugin to proxy the incoming connections from clients to
another proxy server:

pss.urlprefix root://other_proxy_host:other_proxy_port//

Note that the url prefix needs to be a valid endpoint for an XRootD
service and must end with double slashes.