### PR TITLE
XrdHTTP: Deny access if the secXtractor fails

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -333,8 +333,12 @@ int XrdHttpProtocol::GetVOMSData(XrdLink *lp) {
   // This will fill the XrdSec thing with VOMS info, if VOMS is
   // installed. If we have no sec extractor then do nothing, just plain https
   // will work.
-  if (secxtractor)
-    secxtractor->GetSecData(lp, SecEntity, ssl);
+  if (secxtractor) {
+    int r = secxtractor->GetSecData(lp, SecEntity, ssl);
+    if (r)
+      TRACEI(ALL, " Certificate data extraction failed: " << peer_cert->name << " Failed. err: " << r);
+    return r;
+  }
   
   return 0;
 }


### PR DESCRIPTION
A proper secXtractor will accept good Grid proxy certificates and deny fraudulent ones