### PR TITLE
Make Xrdhttp secure by default, by rejecting proxy cert in the absence of a proper SecXtractor plugin

### DIFF
--- a/src/XrdHttp/XrdHttpSecXtractor.hh
+++ b/src/XrdHttp/XrdHttpSecXtractor.hh
@@ -48,7 +48,10 @@ public:
 
 
     // Initializes an ssl ctx
-    virtual int Init(SSL_CTX *, int) = 0;
+    virtual int InitCTX(SSL_CTX *, int) = 0;
+    virtual int InitSSL(SSL *, char *) = 0;
+    virtual int FreeSSL(SSL *) = 0;
+    
 //------------------------------------------------------------------------------
 //! Constructor
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Fix some minor memory leaks
Change the secxtractor interface to use the new lib and initialize it properly