### PR TITLE
Add example of proxy file cache configuration in xrootd server rpm

### DIFF
--- a/packaging/common/xrootd-filecache-clustered.cfg
+++ b/packaging/common/xrootd-filecache-clustered.cfg
@@ -1,0 +1,90 @@
+###########################################################################
+# This is a very simple sample configuration file sufficient to start an  #
+# xrootd file caching data server using the default port 1094 and its     #
+# companion cmsd. Trying to use the xrootd will cause the client to       #
+# simply wait there is no redirector and this configuration file is       #
+# insufficient to start one. Consult the reference manuals on how to      #
+# create a usable configuration file to completely describe a functional  #
+# xrootd cluster.                                                         #
+#                                                                         #
+# On start-up the xrootd will complain about not connecting to the pipe   #
+# named '/var/spool/xrootd/.olb/olbd.admin'. This will continue until the #
+# cmsd starts. When the cmsd start is will say ' Waiting for primary      #
+# server to login.' Once xrootd is started and connects to the cmsd, the  #
+# cmsd will complain 'Unable to connect socket to localhost' because      #
+# there is no redirector. However, this shows that xrootd and cmsd have   #
+# been correctly installed.                                               #
+#                                                                         #
+# Note: You should always create a *single* configuration file and use it #
+# when starting each daemon that you need to run in the cluster!          #
+###########################################################################
+# Tell everyone who the manager is
+#
+all.manager redirector:1213
+
+# The redirector and all cmsd’s export /data red-only with the stage option. The stage
+# option requests that if the file isn’t found in the cluster the redirector should send
+# the client to a PFC server with enough space to cache the file.
+#
+all.export /data stage r/o
+
+# Configuration is different for the redirector, the server cmsd, and
+# for the server xrootd. We break those out in the if-else-fi clauses.
+#
+if redirector
+
+all.role manager
+
+# Export with stage option - if the file isn’t found in the cluster the
+# redirector sends the client to a PFC server with enough free space.
+#
+
+all.export /data stage r/o
+
+# Server’s cmsd configuration – all PFC’s are virtual data servers
+#
+
+else if exec cmsd
+
+all.role server
+
+# Export with stage option - this tells manager cmsd we can pull files from the origin
+#
+all.export /data stage r/o
+
+# The cmsd uses the standard oss plug-in to locate files in the cache.
+# oss.localroot directive should be the same as for the server.
+#
+
+oss.localroot /pfc-cache
+
+# Server’s xrootd configuration – all PFC’s are virtual data servers
+#
+else
+
+all.role server
+
+# For xrootd, load the proxy plugin and the disk caching plugin.
+#
+ofs.osslib   libXrdPss.so
+pss.cachelib libFileCache.so
+
+# The server needs to write to disk, stage not relevant
+#
+all.export /data rw
+
+
+# Tell the proxy where the data is coming from (arbitrary).
+#
+pss.origin someserver.domain.org:1094
+
+# Tell the PFC’s where the disk cache resides (arbitrary).
+#
+oss.localroot /pfc-cache
+
+# Tell the PFC’s available RAM
+#
+pfc.ram 100g
+
+fi
+

--- a/packaging/common/xrootd-filecache-standalone.cfg
+++ b/packaging/common/xrootd-filecache-standalone.cfg
@@ -1,0 +1,37 @@
+###########################################################################
+# This is a very simple sample configuration file sufficient to start an  #
+# xrootd file caching proxy server using the default port 1094. This      #
+# server runs by itself (stand-alone) and does not assume it is part of a #
+# cluster. You can then connect to this server to access files in '/tmp'. #
+# Consult the the reference manuals on how to create more complicated     #
+# configurations.                                                         #
+#                                                                         #
+# On successful start-up you will see 'initialization completed' in the   #
+# last message. You can now connect to the xrootd server.                 #
+#                                                                         #
+# Note: You should always create a *single* configuration file for all    #
+# daemons related to xrootd.                                              #
+###########################################################################
+
+# Allow access to path with given prefix.
+#
+all.export  /test/
+
+# Load the proxy plugin and the disk caching plugin.
+#
+ofs.osslib  libXrdPss.so
+pss.cachelib libXrdFileCache.so
+
+# Tell the proxy where the data is coming from (arbitrary).
+#
+pss.origin source.edu:1094
+
+# Specify where the local file system name space is actually rooted.
+#
+oss.localroot /data/xrd
+
+# Tell maximum allowed RAM usage.
+#
+pfc.ram 16g
+
+

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -481,6 +481,8 @@ install -p -m 644 packaging/common/xrootd.logrotate $RPM_BUILD_ROOT%{_sysconfdir
 
 install -m 644 packaging/common/xrootd-clustered.cfg $RPM_BUILD_ROOT%{_sysconfdir}/xrootd/xrootd-clustered.cfg
 install -m 644 packaging/common/xrootd-standalone.cfg $RPM_BUILD_ROOT%{_sysconfdir}/xrootd/xrootd-standalone.cfg
+install -m 644 packaging/common/xrootd-filecache-clustered.cfg $RPM_BUILD_ROOT%{_sysconfdir}/xrootd/xrootd-filecache-clustered.cfg
+install -m 644 packaging/common/xrootd-filecache-standalone.cfg $RPM_BUILD_ROOT%{_sysconfdir}/xrootd/xrootd-filecache-standalone.cfg
 
 # client plug-in config
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/xrootd/client.plugins.d
@@ -640,6 +642,8 @@ fi
 %{_datadir}/xrootd
 %attr(-,xrootd,xrootd) %config(noreplace) %{_sysconfdir}/xrootd/xrootd-clustered.cfg
 %attr(-,xrootd,xrootd) %config(noreplace) %{_sysconfdir}/xrootd/xrootd-standalone.cfg
+%attr(-,xrootd,xrootd) %config(noreplace) %{_sysconfdir}/xrootd/xrootd-filecache-clustered.cfg
+%attr(-,xrootd,xrootd) %config(noreplace) %{_sysconfdir}/xrootd/xrootd-filecache-standalone.cfg
 %attr(-,xrootd,xrootd) %dir %{_var}/log/xrootd
 %attr(-,xrootd,xrootd) %dir %{_var}/run/xrootd
 %attr(-,xrootd,xrootd) %dir %{_var}/spool/xrootd


### PR DESCRIPTION
Changes:
2 new xrootd server config files packaging/common
include them in server's rpm (change in xrootd.spec.in )

 