### PR TITLE
Gcc7 issues

### DIFF
--- a/src/XrdClient/XrdClient.cc
+++ b/src/XrdClient/XrdClient.cc
@@ -1372,7 +1372,7 @@ bool XrdClient::OpenFileWhenRedirected(char *newfhandle, bool &wasopen)
 	Info(XrdClientDebug::kHIDEBUG,
 	     "OpenFileWhenRedirected", "Stripping off the 'delete' option." );
 
-	options &= !kXR_delete;
+	options &= ~kXR_delete;
 	options |= kXR_open_updt;
     }
 
@@ -1380,7 +1380,7 @@ bool XrdClient::OpenFileWhenRedirected(char *newfhandle, bool &wasopen)
 	Info(XrdClientDebug::kHIDEBUG,
 	     "OpenFileWhenRedirected", "Stripping off the 'new' option." );
 
-	options &= !kXR_new;
+	options &= ~kXR_new;
 	options |= kXR_open_updt;
     }
 

--- a/src/XrdSecpwd/XrdSecProtocolpwd.cc
+++ b/src/XrdSecpwd/XrdSecProtocolpwd.cc
@@ -1015,7 +1015,7 @@ if (hs->Step == kXPS_init)
          SessionSt.options = kOptsClntTty;
    }
 // case kXPS_puk:
-if (hs->Step == kXPS_puk)
+if ((hs->Step == kXPS_init) || (hs->Step == kXPS_puk))
    {
       // After auto-reg request, server puk have been saved in ParseClientInput:
       // we need to start a full normal login now
@@ -1045,8 +1045,6 @@ if (hs->Step == kXPS_puk)
       }
    }
 // case kXPS_signedrtag:     // (after kXRC_verifysrv)
-if (hs->Step == kXPS_signedrtag)
-   {
       //
       // Add the username
       if (hs->User.length()) {
@@ -1081,7 +1079,6 @@ if (hs->Step == kXPS_signedrtag)
          SessionSt.options |= kOptsChngPwd;
       //
       nextstep = kXPC_normal;
-   }
       break;
 
    case kXPS_credsreq:


### PR DESCRIPTION
Here are two issues I found while extracting the gcc 7 fixes from git.
1) The compilation fails where logical not is used instead if bitwise not in XrdClient.cc
2) In XrdSecProtocolpwd.cc the if statements added to replace the fall though doesn't actually fall through.
