### PR TITLE
Fix CRL verification bug

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3946,12 +3946,15 @@ XrdCryptoX509Crl *XrdSecProtocolgsi::LoadCRL(XrdCryptoX509 *xca, const char *sub
       return crl;
    }
 
+   String caroot(subjhash);
+   if (caroot.endswith(".0"))
+     caroot.erase(caroot.length() - 2, 2);
+
    // Get the CA hash
-   String cahash(subjhash);
    int hashalg = 0;
-   if (strcmp(subjhash, xca->SubjectHash())) hashalg = 1;
-   // Drop the extension (".0")
-   String caroot(cahash, 0, cahash.find(".0")-1);
+   if (strcmp(caroot.c_str(), xca->SubjectHash())) hashalg = 1;
+
+   String cahash = caroot + ".0";
 
    // The dir
    String crlext = XrdSecProtocolgsi::DefCRLext;


### PR DESCRIPTION
Hi!

After uploading xrootd 4.6.0 to Fedora and EPEL I got some feedback that authentication failed with many sites, see:

https://bodhi.fedoraproject.org/updates/FEDORA-2017-0eca8dbb12

I could reproduce the problem, and this is my proposed fix.

This issue was not caused by the changes to support openssl 1.1.0, but was introduced with the improvements to the CRL handling that was part of the 4.6.0 release.
