### PR TITLE
Use CommonCrypto header instead of openssl for SHA on OSX

### DIFF
--- a/src/XrdSec/XrdSecProtect.cc
+++ b/src/XrdSec/XrdSecProtect.cc
@@ -35,7 +35,12 @@
 #include <sys/types.h>
 #include <sys/uio.h>
 
+#ifdef __APPLE__
+#define COMMON_DIGEST_FOR_OPENSSL
+#include "CommonCrypto/CommonDigest.h"
+#else
 #include "openssl/sha.h"
+#endif
 
 #include "XrdVersion.hh"
 


### PR DESCRIPTION
Apple deprecated openssl on OSX a while back, and stopped shipping the headers at all on release 10.11 (El Capitan).  This patch uses the Apple-preferred CommonCrypto/CommonDigest.h instead when compiling on OSX.  Fixes #439