### PR TITLE
A valid legacy proxy should not trigger an error msg

### DIFF
--- a/src/XrdCrypto/XrdCryptosslX509.cc
+++ b/src/XrdCrypto/XrdCryptosslX509.cc
@@ -358,12 +358,20 @@ void XrdCryptosslX509::CertType()
       type = kUnknown;
       if ((idx = X509_get_ext_by_NID(cert, NID_proxyCertInfo,-1)) == -1) {
          XrdOucString emsg;
-         if (XrdCryptosslX509CheckProxy3(this, emsg) == 0) {
+         switch (XrdCryptosslX509CheckProxy3(this, emsg)) {
+         case 0:
+         {
             type = kProxy;
+            done = 1;
             pxytype = 3;
             DEBUG("Found GSI 3 proxyCertInfo extension");
-         } else {
+            break;
+         }
+         case -1:
+         {
             PRINT("ERROR: "<<emsg);
+            break;
+         }
          }
       } else {
          if ((ext = X509_get_ext(cert,idx)) == 0) {

--- a/src/XrdCrypto/XrdCryptosslgsiAux.cc
+++ b/src/XrdCrypto/XrdCryptosslgsiAux.cc
@@ -1374,7 +1374,7 @@ int XrdCryptosslX509CheckProxy3(XrdCryptoX509 *xcpi, XrdOucString &emsg) {
    }
    if (!ext) {
       emsg = "proxyCertInfo extension not found";
-      return -1;
+      return -2;
    }
    if (!pci) {
       emsg = "proxyCertInfo extension could not be deserialized";


### PR DESCRIPTION
This addresses a comment received on the xrootd update for EPEL 7:
https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2017-9b2cd39ee3

"xrdcp from xrootd-client-4.6.0-3.el7.x86_64 downloads file but with ERROR message"
