### PR TITLE
Ignore unnecessary parameter.

### DIFF
--- a/src/XrdFileCache/XrdFileCacheConfiguration.cc
+++ b/src/XrdFileCache/XrdFileCacheConfiguration.cc
@@ -353,6 +353,7 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
    else if ( part == "nramread" )
    {
       m_log.Emsg("Config", "pfc.nramread is deprecated, please use pfc.ram instead. Ignoring this directive.");
+      config.GetWord(); // Ignoring argument.
    }
    else if ( part == "ram" )
    {


### PR DESCRIPTION
Without explicitly ignoring the argument value, we trigger an assert to make sure all arguments have been processed - even if it is otherwise ignored.

Assert failure looked like:
```
170301 22:44:17 2410886 XrdFileCache_Config: pfc.nramread is deprecated, please use pfc.ram instead. Ignoring this directive.
xrootd: /home/cse496/bbockelm/projects/xrootd/src/XrdFileCache/XrdFileCacheConfiguration.cc:413: bool XrdFileCache::Cache::ConfigParameters(std::string, XrdOucStream&, XrdFileCache::TmpConfiguration&): Assertion `config.GetWord() == 0 && "Cache::ConfigParameters() lost argument"' failed.
```

triggered by the presence of `pfc.nramread 4`.