### PR TITLE
Fix ability to read back a file written with O_RDWR flags + improvements in the logs

### DIFF
--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -577,7 +577,7 @@ static int ceph_posix_internal_truncate(const CephFile &file, unsigned long long
 int ceph_posix_open(XrdOucEnv* env, const char *pathname, int flags, mode_t mode) {
   CephFileRef fr = getCephFileRef(pathname, env, flags, mode, 0);
   int fd = insertFileRef(fr);
-  logwrapper((char*)"ceph_open : fd %d associated to %s", fd, pathname);
+  logwrapper((char*)"ceph_open: fd %d associated to %s", fd, pathname);
   if (flags & (O_WRONLY|O_RDWR)) {
     insertOpenForWrite(fr.name);
   }
@@ -674,7 +674,8 @@ ssize_t ceph_posix_write(int fd, const void *buf, size_t count) {
 ssize_t ceph_posix_pwrite(int fd, const void *buf, size_t count, off64_t offset) {
   CephFileRef* fr = getFileRef(fd);
   if (fr) {
-    logwrapper((char*)"ceph_write: for fd %d, count=%d", fd, count);
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_write: for fd %d, count=%d", fd, count);
     if ((fr->flags & (O_WRONLY|O_RDWR)) == 0) {
       return -EBADF;
     }
@@ -706,11 +707,12 @@ ssize_t ceph_aio_write(int fd, XrdSfsAio *aiop, AioCB *cb) {
     size_t count = aiop->sfsAio.aio_nbytes;
     const char *buf = (const char*)aiop->sfsAio.aio_buf;
     size_t offset = aiop->sfsAio.aio_offset;
-    // get the striper object
-    logwrapper((char*)"ceph_aio_write: for fd %d, count=%d", fd, count);
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_aio_write: for fd %d, count=%d", fd, count);
     if ((fr->flags & (O_WRONLY|O_RDWR)) == 0) {
       return -EBADF;
     }
+    // get the striper object
     libradosstriper::RadosStriper *striper = getRadosStriper(*fr);
     if (0 == striper) {
       return -EINVAL;
@@ -741,7 +743,8 @@ ssize_t ceph_aio_write(int fd, XrdSfsAio *aiop, AioCB *cb) {
 ssize_t ceph_posix_read(int fd, void *buf, size_t count) {
   CephFileRef* fr = getFileRef(fd);
   if (fr) {
-    logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
     if ((fr->flags & O_WRONLY) != 0) {
       return -EBADF;
     }
@@ -763,7 +766,8 @@ ssize_t ceph_posix_read(int fd, void *buf, size_t count) {
 ssize_t ceph_posix_pread(int fd, void *buf, size_t count, off64_t offset) {
   CephFileRef* fr = getFileRef(fd);
   if (fr) {
-    logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
     if ((fr->flags & O_WRONLY) != 0) {
       return -EBADF;
     }
@@ -801,11 +805,12 @@ ssize_t ceph_aio_read(int fd, XrdSfsAio *aiop, AioCB *cb) {
     // get the parameters from the Xroot aio object
     size_t count = aiop->sfsAio.aio_nbytes;
     size_t offset = aiop->sfsAio.aio_offset;
-    // get the striper object
-    logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
-    if ((fr->flags & (O_WRONLY|O_RDWR)) != 0) {
+    // TODO implement proper logging level for this plugin - this should be only debug
+    //logwrapper((char*)"ceph_aio_read: for fd %d, count=%d", fd, count);
+    if ((fr->flags & O_WRONLY) != 0) {
       return -EBADF;
     }
+    // get the striper object
     libradosstriper::RadosStriper *striper = getRadosStriper(*fr);
     if (0 == striper) {
       return -EINVAL;
@@ -858,7 +863,7 @@ int ceph_posix_fstat(int fd, struct stat *buf) {
 }
 
 int ceph_posix_stat(XrdOucEnv* env, const char *pathname, struct stat *buf) {
-  logwrapper((char*)"ceph_stat : %s", pathname);
+  logwrapper((char*)"ceph_stat: %s", pathname);
   // minimal stat : only size and times are filled
   // atime, mtime and ctime are set all to the same value
   // mode is set arbitrarily to 0666

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -742,7 +742,7 @@ ssize_t ceph_posix_read(int fd, void *buf, size_t count) {
   CephFileRef* fr = getFileRef(fd);
   if (fr) {
     logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
-    if ((fr->flags & (O_WRONLY|O_RDWR)) != 0) {
+    if ((fr->flags & O_WRONLY) != 0) {
       return -EBADF;
     }
     libradosstriper::RadosStriper *striper = getRadosStriper(*fr);
@@ -764,7 +764,7 @@ ssize_t ceph_posix_pread(int fd, void *buf, size_t count, off64_t offset) {
   CephFileRef* fr = getFileRef(fd);
   if (fr) {
     logwrapper((char*)"ceph_read: for fd %d, count=%d", fd, count);
-    if ((fr->flags & (O_WRONLY|O_RDWR)) != 0) {
+    if ((fr->flags & O_WRONLY) != 0) {
       return -EBADF;
     }
     libradosstriper::RadosStriper *striper = getRadosStriper(*fr);


### PR DESCRIPTION
The bug manifested itself only 2 times when the xrootd server attempted to read back a file written out of order (to compute the checksum).
The 'improvements' are actually about dropping way too many messages in the absence of a proper mechanism to classify them as debug level. @sponce, what do you think?