### PR TITLE
pfc: Change severity IO::initLocalStat() log message

### DIFF
--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.cc
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.cc
@@ -129,7 +129,7 @@ int IOEntireFile::initCachedStat(const char* path)
          else
          {
             // file exist but can't read it
-            TRACEIO(Error, "IOEntireFile::initCachedStat failed to read file size from info file");
+            TRACEIO(Debug, "IOEntireFile::initCachedStat info file is not complete");
          }
       }
       else

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -213,7 +213,7 @@ int IOFileBlock::initLocalStat()
          else
          {
             // file exist but can't read it
-            TRACEIO(Error, "IOFileBlock::initCachedStat failed to read file size from info file");
+            TRACEIO(Debug, "IOFileBlock::initCachedStat info file is not complete");
          }
       }
    }


### PR DESCRIPTION
When file is open and prefetching  the  IO::initLocalStat() reported an error called from the purge thread. This is not an error, since info file was still modifying. This is the reason I moved the severity from error to debug mode.