### PR TITLE
secgsi: do not build/package libXrdSecgsiGMAPLDAP-4.so

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -809,7 +809,6 @@ fi
 %{_libdir}/libXrdPosix.so.1*
 %{_libdir}/libXrdSecgsiAuthzVO.so*
 %{_libdir}/libXrdSecgsiGMAPDN.so*
-%{_libdir}/libXrdSecgsiGMAPLDAP.so*
 %{_libdir}/libXrdSecgsi.so*
 %{_libdir}/libXrdSeckrb5.so*
 %{_libdir}/libXrdSecpwd.so*

--- a/src/XrdCl/XrdClDefaultEnv.cc
+++ b/src/XrdCl/XrdClDefaultEnv.cc
@@ -670,7 +670,6 @@ namespace XrdCl
       "libXrdSecgsi.so",
       "libXrdSecgsiAuthzVO.so",
       "libXrdSecgsiGMAPDN.so",
-      "libXrdSecgsiGMAPLDAP.so",
       "libXrdSecpwd.so",
       "libXrdSecsss.so",
       "libXrdSecunix.so",

--- a/src/XrdSecgsi.cmake
+++ b/src/XrdSecgsi.cmake
@@ -5,7 +5,6 @@ include( XRootDCommon )
 # Shared library version
 #-------------------------------------------------------------------------------
 set( LIB_XRD_SEC_GSI          XrdSecgsi-${PLUGIN_VERSION} )
-set( LIB_XRD_SEC_GSI_GMAPLDAP XrdSecgsiGMAPLDAP-${PLUGIN_VERSION} )
 set( LIB_XRD_SEC_GSI_GMAPDN   XrdSecgsiGMAPDN-${PLUGIN_VERSION} )
 set( LIB_XRD_SEC_GSI_AUTHZVO  XrdSecgsiAUTHZVO-${PLUGIN_VERSION} )
 
@@ -26,20 +25,6 @@ target_link_libraries(
 
 set_target_properties(
   ${LIB_XRD_SEC_GSI}
-  PROPERTIES
-  INTERFACE_LINK_LIBRARIES ""
-  LINK_INTERFACE_LIBRARIES "" )
-
-#-------------------------------------------------------------------------------
-# The XrdSecgsiGMAPLDAP module
-#-------------------------------------------------------------------------------
-add_library(
-  ${LIB_XRD_SEC_GSI_GMAPLDAP}
-  MODULE
-  XrdSecgsi/XrdSecgsiGMAPFunLDAP.cc )
-
-set_target_properties(
-  ${LIB_XRD_SEC_GSI_GMAPLDAP}
   PROPERTIES
   INTERFACE_LINK_LIBRARIES ""
   LINK_INTERFACE_LIBRARIES "" )
@@ -112,7 +97,6 @@ target_link_libraries(
 install(
   TARGETS
   ${LIB_XRD_SEC_GSI}
-  ${LIB_XRD_SEC_GSI_GMAPLDAP}
   ${LIB_XRD_SEC_GSI_AUTHZVO}
   ${LIB_XRD_SEC_GSI_GMAPDN}
   xrdgsiproxy

--- a/src/XrdSecgsi/XrdSecgsiGMAPFunLDAP.cc
+++ b/src/XrdSecgsi/XrdSecgsiGMAPFunLDAP.cc
@@ -38,6 +38,15 @@ XrdVERSIONINFO(XrdSecgsiGMAPFun,secgsigmap);
 /*                                                                            */
 /* GMAP function implementation querying a LDAP database                      */
 /*                                                                            */
+/* Warning: this plug-in is not build any longer because the external         */
+/* LDAP query via the popen() represents a potential security threat          */
+/* and it is believed that functionality provided is not actually used.       */
+/* If this believe happens to be uncorrect please report at                   */
+/*                                                                            */
+/*                   https://github.com/xrootd                                */
+/*                                                                            */
+/* a sanitized version of the plug-in can be provided using a proper library. */
+/*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>

--- a/src/XrdVersionPlugin.hh
+++ b/src/XrdVersionPlugin.hh
@@ -170,7 +170,6 @@
          "libXrdSecgsi.so",          \
          "libXrdSecgsiAUTHZVO.so",   \
          "libXrdSecgsiGMAPDLAP.so",  \
-         "libXrdSecgsiGMAPLDAP.so",  \
          "libXrdSeckrb5.so",         \
          "libXrdSecpwd.so",          \
          "libXrdSecsss.so",          \


### PR DESCRIPTION
The way the LDAP query is implemented may represent a security threat.
Any related building and packaging reference is removed.
The code is left in place (for the time being) to remind its functionality
in the case a sanitized version is required.