### PR TITLE
[XrdFileCache] Use ref-counts on File objects

### DIFF
--- a/src/XrdFileCache/XrdFileCache.cc
+++ b/src/XrdFileCache/XrdFileCache.cc
@@ -164,7 +164,7 @@ XrdOucCacheIO2 *Cache::Attach(XrdOucCacheIO2 *io, int Options)
 {
    if (Cache::GetInstance().Decide(io))
    {
-      TRACE(Debug, "Cache::Attach() " << io->Path());
+      TRACE(Info, "Cache::Attach() " << io->Path());
       IO* cio;
       if (Cache::GetInstance().RefConfiguration().m_hdfsmode)
          cio = new IOFileBlock(io, m_stats, *this);

--- a/src/XrdFileCache/XrdFileCacheFile.cc
+++ b/src/XrdFileCache/XrdFileCacheFile.cc
@@ -53,14 +53,14 @@ const char *File::m_traceID = "File";
 
 //------------------------------------------------------------------------------
 
-File::File(IO *io, std::string& disk_file_path, long long iOffset, long long iFileSize) :
+File::File(IO *io, const std::string& path, long long iOffset, long long iFileSize) :
    m_ref_cnt(0),
    m_is_open(false),
    m_io(io),
    m_output(0),
    m_infoFile(0),
    m_cfi(Cache::GetInstance().GetTrace(), Cache::GetInstance().RefConfiguration().m_prefetch_max_blocks > 0),
-   m_temp_filename(disk_file_path),
+   m_filename(path),
    m_offset(iOffset),
    m_fileSize(iFileSize),
    m_non_flushed_cnt(0),
@@ -92,7 +92,6 @@ File::~File()
       delete m_output;
       m_output = NULL;
    }
-
 
    TRACEF(Debug, "File::~File() ended, prefetch score = " <<  m_prefetchScore);
 }
@@ -126,7 +125,6 @@ bool File::ioActive()
          cache()->DeRegisterPrefetchFile(this);
       }
 
-
       // High debug print
       // for (BlockMap_i it = m_block_map.begin(); it != m_block_map.end(); ++it)
       // {
@@ -152,45 +150,41 @@ bool File::ioActive()
          }
       }
 
-      blockMapEmpty =  m_block_map.empty();
+      blockMapEmpty = m_block_map.empty();
    }
 
    return !blockMapEmpty;
 }
 
-//______________________________________________________________________________
-bool File::FinalizeSyncBeforeExit()
+//------------------------------------------------------------------------------
+
+void File::RequestSyncOfDetachStats()
 {
-
-   // returns true if sync is required
-   // this method is called after corresponding IO is detached from PosixCache
-   
-   TRACEF(Info, "File::FinalizeSyncBeforeExit" );
-   bool schedule_sync = false;
-   {
-      XrdSysCondVarHelper _lck(m_downloadCond);
-
-
-      if (m_writes_during_sync.empty()  && m_non_flushed_cnt == 0)
-      {
-         if (! m_detachTimeIsLogged)
-         {
-            m_cfi.WriteIOStatDetach(m_stats);
-            m_detachTimeIsLogged = true;
-            schedule_sync = true;
-         }
-      }
-      else
-      {
-         schedule_sync = true;
-      }
-   }
-
-   return schedule_sync;
+   XrdSysCondVarHelper _lck(m_downloadCond);
+   m_detachTimeIsLogged = false;
 }
 
+bool File::FinalizeSyncBeforeExit()
+{
+   // Returns true if sync is required.
+   // This method is called after corresponding IO is detached from PosixCache.
+
+   XrdSysCondVarHelper _lck(m_downloadCond);
+
+   if ( ! m_writes_during_sync.empty() || m_non_flushed_cnt > 0 || ! m_detachTimeIsLogged)
+   {
+      m_cfi.WriteIOStatDetach(m_stats);
+      m_detachTimeIsLogged = true;
+      TRACEF(Debug, "File::FinalizeSyncBeforeExit scheduling sync to write detach stats");
+      return true;
+   }
+
+   TRACEF(Debug, "File::FinalizeSyncBeforeExit sync not required");
+   return false;
+}
 
 //------------------------------------------------------------------------------
+
 void File::ReleaseIO()
 {
    // called from Cache::ReleaseFile
@@ -198,8 +192,7 @@ void File::ReleaseIO()
    m_downloadCond.Lock();
    m_io = 0;
    m_downloadCond.UnLock();
-   
-}
+ }
 
 //------------------------------------------------------------------------------
 
@@ -213,13 +206,14 @@ IO* File::SetIO(IO *io)
    IO* oldIO = m_io;
    m_downloadCond.Lock();
    m_io = io;
-   if (io && m_prefetchState != kComplete) {
-       cacheActivatePrefetch = true;
-       m_prefetchState = kOn;
+   if (io && m_prefetchState != kComplete)
+   {
+      cacheActivatePrefetch = true;
+      m_prefetchState = kOn;
    }
    m_downloadCond.UnLock();
    
-   if(cacheActivatePrefetch) cache()->RegisterPrefetchFile(this);
+   if (cacheActivatePrefetch) cache()->RegisterPrefetchFile(this);
    return oldIO;
 }
 
@@ -237,24 +231,24 @@ bool File::Open()
    char size_str[16]; sprintf(size_str, "%lld", m_fileSize);
    myEnv.Put("oss.asize",  size_str);
    myEnv.Put("oss.cgroup", Cache::GetInstance().RefConfiguration().m_data_space.c_str());
-   if (myOss.Create(myUser, m_temp_filename.c_str(), 0600, myEnv, XRDOSS_mkpath) != XrdOssOK)
+   if (myOss.Create(myUser, m_filename.c_str(), 0600, myEnv, XRDOSS_mkpath) != XrdOssOK)
    {
-      TRACEF(Error, "File::Open() Create failed for data file " << m_temp_filename
+      TRACEF(Error, "File::Open() Create failed for data file " << m_filename
                                                                 << ", err=" << strerror(errno));
       return false;
    }
 
    m_output = myOss.newFile(myUser);
-   if (m_output->Open(m_temp_filename.c_str(), O_RDWR, 0600, myEnv) != XrdOssOK)
+   if (m_output->Open(m_filename.c_str(), O_RDWR, 0600, myEnv) != XrdOssOK)
    {
-      TRACEF(Error, "File::Open() Open failed for data file " << m_temp_filename
+      TRACEF(Error, "File::Open() Open failed for data file " << m_filename
                                                               << ", err=" << strerror(errno));
       delete m_output; m_output = 0;
       return false;
    }
 
    // Create the info file
-   std::string ifn = m_temp_filename + Info::m_infoExtension;
+   std::string ifn = m_filename + Info::m_infoExtension;
 
    struct stat infoStat;
    bool fileExisted = (myOss.Stat(ifn.c_str(), &infoStat) == XrdOssOK);
@@ -272,8 +266,8 @@ bool File::Open()
    m_infoFile = myOss.newFile(myUser);
    if (m_infoFile->Open(ifn.c_str(), O_RDWR, 0600, myEnv) != XrdOssOK)
    {
-      TRACEF(Error, "File::Open() Open failed for info file " << ifn
-                                                              << ", err=" << strerror(errno));
+      TRACEF(Error, "File::Open() Open failed for info file " << ifn << ", err=" << strerror(errno));
+
       delete m_infoFile; m_infoFile = 0;
       delete m_output;   m_output   = 0;
       return false;
@@ -879,7 +873,7 @@ long long File::BufferSize()
 
 const char* File::lPath() const
 {
-   return m_temp_filename.c_str();
+   return m_filename.c_str();
 }
 
 //------------------------------------------------------------------------------

--- a/src/XrdFileCache/XrdFileCacheIO.hh
+++ b/src/XrdFileCache/XrdFileCacheIO.hh
@@ -35,8 +35,6 @@ public:
 
    virtual void RelinquishFile(File*) = 0;
 
-   virtual bool FinalizeSyncBeforeExit() = 0;
-
    XrdOucTrace* GetTrace() {return m_cache.GetTrace(); }
 
    XrdOucCacheIO2* GetInput();

--- a/src/XrdFileCache/XrdFileCacheIO.hh
+++ b/src/XrdFileCache/XrdFileCacheIO.hh
@@ -35,22 +35,21 @@ public:
 
    virtual void RelinquishFile(File*) = 0;
 
-   XrdOucTrace* GetTrace() {return m_cache.GetTrace(); }
+   XrdOucTrace* GetTrace() { return m_cache.GetTrace(); }
 
    XrdOucCacheIO2* GetInput();
 
 protected:
-   XrdOucCacheStats &m_statsGlobal;       //!< reference to Cache statistics
-   Cache            &m_cache;             //!< reference to Cache needed in detach
+   XrdOucCacheStats &m_statsGlobal;     //!< reference to Cache statistics
+   Cache            &m_cache;           //!< reference to Cache needed in detach
 
-   const char* m_traceID;
-   std::string m_path;
-   const char* GetPath() { return m_path.c_str(); }
+   const char  *m_traceID;
+   std::string  m_path;
+   const char*  GetPath() { return m_path.c_str(); }
 
-   bool  m_syncDiskAfterDetach;
 private:
-   XrdOucCacheIO2   *m_io;                //!< original data source
-   XrdSysMutex updMutex;
+   XrdOucCacheIO2 *m_io;                //!< original data source
+   XrdSysMutex     updMutex;
    void SetInput(XrdOucCacheIO2*);
 };
 }

--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.cc
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.cc
@@ -149,7 +149,7 @@ XrdOucCacheIO *IOEntireFile::Detach()
 {
    // Called from XrdPosixFile destructor
 
-   TRACE(Debug, "IOEntireFile::Detach() " << this);
+   TRACE(Info, "IOEntireFile::Detach() " << this);
 
    {
       XrdSysMutexHelper lock(&m_mutex);

--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
@@ -82,8 +82,6 @@ public:
    //! Called to check if destruction needs to be done in a separate task.
    virtual bool ioActive();
    
-   virtual bool FinalizeSyncBeforeExit();
-   
    virtual int  Fstat(struct stat &sbuff);
 
    virtual long long FSize();

--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
@@ -89,9 +89,10 @@ public:
    virtual void RelinquishFile(File*);
 
 private:
-   File* m_file;
-   struct stat      *m_localStat;
-   int     initCachedStat(const char* path);
+   XrdSysMutex  m_mutex;
+   File        *m_file;
+   struct stat *m_localStat;
+   int initCachedStat(const char* path);
 };
 
 }

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -59,7 +59,7 @@ XrdOucCacheIO* IOFileBlock::Detach()
 {
    // Called from XrdPosixFile destructor
 
-   TRACEIO(Debug, "Detach IOFileBlock");
+   TRACEIO(Info, "Detach IOFileBlock");
 
    CloseInfoFile();
    {

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.cc
@@ -52,13 +52,6 @@ IOFileBlock::~IOFileBlock()
    // from Cache's sync thread
 
    TRACEIO(Debug, "deleting IOFileBlock");
-   
-   while (! m_blocks.empty())
-   {
-      std::map<int, File*>::iterator it = m_blocks.begin();
-      m_cache.Detach(it->second);
-      m_blocks.erase(it);
-   }
 }
 
 //______________________________________________________________________________
@@ -66,34 +59,22 @@ XrdOucCacheIO* IOFileBlock::Detach()
 {
    // Called from XrdPosixFile destructor
 
-   TRACEIO(Debug, "detach IOFileBlock");
-         
-   XrdOucCacheIO * io = GetInput();
+   TRACEIO(Debug, "Detach IOFileBlock");
+    
+   CloseInfoFile();     
 
-   // call need sync on all
-   if ( ! FinalizeSyncBeforeExit() )
+   while (! m_blocks.empty())
    {
-      delete this;
-   }
-   else
-   {
-      m_cache.RegisterDyingFilesNeedSync(this);
+      std::map<int, File*>::iterator it = m_blocks.begin();
+      if (it->second) m_cache.ReleaseFile(it->second);
+      m_blocks.erase(it);
    }
    
+   XrdOucCacheIO * io = GetInput();
+   delete this;
    return io;
 }
 
-//______________________________________________________________________________
-bool IOFileBlock::FinalizeSyncBeforeExit()
-{
-   bool syncDone = false;
-   for (std::map<int, File*>::iterator it = m_blocks.begin(); it != m_blocks.end(); ++it)
-   {
-     bool s =  it->second->FinalizeSyncBeforeExit();
-     syncDone = syncDone | s;
-   }
-   return syncDone;
-}
 
 //______________________________________________________________________________
 void IOFileBlock::CloseInfoFile()
@@ -157,13 +138,7 @@ File* IOFileBlock::newBlockFile(long long off, int blocksize)
 
    TRACEIO(Debug, "FileBlock::FileBlock(), create XrdFileCacheFile ");
 
-   File* file = Cache::GetInstance().GetFileWithLocalPath(fname, this);
-   if (! file)
-   {
-      file = new File(this, fname, off, blocksize);
-      Cache::GetInstance().AddActive(file);
-   }
-
+   File* file = Cache::GetInstance().GetFile( fname, this, off, blocksize);
    return file;
 }
 
@@ -265,30 +240,24 @@ int IOFileBlock::initLocalStat()
 //______________________________________________________________________________
 void IOFileBlock::RelinquishFile(File* f)
 {
-   // called from Cache::Detach() or Cache::GetFileWithLocalPath()
-   // the object is in process of dying
-
-   XrdSysMutexHelper lock(&m_mutex);
-   for (std::map<int, File*>::iterator it = m_blocks.begin(); it != m_blocks.end(); ++it)
+   // called from cache::GetFile if File change ownership
+   
+   while (! m_blocks.empty())
    {
+      std::map<int, File*>::iterator it = m_blocks.begin();
       if (it->second == f)
-      {
-         m_blocks.erase(it);
-         break;
-      }
+         it->second = 0;
    }
 }
-
 //______________________________________________________________________________
 bool IOFileBlock::ioActive()
 {
-   CloseInfoFile();
-
    XrdSysMutexHelper lock(&m_mutex);
    bool active = false;
    for (std::map<int, File*>::iterator it = m_blocks.begin(); it != m_blocks.end(); ++it)
    {
-      if (it->second->ioActive()) {
+      // need to initiate stop on all File object
+      if ( it->second  && it->second->ioActive()) {
          active = true;
       }
    }

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
@@ -63,15 +63,12 @@ public:
    //! \brief Virtual method of XrdOucCacheIO.
    //! Called to check if destruction needs to be done in a separate task.
    virtual bool ioActive();
-
-   virtual bool FinalizeSyncBeforeExit();
    
    virtual int  Fstat(struct stat &sbuff);
 
    virtual long long FSize();
 
    virtual void RelinquishFile(File*);
-
 private:
    long long                  m_blocksize;       //!< size of file-block
    std::map<int, File*>       m_blocks;          //!< map of created blocks

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
@@ -69,6 +69,7 @@ public:
    virtual long long FSize();
 
    virtual void RelinquishFile(File*);
+
 private:
    long long                  m_blocksize;       //!< size of file-block
    std::map<int, File*>       m_blocks;          //!< map of created blocks
@@ -77,8 +78,8 @@ private:
    Info                       m_info;
    XrdOssDF*                  m_infoFile;
 
-   void GetBlockSizeFromPath();
-   int initLocalStat();
+   void  GetBlockSizeFromPath();
+   int   initLocalStat();
    File* newBlockFile(long long off, int blocksize);
    void  CloseInfoFile();
 };

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -306,7 +306,7 @@ void Info::GetCksum( unsigned char* buff, char* digest)
 //------------------------------------------------------------------------------
 void Info::DisableDownloadStatus()
 {
-   // use version sign to skip downlaod status
+   // use version sign to skip download status
    m_store.m_version = -m_store.m_version;
 }
 //------------------------------------------------------------------------------
@@ -364,7 +364,7 @@ void Info::WriteIOStatDetach(Stats& s)
 void Info::WriteIOStatAttach()
 {
    m_store.m_accessCnt++;
-   if ( m_store.m_astats.size() >= m_maxNumAccess)
+   if (m_store.m_astats.size() >= m_maxNumAccess)
       m_store.m_astats.erase( m_store.m_astats.begin());
 
    AStat as;


### PR DESCRIPTION
File ref-counts are made from CacheIO objects and from sync tasks. This common management of usage somewhat simplifies the destruction of CacheIO and File objects.

There is a bunch of white-space changes I couldn't refrain myself from doing while reviewing the code.