### PR TITLE
xrootdfs: remove default fuse argument "allow_other" as it is impossible to unset

### DIFF
--- a/src/XrdFfs/README
+++ b/src/XrdFfs/README
@@ -49,6 +49,7 @@ XROOTDFS_OFSFWD: if the xrootd cluster uses ofs.forward (or ofs.forward 3way)
     and expect the operations to be forwarded to the data nodes by the 
     redirector. Otherwise one can define XROOTDFS_OFSFWD to '0'. XrootdFS will 
     then go to individual data node for mv/rm/rmdir/trunc.
+XROOTDFS_NO_ALLOW_OTHER: do not pass option allow_other to fuse.
 
 Please refer to the "Introduction to the XrootdFS" document in the above web
 page for more general idea of XrootdFS.
@@ -104,6 +105,9 @@ max_write=131072
 attr_timeout=10
 entry_timeout=10
 negative_timeout=5
+
+Note that allow_other cannot be unset by command line. To disable it set the
+environment variable XROOTDFS_NO_ALLOW_OTHER=1.
 
 Extended file system attributes:
 ===============================

--- a/src/XrdFfs/XrdFfsXrootdfs.cc
+++ b/src/XrdFfs/XrdFfsXrootdfs.cc
@@ -1233,7 +1233,7 @@ int main(int argc, char *argv[])
     cmdline_opts = (char **) malloc(sizeof(char*) * (argc -1 + 3));
     cmdline_opts[0] = argv[0];
     cmdline_opts[1] = strdup("-o");
-    cmdline_opts[2] = strdup("fsname=xrootdfs,allow_other,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");
+    cmdline_opts[2] = strdup("fsname=xrootdfs,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");
 
     for (int i = 1; i < argc; i++)
         cmdline_opts[i+2] = argv[i];

--- a/src/XrdFfs/XrdFfsXrootdfs.cc
+++ b/src/XrdFfs/XrdFfsXrootdfs.cc
@@ -1233,7 +1233,10 @@ int main(int argc, char *argv[])
     cmdline_opts = (char **) malloc(sizeof(char*) * (argc -1 + 3));
     cmdline_opts[0] = argv[0];
     cmdline_opts[1] = strdup("-o");
-    cmdline_opts[2] = strdup("fsname=xrootdfs,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");
+    if (getenv("XROOTDFS_NOALLOWOTHER") != NULL && ! strcmp(getenv("XROOTDFS_NOALLOWOTHER"),"1") )
+        cmdline_opts[2] = strdup("fsname=xrootdfs,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");
+    else
+        cmdline_opts[2] = strdup("fsname=xrootdfs,allow_other,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");
 
     for (int i = 1; i < argc; i++)
         cmdline_opts[i+2] = argv[i];

--- a/src/XrdFfs/XrdFfsXrootdfs.cc
+++ b/src/XrdFfs/XrdFfsXrootdfs.cc
@@ -1233,7 +1233,7 @@ int main(int argc, char *argv[])
     cmdline_opts = (char **) malloc(sizeof(char*) * (argc -1 + 3));
     cmdline_opts[0] = argv[0];
     cmdline_opts[1] = strdup("-o");
-    if (getenv("XROOTDFS_NOALLOWOTHER") != NULL && ! strcmp(getenv("XROOTDFS_NOALLOWOTHER"),"1") )
+    if (getenv("XROOTDFS_NO_ALLOW_OTHER") != NULL && ! strcmp(getenv("XROOTDFS_NO_ALLOW_OTHER"),"1") )
         cmdline_opts[2] = strdup("fsname=xrootdfs,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");
     else
         cmdline_opts[2] = strdup("fsname=xrootdfs,allow_other,max_write=131072,attr_timeout=10,entry_timeout=10,negative_timeout=5");


### PR DESCRIPTION
Motivation:
This prevented mounting if user_allow_other is not set in fuse.conf
So a user with no root access could not use xrootdfs and could not change this argument without recompiling.
Change:
Don't pass allow_other to fuse by default.
Result:
Now xrootdfs works if user_allow_other is disabled, and allow_other argument can be passed when mounting if it is needed.