### PR TITLE
xrdposix: interpret kXR_Unsupported as ENOTSUP instead of ENOSYS

### DIFF
--- a/src/XProtocol/XProtocol.hh
+++ b/src/XProtocol/XProtocol.hh
@@ -887,7 +887,7 @@ static int toErrno( int xerr )
         case kXR_NotAuthorized: return EACCES;
         case kXR_NotFound:      return ENOENT;
         case kXR_ServerError:   return ENOMSG;
-        case kXR_Unsupported:   return ENOSYS;
+        case kXR_Unsupported:   return ENOTSUP;
         case kXR_noserver:      return EHOSTUNREACH;
         case kXR_NotFile:       return ENOTBLK;
         case kXR_isDirectory:   return EISDIR;

--- a/src/XrdCns/XrdCnsLogClient.cc
+++ b/src/XrdCns/XrdCnsLogClient.cc
@@ -605,7 +605,7 @@ int XrdCnsLogClient::mapError(int rc)
         case kXR_noserver:      return EHOSTUNREACH;
         case kXR_NotFile:       return ENOTBLK;
         case kXR_isDirectory:   return EISDIR;
-        case kXR_FSError:       return ENOSYS;
+        case kXR_FSError:       return EREMOTEIO;
         default:                return ECANCELED;
        }
 }

--- a/src/XrdFfs/XrdFfsPosix.cc
+++ b/src/XrdFfs/XrdFfsPosix.cc
@@ -96,7 +96,8 @@ int XrdFfsPosix_mkdir(const char *path, mode_t mode)
 
 int XrdFfsPosix_rmdir(const char *path)
 {
-/* Note: Xrootd returns ENOSYS rather than ENOTEMPTY when a directory is not empty */
+/* TODO: check this */
+/* Note: Xrootd returns ENOTSUP rather than ENOTEMPTY when a directory is not empty */
     return XrdPosixXrootd::Rmdir(path);
 }
 

--- a/src/XrdOss/XrdOssCache.cc
+++ b/src/XrdOss/XrdOssCache.cc
@@ -484,7 +484,7 @@ int XrdOssCache::Alloc(XrdOssCache::allocInfo &aInfo)
            *Info.Slash='\0'; rc=mkdir(aInfo.cgPFbf,theMode); *Info.Slash='/';
            madeDir = 1;
           } while(!rc);
-       if (datfd < 0) return (errno ? -errno : -ENOSYS);
+       if (datfd < 0) return (errno ? -errno : -EMFILE);
       }
 
 // All done (temporarily adjust down the free space)x

--- a/src/XrdPosix/XrdPosixFile.cc
+++ b/src/XrdPosix/XrdPosixFile.cc
@@ -95,7 +95,8 @@ XrdPosixFile::XrdPosixFile(bool &aOK, const char *path, XrdPosixCallBack *cbP,
    fOpen = strdup(path); aOK = true;
    if (!XrdPosixGlobals::theN2N || !XrdPosixGlobals::theCache) fPath = fOpen;
       else if (!XrdPosixXrootPath::P2L("file",path,fPath)) aOK = false;
-              else if (!fPath) fPath = fOpen;
+              else if (!fPath) fPath = fOpen;   //         ^
+   // Why not set errno ---------- here -------------------|
 
 // Check for structured file check
 //

--- a/src/XrdPosix/XrdPosixXrootd.cc
+++ b/src/XrdPosix/XrdPosixXrootd.cc
@@ -527,7 +527,7 @@ int XrdPosixXrootd::Open(const char *path, int oflags, mode_t mode,
 //
    if (oflags & isStream)
       {if (XrdPosixObject::CanStream()) Opts |= XrdPosixFile::isStrm;
-          else {errno = EMFILE; return -1;}
+      else {errno = EMFILE; return -1;} //is EMFILE the only correct errno?
       }
 
 // Translate create vs simple open. Always make dirpath on create!
@@ -544,13 +544,15 @@ int XrdPosixXrootd::Open(const char *path, int oflags, mode_t mode,
 // Allocate the new file object
 //
    if (!(fp = new XrdPosixFile(aOK, path, cbP, Opts)))
-      {errno = EMFILE;
+      {// can execution ever reach here?
+       // if it can, is EMFILE correct?
+       errno = EMFILE;
        return -1;
       }
 
 // Check if all went well during allocation
 //
-   if (!aOK) {delete fp; return -1;}
+   if (!aOK) {delete fp; return -1;} //why not set errno here?
 
 // If we have a cache, then issue a prepare as the cache may want to defer the
 // open request ans we have a lot more work to do.


### PR DESCRIPTION
Motivation
To quote errno.h comment on ENOSYS /\*Invalid system call number"\*/
> This error code is special: arch syscall entry code will return
> -ENOSYS if users try to call a syscall that doesn't exist.  To keep
> failures of syscalls that really do exist distinguishable from
> failures due to attempts to use a nonexistent syscall, syscall
> implementations should refrain from returning -ENOSYS.

There are many reasons for the server to respond kXR_Unsupported, most of them not reasonably comparable to ENOSYS.
Some systems, like FUSE, treat ENOSYS very differently from other errors.
For example, when OPEN returns ENOSYS, it's considered a success (probably intended for cases where a filesystem does not need to implement an open syscall to work).
When xrootdfs OPEN fails because the server returned kXR_Unsupported because it does not support a specific set of open flags,
it is an error and should be treated as such. The file is not ready to be used after this open.
When FUSE requests an extended attribute and the server responds kXR_Unsupported, meaning that a particular xrootd query is not supported,
FUSE interprets it as a missing getxattr syscall and never tries to call getxattr again, even for the supported attributes.
In conclusion, FUSE shows that ENOSYS has a specific meaning and can't work as a mapping of kXR_Unsupported.
Why not use ENOTSUP instead?

Change: map kXR_Unsupported to ENOTSUP when interpreting protocol responses into error codes.

Result:
Will make dealing with kXR_Usupported errors easier and more predictable.
Should not break anything in xrootd code. The following was checked:
Errno is only compared to ENOSYS is oss, not on the network side where it can expect kXR_Unsupported to be ENOSYS.
Errno is never compared to EOPNOTSUPP.
Errno is only compared to ENOTSUP in:
 * XrdFrmAdmin::Chksum, comparison for logging only
 * XrdFrmAdmin::ChksumList, interrupt printing checksums if error is not ESTALE or ENOTSUP. The change makes sense in this context and should not break this.
 * XrdFrmAdmin::ChksumPrint, logging
 * XrdFrmAdmin::ConvTest, logging
 * XrdFrmConfig::Configure
   * looks like filesystem-side, not protocol-side?
   * if it *is* network-side, makes sense to interpret kXR_Unsupported as ENOTSUP in this context
 * XrdOfsFile::open
   // Create the file. If ENOTSUP is returned, promote the creation to
   // the subsequent open. This is to accomodate proxy support.
   if it *is* networks-side, makes sense to interpret kXR_Unsupported as ENOTSUP
 * XrdSysXAttr::Copy
   * called from XrdOssCopy::Copy
   * if it *is* network-side, makes sense to interpret kXR_Unsupported as ENOTSUP