### PR TITLE
Add working Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+dist: trusty
+addons:
+  apt:
+    packages:
+      - libxml2-dev
+      - libcppunit-dev
+language: cpp
+compiler:
+  - clang
+  - gcc
+script:
+  - mkdir build && cd build
+  - cmake -DENABLE_TESTS=1 ..
+  - make
+  - make test
+  - make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,13 @@ compiler:
   - clang
   - gcc
 script:
-  - mkdir build && cd build
-  - cmake -DENABLE_TESTS=1 ..
+  - mkdir build
+  - pushd build
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/xrootd -DENABLE_TESTS=1 ..
   - make
-  - make test
   - make install
+  - popd
+after_script:
+  - pushd build
+  - ./tests/common/text-runner ./tests/XrdClTests/libXrdClTests.so 'All Tests'
+  - popd


### PR DESCRIPTION
I've tweaked the configuration after #502 so that XRootD now [builds and installs](https://travis-ci.org/alexpearce/xrootd/builds/233557963), and the tests are run in the build directory with the command:

```shell
$ ./tests/common/text-runner ./tests/XrdClTests/libXrdClTests.so 'All Tests'
```

This returns exit code 0, but the tests [actually fail](https://travis-ci.org/alexpearce/xrootd/jobs/233557965#L1507):

```
........F..terminate called after throwing an instance of 'CppUnit::Exception'
terminate called recursively
terminate called recursively
/home/travis/.travis/job_stages: line 54:  6746 Aborted                 (core dumped) ./tests/common/text-runner ./tests/XrdClTests/libXrdClTests.so 'All Tests'
```

Is this due to the way I'm running the tests, or is this failure 'expected' given the master branch (i.e. are the tests failing elsewhere)?