### PR TITLE
Make tmoMask unsigned

### DIFF
--- a/src/XrdSys/XrdSysIOEvents.hh
+++ b/src/XrdSys/XrdSysIOEvents.hh
@@ -506,7 +506,7 @@ struct          PipeData {char req; char evt; short ent; int fd;
 PipeData        reqBuff;    // Buffer used by poller thread to recv data
 char           *pipeBuff;   // Read resumption point in buffer
 int             pipeBlen;   // Number of outstanding bytes
-char            tmoMask;    // Timeout mask
+unsigned char   tmoMask;    // Timeout mask
 CPP_ATOMIC_TYPE(bool) wakePend;   // Wakeup is effectively pending (don't send)
 bool            chDead;     // True if channel deleted by callback
 


### PR DESCRIPTION
Fixes the following warning:

```
/Users/gbitzes/xrootd/src/XrdSys/XrdSysIOEvents.cc:557:22: warning: implicit conversion from 'int' to 'char' changes value from 255 to -1 [-Wconstant-conversion]
   tmoMask         = 255;
                   ~ ^~~
```