### PR TITLE
Disable Ceph build unless enabled.

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -366,11 +366,18 @@ export CXX=clang++
 
 mkdir build
 pushd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 %if %{?_with_tests:1}%{!?_with_tests:0}
-cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_TESTS=TRUE -DUSE_LIBC_SEMAPHORE=%{use_libc_semaphore} ../
+      -DENABLE_TESTS=TRUE \
 %else
-cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUSE_LIBC_SEMAPHORE=%{use_libc_semaphore} ../
+      -DENABLE_TESTS=FALSE \
 %endif
+%if %{?_with_ceph:1}%{!?_with_ceph:0}
+      -DENABLE_CEPH=TRUE \
+%else
+      -DENABLE_CEPH=FALSE \
+%endif
+      -DUSE_LIBC_SEMAPHORE=%{use_libc_semaphore} ../
 
 make -i VERBOSE=1 %{?_smp_mflags}
 popd


### PR DESCRIPTION
If Ceph is in the compile environment - but not explicitly enabled, then the RPM build may fail (installed but unpackaged files).

Thus, we should explicitly disable the Ceph build in cmake when Ceph is disabled in the RPM (and vice-versa).