### PR TITLE
Make generated RPMs and version numbers monotonically increasing.

### DIFF
--- a/genversion.sh
+++ b/genversion.sh
@@ -4,7 +4,7 @@
 # Process the git decoration expansion and try to derive version number
 #-------------------------------------------------------------------------------
 EXP1='^v[12][0-9][0-9][0-9][01][0-9][0-3][0-9]-[0-2][0-9][0-5][0-9]$'
-EXP2='^v[0-9]+\.[0-9]+\.[0-9]+$'
+EXP2='^v[0-9]+\.[0-9]+\.[0-9]+(-pre)?$'
 EXP3='^v[0-9]+\.[0-9]+\.[0-9]+\-rc.*$'
 
 #-------------------------------------------------------------------------------
@@ -19,8 +19,24 @@ function getNumericVersion()
   fi
   VERSION=${VERSION/v/}
   VERSION=${VERSION//./ }
+  VERSION=${VERSION//-/ }
   VERSION=($VERSION)
   printf "%d%02d%02d\n" ${VERSION[0]} ${VERSION[1]} ${VERSION[2]}
+}
+
+#-------------------------------------------------------------------------------
+# Extract pre-release version number from git references
+#-------------------------------------------------------------------------------
+function getPrereleaseVersion()
+{
+  VERSION=`git describe --abbrev=0`
+  VERSION=${VERSION/v/}
+  VERSION=${VERSION//./ }
+  VERSION=${VERSION//-/ }
+  VERSION=($VERSION)
+
+  echo "v${VERSION[0]}.${VERSION[1]}.$((${VERSION[2]}+1))-pre"
+  return 0
 }
 
 #-------------------------------------------------------------------------------
@@ -171,10 +187,7 @@ else
       if test ${?} -eq 0; then
         VERSION="`git describe --tags --abbrev=0 --exact-match`"
       else
-        LOGINFO="`git log -1 --format='%ai %h'`"
-	if test ${?} -eq 0; then
-          VERSION="`getVersionFromLog $LOGINFO`"
-        fi
+        VERSION="`getPrereleaseVersion`"
       fi
     fi
     cd $CURRENTDIR

--- a/packaging/makesrpm.sh
+++ b/packaging/makesrpm.sh
@@ -6,6 +6,7 @@
 
 RCEXP='^[0-9]+\.[0-9]+\.[0-9]+\-rc.*$'
 CERNEXP='^[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\.CERN.*$'
+PREEXP='^[0-9]+\.[0-9]+\.[0-9]+-pre.*$'
 
 #-------------------------------------------------------------------------------
 # Find a program
@@ -138,6 +139,17 @@ fi
 #-------------------------------------------------------------------------------
 if test x`echo $VERSION | egrep $CERNEXP` != x; then
   RELEASE=`echo $VERSION | sed 's/.*-//'` 
+  VERSION=`echo $VERSION | sed 's/-.*\.CERN//'`
+fi
+
+#-------------------------------------------------------------------------------
+# Deal with pre-releases
+#-------------------------------------------------------------------------------
+if test x`echo $VERSION | egrep $PREEXP` != x; then
+  DESCRIBE=`git describe --tags`
+  DESCRIBE=${DESCRIBE//-/ }
+  DESCRIBE=($DESCRIBE)
+  RELEASE="0.${DESCRIBE[-2]}.git.${DESCRIBE[-1]}"
   VERSION=`echo $VERSION | sed 's/-.*\.CERN//'`
 fi
 


### PR DESCRIPTION
Working with RPMs and pre-releases is currently a pain - the output
of `makesrpm.sh` is not generally usable.  This is because the RPM
has distinct versioning schemes (4.6.1234 vs 20161215) depending
whether you are on an exact tag or not.  This means that upgrades
from a pre-release version to an official release is generally
impossible (at least, one wouldn't give a tester a pre-release out of
fear of messing up their system).

This introduces a new scheme for pre-releases:
```
$MAJ.$MIN.$BUG+1-pre
```

where maj / min / bug versioning is based on the most recent tag.

For example, if the latest release is 4.6.1, then the pre-release
would be 4.6.2.pre.  If `makesrpm.sh` is run, then the RPM NVR would
be

```
4.6.2.pre-0.164.git.gbddc68e
```

where `164` is the number of commits since the 4.6.1 tag and `gbddc68e`
is the current git short hash.

NOTE: when master is pointing at a new release series, we should then
tag something along the lines of the next release.  For example, once
master is pointing at 4.7.x, we should make a tag of 4.6.99.

With this scheme, testers can cleanly upgrade from a pre-release to
a final release, reducing the likelihood they need to trash their sytem
setup in order to do testing.