### PR TITLE
Fixes for XrdXrootdJob and XrdCnsSsi

### DIFF
--- a/src/XrdCns/XrdCnsSsi.cc
+++ b/src/XrdCns/XrdCnsSsi.cc
@@ -60,7 +60,8 @@ struct XrdCnsSsiFRec
 {
 char Info[XrdCnsLogRec::FixDLen];
 
-void Updt(const char *nInfo) {strncpy(Info, nInfo, sizeof(Info));}
+void Updt(const char *nInfo) {
+  if(nInfo != nullptr) strncpy(Info, nInfo, sizeof(Info));}
 
      XrdCnsSsiFRec(const char *Data) {if (!Data) Data = XrdCnsLogRec::iArg;
                                       strncpy(Info, Data, sizeof(Info));

--- a/src/XrdXrootd/XrdXrootdJob.cc
+++ b/src/XrdXrootd/XrdXrootdJob.cc
@@ -324,7 +324,7 @@ int XrdXrootdJob2Do::verClient(int dodel)
    for (i = 0; i < numClients; i++)
        if (!Client[i].Link->isInstance(Client[i].Inst))
           {k = i;
-           for (j = i+1; j < numClients; j++,k++) Client[k] = Client[j];
+           for (j = i+1; j < numClients && j < maxClients; j++,k++) Client[k] = Client[j];
            numClients--; i--;
           }
 


### PR DESCRIPTION
  * src/XrdXrootd/XrdXrootdJob.cc, src/XrdCns/XrdCnsSsi.cc: gcc 7.1+
    complains about verClient() [XrdXrootdJob] (-Werror=array-bounds) and
    Updt() [XrdCnsSsi] (-Werror=nonnull), make it "happy".

Signed-off-by: Vladimir Lomov <lomov.vl@gmail.com>