### PR TITLE
Fix handling of sendfile offset argument

### DIFF
--- a/src/Xrd/XrdLink.cc
+++ b/src/Xrd/XrdLink.cc
@@ -889,7 +889,7 @@ do{retc = sendfilev(FD, vecSFP, sfN, &xframt);
            else {myOffset = sfP->offset; bytesleft = sfP->sendsz;
                  while(bytesleft
                     && (retc=sendfile(FD,sfP->fdnum,&myOffset,bytesleft)) > 0)
-                      {myOffset += retc; bytesleft -= retc; xIntr++;}
+                      {bytesleft -= retc; xIntr++;}
                 }
         if (retc <  0 && errno == EINTR) continue;
         if (retc <= 0) break;


### PR DESCRIPTION
Fixes handling of the offset used in further sendfile calls if the first one transmitted only part of the request size.

sendfile doesn't guarantee that all requested bytes are send. Only a fraction might have been send, one would then continue from the new offset and transfer the remain bytes (bytesleft). sendfile will set the offset variable (off_t *offset, myOffset in the xrootd code) to the offset of the byte following the last byte that was read and return the number of bytes read (into retc). By adding retc to myOffset, the offset gets moved away from the byte following the last byte that was read to a (false) position further forward in the file.