### PR TITLE
[XrdSecgsi] Make sure client does not segv if gsi credentail is not p…

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -4595,7 +4595,7 @@ static bool QueryProxyCheck(XrdSutCacheEntry *e, void *a) {
 
    time_t ts_ref = (time_t)(*((XrdSutCacheArg_t *)a)).arg1;
 
-   if (e) {
+   if (e && e->buf1.buf) {
       X509Chain *chain = (X509Chain *)(e->buf1.buf);
       if (chain->CheckValidity(1, ts_ref) == 0) return true;
    }


### PR DESCRIPTION
It seems that there is a regression in XrdSecgsi causing the client to segv if the gsi credential is not present.

Previously we were checking that both the cache entry and the cent->buf1.buf are not null:

https://github.com/xrootd/xrootd/commit/245b8bf5cad7e9a23d2d8f0aa3c15d37243d386b#diff-d0cbc94ca618f1d6c49b85aa3e787753L4635

Currently we are only checking if the cache entry is not null:

https://github.com/xrootd/xrootd/commit/245b8bf5cad7e9a23d2d8f0aa3c15d37243d386b#diff-d0cbc94ca618f1d6c49b85aa3e787753R4611

This pull request re-adds the second check to the if statement.

Michal



