### PR TITLE
Add missing XrdSfsFileSystem virtual overrides.

### DIFF
--- a/src/XrdThrottle/XrdThrottle.hh
+++ b/src/XrdThrottle/XrdThrottle.hh
@@ -121,11 +121,25 @@ public:
    newFile(char *user=0, int monid=0);
 
    virtual int
+   chksum(      csFunc         Func,
+          const char          *csName,
+          const char          *path,
+                XrdOucErrInfo &eInfo,
+          const XrdSecEntity  *client = 0,
+          const char          *opaque = 0);
+
+   virtual int
    chmod(const char             *Name,
                XrdSfsMode        Mode,
                XrdOucErrInfo    &out_error,
          const XrdSecEntity     *client,
          const char             *opaque = 0);
+
+   virtual void
+   Disc(const XrdSecEntity   *client = 0);
+
+   virtual void
+   EnvInfo(XrdOucEnv *envP);
 
    virtual int
    exists(const char                *fileName,

--- a/src/XrdThrottle/XrdThrottleFileSystem.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystem.cc
@@ -35,6 +35,17 @@ FileSystem::newFile(char *user,
 }
 
 int
+FileSystem::chksum(      csFunc         Func,
+                  const char          *csName,
+                  const char          *path,
+                        XrdOucErrInfo &eInfo,
+                  const XrdSecEntity  *client,
+                  const char          *opaque)
+{
+   return m_sfs_ptr->chksum(Func, csName, path, eInfo, client, opaque);
+}
+
+int
 FileSystem::chmod(const char             *Name,
                         XrdSfsMode        Mode,
                         XrdOucErrInfo    &out_error,
@@ -42,6 +53,18 @@ FileSystem::chmod(const char             *Name,
                   const char             *opaque)
 {
    return m_sfs_ptr->chmod(Name, Mode, out_error, client, opaque);
+}
+
+void
+FileSystem::Disc(const XrdSecEntity *client)
+{
+   m_sfs_ptr->Disc(client);
+}
+
+void
+FileSystem::EnvInfo(XrdOucEnv *envP)
+{
+   m_sfs_ptr->EnvInfo(envP);
 }
 
 int


### PR DESCRIPTION
All the missing passthroughs for the throttle code should now be there.