### PR TITLE
XrdBuffer: Decrement total buffer count when freeing buffers

### DIFF
--- a/src/Xrd/XrdBuffer.cc
+++ b/src/Xrd/XrdBuffer.cc
@@ -290,6 +290,7 @@ while(1)
                     delete bp;
                     bucket[i].numbuf--; numfreed++;
                     memhave -= memslot; totalo  -= memslot;
+                    totbuf--;
                    } else {bucket[i].numbuf = 0; break;}
            Reshaper.UnLock();
            memslot = memslot>>1;


### PR DESCRIPTION
If the total buffer count (totbuf) is incorrectly high, the request profile (bufprof) will also be disproportionately high: it's scaled by the buffer count. The buffer pool is not reshaped, with too many buffers being held.

This patch decrements the total buffer count as buffers are deleted, matching the behavior of XrdBuffXL.