### PR TITLE
Fix comparison always false error

### DIFF
--- a/src/XrdSsi/XrdSsiShMat.hh
+++ b/src/XrdSsi/XrdSsiShMat.hh
@@ -101,10 +101,12 @@ struct CRZParms
        int  maxKeys; //!< Maximum number of keys-value pairs expected in table.
        int  maxKLen; //!< The maximum acceptable key length.
        int  mode;    //!< Filemode for the newly created file.
-       char multW;   //!<  1: Table can have multiple processes writing.
+       signed char multW;
+                     //!<  1: Table can have multiple processes writing.
                      //!<  0: Table has only one process writing.
                      //!< -1: Use default or, for resize, previous setting.
-       char reUse;   //!<  1: Reuse deleted objects.
+       signed char reUse;
+                     //!<  1: Reuse deleted objects.
                      //!<  0: Never reuse deleted objects.
                      //!< -1: Use default or, for resize, previous setting.
        char rsvd[6]; //!< Reserved for future options


### PR DESCRIPTION
On systems where char by default is unsigned compilation fails with:
```
/builddir/build/BUILD/xrootd-4.7.0/src/XrdSsi/XrdSsiShMam.cc: In member function 'virtual bool XrdSsiShMam::Resize(XrdSsiShMat::CRZParms&)':
/builddir/build/BUILD/xrootd-4.7.0/src/XrdSsi/XrdSsiShMam.cc:1128:22: error: comparison is always false due to limited range of data type [-Werror=type-limits]
    if (parms.reUse < 0) parms.reUse   = reUse;
                      ^
/builddir/build/BUILD/xrootd-4.7.0/src/XrdSsi/XrdSsiShMam.cc:1129:22: error: comparison is always false due to limited range of data type [-Werror=type-limits]
    if (parms.multW < 0) parms.multW   = multW;
                      ^
cc1plus: all warnings being treated as errors
make[2]: Leaving directory `/builddir/build/BUILD/xrootd-4.7.0/build'
make[2]: *** [src/CMakeFiles/XrdSsiShMap.dir/XrdSsi/XrdSsiShMam.cc.o] Error 1
```

This pull request fixes the issue.

Affected (char is unsigned by default):
* aarch64
* armv7hl
* ppc64
* ppc64le
* s390x

Not affected (char is signed by default):
* i686
* x86_64

See: https://koji.fedoraproject.org/koji/taskinfo?taskID=21518473
