### PR TITLE
Make xlBuff static to fix ODR violation

### DIFF
--- a/src/Xrd/XrdBuffer.cc
+++ b/src/Xrd/XrdBuffer.cc
@@ -66,15 +66,9 @@ const char *XrdBuffManager::TraceID = "BuffManager";
 namespace
 {
 static const int minBuffSz = 1 << XRD_BUSHIFT;
+static XrdBuffXL xlBuff;
 }
 
-namespace XrdGlobal
-{
-XrdBuffXL xlBuff;
-}
-
-using namespace XrdGlobal;
- 
 /******************************************************************************/
 /*                           C o n s t r u c t o r                            */
 /******************************************************************************/

--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -89,13 +89,9 @@ extern int ka_Itvl;
 extern int ka_Icnt;
 };
 
-namespace XrdGlobal
-{
-XrdBuffXL xlBuff;
-}
-
 namespace
 {
+XrdBuffXL  xlBuff;
 XrdOucEnv  theEnv;
 };
 
@@ -501,7 +497,7 @@ int XrdConfig::Configure(int argc, char **argv)
 
 // Put largest buffer size in the env
 //
-   theEnv.PutInt("MaxBuffSize", XrdGlobal::xlBuff.MaxSize());
+   theEnv.PutInt("MaxBuffSize", xlBuff.MaxSize());
 
 // Export the network interface list at this point
 //
@@ -1196,7 +1192,7 @@ int XrdConfig::xbuf(XrdSysError *eDest, XrdOucStream &Config)
            {eDest->Emsg("Config", "max buffer size not specified"); return 1;}
         if (XrdOuca2x::a2sz(*eDest,"maxbz value",val,&blim,minBSZ,maxBSZ))
            return 1;
-        XrdGlobal::xlBuff.Init(blim);
+        xlBuff.Init(blim);
         if (!(val = Config.GetWord())) return 0;
        }
 


### PR DESCRIPTION
xlBuff was being defined in two separate compilation units,
thus violating C++'s one-definition-rule. The linker did not
complain, since the two symbols were defined in two different
libraries loaded at runtime.

Caught by ASan:

==10109==ERROR: AddressSanitizer: odr-violation (0x00000144a5e0):
  [1] size=80 'XrdGlobal::xlBuff' /home/gbitzes/xrootd/src/Xrd/XrdConfig.cc:94:11
  [2] size=80 'XrdGlobal::xlBuff' /home/gbitzes/xrootd/src/Xrd/XrdBuffer.cc:73:11
These globals were registered at these points:
  [1]:
    #0 0x435b40 (/home/gbitzes/xrootd/build-asan-clang/install/bin/xrootd+0x435b40)
    #1 0x51eee9 (/home/gbitzes/xrootd/build-asan-clang/install/bin/xrootd+0x51eee9)
  [2]:
    #0 0x435b40 (/home/gbitzes/xrootd/build-asan-clang/install/bin/xrootd+0x435b40)
    #1 0x7f7a70ceb41b (/home/gbitzes/xrootd/build-asan-clang/install/lib64/libXrdUtils.so.2+0x12441b)