### PR TITLE
Pass Authorization header to the bridge via opaque info

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -185,6 +185,9 @@ int XrdHttpReq::parseLine(char *line, int len) {
     } else if (!strcmp(key, "Destination")) {
       destination.assign(val, line+len-val);
       trim(destination);
+    } else if (!strcmp(key, "Authorization")) {
+      authorization.assign(val, line+len-val);
+      trim(authorization);
     } else if (!strcmp(key, "Depth")) {
       depth = -1;
       if (strcmp(val, "infinity"))
@@ -762,9 +765,24 @@ int XrdHttpReq::ProcessHTTPReq() {
     return 1; // There was an error and a response was sent
     
   }
-  
-  
-  
+
+  /// If we have received extra authorization information, add it here.
+  //  NOTE: this was already added to the headers given to the XrdHttpExtReq -
+  //  no need to interact with the code above
+  if (!authorization.empty()) {
+    const char *p = strchr(resourceplusopaque.c_str(), '?');
+    if (p) {
+      resourceplusopaque.append("&authz=");
+    } else {
+      resourceplusopaque.append("?authz=");
+    }
+    resourceplusopaque.append(quote(authorization.c_str()));
+    // Once we've appended the authorization to the full resource+opaque string,
+    // reset the authz to empty: this way, any operation that triggers repeated ProcessHTTPReq
+    // calls won't also trigger multiple copies of the authz.
+    authorization = "";
+  }
+
   //
   // Here we process the request locally
   //

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -776,6 +776,7 @@ int XrdHttpReq::ProcessHTTPReq() {
     } else {
       resourceplusopaque.append("?authz=");
     }
+    TRACEI(DEBUG, "Appended Authorization header to opaque info.");
     resourceplusopaque.append(quote(authorization.c_str()));
     // Once we've appended the authorization to the full resource+opaque string,
     // reset the authz to empty: this way, any operation that triggers repeated ProcessHTTPReq

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -194,6 +194,8 @@ public:
   /// The destination field specified in the req
   std::string destination;
 
+  /// The authorization specified in the req;
+  std::string authorization;
 
   //
   // Area for coordinating request and responses to/from the bridge

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -319,7 +319,7 @@ char *unquote(char *str) {
 
 // Quote a string and return a new one
 
-char *quote(char *str) {
+char *quote(const char *str) {
   int l = strlen(str);
   char *r = (char *) malloc(l*3 + 1);
   r[0] = '\0';

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -73,7 +73,7 @@ int compareHash(
 
 
 // Create a new quoted string
-char *quote(char *str);
+char *quote(const char *str);
 
 // unquote a string and return a new one
 char *unquote(char *str);


### PR DESCRIPTION
This translates the `Authorization` HTTP header into the `authz` opaque info.

It allows for the ACC layer to do things like authorize requests based on tokens, analogously to how ALICE token-based auth has always worked.