### PR TITLE
XrdLink: Increment the IOSemaphore once for each waiting thread

### DIFF
--- a/src/Xrd/XrdLink.cc
+++ b/src/Xrd/XrdLink.cc
@@ -1112,9 +1112,10 @@ void XrdLink::setRef(int use)
              XrdLog->Emsg("Link", "Zero use count for", ID);
             }
     else if (InUse == 1 && doPost)
-            {doPost--;
-             IOSemaphore.Post();
-             TRACEI(CONN, "setRef posted link");
+            {while(doPost--)
+                {IOSemaphore.Post();
+                 TRACEI(CONN, "setRef posted link");
+                }
              opMutex.UnLock();
             }
     else if (InUse < 0)


### PR DESCRIPTION
Under some workloads, there's a timing issue that can show up in XrdLink and the reference count. XrdLink uses a semaphore (IOSemaphore) to block XrdLink::Close() until all the threads associated with a link are complete. In some cases, two threads are waiting for the semaphore, but only a single signal is eventually given. This leaves a stuck thread and an open XrdLink object. Here's a backtrace of a stuck thread:

```
Thread 504 (Thread 0x7fe3254dc700 (LWP 964972)):
#0  0x00007fe60927d79b in futex_abstimed_wait (cancel=true, private=<optimized out>, abstime=0x0, expected=0, futex=0x7fe50c018c40) at ../nptl/sysdeps/unix/sysv/linux/sem_waitcommon.c:43
#1  do_futex_wait (sem=sem@entry=0x7fe50c018c40, abstime=0x0) at ../nptl/sysdeps/unix/sysv/linux/sem_waitcommon.c:223
#2  0x00007fe60927d82f in __new_sem_wait_slow (sem=0x7fe50c018c40, abstime=0x0) at ../nptl/sysdeps/unix/sysv/linux/sem_waitcommon.c:292
#3  0x00007fe60927d8cb in __new_sem_wait (sem=<optimized out>) at ../nptl/sysdeps/unix/sysv/linux/sem_wait.c:28
#4  0x00007fe6096f73ae in Wait (this=<optimized out>) at /usr/src/debug/xrootd/xrootd/src/XrdSys/XrdSysPthread.hh:348
#5  XrdLink::Serialize (this=0x7fe50c018a08) at /usr/src/debug/xrootd/xrootd/src/Xrd/XrdLink.cc:1070
#6  0x00007fe6096f7d50 in XrdLink::Close (this=0x7fe50c018a08, defer=<optimized out>) at /usr/src/debug/xrootd/xrootd/src/Xrd/XrdLink.cc:358
#7  0x00007fe6096fb3ff in XrdScheduler::Run (this=0x610e58 <XrdMain::Config+440>) at /usr/src/debug/xrootd/xrootd/src/Xrd/XrdScheduler.cc:357
#8  0x00007fe6096fb549 in XrdStartWorking (carg=<optimized out>) at /usr/src/debug/xrootd/xrootd/src/Xrd/XrdScheduler.cc:87
#9  0x00007fe6096bb097 in XrdSysThread_Xeq (myargs=0x7fe1e1515f70) at /usr/src/debug/xrootd/xrootd/src/XrdSys/XrdSysPthread.cc:86
#10 0x00007fe609277dc5 in start_thread (arg=0x7fe3254dc700) at pthread_create.c:308
#11 0x00007fe60857d73d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:113
```

The XrdLink reference count is updated by XrdLink::setRef(). When the refcount drops to one and there's a thread waiting in XrdLink::Serialize(), it increments IOSemaphore, allowing the waiting Serialize() call to complete.

> https://github.com/xrootd/xrootd/blob/master/src/Xrd/XrdLink.cc#L1114

However, there can be more than one active XrdLink::Serialize() call. Evidence of the issue shows up in the logs.

```
170909 07:19:01 1757843 nobody.203:2841@proxy-2.example.edu XrdLink: Waiting for link serialization; use=5
^-- One thread waiting on IOSemaphore in Serialize()
170909 07:19:02 1764813 XrdPoll: Poller 0 enabled nobody.203:2841@proxy-2.example.edu
170909 07:19:03 1770916 XrdLink: Unable to send to nobody.203:2841@proxy-2.example.edu; connection reset by peer
170909 07:19:03 1766122 XrdLink: Unable to send to nobody.203:2841@proxy-2.example.edu; broken pipe
170909 07:19:03 1765927 XrdLink: Unable to send to nobody.203:2841@proxy-2.example.edu; broken pipe
170909 07:19:03 1765031 nobody.203:2841@proxy-2.example.edu XrdLink: Setting ref to 5+-1 post=1
170909 07:19:03 1770966 XrdLink: Unable to send to nobody.203:2841@proxy-2.example.edu; broken pipe
170909 07:19:03 1770916 XrdSched: running nobody.203:2841@proxy-2.example.edu inq=0
170909 07:19:03 1765762 nobody.203:2841@proxy-2.example.edu XrdLink: Setting ref to 4+-1 post=1
170909 07:19:03 1765244 nobody.203:2841@proxy-2.example.edu XrdLink: Setting ref to 3+-1 post=1
170909 07:19:03 1770916 nobody.203:2841@proxy-2.example.edu XrdLink: Close defered, use count=2
170909 07:19:03 1770916 nobody.203:2841@proxy-2.example.edu XrdLink: Waiting for link serialization; use=2
^-- Two threads waiting on IOSemaphore in Serialize()
170909 07:19:03 1765198 nobody.203:2841@proxy-2.example.edu XrdLink: Setting ref to 2+-1 post=2
^-- Refcount has dropped to 1
170909 07:19:03 1765198 nobody.203:2841@proxy-2.example.edu XrdLink: setRef posted link
^-- IOSemaphore has been incremented, releasing one waiting thread
```

This patch increments IOSemaphore once for each waiting thread.