### PR TITLE
Make HTTP external handlers more flexible

### DIFF
--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -104,7 +104,7 @@ set( XROOTD_PUBLIC_HEADERS
   XrdXrootd/XrdXrootdMonData.hh
   XrdXrootd/XrdXrootdBridge.hh
   XrdHttp/XrdHttpSecXtractor.hh
-
+  XrdHttp/XrdHttpExtHandler.hh
 )
 
 set( XROOTD_PRIVATE_HEADERS
@@ -145,7 +145,6 @@ set( XROOTD_PRIVATE_HEADERS
   XrdOss/XrdOssError.hh
   XrdOuc/XrdOucExport.hh
   XrdOuc/XrdOucPList.hh
-  XrdHttp/XrdHttpExtHandler.hh
 )
 
 install_headers(

--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -43,6 +43,12 @@ int XrdHttpExtReq::BuffgetData(int blen, char **data, bool wait) {
 }
 
 
+const XrdSecEntity &XrdHttpExtReq::GetSecEntity() const
+{
+  return prot->SecEntity;
+}
+
+
 XrdHttpExtReq::XrdHttpExtReq(XrdHttpReq *req, XrdHttpProtocol *pr): prot(pr),
 verb(req->requestverb), headers(req->allheaders) {
   // Here we fill the request summary with all the fields we can

--- a/src/XrdHttp/XrdHttpExtHandler.hh
+++ b/src/XrdHttp/XrdHttpExtHandler.hh
@@ -71,7 +71,7 @@ public:
   
   /// Tells if the incoming path is recognized as one of the paths that have to be processed
   // e.g. applying a prefix matching scheme or whatever
-  virtual bool MatchesPath(const char *path) = 0;
+  virtual bool MatchesPath(const char *verb, const char *path) = 0;
   
   /// Process an HTTP request and send the response using the calling
   ///  XrdHttpProtocol instance directly

--- a/src/XrdHttp/XrdHttpExtHandler.hh
+++ b/src/XrdHttp/XrdHttpExtHandler.hh
@@ -55,6 +55,9 @@ public:
   std::string clientdn, clienthost, clientgroups;
   long long length;
   
+  // A view of the XrdSecEntity associated with the request.
+  const XrdSecEntity &GetSecEntity() const;
+
   /// Get a pointer to data read from the client, valid for up to blen bytes from the buffer. Returns the validity
   int BuffgetData(int blen, char **data, bool wait);
 
@@ -111,6 +114,8 @@ public:
 //!                  may be null though that would be impossible.
 //! @param  parms -> Argument string specified on the namelib directive. It may
 //!                  be null or point to a null string if no parms exist.
+//! @param  myEnv -> Environment variables for configuring the external handler;
+//!                  it my be null.
 //!
 //! @return Success: A pointer to an instance of the XrdHttpSecXtractor object.
 //!         Failure: A null pointer which causes initialization to fail.
@@ -119,10 +124,12 @@ public:
 //------------------------------------------------------------------------------
 
 class XrdSysError;
+class XrdOucEnv;
 
 #define XrdHttpExtHandlerArgs XrdSysError       *eDest, \
                               const char        *confg, \
-                              const char        *parms
+                              const char        *parms, \
+                              XrdOucEnv         *myEnv
 
 extern "C" XrdHttpExtHandler *XrdHttpGetExtHandler(XrdHttpExtHandlerArgs);
 

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -25,6 +25,7 @@
 
 #include "Xrd/XrdBuffer.hh"
 #include "Xrd/XrdLink.hh"
+#include "Xrd/XrdInet.hh"
 #include "XProtocol/XProtocol.hh"
 #include "XrdOuc/XrdOucStream.hh"
 #include "XrdOuc/XrdOucEnv.hh"
@@ -830,10 +831,10 @@ int XrdHttpProtocol::Stats(char *buff, int blen, int do_sync) {
 /******************************************************************************/
 
 #define TS_Xeq(x,m) (!strcmp(x,var)) GoNo = m(Config)
+#define TS_Xeq3(x,m) (!strcmp(x,var)) GoNo = m(Config, ConfigFN, myEnv)
 
-int XrdHttpProtocol::Config(const char *ConfigFN) {
-  XrdOucEnv myEnv;
-  XrdOucStream Config(&eDest, getenv("XRDINSTANCE"), &myEnv, "=====> ");
+int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
+  XrdOucStream Config(&eDest, getenv("XRDINSTANCE"), myEnv, "=====> ");
   char *var;
   int cfgFD, GoNo, NoGo = 0, ismine;
 
@@ -860,7 +861,7 @@ int XrdHttpProtocol::Config(const char *ConfigFN) {
       else if TS_Xeq("secretkey", xsecretkey);
       else if TS_Xeq("desthttps", xdesthttps);
       else if TS_Xeq("secxtractor", xsecxtractor);
-      else if TS_Xeq("exthandler", xexthandler);
+      else if TS_Xeq3("exthandler", xexthandler);
       else if TS_Xeq("selfhttps2http", xselfhttps2http);
       else if TS_Xeq("embeddedstatic", xembeddedstatic);
       else if TS_Xeq("listingredir", xlistredir);
@@ -1294,7 +1295,10 @@ int XrdHttpProtocol::Configure(char *parms, XrdProtocol_Config * pi) {
 
   Window = pi->WSize;
 
-
+  pi->NetTCP->netIF.Port(Port);
+  pi->NetTCP->netIF.Display("Config ");
+  pi->theEnv->PutPtr("XrdInet*", (void *)(pi->NetTCP));
+  pi->theEnv->PutPtr("XrdNetIF*", (void *)(&(pi->NetTCP->netIF)));
 
   // Prohibit this program from executing as superuser
   //
@@ -1323,7 +1327,7 @@ int XrdHttpProtocol::Configure(char *parms, XrdProtocol_Config * pi) {
   // Now process and configuration parameters
   //
   rdf = (parms && *parms ? parms : pi->ConfigFN);
-  if (rdf && Config(rdf)) return 0;
+  if (rdf && Config(rdf, pi->theEnv)) return 0;
   if (pi->DebugON) XrdHttpTrace->What = TRACE_ALL;
 
   // Set the redirect flag if we are a pure redirector
@@ -2194,7 +2198,7 @@ int XrdHttpProtocol::xsecxtractor(XrdOucStream & Config) {
  *  Output: 0 upon success or !0 upon failure.
  */
 
-int XrdHttpProtocol::xexthandler(XrdOucStream & Config) {
+int XrdHttpProtocol::xexthandler(XrdOucStream & Config, const char *ConfigFN, XrdOucEnv *myEnv) {
   char *val, valbuf[1024];
   char *parm;
   
@@ -2210,7 +2214,7 @@ int XrdHttpProtocol::xexthandler(XrdOucStream & Config) {
     
     // Try to load the plugin (if available) that extracts info from the user cert/proxy
     //
-    if (LoadExtHandler(&eDest, valbuf, parm))
+    if (LoadExtHandler(&eDest, valbuf, ConfigFN, parm, myEnv))
       return 1;
   }
   
@@ -2367,7 +2371,8 @@ int XrdHttpProtocol::LoadSecXtractor(XrdSysError *myeDest, const char *libName,
 
 // Loads the external handler plugin, if available
 int XrdHttpProtocol::LoadExtHandler(XrdSysError *myeDest, const char *libName,
-                                     const char *libParms) {
+                                    const char *configFN, const char *libParms,
+                                    XrdOucEnv *myEnv) {
   
   // We don't want to load it more than once
   if (exthandler) return 1;
@@ -2379,7 +2384,7 @@ int XrdHttpProtocol::LoadExtHandler(XrdSysError *myeDest, const char *libName,
   // Get the entry point of the object creator
   //
   ep = (XrdHttpExtHandler *(*)(XrdHttpExtHandlerArgs))(myLib.Resolve("XrdHttpGetExtHandler"));
-  if (ep && (exthandler = ep(myeDest, NULL, libParms))) return 0;
+  if (ep && (exthandler = ep(myeDest, configFN, libParms, myEnv))) return 0;
   myLib.Unload();
   return 1;
 }

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -737,7 +737,7 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
   // Now we have everything that is needed to try the login
   // Remember that if there is an exthandler then it has the responsibility
   // for authorization in the paths that it manages
-  if (!exthandler || !exthandler->MatchesPath(CurrentReq.resource.c_str())) {
+  if (!exthandler || !exthandler->MatchesPath(CurrentReq.requestverb.c_str(), CurrentReq.resource.c_str())) {
     if (!Bridge) {
       if (SecEntity.name)
         Bridge = XrdXrootd::Bridge::Login(&CurrentReq, Link, &SecEntity, SecEntity.name, "XrdHttp");

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -149,12 +149,12 @@ private:
 
   
   /// Functions related to the configuration
-  static int Config(const char *fn);
+  static int Config(const char *fn, XrdOucEnv *myEnv);
   static int xtrace(XrdOucStream &Config);
   static int xsslcert(XrdOucStream &Config);
   static int xsslkey(XrdOucStream &Config);
   static int xsecxtractor(XrdOucStream &Config);
-  static int xexthandler(XrdOucStream & Config);
+  static int xexthandler(XrdOucStream & Config, const char *ConfigFN, XrdOucEnv *myEnv);
   static int xsslcadir(XrdOucStream &Config);
   static int xdesthttps(XrdOucStream &Config);
   static int xlistdeny(XrdOucStream &Config);
@@ -177,7 +177,8 @@ private:
   
   // Loads the ExtHandler plugin, if available
   static int LoadExtHandler(XrdSysError *eDest, const char *libName,
-                             const char *libParms);
+                            const char *configFN, const char *libParms,
+                            XrdOucEnv *myEnv);
 
   /// Circular Buffer used to read the request
   XrdBuffer *myBuff;

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -756,7 +756,7 @@ int XrdHttpReq::ProcessHTTPReq() {
   
   
   // Verify if we have an external handler for this request
-  if (prot->exthandler && prot->exthandler->MatchesPath(this->resource.c_str())) {
+  if (prot->exthandler && prot->exthandler->MatchesPath(this->requestverb.c_str(), this->resource.c_str())) {
     XrdHttpExtReq xreq(this, prot);
     int r = prot->exthandler->ProcessReq(xreq);
     reset();

--- a/src/XrdVersionPlugin.hh
+++ b/src/XrdVersionPlugin.hh
@@ -96,6 +96,7 @@
         XrdVERSIONPLUGIN_Rule(DoNotChk,  4,  0, XrdgetProtocol                )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdgetProtocolPort            )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdHttpGetSecXtractor         )\
+        XrdVERSIONPLUGIN_Rule(Required,  4,  8, XrdHttpGetExtHandler          )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdSysLogPInit                )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdOssGetStorageSystem        )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdOssStatInfoInit            )\


### PR DESCRIPTION
This improves the HTTP external handler environment and interface to have richer semantics.

- Pass down the `XrdOucEnv` object when the object is initialized; necessary to initialize other parts of Xrootd.
- Allow one to access the `XrdSecEntity` object associated with a request.
- Allow filtering based on HTTP verb in `MatchesPath`.
- Make this a public plug-in interface and declare ABI compatibility.

@ffurano - this is meant to fix #585 