### PR TITLE
Allow XrdSfsGetDefaultFileSystem to be called multiple times

### DIFF
--- a/src/XrdOfs/XrdOfsConfig.cc
+++ b/src/XrdOfs/XrdOfsConfig.cc
@@ -134,6 +134,11 @@ int XrdOfs::Configure(XrdSysError &Eroute, XrdOucEnv *EnvInfo) {
 //
    Eroute.Say("++++++ File system initialization started.");
 
+// Each time XrdSfsGetDefaultFileSystem is invoked, it'll reuse the same XrdOfs
+// object but call the Configure method again.  If poscLog is not reset, then
+// a stale value may be reused.
+   poscLog = NULL;
+
 // Establish the network interface that the caller must provide
 //
    if (!EnvInfo || !(myIF = (XrdNetIF *)EnvInfo->GetPtr("XrdNetIF*")))
@@ -190,7 +195,8 @@ int XrdOfs::Configure(XrdSysError &Eroute, XrdOucEnv *EnvInfo) {
 
 // Check if redirection wanted
 //
-   if (getenv("XRDREDIRECT")) i  = isManager;
+   const char *redirect_val = getenv("XRDREDIRECT");
+   if (redirect_val && strcmp(redirect_val, "0")) i  = isManager;
       else i = 0;
    if (getenv("XRDRETARGET")) i |= isServer;
    if (getenv("XRDREDPROXY")) i |= isProxy;


### PR DESCRIPTION
When requesting the default filesystem, a statically-initialized singleton object is returned - but the `Configure` method of that singleton is invoked for each call to `XrdSfsGetDefaultFileSystem`.

Unfortunately, there are several pieces of the object's state that leak through after each `Configure` call (in the environment or in the `XrdOfs` object member variables).  This effectively limits us to a single invocation of `XrdSfsGetDefaultFileSystem`.

This PR resets the leaky pieces of state, allowing a valid OFS object to be returned each time.