### PR TITLE
[XrdCl] Fix error checking when setting sec.uid, sec.gid

### DIFF
--- a/src/XrdCl/XrdClUtils.hh
+++ b/src/XrdCl/XrdClUtils.hh
@@ -255,7 +255,7 @@ namespace XrdCl
         if(pFsUid >= 0) {
           pPrevFsUid = setfsuid(pFsUid);
 
-          if(setfsuid(-1) != pFsUid) {
+          if(setfsuid(pFsUid) != pFsUid) {
             pOk = false;
             return;
           }
@@ -267,7 +267,7 @@ namespace XrdCl
         if(pFsGid >= 0) {
           pPrevFsGid = setfsgid(pFsGid);
 
-          if(setfsgid(-1) != pFsGid) {
+          if(setfsgid(pFsGid) != pFsGid) {
             pOk = false;
             return;
           }

--- a/src/XrdCl/XrdClUtils.hh
+++ b/src/XrdCl/XrdClUtils.hh
@@ -26,6 +26,8 @@
 #include "XrdCl/XrdClURL.hh"
 #include "XrdCl/XrdClXRootDResponses.hh"
 #include "XrdCl/XrdClPropertyList.hh"
+#include "XrdCl/XrdClDefaultEnv.hh"
+#include "XrdCl/XrdClConstants.hh"
 #include "XrdNet/XrdNetUtils.hh"
 
 #include <sys/time.h>
@@ -243,7 +245,8 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Constructor
       //------------------------------------------------------------------------
-      ScopedFsUidSetter(uid_t fsuid, gid_t fsgid) : pFsUid(fsuid), pFsGid(fsgid)
+      ScopedFsUidSetter(uid_t fsuid, gid_t fsgid, const std::string &streamName)
+      : pFsUid(fsuid), pFsGid(fsgid), pStreamName(streamName)
       {
         pOk = true;
         pPrevFsUid = -1;
@@ -278,12 +281,16 @@ namespace XrdCl
       //! Destructor
       //------------------------------------------------------------------------
       ~ScopedFsUidSetter() {
+        Log *log = DefaultEnv::GetLog();
+
         if(pPrevFsUid >= 0) {
-          setfsuid(pPrevFsUid);
+          int retcode = setfsuid(pPrevFsUid);
+          log->Dump(XRootDTransportMsg, "[%s] Restored fsuid from %d to %d", pStreamName.c_str(), retcode, pPrevFsUid);
         }
 
         if(pPrevFsGid >= 0) {
-          setfsgid(pPrevFsGid);
+          int retcode = setfsgid(pPrevFsGid);
+          log->Dump(XRootDTransportMsg, "[%s] Restored fsgid from %d to %d", pStreamName.c_str(), retcode, pPrevFsGid);
         }
       }
 
@@ -294,6 +301,8 @@ namespace XrdCl
     private:
       int pFsUid;
       int pFsGid;
+
+      const std::string &pStreamName;
 
       int pPrevFsUid;
       int pPrevFsGid;

--- a/src/XrdCl/XrdClXRootDTransport.cc
+++ b/src/XrdCl/XrdClXRootDTransport.cc
@@ -1836,7 +1836,7 @@ namespace XrdCl
     if(secgidc) secgid = atoi(secgidc);
 
 #ifdef __linux__
-    ScopedFsUidSetter uidSetter(secuid, secgid);
+    ScopedFsUidSetter uidSetter(secuid, secgid, hsData->streamName);
     if(!uidSetter.IsOk()) {
       log->Error( XRootDTransportMsg, "[%s] Error while setting (fsuid, fsgid) to (%d, %d)",
                   hsData->streamName.c_str(), secuid, secgid );


### PR DESCRIPTION
Previously, I was calling setfsuid(-1) to check if the
previous call had succeeded, since this syscall will
always return the current fsuid, whether the syscall
itself succeeded or not. There's no way to check
other than calling setfsuid again, since there's no
getfsuid.

The expectation was that setfsuid(-1) will always fail
and not affect the fsuid, effectively acting as getfsuid,
but it appears that on SLC6 it succeeds, setting the
fsuid to.. 4294967295. On Fedora 26 it fails as expected,
I have no idea why there's a difference.

Instead, let's use setfsuid(pFsUid) again, just to
check if the previous call succeeded.