### PR TITLE
[pfc] Bugfix in reading of last access time for file purging.

### DIFF
--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -378,6 +378,7 @@ bool Info::GetLatestDetachTime(time_t& t) const
 {
    if (! m_store.m_accessCnt) return false;
 
-   t =  m_store.m_astats[m_store.m_accessCnt-1].DetachTime;
+   size_t entry = std::min(m_store.m_accessCnt, m_maxNumAccess) - 1;
+   t =  m_store.m_astats[entry].DetachTime;
    return true;
 }


### PR DESCRIPTION
Access history in cache meta-data is fixed size now, make sure we do not read beyond the end.

The file purge checking code was reading beyond the end and could lead to random behavior or crashes once the number of times a file was accessed grew beyond the internal size limit (20).

Please merge this also into stable-4.7.x.