### PR TITLE
Allow overwrites to be done on PUT.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1090,7 +1090,7 @@ int XrdHttpReq::ProcessHTTPReq() {
         l = resourceplusopaque.length() + 1;
         xrdreq.open.dlen = htonl(l);
         xrdreq.open.mode = htons(kXR_ur | kXR_uw | kXR_gw | kXR_gr | kXR_or);
-        xrdreq.open.options = htons(kXR_mkpath | kXR_open_updt | kXR_new);
+        xrdreq.open.options = htons(kXR_mkpath | kXR_open_wrto );
 
         if (!prot->Bridge->Run((char *) &xrdreq, (char *) resourceplusopaque.c_str(), l)) {
           prot->SendSimpleResp(404, NULL, NULL, (char *) "Could not run request.", 0);


### PR DESCRIPTION
HTTP PUT is supposed to be idempotent - i.e., it should be done many times.  Hence, we should be able to overwrite an existing file; this requires tweaking the existing flags used to open the file.