### PR TITLE
[XrdSys] Fix data race on cP->dlType

### DIFF
--- a/src/XrdSys/XrdSysIOEvents.cc
+++ b/src/XrdSys/XrdSysIOEvents.cc
@@ -593,8 +593,9 @@ void XrdSys::IOEvents::Poller::CbkTMO()
 //
    toMutex.Lock();
    while((cP = tmoBase) && cP->deadLine <= time(0))
-        {toMutex.UnLock();
-         CbkXeq(cP, cP->dlType, 0, 0);
+        {int dlType = cP->dlType;
+         toMutex.UnLock();
+         CbkXeq(cP, dlType, 0, 0);
          toMutex.Lock();
         }
    toMutex.UnLock();


### PR DESCRIPTION
cP->dlType is being read outside of the lock. Diagnosed through the
following report from ThreadSanitizer:

WARNING: ThreadSanitizer: data race (pid=13166)
  Write of size 1 at 0x7b28000100d0 by thread T29 (mutexes: write M0, write M0, write M1382, write M0, write M1385):
    -0 XrdSys::IOEvents::Poller::TmoAdd(XrdSys::IOEvents::Channel*, int) /home/gbitzes/xrootd/src/XrdSys/XrdSysIOEvents.cc:1088 (libXrdUtils.so.2+0x0000000338f1)
    -1 XrdSys::IOEvents::Channel::Enable(int, int, char const**) /home/gbitzes/xrootd/src/XrdSys/XrdSysIOEvents.cc:415 (libXrdUtils.so.2+0x0000000355b6)
    -2 XrdCl::PollerBuiltIn::EnableWriteNotification(XrdCl::Socket*, bool, unsigned short) /home/gbitzes/xrootd/src/XrdCl/XrdClPollerBuiltIn.cc:481 (libXrdCl.so.2+0x000000063c50)
    -3 XrdCl::AsyncSocketHandler::EnableUplink() /home/gbitzes/xrootd/src/./XrdCl/XrdClAsyncSocketHandler.hh:96 (libXrdCl.so.2+0x00000006d06f)
    -4 XrdCl::Stream::EnableLink(XrdCl::PathID&) /home/gbitzes/xrootd/src/XrdCl/XrdClStream.cc:226 (libXrdCl.so.2+0x00000006d06f)
    -5 XrdCl::Stream::Send(XrdCl::Message*, XrdCl::OutgoingMsgHandler*, bool, long) /home/gbitzes/xrootd/src/XrdCl/XrdClStream.cc:316 (libXrdCl.so.2+0x00000006e0d7)
    -6 XrdCl::Channel::Send(XrdCl::Message*, XrdCl::OutgoingMsgHandler*, bool, long, XrdCl::VirtualRedirector*) /home/gbitzes/xrootd/src/XrdCl/XrdClChannel.cc:306 (libXrdCl.so.2+0x000000068686)
    -7 XrdCl::PostMaster::Send(XrdCl::URL const&, XrdCl::Message*, XrdCl::OutgoingMsgHandler*, bool, long) /home/gbitzes/xrootd/src/XrdCl/XrdClPostMaster.cc:198 (libXrdCl.so.2+0x000000066ec9)
    -8 XrdCl::MessageUtils::SendMessage(XrdCl::URL const&, XrdCl::Message*, XrdCl::ResponseHandler*, XrdCl::MessageSendParams const&) /home/gbitzes/xrootd/src/XrdCl/XrdClMessageUtils.cc:114 (libXrdCl.so.2+0x0000000b349e)
    -9 XrdCl::FileSystem::Send(XrdCl::Message*, XrdCl::ResponseHandler*, XrdCl::MessageSendParams&) /home/gbitzes/xrootd/src/XrdCl/XrdClFileSystem.cc:1419 (libXrdCl.so.2+0x000000085b3d)
    -10 XrdCl::FileSystem::Query(XrdCl::QueryCode::Code, XrdCl::Buffer const&, XrdCl::ResponseHandler*, unsigned short) /home/gbitzes/xrootd/src/XrdCl/XrdClFileSystem.cc:720 (libXrdCl.so.2+0x00000008fbe3)
    -11 XrdCl::FileSystem::Query(XrdCl::QueryCode::Code, XrdCl::Buffer const&, XrdCl::Buffer*&, unsigned short) /home/gbitzes/xrootd/src/XrdCl/XrdClFileSystem.cc:732 (libXrdCl.so.2+0x00000009006e)
    -12 backend::Query(XrdCl::FileSystem&, XrdCl::QueryCode::Code, XrdCl::Buffer&, XrdCl::Buffer*&) /afs/cern.ch/user/g/gbitzes/dev/eos/fusex/backend/backend.cc:875 (eosxd+0x00000067fb9f)
    -13 backend::putMD(fuse_id const&, eos::fusex::md*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, XrdSysMutex*) /afs/cern.ch/user/g/gbitzes/dev/eos/fusex/backend/backend.cc:454 (eosxd+0x00000068912e)
    -14 metad::mdcflush(ThreadAssistant&) /afs/cern.ch/user/g/gbitzes/dev/eos/fusex/md/md.cc:1887 (eosxd+0x000000611515)
    -15 void std::__invoke_impl<void, void (metad::*)(ThreadAssistant&), metad*, ThreadAssistant&>(std::__invoke_memfun_deref, void (metad::*&&)(ThreadAssistant&), metad*&&, ThreadAssistant&) /usr/include/c++/7/bits/invoke.h:73 (eosxd+0x0000005b1fb6)
    -16 std::__invoke_result<void (metad::*)(ThreadAssistant&), metad*, ThreadAssistant&>::type std::__invoke<void (metad::*)(ThreadAssistant&), metad*, ThreadAssistant&>(void (metad::*&&)(ThreadAssistant&), metad*&&, ThreadAssistant&) /usr/include/c++/7/bits/invoke.h:95 (eosxd+0x0000005b1fb6)
    -17 decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)(), (_S_declval<2ul>)())) std::thread::_Invoker<std::tuple<void (metad::*)(ThreadAssistant&), metad*, ThreadAssistant&> >::_M_invoke<0ul, 1ul, 2ul>(std::_Index_tuple<0ul, 1ul, 2ul>) /usr/include/c++/7/thread:234 (eosxd+0x0000005b1fb6)
    -18 std::thread::_Invoker<std::tuple<void (metad::*)(ThreadAssistant&), metad*, ThreadAssistant&> >::operator()() /usr/include/c++/7/thread:243 (eosxd+0x0000005b1fb6)
    -19 std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (metad::*)(ThreadAssistant&), metad*, ThreadAssistant&> > >::_M_run() /usr/include/c++/7/thread:186 (eosxd+0x0000005b1fb6)
    -20 <null> <null> (libstdc++.so.6+0x0000000bc01e)

  Previous read of size 1 at 0x7b28000100d0 by thread T34:
    -0 XrdSys::IOEvents::Poller::CbkTMO() /home/gbitzes/xrootd/src/XrdSys/XrdSysIOEvents.cc:597 (libXrdUtils.so.2+0x000000034d8a)
    -1 XrdSys::IOEvents::Poller::TmoGet() /home/gbitzes/xrootd/src/XrdSys/XrdSysIOEvents.cc:1150 (libXrdUtils.so.2+0x000000035166)
    -2 XrdSys::IOEvents::PollE::Begin(XrdSysSemaphore*, int&, char const**) /home/gbitzes/xrootd/src/./XrdSys/XrdSysIOEventsPollE.icc:213 (libXrdUtils.so.2+0x000000036787)
    -3 XrdSys::IOEvents::BootStrap::Start(void*) /home/gbitzes/xrootd/src/XrdSys/XrdSysIOEvents.cc:131 (libXrdUtils.so.2+0x000000030c5c)
    -4 XrdSysThread_Xeq /home/gbitzes/xrootd/src/XrdSys/XrdSysPthread.cc:86 (libXrdUtils.so.2+0x00000002d50f)
    -5 <null> <null> (libtsan.so.0+0x0000000257eb)