### PR TITLE
Allow parsing of unknown HTTP verbs.

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -545,9 +545,12 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
       }
 
 
-      if (CurrentReq.request == CurrentReq.rtUnknown) {
+      if (CurrentReq.request == CurrentReq.rtUnset) {
         TRACE(DEBUG, " Parsing first line: " << tmpline);
-        CurrentReq.parseFirstLine((char *)tmpline.c_str(), rc);
+        int result = CurrentReq.parseFirstLine((char *)tmpline.c_str(), rc);
+        if (result < 0) {
+          TRACE(DEBUG, " Parsing of first line failed with " << result);
+        }
       }
       else
         CurrentReq.parseLine((char *)tmpline.c_str(), rc);

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -814,7 +814,13 @@ int XrdHttpReq::ProcessHTTPReq() {
   //
 
   switch (request) {
+    case XrdHttpReq::rtUnset:
     case XrdHttpReq::rtUnknown:
+    {
+      prot->SendSimpleResp(400, NULL, NULL, (char *) "Request unknown", 0);
+      reset();
+      return -1;
+    }
     case XrdHttpReq::rtMalformed:
     {
       prot->SendSimpleResp(400, NULL, NULL, (char *) "Request malformed", 0);
@@ -2254,7 +2260,7 @@ void XrdHttpReq::reset() {
   if (ralist) free(ralist);
   ralist = 0;
 
-  request = rtUnknown;
+  request = rtUnset;
   resource = "";
   allheaders.clear();
 

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -144,6 +144,7 @@ public:
   /// These are the HTTP/DAV requests that we support
 
   enum ReqType {
+    rtUnset = -1,
     rtUnknown = 0,
     rtMalformed,
     rtGET,


### PR DESCRIPTION
If a HTTP verb (such as COPY) is encountered in an request, the
current code will try to parse subsequent headers as a HTTP status
line (mostly encountering garbage, but sometimes actually succeeding!).

We should instead note that a valid -- but unknown -- verb was encountered
and parse the remaining headers as headers.  This is useful because
external handlers might actually understand verbs (again, COPY) that the
built-in handlers do not.