### PR TITLE
Another attempt at getting HTTP PUT flags right.  Fix #637

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1090,7 +1090,7 @@ int XrdHttpReq::ProcessHTTPReq() {
         l = resourceplusopaque.length() + 1;
         xrdreq.open.dlen = htonl(l);
         xrdreq.open.mode = htons(kXR_ur | kXR_uw | kXR_gw | kXR_gr | kXR_or);
-        xrdreq.open.options = htons(kXR_mkpath | kXR_open_wrto );
+        xrdreq.open.options = htons(kXR_mkpath | kXR_open_wrto | kXR_delete);
 
         if (!prot->Bridge->Run((char *) &xrdreq, (char *) resourceplusopaque.c_str(), l)) {
           prot->SendSimpleResp(404, NULL, NULL, (char *) "Could not run request.", 0);


### PR DESCRIPTION
Originally, HTTP PUT could create but not overwrite.  While fixing
this, the flags were changed -- but it could overwrite and not create!

With this change, I have tested that both overwriting and creating
work.

We likely need additional follow-up because, with this change, a
user cannot perform HTTP PUT with the "create" authorization alone.