### PR TITLE
readline.h requires stdio.h to be compileable

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -24,6 +24,7 @@ else( READLINE_INCLUDE_DIR AND READLINE_LIBRARY )
     set( CMAKE_REQUIRED_INCLUDES ${READLINE_INCLUDE_DIR} )
     check_cxx_source_compiles(
       "
+      #include <stdio.h>
       #include <readline/readline.h>
       int main()
       {


### PR DESCRIPTION
readline.h uses the `FILE` datatype from stdio.h, without an #include for that system header. Upstream documents that it is the responsibility of any code using readline.h to include that other header itself, and relies on the fact that it is documented to declare that this is not a bug. Some distros patch their readline.h with this dependent #include, but for maximum portability the READLINE compile-test function should do it.

The xroot4 source files that use readline.h have includes for stdio.h (or cstdio) already.