### PR TITLE
Include crypt.h on Linux

### DIFF
--- a/src/XrdSecpwd/XrdSecpwdPlatform.hh
+++ b/src/XrdSecpwd/XrdSecpwdPlatform.hh
@@ -31,7 +31,7 @@
 //
 // crypt
 //
-#if defined(__solaris__)
+#if defined(__linux__) || defined(__solaris__)
 #include <crypt.h>
 #endif
 #if defined(__osf__) || defined(__sgi) || defined(__APPLE__)


### PR DESCRIPTION
With the update of glibc to version 2.27 crypt.h is not included recursively by some other include statement any longer but must be included explicitly.