### PR TITLE
Fix compilation on Mac with ENABLE_TESTS=ON

### DIFF
--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -13,7 +13,8 @@ target_link_libraries(
   pthread
   ${CPPUNIT_LIBRARIES}
   ${ZLIB_LIBRARY}
-  XrdCl)
+  XrdCl
+  XrdUtils)
 
 add_executable(text-runner TextRunner.cc PathProcessor.hh)
 target_link_libraries(text-runner dl ${CPPUNIT_LIBRARIES} pthread)


### PR DESCRIPTION
Fixes a linking error on macOS when `ENABLE_TESTS` is `ON`:
```
Undefined symbols for architecture x86_64:
  "XrdNetUtils::IPFormat(int, char*, int, int)", referenced from:
      XrdClTests::Server::HandleConnections() in Server.cc.o
```

My environment is macOS 10.13.3 High Sierra, CMake 3.10.2, XCode 9.2.

This change should not interfere with the Linux build.