### PR TITLE
Added XrdHttp cipherlist filter string config option

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -162,6 +162,7 @@ private:
   static int xsecxtractor(XrdOucStream &Config);
   static int xexthandler(XrdOucStream & Config, const char *ConfigFN, XrdOucEnv *myEnv);
   static int xsslcadir(XrdOucStream &Config);
+  static int xsslcipherfilter(XrdOucStream &Config);
   static int xdesthttps(XrdOucStream &Config);
   static int xlistdeny(XrdOucStream &Config);
   static int xlistredir(XrdOucStream &Config);
@@ -332,7 +333,7 @@ protected:
   static int Window;
 
   /// OpenSSL stuff
-  static char *sslcert, *sslkey, *sslcadir, *sslcafile;
+  static char *sslcert, *sslkey, *sslcadir, *sslcafile, *sslcipherfilter;
 
   /// Gridmap file location. The same used by XrdSecGsi
   static char *gridmap;// [s] gridmap file [/etc/grid-security/gridmap]


### PR DESCRIPTION
Added the **http.cipherfilter** config directive to specify the cipherlist filter string. 
The provided cipherlist filter string will be used when initializing the SSL context.

If the config misses the cipher filter directive, the following default is assumed: "ALL:!LOW:!EXP:!MD5:!MD2"

If the config specifies the directive, but no string or an invalid string is provided, initialization fails with an error message.

The goal is to make it easier to modify the list of permitted ciphers used by the XrdHttp component.