### PR TITLE
cryptossl/RSA : fix ExportPrivate and ExportPublic signatures

### DIFF
--- a/src/XrdCrypto/XrdCryptoRSA.cc
+++ b/src/XrdCrypto/XrdCryptoRSA.cc
@@ -88,7 +88,7 @@ int XrdCryptoRSA::ImportPublic(const char *, int)
 }
 
 //_____________________________________________________________________________
-int XrdCryptoRSA::ExportPublic(char *, int)
+int XrdCryptoRSA::ExportPublic(char *&, int)
 {
    // Abstract method to export the public key
    ABSTRACTMETHOD("XrdCryptoRSA::ExportPublic");
@@ -104,7 +104,7 @@ int XrdCryptoRSA::ImportPrivate(const char *, int)
 }
 
 //_____________________________________________________________________________
-int XrdCryptoRSA::ExportPrivate(char *, int)
+int XrdCryptoRSA::ExportPrivate(char *&, int)
 {
    // Abstract method to export the private key
    ABSTRACTMETHOD("XrdCryptoRSA::ExportPrivate");

--- a/src/XrdCrypto/XrdCryptoRSA.hh
+++ b/src/XrdCrypto/XrdCryptoRSA.hh
@@ -75,10 +75,10 @@ public:
 
    // Import / Export methods
    virtual int ImportPublic(const char *in, int lin);
-   virtual int ExportPublic(char *out, int lout);
+   virtual int ExportPublic(char *&out, int lout);
    int ExportPublic(XrdOucString &exp);
    virtual int ImportPrivate(const char *in, int lin);
-   virtual int ExportPrivate(char *out, int lout);
+   virtual int ExportPrivate(char *&out, int lout);
    int ExportPrivate(XrdOucString &exp);
 
    // Encryption / Decryption methods


### PR DESCRIPTION
This was broken by a partial change back in Dec 2017
(commit 0421bc639e1f1e581e2f597264f445ffa3380660)
Should restore proper behaviour when XrdSecGSIDELEGPROXY is set to 2.

NB: this breaks backward compatibility of some ExportPublic and ExportPrivate methods .