### PR TITLE
Fix signatures of XrdCryptosslRSA Export methods

### DIFF
--- a/src/XrdCrypto/XrdCryptosslRSA.cc
+++ b/src/XrdCrypto/XrdCryptosslRSA.cc
@@ -361,17 +361,23 @@ int XrdCryptosslRSA::GetPublen()
    return publen;
 }
 //_____________________________________________________________________________
-int XrdCryptosslRSA::ExportPublic(char *&out, int)
+int XrdCryptosslRSA::ExportPublic(char *out, int)
 {
    // Export the public key into buffer out. The length of the buffer should be
-   // at least GetPublen()+1 bytes. If out=0 the buffer is m-allocated internally
-   // and should be freed by the caller.
+   // at least GetPublen()+1 bytes. The buffer out must be passed-by and it
+   // responsability-of the caller.
    // Return 0 in case of success, -1 in case of failure
    EPNAME("RSA::ExportPublic");
 
    // Make sure we have a valid key
    if (!IsValid()) {
       DEBUG("key not valid");
+      return -1;
+   }
+
+   // Check output buffer
+   if (!out) {
+      DEBUG("output buffer undefined!");
       return -1;
    }
 
@@ -389,14 +395,6 @@ int XrdCryptosslRSA::ExportPublic(char *&out, int)
       return -1;
    }
 
-   // Check output buffer
-   if (!out) {
-      out = (char *) malloc(lbio+1);
-      if (!out) {
-         DEBUG("problems allocating output buffer");
-         return -1;
-      }
-   }
    // Read key from BIO to buf
    memcpy(out, cbio, lbio);
    // Null terminate
@@ -426,17 +424,23 @@ int XrdCryptosslRSA::GetPrilen()
 }
 
 //_____________________________________________________________________________
-int XrdCryptosslRSA::ExportPrivate(char *&out, int)
+int XrdCryptosslRSA::ExportPrivate(char *out, int)
 {
    // Export the private key into buffer out. The length of the buffer should be
-   // at least GetPrilen()+1 bytes. If out=0 the buffer is m-allocated internally
-   // and should be freed by the caller.
+   // at least GetPrilen()+1 bytes. The buffer out must be passed-by and it
+   // responsability-of the caller.
    // Return 0 in case of success, -1 in case of failure
    EPNAME("RSA::ExportPrivate");
 
    // Make sure we have a valid key
    if (!IsValid()) {
       DEBUG("key not valid");
+      return -1;
+   }
+
+   // Check output buffer
+   if (!out) {
+      DEBUG("output buffer undefined!");
       return -1;
    }
 
@@ -454,14 +458,6 @@ int XrdCryptosslRSA::ExportPrivate(char *&out, int)
       return -1;
    }
 
-   // Check output buffer
-   if (!out) {
-      out = (char *) malloc(lbio+1);
-      if (!out) {
-         DEBUG("problems allocating output buffer");
-         return -1;
-      }
-   }
    // Read key from BIO to buf
    memcpy(out, cbio, lbio);
    // Null terminate

--- a/src/XrdCrypto/XrdCryptosslRSA.hh
+++ b/src/XrdCrypto/XrdCryptosslRSA.hh
@@ -70,9 +70,9 @@ public:
 
    // Import / Export methods
    int ImportPublic(const char *in, int lin);
-   int ExportPublic(char *&out, int lout);
+   int ExportPublic(char *out, int lout);
    int ImportPrivate(const char *in, int lin);
-   int ExportPrivate(char *&out, int lout);
+   int ExportPrivate(char *out, int lout);
 
    // Encryption / Decryption methods
    int EncryptPrivate(const char *in, int lin, char *out, int lout);


### PR DESCRIPTION
This is a partial revert back of commit
    https://github.com/xrootd/xrootd/commit/0421bc639e1f1e581e2f597264f445ffa3380660

fixing the problem in a different way, without breaking interfaces.

Should restore proper behaviour when XrdSecGSIDELEGPROXY is set to 2.
