### PR TITLE
Remove declarations of crc32 and adler32

### DIFF
--- a/src/XrdSsi/XrdSsiShMam.cc
+++ b/src/XrdSsi/XrdSsiShMam.cc
@@ -882,7 +882,7 @@ bool XrdSsiShMam::GetItem(void *data, const char *key, int hash)
 /******************************************************************************/
   
 int XrdSsiShMam::HashVal(const char *key)
-{  ZEXTERN uLong ZEXPORT crc32 OF((uLong crc, const Bytef *buf, uInt len));
+{
    uLong crc;
    int hval, klen = strlen(key);
 

--- a/tests/XrdSsiTests/XrdShMap.cc
+++ b/tests/XrdSsiTests/XrdShMap.cc
@@ -415,7 +415,6 @@ void Explain(const char *what)
   
 int DoA32(const char *buff)
 {
-   ZEXTERN uLong ZEXPORT adler32 OF((uLong adler, const Bytef *buf, uInt len));
    uLong adler = adler32(0L, Z_NULL, 0);
 
 // Check for ID request now
@@ -438,8 +437,6 @@ int DoA32(const char *buff)
   
 int DoC32(const char *buff)
 {
-   ZEXTERN uLong ZEXPORT crc32 OF((uLong crc, const Bytef *buf, uInt len));
-
 // Check for ID request now
 //
    if (!buff) {int myID; memcpy(&myID, "c32 ", sizeof(int)); return myID;}


### PR DESCRIPTION
These breaks compilation with the error below on my machine.

```
xrootd-4.8.3/tests/XrdSsiTests/XrdShMap.cc:
    In function ‘int DoA32(const char*)’:
xrootd-4.8.3/tests/XrdSsiTests/XrdShMap.cc:418:34:
    error: expected initializer before ‘OF’
ZEXTERN uLong ZEXPORT adler32 OF((uLong adler, const Bytef *buf, uInt len));
                              ^^
```

This PR is a fix for issue #708.