### PR TITLE
Allow XRootD client to accept subjectAltNames.

### DIFF
--- a/src/XrdCrypto/XrdCryptoX509.cc
+++ b/src/XrdCrypto/XrdCryptoX509.cc
@@ -252,3 +252,77 @@ int XrdCryptoX509::DumpExtensions(bool)
    ABSTRACTMETHOD("XrdCryptoX509::DumpExtensions");
    return -1;
 }
+
+/**
+--_____________________________________________________________________________
+ * Compare two hostnames and see if they are the same, including wildcards.
+ *
+ * For example,
+ *
+ * - foo.example.com and foo.example.com are considered equal.
+ * - bar.example.com and foo.example.com are not equal.
+ * - *.example.com and foo.example.com are equal.
+ * - FOO.example.com and foo.EXAMPLE.COM are equal (comparison is not case sensitive).
+ * - F*.com and foo.com are equal
+ *
+ * Returns true if the hostnames are considered a match
+ */
+bool
+XrdCryptoX509::MatchHostnames(const char * match_pattern, const char * hostname)
+{
+    char match_copy[256], host_copy[256];
+    char *tok1, *tok2;
+    char *run1, *run2;
+    int idx;
+
+    if ((match_pattern == NULL || hostname == NULL) ||
+       ((strlen(match_pattern) > 255) || strlen(hostname) > 255))
+        return false;
+
+    // Create a lowercase copy of both hostnames
+    for (idx = 0; match_pattern[idx]; idx++) {
+        match_copy[idx] = tolower(match_pattern[idx]);
+    }
+    match_copy[idx] = '\0';
+    for (idx = 0; hostname[idx]; idx++) {
+        host_copy[idx] = tolower(hostname[idx]);
+    }
+    host_copy[idx] = '\0';
+
+    // Split the strings by '.' character, iterate through each sub-component.
+    run1 = match_copy;
+    run2 = host_copy;
+    for (tok1 = strsep(&run1, "."), tok2 = strsep(&run2, ".");
+         tok1 && tok2;
+         tok1 = strsep(&run1, "."), tok2 = strsep(&run2, "."))
+    {
+        // Match non-wildcard bits
+        while (*tok1 && *tok2 && *tok1 == *tok2) {
+            if (*tok2 == '*')
+               return false;
+            if (*tok1 == '*')
+                break;
+            tok1++;
+            tok2++;
+        }
+
+        /**
+         * At this point, one of the following must be true:
+         * - We hit a wildcard.  In this case, we accept the match as
+         *   long as there is no non-wildcard after it.
+         * - We hit a character that doesn't match.
+         * - We hit the of at least one string.
+         */
+        if (*tok1 == '*') {
+            tok1++;
+            // Non-wildcard after wildcard -- not acceptable.
+            if (*tok1 != '\0')
+                return false;
+        }
+        // Only accept the match if both components are at their end.
+        else if (*tok1 || *tok2) {
+            return false;
+        }
+    }
+    return !tok1 && !tok2;
+}

--- a/src/XrdCrypto/XrdCryptoX509.hh
+++ b/src/XrdCrypto/XrdCryptoX509.hh
@@ -103,11 +103,22 @@ public:
    virtual const char *SubjectHash(int);   // hash 
    const char *SubjectHash() { return SubjectHash(0); }  // hash 
 
+   // Returns true if the certificate has a subject alt name which matches
+   // the given hostnem.
+   virtual bool MatchesSAN(const char * fqdn) = 0;
+
    // Retrieve a given extension if there (in opaque form) 
    virtual XrdCryptoX509data GetExtension(const char *oid);
 
    // Verify signature
    virtual bool Verify(XrdCryptoX509 *ref);
+
+   // Compare two hostnames, handling wildcards as appropriate.  Necessary
+   // for support for accepting connections where the remote X509 certificate
+   // is a wildcard certificate.
+   //
+   // Returns true if the FQDN matches the specified pattern
+   static bool MatchHostnames(const char *match_pattern, const char *fqdn);
 
 private:
 

--- a/src/XrdCrypto/XrdCryptosslX509.hh
+++ b/src/XrdCrypto/XrdCryptosslX509.hh
@@ -98,6 +98,9 @@ public:
    const char *SubjectHash(int = 0);  // get hash of subject name
    const char *IssuerHash(int = 0);   // get hash of issuer name 
 
+   // Check SANs
+   virtual bool MatchesSAN(const char *);
+
    // Retrieve a given extension if there (in opaque form)
    XrdCryptoX509data GetExtension(const char *oid);
 

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -48,6 +48,7 @@
 #include "XrdOuc/XrdOucStream.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 
+#include "XrdNet/XrdNetAddr.hh"
 #include "XrdSut/XrdSutAux.hh"
 
 #include "XrdCrypto/XrdCryptoMsgDigest.hh"
@@ -293,7 +294,15 @@ XrdSecProtocolgsi::XrdSecProtocolgsi(int opts, const char *hname,
    }
 
    // Set host name and address
-      Entity.host = strdup(endPoint.Name("*unknown*"));
+   // The hostname is critical for the GSI protocol; it must match the potential
+   // names on the remote EEC.  However, as we may have been redirected to an IP
+   // address instead of an actual hostname, we must fallback to a reverse DNS lookup.
+      XrdNetAddr testAddr;
+      if (!hname || testAddr.Set(hname) == NULL) {
+         Entity.host = strdup(endPoint.Name(""));
+      } else {
+         Entity.host = strdup(hname);
+      }
       epAddr = endPoint;
       Entity.addrInfo = &epAddr;
 

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3048,7 +3048,10 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
    }
    //
    // Verify server identity
-   if (!ServerCertNameOK(hs->Chain->End()->Subject(), emsg)) {
+   // First, check the DN.  On failure, we will iterate through
+   // the alternate names.
+   if (!ServerCertNameOK(hs->Chain->End()->Subject(), emsg) &&
+       !hs->Chain->End()->MatchesSAN(Entity.host)) {
       return -1;
    }
    //
@@ -5154,6 +5157,7 @@ XrdSecgsiVOMS_t XrdSecProtocolgsi::LoadVOMSFun(const char *plugin,
    return ep;
 }
 
+
 //_____________________________________________________________________________
 bool XrdSecProtocolgsi::ServerCertNameOK(const char *subject, XrdOucString &emsg)
 {
@@ -5174,16 +5178,12 @@ bool XrdSecProtocolgsi::ServerCertNameOK(const char *subject, XrdOucString &emsg
 
    // Always check if the server CN is in the standard form "[*/]<target host name>[/*]"
    if (Entity.host) {
-      if (srvcn != (const char *) Entity.host) {
-         int ih = srvcn.find((const char *) Entity.host);
-         if (ih == 0 || (ih > 0 && srvcn[ih-1] == '/')) {
-            ih += strlen(Entity.host);
-            if (ih >= srvcn.length() ||
-                srvcn[ih] == '\0' || srvcn[ih] == '/') allowed = 1;
-         }
-      } else {
-         allowed = 1;
+      size_t ih = srvcn.find("/");
+      if (ih != std::string::npos) {
+         srvcn.erasefromstart(ih + 1);
       }
+      allowed = XrdCryptoX509::MatchHostnames(srvcn.c_str(), Entity.host);
+
       // Update the error msg, if the case
       if (!allowed) {
          if (emsg.length() <= 0) {


### PR DESCRIPTION
With this, if the CN doesn't follow the expected matching rules, then the client will iterate through the listed `subjectAltNames` to determine whether the certificate matches the current host.

This includes support for CNs and SANs with wildcards.

One thing I noticed when testing this branch is XRootD is internally still doing a reverse DNS lookup on the IP address it connects to when filling out the `XrdSecEntity` structure.  This is widely considered insecure despite the fact it was commonly done at the grid level until a few years ago.  I'd strongly suggest we remove the reverse DNS lookup on the client side once there's appropriate SAN support.