### PR TITLE
SSS: add possiblity to inject an endorsement string into an SSS SecEn…

### DIFF
--- a/src/XrdSecsss/XrdSecsssID.cc
+++ b/src/XrdSecsss/XrdSecsssID.cc
@@ -46,6 +46,7 @@
 /******************************************************************************/
   
 #define XRDSECSSSID "XrdSecsssID"
+#define XRDSECSSSENDO "XrdSecsssENDORSEMENT"
 
 XrdSysMutex         XrdSecsssID::InitMutex;
 
@@ -203,6 +204,9 @@ XrdSecsssID::sssID *XrdSecsssID::genID(int Secure)
              ? (char *)"nobody"  : pBuff;
    myID.grps = (Secure || XrdOucUtils::GroupName(getegid(), gBuff, pgSz) == 0)
              ? (char *)"nogroup" : gBuff;
+
+   if (getenv(XRDSECSSSENDO)) 
+     {myID.endorsements = getenv(XRDSECSSSENDO); }
 
 // Just return the sssID
 //


### PR DESCRIPTION
I would like to have the possibility to inject an arbitrary string into the endorsement field of an 'sss' sec entity. I could do the same with the registry, but this over complicates things for this nice simple feature.