### PR TITLE
Use DNS lookups to expand non-FQDNs

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -35,8 +35,6 @@
 #include <sys/param.h>
 #include <pwd.h>
 #include <sys/types.h>
-#include <sys/socket.h>
-#include <netdb.h>
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <dirent.h>

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -43,6 +43,7 @@
 
 #include "XrdVersion.hh"
 
+#include "XrdNet/XrdNetAddr.hh"
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysLogger.hh"
 #include "XrdSys/XrdSysError.hh"
@@ -309,33 +310,25 @@ XrdSecProtocolgsi::XrdSecProtocolgsi(int opts, const char *hname,
    if (trust_dns == NULL || !strcmp(trust_dns, "1")) {
       if (!hname || !XrdNetAddrInfo::isHostName(hname)) {
          Entity.host = strdup(endPoint.Name(""));
-      } else if (hname && (hname[0] != '\0') && (hname[strlen(hname)-1] == '.')) {
-         Entity.host = strdup(hname);
       } else {
          // At this point, hname still may possibly be a non-qualified domain name.
-         // We append a '.' to the name, which prevents getaddrinfo from doing any
-         // appending of search domains (i.e., expanding "www" to "wwww.unl.edu").
-         // If getaddrinfo succeeds, then we know this was a valid FQDN and we use that.
-         // If it doesn't succeed, then we do a full lookup.
-         struct addrinfo hints;
-         struct addrinfo *results;
-         std::string hname_with_dot(hname);
-         hname_with_dot += ".";
-         memset(&hints, '\0', sizeof(struct addrinfo));
-         hints.ai_family = AF_UNSPEC;
-         int retval = getaddrinfo(hname_with_dot.c_str(), NULL, &hints, &results);
-         if (retval == 0) {
-             freeaddrinfo(results);
+         // If there is a '.' character, then we assume it is a qualified domain name --
+         // otherwise, we use DNS.
+         //
+         // NOTE: We can definitively test whether this is a qualified domain name by
+         // simply appending a '.' to `hname` and performing a lookup.  However, this
+         // causes DNS to be used by every lookup - meaning we rely on the security
+         // of DNS for all cases; we want to avoid this.
+         if (strchr(hname, '.')) {
              // We have a valid hostname; proceed.
              Entity.host = strdup(hname);
          } else {
-             hints.ai_flags = AI_CANONNAME;
-             int retval = getaddrinfo(hname, NULL, &hints, &results);
-             if (retval == 0 && results && results->ai_canonname) {
-                 Entity.host = strdup(results->ai_canonname);
-                 freeaddrinfo(results);
-             } else { // Lookups aren't working; trust user has done something reasonable.
+             XrdNetAddr xrd_addr;
+             char canonname[256];
+             if (!xrd_addr.Set(hname) || (xrd_addr.Format(canonname, 256, XrdNetAddrInfo::fmtName, XrdNetAddrInfo::noPort) <= 0)) {
                  Entity.host = strdup(hname);
+             } else {
+                 Entity.host = strdup(canonname);
              }
          }
       }

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -200,6 +200,8 @@ public:
    int    moninfo; // [s] 0 do not look for; 1 use DN as default
    int    hashcomp; // [cs] 1 send hash names with both algorithms; 0 send only the default [1]
 
+   bool   trustdns; // [cs] 'true' if DNS is trusted [true]
+
    gsiOptions() { debug = -1; mode = 's'; clist = 0; 
                   certdir = 0; crldir = 0; crlext = 0; cert = 0; key = 0;
                   cipher = 0; md = 0; ca = 1 ; crl = 1; crlrefresh = 86400;
@@ -208,7 +210,7 @@ public:
                   gmapfun = 0; gmapfunparms = 0; authzfun = 0; authzfunparms = 0; authzto = -1;
                   ogmap = 1; dlgpxy = 0; sigpxy = 1; srvnames = 0;
                   exppxy = 0; authzpxy = 0;
-                  vomsat = 1; vomsfun = 0; vomsfunparms = 0; moninfo = 0; hashcomp = 1; }
+                  vomsat = 1; vomsfun = 0; vomsfunparms = 0; moninfo = 0; hashcomp = 1; trustdns = true; }
    virtual ~gsiOptions() { } // Cleanup inside XrdSecProtocolgsiInit
    void Print(XrdOucTrace *t); // Print summary of gsi option status
 };
@@ -341,6 +343,7 @@ private:
    static int              VOMSCertFmt; 
    static int              MonInfoOpt;
    static bool             HashCompatibility;
+   static bool             TrustDNS;
    //
    // Crypto related info
    static int              ncrypt;                  // Number of factories


### PR DESCRIPTION
Fixes #725.  @simonmichal - please test.

If the user provides a non-FQDN (such as `xrootd` instead of `xrootd.cern.ch`), this will detect the situation and use `getaddrinfo` to expand to the canonical name.

Note that the canonical name may be somewhat unexpected as it resolves CNAMEs all the way down to an A record.  For example, if you set your search domain to `unl.edu`, then the canonical name for `www` is not `www.unl.edu` but rather `unlcms-rs.autosplit.its-sys.unl.edu`.

This also allows the environment variable `XrdSecGSITrustDNS` to be set to 0; if it is, all DNS lookups are skipped.