### PR TITLE
XrdHttp: Xrd error code to HTTP status translation

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1426,9 +1426,12 @@ int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *hea
     ss << desc;
   } else {
     if (code == 200) ss << "OK";
-    else if (code == 206) ss << "Partial content";
+    else if (code == 206) ss << "Partial Content";
     else if (code == 302) ss << "Redirect";
-    else if (code == 404) ss << "Not found";
+    else if (code == 403) ss << "Forbidden";
+    else if (code == 404) ss << "Not Found";
+    else if (code == 405) ss << "Method Not Allowed";
+    else if (code == 500) ss << "Internal Server Error";
     else ss << "Unknown";
   }
   ss << crlf;

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -797,6 +797,8 @@ void XrdHttpReq::mapXrdErrorToHttpStatus() {
 
     TRACEI(REQ, "PostProcessHTTPReq mapping Xrd error [" << xrderrcode
                  << "] to status code [" << httpStatusCode << "]");
+
+    httpStatusText += "\n";
   }
 }
 

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1486,12 +1486,12 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
         }
 
         prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                             httpStatusText.c_str(), 0);
+                             httpStatusText.c_str(), httpStatusText.length());
         reset();
         return 1;
       } else {
         prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                             httpStatusText.c_str(), 0);
+                             httpStatusText.c_str(), httpStatusText.length());
         return -1;
       }
     }
@@ -1503,7 +1503,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
         if (xrdresp == kXR_error) {
           prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                               httpStatusText.c_str(), 0);
+                               httpStatusText.c_str(), httpStatusText.length());
           return -1;
         }
 
@@ -1732,7 +1732,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
             
             if (prot->myRole == kXR_isManager) {
               prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                                   httpStatusText.c_str(), 0);
+                                   httpStatusText.c_str(), httpStatusText.length());
               return -1;
             }
 
@@ -1823,7 +1823,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               //  return 0;
               //}
               prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                                   httpStatusText.c_str(), 0);
+                                   httpStatusText.c_str(), httpStatusText.length());
               return -1;
             }
             
@@ -1833,7 +1833,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
           }
           default: //read or readv
           {
-            
+
             // Nothing to do if we are postprocessing a close
             if (ntohs(xrdreq.header.requestid) == kXR_close) return 1;
             
@@ -1961,7 +1961,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
             return 1;
           } else {
             prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                                 httpStatusText.c_str(), 0);
+                                 httpStatusText.c_str(), httpStatusText.length());
             return -1;
           }
         }
@@ -1983,7 +1983,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
       if (xrdresp != kXR_ok) {
         prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                             httpStatusText.c_str(), 0);
+                             httpStatusText.c_str(), httpStatusText.length());
         return -1;
       }
 
@@ -2016,7 +2016,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
             return 1;
           }
           prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                               httpStatusText.c_str(), 0);
+                               httpStatusText.c_str(), httpStatusText.length());
           return -1;
         }
       }
@@ -2029,7 +2029,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
       if (xrdresp == kXR_error) {
         prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                             httpStatusText.c_str(), 0);
+                             httpStatusText.c_str(), httpStatusText.length());
         return -1;
       }
 
@@ -2269,7 +2269,8 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
   switch (xrdresp) {
     case kXR_error:
-      prot->SendSimpleResp(httpStatusCode, NULL, NULL, httpStatusText.c_str(), 0);
+      prot->SendSimpleResp(httpStatusCode, NULL, NULL,
+                           httpStatusText.c_str(), httpStatusText.length());
       return -1;
       break;
 

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -76,6 +76,10 @@ class XrdOucEnv;
 
 class XrdHttpReq : public XrdXrootd::Bridge::Result {
 private:
+  // HTTP response parameters to be sent back to the user
+  int httpStatusCode;
+  std::string httpStatusText;
+
   int parseContentRange(char *);
   int parseHost(char *);
   int parseRWOp(char *);
@@ -93,6 +97,8 @@ private:
 
   // Parse a resource string, typically a filename, setting the resource field and the opaque data
   void parseResource(char *url);
+  // Map an XRootD error code to an appropriate HTTP status code and message
+  void mapXrdErrorToHttpStatus();
 public:
 
   XrdHttpReq(XrdHttpProtocol *protinstance) {


### PR DESCRIPTION
This change introduces a new method which translates from an Xrd error code into an appropriate HTTP 
status code.

It introduces 2 new private variables in XrdHttpReq: `httpStatusCode` & `httpStatusText`.
`httpStatusCode`: HTTP Status compliant code
`httpStatusText`: the Xrd error text, if present, or a minimal description otherwise
Default values are 500 and "Unrecognized error".

During the request post-processing, the branches which end in an error will send back the status code and text mentioned above.

This pull request addresses issue #713 