### PR TITLE
Fix potential crash in XrdPosixXrootdPath::P2L

### DIFF
--- a/src/XrdPosix/XrdPosixXrootdPath.cc
+++ b/src/XrdPosix/XrdPosixXrootdPath.cc
@@ -165,13 +165,13 @@ const char *XrdPosixXrootPath::P2L(const char  *who,
    int cgiLen, lfnLen, pfnLen, pfxLen, n;
    bool notOurs = true;
 
-// Check if we need to do any translation at all
-//
-   if (!XrdPosixGlobals::theN2N && !ponly) return inP;
-
 // Preset repP to zero to indicate no translation required, nothing to free
 //
    relP = 0;
+
+// Check if we need to do any translation at all
+//
+   if (!XrdPosixGlobals::theN2N && !ponly) return inP;
 
 // If this is a protocol we support, then we can convert the path
 //


### PR DESCRIPTION
If `XrdPosixXrootdPath::P2L` made an early exit, the variable `relP` wasn't set to 0, triggering a crash in `LfnPath::~LfnPath`.