### PR TITLE
XrdHttp: Prevent segmentation fault when using http.gridmap

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -355,7 +355,7 @@ int XrdHttpProtocol::GetVOMSData(XrdLink *lp) {
     // To set the name we pick the first CN of the certificate subject
     // and hope that it makes some sense, it usually does
     char *lnpos = strstr(SecEntity.moninfo, "/CN=");
-    char bufname[64], bufname2[9];
+    char bufname[256], bufname2[9];
         
     if (lnpos) {
       lnpos += 4;
@@ -384,7 +384,7 @@ int XrdHttpProtocol::GetVOMSData(XrdLink *lp) {
     }
     
     if (servGMap) {
-      int e = servGMap->dn2user(SecEntity.moninfo, bufname, 127, 0);
+      int e = servGMap->dn2user(SecEntity.moninfo, bufname, sizeof(bufname), 0);
       if ( !e ) {
         TRACEI(DEBUG, " Mapping Username: " << SecEntity.moninfo << " --> " << bufname);
         if (SecEntity.name) free(SecEntity.name);


### PR DESCRIPTION
XrdHttp with the http.gridmap on results in a segmentation fault.

The array `bufname[64]` is passed with `127` as the array size to the DN2user translation function.
This eventually generates a segmentation fault as the DN2user function performs memset on the array and the received array size.

This change passes `sizeof(bufname)` for the array size.
Also, the size of the array is increased to 256.