### PR TITLE
XrdHttp: Prevent loop in scenario where stat request provides larger size than the read request

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1803,6 +1803,15 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
             // Close() if this was the third state of a readv, otherwise read the next chunk
             if ((reqstate == 3) && (ntohs(xrdreq.header.requestid) == kXR_readv)) return 1;
 
+            // Prevent scenario where data is expected but none is actually read
+            // E.g. Accessing files which return the results of a script
+            if ((ntohs(xrdreq.header.requestid) == kXR_read) &&
+                (reqstate > 2) && (iovN == 0)) {
+              TRACEI(REQ, "Stopping request because more data is expected "
+                          "but no data has been read.");
+              return -1;
+            }
+
             // If we are here it's too late to send a proper error message...
             if (xrdresp == kXR_error) return -1;
 


### PR DESCRIPTION
Hello,

In the following scenario, where the "Stat request" of a file returns a larger size than the actual "read request", the XrdHttp component would enter a loop.

To reproduce this, perform a GET request on a "script file". The stat on the script will return a fixed size (e.g 4096), but upon the read request, the actual output will be different. At this point, XrdHttp enters a loop trying to read the remaining bytes.

In my particular case, I am accessing the `/proc/whoami` script on an EOS system (logs attached).

This change prevents this scenario and abruptly interrupts the HTTP connection.

[xrdhttp.log](https://github.com/xrootd/xrootd/files/2098289/xrdhttp.log)