### PR TITLE
Prt back fixes of time_t issues to stable-4.8.x

### DIFF
--- a/src/XrdCrypto/XrdCryptoAux.cc
+++ b/src/XrdCrypto/XrdCryptoAux.cc
@@ -39,7 +39,7 @@ static XrdSysError eDest(0,"crypto_");
 XrdOucTrace *cryptoTrace = 0;
 //
 // Time Zone correction (wrt UTC)
-static int TZCorr = 0;
+static time_t TZCorr = 0;
 static bool TZInitialized = 0;
 
 /******************************************************************************/
@@ -74,7 +74,7 @@ void XrdCryptoSetTrace(kXR_int32 trace)
 /*  X r d C r y p t o T i m e G m                                             */
 /******************************************************************************/
 //______________________________________________________________________________
-int XrdCryptoTZCorr()
+time_t XrdCryptoTZCorr()
 {
    // Time Zone correction (wrt UTC)
    
@@ -82,7 +82,7 @@ int XrdCryptoTZCorr()
       time_t now = time(0);
       struct tm ltn, gtn;
       if (localtime_r(&now, &ltn) != 0 && gmtime_r(&now, &gtn) != 0) {
-         TZCorr = int(difftime(mktime(&ltn), mktime(&gtn)));
+         TZCorr = time_t(difftime(mktime(&ltn), mktime(&gtn)));
          TZInitialized = 1;
       }
    }

--- a/src/XrdCrypto/XrdCryptoAux.hh
+++ b/src/XrdCrypto/XrdCryptoAux.hh
@@ -82,7 +82,7 @@ void XrdCryptoSetTrace(kXR_int32 trace);
 /*                                                                            */
 /******************************************************************************/
 //______________________________________________________________________________
-int XrdCryptoTZCorr();
-const int XrdCryptoDSTShift = 3600;
+time_t XrdCryptoTZCorr();
+const time_t XrdCryptoDSTShift = 3600;
 
 #endif

--- a/src/XrdCrypto/XrdCryptoX509.cc
+++ b/src/XrdCrypto/XrdCryptoX509.cc
@@ -126,7 +126,7 @@ bool XrdCryptoX509::IsExpired(int when)
 }
 
 //_____________________________________________________________________________
-int XrdCryptoX509::NotBefore()
+time_t XrdCryptoX509::NotBefore()
 {
    // Begin-validity time in secs since Epoch
    ABSTRACTMETHOD("XrdCryptoX509::NotBefore");
@@ -134,7 +134,7 @@ int XrdCryptoX509::NotBefore()
 }
 
 //_____________________________________________________________________________
-int XrdCryptoX509::NotAfter()
+time_t XrdCryptoX509::NotAfter()
 {
    // End-validity time in secs since Epoch
    ABSTRACTMETHOD("XrdCryptoX509::NotAfter");

--- a/src/XrdCrypto/XrdCryptoX509.hh
+++ b/src/XrdCrypto/XrdCryptoX509.hh
@@ -90,8 +90,8 @@ public:
    virtual XrdOucString SerialNumberString();
 
    // Validity interval
-   virtual int  NotBefore();  // begin-validity time in secs since Epoch
-   virtual int  NotAfter();   // end-validity time in secs since Epoch
+   virtual time_t  NotBefore();  // begin-validity time in secs since Epoch
+   virtual time_t  NotAfter();   // end-validity time in secs since Epoch
 
    // Issuer of top certificate
    virtual const char *Issuer();

--- a/src/XrdCrypto/XrdCryptoX509Crl.cc
+++ b/src/XrdCrypto/XrdCryptoX509Crl.cc
@@ -62,7 +62,7 @@ bool XrdCryptoX509Crl::IsExpired(int when)
 }
 
 //_____________________________________________________________________________
-int XrdCryptoX509Crl::LastUpdate()
+time_t XrdCryptoX509Crl::LastUpdate()
 {
    // Time of last update
    ABSTRACTMETHOD("XrdCryptoX509Crl::LastUpdate");
@@ -70,7 +70,7 @@ int XrdCryptoX509Crl::LastUpdate()
 }
 
 //_____________________________________________________________________________
-int XrdCryptoX509Crl::NextUpdate()
+time_t XrdCryptoX509Crl::NextUpdate()
 {
    // Time of next update
    ABSTRACTMETHOD("XrdCryptoX509Crl::NextUpdate");

--- a/src/XrdCrypto/XrdCryptoX509Crl.hh
+++ b/src/XrdCrypto/XrdCryptoX509Crl.hh
@@ -64,8 +64,8 @@ public:
    virtual const char *ParentFile();
 
    // Validity interval
-   virtual int  LastUpdate();  // time when last updated
-   virtual int  NextUpdate();  // time foreseen for next update
+   virtual time_t LastUpdate();  // time when last updated
+   virtual time_t NextUpdate();  // time foreseen for next update
 
    // Issuer of top certificate
    virtual const char *Issuer();

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -612,12 +612,12 @@ int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *chain)
 }
 
 //____________________________________________________________________________
-int XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1)
+time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1)
 {
    // Function to convert from ASN1 time format into UTC
    // since Epoch (Jan 1, 1970) 
    // Return -1 if something went wrong
-   int etime = -1;
+   time_t etime = -1;
    EPNAME("ASN1toUTC");
 
    //

--- a/src/XrdCrypto/XrdCryptosslAux.hh
+++ b/src/XrdCrypto/XrdCryptosslAux.hh
@@ -62,7 +62,7 @@ int XrdCryptosslX509ParseFile(const char *fname, XrdCryptoX509Chain *c);
 int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *c);
 //
 // Function to convert from ASN1 time format into UTC since Epoch (Jan 1, 1970) 
-int XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1);
+time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1);
 
 // Function to convert X509_NAME into a one-line human readable string
 void XrdCryptosslNameOneLine(X509_NAME *nm, XrdOucString &s);

--- a/src/XrdCrypto/XrdCryptosslX509.cc
+++ b/src/XrdCrypto/XrdCryptosslX509.cc
@@ -427,7 +427,7 @@ void XrdCryptosslX509::SetPKI(XrdCryptoX509data newpki)
 }
 
 //_____________________________________________________________________________
-int XrdCryptosslX509::NotBefore()
+time_t XrdCryptosslX509::NotBefore()
 {
    // Begin-validity time in secs since Epoch
 
@@ -443,7 +443,7 @@ int XrdCryptosslX509::NotBefore()
 }
 
 //_____________________________________________________________________________
-int XrdCryptosslX509::NotAfter()
+time_t XrdCryptosslX509::NotAfter()
 {
    // End-validity time in secs since Epoch
 

--- a/src/XrdCrypto/XrdCryptosslX509.hh
+++ b/src/XrdCrypto/XrdCryptosslX509.hh
@@ -87,8 +87,8 @@ public:
    XrdOucString SerialNumberString();
 
    // Validity
-   int NotBefore();  // get begin-validity time in secs since Epoch
-   int NotAfter();   // get end-validity time in secs since Epoch
+   time_t NotBefore();  // get begin-validity time in secs since Epoch
+   time_t NotAfter();   // get end-validity time in secs since Epoch
 
    // Relevant Names
    const char *Subject();  // get subject name
@@ -106,8 +106,8 @@ public:
 
 private:
    X509        *cert;       // The certificate object
-   int          notbefore;  // begin-validity time in secs since Epoch
-   int          notafter;   // end-validity time in secs since Epoch
+   time_t       notbefore;  // begin-validity time in secs since Epoch
+   time_t       notafter;   // end-validity time in secs since Epoch
    XrdOucString subject;    // subject;
    XrdOucString issuer;     // issuer name;
    XrdOucString subjecthash; // Default hash of subject;

--- a/src/XrdCrypto/XrdCryptosslX509Crl.cc
+++ b/src/XrdCrypto/XrdCryptosslX509Crl.cc
@@ -418,7 +418,7 @@ int XrdCryptosslX509Crl::LoadCache()
 }
 
 //_____________________________________________________________________________
-int XrdCryptosslX509Crl::LastUpdate()
+time_t XrdCryptosslX509Crl::LastUpdate()
 {
    // Time of last update
 
@@ -434,7 +434,7 @@ int XrdCryptosslX509Crl::LastUpdate()
 }
 
 //_____________________________________________________________________________
-int XrdCryptosslX509Crl::NextUpdate()
+time_t XrdCryptosslX509Crl::NextUpdate()
 {
    // Time of next update
 

--- a/src/XrdCrypto/XrdCryptosslX509Crl.hh
+++ b/src/XrdCrypto/XrdCryptosslX509Crl.hh
@@ -65,8 +65,8 @@ public:
    const char *ParentFile() { return (const char *)(srcfile.c_str()); }
 
    // Validity interval
-   int  LastUpdate();  // time when last updated
-   int  NextUpdate();  // time foreseen for next update
+   time_t LastUpdate();  // time when last updated
+   time_t NextUpdate();  // time foreseen for next update
 
    // Issuer of top certificate
    const char *Issuer();
@@ -81,8 +81,8 @@ public:
 
 private:
    X509_CRL    *crl;       // The CRL object
-   int          lastupdate; // time of last update
-   int          nextupdate; // time of next update
+   time_t       lastupdate; // time of last update
+   time_t       nextupdate; // time of next update
    XrdOucString issuer;     // issuer name;
    XrdOucString issuerhash; // hash of issuer name (default algorithm);
    XrdOucString issueroldhash; // hash of issuer name (md5 algorithm);

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -4108,6 +4108,15 @@ bool XrdSecProtocolgsi::VerifyCA(int opt, X509Chain *cca, XrdCryptoFactory *CF)
 
    // Point to the certificate
    XrdCryptoX509 *xc = cca->Begin();
+   if (!xc) {
+      PRINT("Cannot attach to first certificate in chain");
+      return 0;
+   }
+   // Make sure it is valid
+   if (!(xc->IsValid())) {
+      PRINT("CA certificate is expired ("<<xc->SubjectHash()<<", not_before: "<<xc->NotBefore()<<" secs UTC )");
+      return 0;
+   }
    // Is it self-signed ?
    bool self = (!strcmp(xc->IssuerHash(), xc->SubjectHash())) ? 1 : 0;
    if (!self) {


### PR DESCRIPTION
Fixes a bug in processing certificates with dates beyond 2038.
And improves time checks when ca:1 