### PR TITLE
Restructure GSI proxy delegation options

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -967,12 +967,14 @@ char *XrdSecProtocolgsi::Init(gsiOptions opt, XrdOucErrInfo *erp)
          DefBits = opt.bits;
       //
       // Delegate proxy options
-      if (opt.dlgpxy == 1)
-         PxyReqOpts |= kOptsDlgPxy;
-      if (opt.dlgpxy == 2)
-         PxyReqOpts |= kOptsFwdPxy;
-      if (opt.sigpxy > 0 || opt.dlgpxy == 1)
+      if (opt.dlgpxy > 0) {
          PxyReqOpts |= kOptsSigReq;
+         if (opt.dlgpxy == 2) {
+            PxyReqOpts |= kOptsFwdPxy;
+         } else {
+            PxyReqOpts |= kOptsDlgPxy;
+         }
+      }
       //
       // Define valid CNs for the server certificates; default is null, which means that
       // the server CN must be in the form "*/<hostname>"
@@ -2361,11 +2363,9 @@ char *XrdSecProtocolgsiInit(const char mode,
       //                                      2 require,
       //                                      3 require non-expired CRL
       //             "XrdSecGSIDELEGPROXY"   Forwarding of credentials option:
-      //                                     0 none; 1 sign request created
+      //                                     0 deny; 1 sign request created
       //                                     by server; 2 forward local proxy
-      //                                     (include private key) [0]
-      //             "XrdSecGSISIGNPROXY"    permission to sign requests
-      //                                     0 no, 1 yes [1]
+      //                                     (include private key) [1]
       //             "XrdSecGSISRVNAMES"     Server names allowed: if the server CN
       //                                     does not match any of these, or it is
       //                                     explicitely denied by these, or it is
@@ -2454,11 +2454,6 @@ char *XrdSecProtocolgsiInit(const char mode,
       cenv = getenv("XrdSecGSIDELEGPROXY");
       if (cenv)
          opts.dlgpxy = atoi(cenv);
-
-      // Sign delegate proxy requests
-      cenv = getenv("XrdSecGSISIGNPROXY");
-      if (cenv)
-         opts.sigpxy = atoi(cenv);
 
       // Allowed server name formats
       cenv = getenv("XrdSecGSISRVNAMES");
@@ -2565,7 +2560,7 @@ char *XrdSecProtocolgsiInit(const char mode,
       int ogmap = 1;
       int gmapto = 600;
       int authzto = -1;
-      int dlgpxy = -1;
+      int dlgpxy = 0;
       int authzpxy = 0;
       int vomsat = 1;
       int moninfo = 0;
@@ -2652,7 +2647,7 @@ char *XrdSecProtocolgsiInit(const char mode,
       opts.ogmap = ogmap;
       opts.gmapto = gmapto;
       opts.authzto = authzto;
-      opts.dlgpxy = (dlgpxy >= -1 && dlgpxy <= 1) ? dlgpxy : -1;
+      opts.dlgpxy = (dlgpxy >= 0 && dlgpxy <= 1) ? dlgpxy : 0;
       opts.authzpxy = authzpxy;
       opts.vomsat = vomsat;
       opts.moninfo = moninfo;

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -2561,7 +2561,7 @@ char *XrdSecProtocolgsiInit(const char mode,
       int ogmap = 1;
       int gmapto = 600;
       int authzto = -1;
-      int dlgpxy = 0;
+      int dlgpxy = -1;
       int authzpxy = 0;
       int vomsat = 1;
       int moninfo = 0;
@@ -2648,7 +2648,7 @@ char *XrdSecProtocolgsiInit(const char mode,
       opts.ogmap = ogmap;
       opts.gmapto = gmapto;
       opts.authzto = authzto;
-      opts.dlgpxy = dlgpxy;
+      opts.dlgpxy = (dlgpxy >= -1 && dlgpxy <= 1) ? dlgpxy : -1;
       opts.authzpxy = authzpxy;
       opts.vomsat = vomsat;
       opts.moninfo = moninfo;

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3762,6 +3762,8 @@ int XrdSecProtocolgsi::ServerDoSigpxy(XrdSutBuffer *br,  XrdSutBuffer **bm,
       SafeFree(Entity.creds);
       Entity.creds = strdup(spxy.c_str());
       Entity.credslen = spxy.length();
+      PRINT("proxy chain exported in Entity.creds (" << Entity.credslen << " bytes)");
+      PRINT("\n\n" << spxy.c_str() << "\n\n");
       return 0;
    }
 
@@ -3809,6 +3811,7 @@ int XrdSecProtocolgsi::ServerDoSigpxy(XrdSutBuffer *br,  XrdSutBuffer **bm,
             cmsg += pxfile;
             return 0;
          }
+         PRINT("proxy chain dumped to "<< pxfile);
       } else {
          cmsg = "proxy chain not dumped to file: entity name undefined";
          return 0;

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -188,11 +188,11 @@ public:
    char  *authzfunparms;// [s] parameters for the function to fill entities [0]
    int    authzto; // [s] validity in secs of authz cache entries [-1 => unlimited]
    int    ogmap;  // [s] gridmap file checking option 
-   int    dlgpxy; // [c] explicitely ask the creation of a delegated proxy 
-                  // [s] ask client for proxies
-   int    sigpxy; // [c] accept delegated proxy requests 
+   int    dlgpxy; // [c] explicitely ask the creation of a delegated proxy; default 1
+                  // [s] ask client for proxies;default set internally to 0, do not accept delegated proxies
+   int    sigpxy; // [c] accept delegated proxy requests
    char  *srvnames;// [c] '|' separated list of allowed server names
-   char  *exppxy; // [s] template for the exported file with proxies (dlgpxy == 3)
+   char  *exppxy; // [s] template for the exported file with proxies
    int    authzpxy; // [s] if 1 make proxy available in exported form in the 'endorsement'
                     //     field of the XrdSecEntity object for use in XrdAcc
    int    vomsat; // [s] 0 do not look for; 1 extract if any
@@ -209,7 +209,7 @@ public:
                   proxy = 0; valid = 0; deplen = 0; bits = 512;
                   gridmap = 0; gmapto = 600;
                   gmapfun = 0; gmapfunparms = 0; authzfun = 0; authzfunparms = 0; authzto = -1;
-                  ogmap = 1; dlgpxy = 0; sigpxy = 1; srvnames = 0;
+                  ogmap = 1; dlgpxy = 1; sigpxy = 1; srvnames = 0;
                   exppxy = 0; authzpxy = 0;
                   vomsat = 1; vomsfun = 0; vomsfunparms = 0; moninfo = 0; hashcomp = 1; trustdns = true; }
    virtual ~gsiOptions() { } // Cleanup inside XrdSecProtocolgsiInit

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -187,9 +187,9 @@ public:
    char  *authzfun;// [s] file with the function to fill entities [0]
    char  *authzfunparms;// [s] parameters for the function to fill entities [0]
    int    authzto; // [s] validity in secs of authz cache entries [-1 => unlimited]
-   int    ogmap;  // [s] gridmap file checking option 
-   int    dlgpxy; // [c] explicitely ask the creation of a delegated proxy; default 1
-                  // [s] ask client for proxies;default set internally to 0, do not accept delegated proxies
+   int    ogmap;  // [s] gridmap file checking option
+   int    dlgpxy; // [c] explicitely ask the creation of a delegated proxy; default 0
+                  // [s] ask client for proxies; default: do not accept delegated proxies
    int    sigpxy; // [c] accept delegated proxy requests
    char  *srvnames;// [c] '|' separated list of allowed server names
    char  *exppxy; // [s] template for the exported file with proxies
@@ -209,7 +209,7 @@ public:
                   proxy = 0; valid = 0; deplen = 0; bits = 512;
                   gridmap = 0; gmapto = 600;
                   gmapfun = 0; gmapfunparms = 0; authzfun = 0; authzfunparms = 0; authzto = -1;
-                  ogmap = 1; dlgpxy = 1; sigpxy = 1; srvnames = 0;
+                  ogmap = 1; dlgpxy = 0; sigpxy = 1; srvnames = 0;
                   exppxy = 0; authzpxy = 0;
                   vomsat = 1; vomsfun = 0; vomsfunparms = 0; moninfo = 0; hashcomp = 1; trustdns = true; }
    virtual ~gsiOptions() { } // Cleanup inside XrdSecProtocolgsiInit

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -103,7 +103,8 @@ enum kgsiHandshakeOpts {
    kOptsSigReq     = 4,      // 0x0004: Accept to sign delegated proxy
    kOptsSrvReq     = 8,      // 0x0008: Server request for delegated proxy
    kOptsPxFile     = 16,     // 0x0010: Save delegated proxies in file
-   kOptsDelChn     = 32      // 0x0020: Delete chain
+   kOptsDelChn     = 32,     // 0x0020: Delete chain
+   kOptsPxCred     = 64      // 0x0040: Save delegated proxies as credentials
 };
 
 // Error codes

--- a/src/XrdSut/XrdSutAux.cc
+++ b/src/XrdSut/XrdSutAux.cc
@@ -43,6 +43,7 @@
 #include "XrdOuc/XrdOucString.hh"
 
 #include "XrdSut/XrdSutAux.hh"
+#include "XrdSut/XrdSutRndm.hh"
 #include "XrdSut/XrdSutTrace.hh"
 
 static const char *gXRSBucketTypes[] = {
@@ -446,6 +447,13 @@ int XrdSutResolve(XrdOucString &path,
 
    // Replace <user>, if defined
    if (us && strlen(us) > 0) path.replace("<user>", us);
+
+   // Replace <rtag>, if defined
+   if (path.find("<rtag>") != STR_NPOS) {
+      XrdOucString rtag;
+      XrdSutRndm::GetString(2,6,rtag);
+      path.replace("<rtag>", rtag);
+   }
 
    // Done
    return 0;


### PR DESCRIPTION
This patch re-organizes how proxy delegation is handled and controlled in GSI, and it adds the possibility to save the proxy in Entity.creds .

On the server side, the two switches controlling delegation have been 'cleaned': the first switch enables or disables delegation, the second determines where the delegated proxy will be saved. The new meanings are:
              -dlgpxy:0              no delegated proxy [default]
                           1              ask the client to sign a delegated proxy request

              -exppxy:none       delegated proxy available in memory (via a server calle to getCredentials)
                           :=creds    delegated proxy available in Entity.creds
                           :<file_template>  delegated proxy available in the indicated file which can include the
                                           following customization tags: <host>, <vo>, <group>, <user>, <rtag>; e.g.
                                           /tmp/x509up_u<user>_<rtag> .

(rtag is a 6 hex chars random string).

On the client, the env XrdSecGSISIGNPROXY is used to enable or deny proxy signature; default is 1, that is enabled. The env XrdSecGSIDELEGPROXY is used to determine the time of delegated proxy: 1 means standard delegated proxy, i.e. a proxy signed by the initial proxy (proxy request created by teh server); 2 means forwarding of the initial proxy.
