### PR TITLE
[XrdHTTP] Implement RFC3230 for providing resource digest

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -2657,6 +2657,20 @@ int XrdHttpProtocol::doStat(char *fname) {
 }
 
 
+int XrdHttpProtocol::doChksum(const XrdOucString &fname) {
+  size_t length;
+  memset(&CurrentReq.xrdreq, 0, sizeof (ClientRequest));
+  CurrentReq.xrdreq.query.requestid = htons(kXR_query);
+  CurrentReq.xrdreq.query.infotype = htons(kXR_Qcksum);
+  memset(CurrentReq.xrdreq.query.reserved1, '\0', sizeof(CurrentReq.xrdreq.query.reserved1));
+  memset(CurrentReq.xrdreq.query.fhandle, '\0', sizeof(CurrentReq.xrdreq.query.fhandle));
+  memset(CurrentReq.xrdreq.query.reserved2, '\0', sizeof(CurrentReq.xrdreq.query.reserved2));
+  length = fname.length() + 1;
+  CurrentReq.xrdreq.query.dlen = htonl(length);
+
+  return Bridge->Run(reinterpret_cast<char *>(&CurrentReq.xrdreq), const_cast<char *>(fname.c_str()), length) ? 0 : -1;
+}
+
 
 static XrdVERSIONINFODEF(compiledVer, XrdHttpProtocolTest, XrdVNUMBER, XrdVERSION);
 

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -107,7 +107,8 @@ public:
   /// Perform a Stat request
   int doStat(char *fname);
 
-
+  /// Perform a checksum request
+  int doChksum(const XrdOucString &fname);
 
   /// Ctor, dtors and copy ctor
   XrdHttpProtocol operator =(const XrdHttpProtocol &rhs);

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1473,8 +1473,8 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
     case XrdHttpReq::rtHEAD:
     {
       if (xrdresp != kXR_ok) {
-        prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                               httpStatusText.c_str(), httpStatusText.length());
+        // NOTE that HEAD MUST NOT return a body, even in the case of failure.
+        prot->SendSimpleResp(httpStatusCode, NULL, NULL, NULL, 0);
         return -1;
       } else if (reqstate == 0) {
         if (iovN > 0) {
@@ -1491,7 +1491,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
 
           if (m_req_digest.size()) {
             if (prot->doChksum(resourceplusopaque) < 0) {
-              prot->SendSimpleResp(500, NULL, NULL, "Failed to route checksum request", 0);
+              prot->SendSimpleResp(500, NULL, NULL, NULL, 0);
               return -1;
             }
             return 0;
@@ -1501,8 +1501,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
           }
         }
 
-        prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                             httpStatusText.c_str(), httpStatusText.length());
+        prot->SendSimpleResp(httpStatusCode, NULL, NULL, NULL, 0);
         reset();
         return 1;
       } else { // We requested a checksum and now have its response.

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2397,6 +2397,10 @@ void XrdHttpReq::reset() {
   resource = "";
   allheaders.clear();
 
+  // Reset the state of the request's digest request.
+  m_req_digest.clear();
+  m_resource_with_digest = "";
+
   headerok = false;
   keepalive = true;
   length = 0;

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -93,7 +93,12 @@ private:
 
   void getfhandle();
 
-  
+  /// Cook and send the response after the bridge did something
+  /// Return values:
+  ///  0->everything OK, additionsl steps may be required
+  ///  1->request processed completely
+  ///  -1->error
+  int PostProcessHTTPReq(bool final = false);
 
   // Parse a resource string, typically a filename, setting the resource field and the opaque data
   void parseResource(char *url);
@@ -257,19 +262,6 @@ public:
   ///  1->request processed
   ///  -1->error
   int ProcessHTTPReq();
-
-  /// Cook and send the response after the bridge did something
-  /// Return values:
-  ///  0->everything OK, additionsl steps may be required
-  ///  1->request processed completely
-  ///  -1->error
-  int PostProcessHTTPReq(bool final = false);
-
-
-
-
-
-
 
 
   // ------------

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -202,6 +202,9 @@ public:
   /// The destination field specified in the req
   std::string destination;
 
+  /// The requested digest type
+  std::string m_req_digest;
+
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;
   

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -209,6 +209,10 @@ public:
 
   /// The requested digest type
   std::string m_req_digest;
+  /// The checksum algorithm is specified as part of the opaque data in the URL.
+  /// Hence, when a digest is generated to satisfy a request, we cache the tweaked
+  /// URL in this data member.
+  XrdOucString m_resource_with_digest;
 
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -149,7 +149,34 @@ void Tobase64(const unsigned char *input, int length, char *out) {
 }
 
 
+static int
+char_to_int(int c)
+{
+  if (isdigit(c)) {
+    return c - '0';
+  } else {
+    c = tolower(c);
+    if (c >= 'a' && c <= 'f') {
+      return c - 'a' + 10;
+    }
+    return -1;
+  }
+}
 
+
+// Decode a hex digest array to raw bytes.
+//
+bool Fromhexdigest(const unsigned char *input, int length, unsigned char *out) {
+  for (int idx=0; idx < length; idx += 2) {
+    int upper =  char_to_int(input[idx]);
+    int lower =  char_to_int(input[idx+1]);
+    if ((upper < 0) || (lower < 0)) {
+      return false;
+    }
+    out[idx/2] = (upper << 4) + lower;
+  }
+  return true;
+}
 
 
 // Simple itoa function

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -71,6 +71,10 @@ int compareHash(
         const char *h2);
 
 
+bool Fromhexdigest(const unsigned char *input, int length, unsigned char *out);
+
+void Tobase64(const unsigned char *input, int length, char *out);
+
 
 // Create a new quoted string
 char *quote(const char *str);

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -432,13 +432,11 @@ int XrdXrootdProtocol::do_CKsum(char *algT, const char *Path, char *Opaque)
 
 // Diagnose any hard errors
 //
-   if (rc && (myError.getErrInfo() != ENOTSUP)) {
-      return fsError(rc, 0, myError, Path, Opaque);
-   }
+   if (rc) return fsError(rc, 0, myError, Path, Opaque);
 
 // Return result if it is actually available
 //
-   if (!rc && *csData)
+   if (*csData)
       {if (*csData == '!') return Response.Send(csData+1);
        struct iovec iov[4] = {{0,0}, {algT, (size_t)CKTLen}, {&Space, 1},
                               {(char *)csData, strlen(csData)+1}};

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -432,11 +432,13 @@ int XrdXrootdProtocol::do_CKsum(char *algT, const char *Path, char *Opaque)
 
 // Diagnose any hard errors
 //
-   if (rc) return fsError(rc, 0, myError, Path, Opaque);
+   if (rc && (myError.getErrInfo() != ENOTSUP)) {
+      return fsError(rc, 0, myError, Path, Opaque);
+   }
 
 // Return result if it is actually available
 //
-   if (*csData)
+   if (!rc && *csData)
       {if (*csData == '!') return Response.Send(csData+1);
        struct iovec iov[4] = {{0,0}, {algT, (size_t)CKTLen}, {&Space, 1},
                               {(char *)csData, strlen(csData)+1}};


### PR DESCRIPTION
DAVIX et al uses RFC3230 to implement checksumming over HTTP.

This PR implements the RFC to the point where a `gfal-copy` works with the ADLER32 checksum algorithm.

Note that this also contains a bugfix in XrdOfs that prevents checksums from working when the underlying filesystem doesn't support `fattr`s.