### PR TITLE
Fixup builds for Macaroons.

### DIFF
--- a/cmake/XRootDFindLibs.cmake
+++ b/cmake/XRootDFindLibs.cmake
@@ -94,7 +94,7 @@ include (FindPkgConfig)
 pkg_check_modules(JSON json-c)
 pkg_check_modules(UUID uuid)
 
-if( Macaroons_FOUND AND JSON_FOUND AND UUID_FOUND )
+if( MACAROONS_FOUND AND JSON_FOUND AND UUID_FOUND )
   set( BUILD_MACAROONS TRUE )
 else()
   set( BUILD_MACAROONS FALSE )

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -4,10 +4,17 @@
 %if %{?rhel:1}%{!?rhel:0}
     %if %{rhel} >= 7
         %define use_systemd 1
+        %define have_macaroons 1
     %else
         %define use_systemd 0
+        %define have_macaroons 0
     %endif
 %else
+    %if %{?fedora}%{!?fedora:0} >= 28
+        %define have_macaroons 1
+    %else
+        %define have_macaroons 0
+    %endif
     %if %{?fedora}%{!?fedora:0} >= 19
         %define use_systemd 1
     %else
@@ -784,7 +791,9 @@ fi
 %{_libdir}/libXrdHttp-4.so
 %{_libdir}/libXrdHttpTPC-4.so
 %{_libdir}/libXrdHttpUtils.so.*
+%if %{have_macaroons}
 %{_libdir}/libXrdMacaroons-4.so
+%endif
 %{_libdir}/libXrdN2No2p-4.so
 %{_libdir}/libXrdOssSIgpfsT-4.so
 %{_libdir}/libXrdServer.so.*


### PR DESCRIPTION
- Don't package the library on RHEL/Fedora platforms where it is not available.  Note: all Fedora versions on gitlab are so old they are unsupported.
- Older versions of CMake are case sensitive for the `Macaroons_FOUND` variable -> change to the proper `MACAROONS_FOUND`.