### PR TITLE
[XrdMacaroons] Macaroon build fixes, attempt 2

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -71,7 +71,9 @@ BuildRequires: zlib-devel
 BuildRequires: ncurses-devel
 BuildRequires: libcurl-devel
 BuildRequires: libuuid-devel
+%if %{have_macaroons}
 BuildRequires: libmacaroons-devel
+%ensid
 BuildRequires: json-c-devel
 
 BuildRequires: python2-devel

--- a/src/XrdMacaroons/XrdMacaroons.cc
+++ b/src/XrdMacaroons/XrdMacaroons.cc
@@ -82,7 +82,7 @@ XrdAccAuthorize *XrdAccAuthorizeObject(XrdSysLogger *log,
     {
         return new Macaroons::Authz(log, config, chain_authz);
     }
-    catch (std::runtime_error e)
+    catch (std::runtime_error &e)
     {
         XrdSysError err(log, "macaroons");
         err.Emsg("Config", "Configuration of Macaroon authorization handler failed", e.what());
@@ -103,7 +103,7 @@ XrdHttpExtHandler *XrdHttpGetExtHandler(
     {
         return new Macaroons::Handler(log, config, env, def_authz);
     }
-    catch (std::runtime_error e)
+    catch (std::runtime_error &e)
     {
         log->Emsg("Config", "Generation of Macaroon handler failed", e.what());
         return NULL;


### PR DESCRIPTION
Fixes the build requirements on older Fedora / RHEL and squashes a warning on the Fedora rawhide compiler.