### PR TITLE
[XrdThrottle] Improve chaining behavior of throttle plugin.

### DIFF
--- a/src/XrdThrottle/XrdThrottleFileSystem.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystem.cc
@@ -13,7 +13,7 @@ XrdSfsDirectory *
 FileSystem::newDir(char *user,
                    int   monid)
 {
-   return (XrdSfsDirectory *)new XrdOfsDirectory(user, monid);
+   return m_sfs_ptr->newDir(user, monid);
 }
 
 XrdSfsFile *


### PR DESCRIPTION
This fixes a few cases where the presence of the `XrdThrottle` plugin subtly changes the semantics of how the error object is updated.

Most importantly, it fixes the `fctl` command for non-sendfile cases and properly chains the directory object.