### PR TITLE
Obey the `Connection` request header.

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -31,14 +31,14 @@ int XrdHttpExtReq::SendSimpleResp(int code, const char* desc, const char* header
 {
   if (!prot) return -1;
   
-  return prot->SendSimpleResp(code, desc, header_to_add, body, bodylen);
+  return prot->SendSimpleResp(code, desc, header_to_add, body, bodylen, true);
 }
 
 int XrdHttpExtReq::StartChunkedResp(int code, const char *desc, const char *header_to_add)
 {
   if (!prot) return -1;
 
-  return prot->StartChunkedResp(code, desc, header_to_add);
+  return prot->StartChunkedResp(code, desc, header_to_add, true);
 }
 
 int XrdHttpExtReq::ChunkResp(const char *body, long long bodylen)

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -768,7 +768,7 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
 
         
         CurrentReq.appendOpaque(dest, &SecEntity, hash, timenow);
-        SendSimpleResp(302, NULL, (char *) dest.c_str(), 0, 0);
+        SendSimpleResp(302, NULL, (char *) dest.c_str(), 0, 0, true);
         CurrentReq.reset();
         return -1;
       }
@@ -1396,7 +1396,7 @@ int XrdHttpProtocol::SendData(const char *body, int bodylen) {
   return 0;
 }
 
-int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen) {
+int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen, bool keepalive) {
   std::stringstream ss;
   const std::string crlf = "\r\n";
 
@@ -1414,6 +1414,10 @@ int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *hea
     else ss << "Unknown";
   }
   ss << crlf;
+  if (keepalive)
+    ss << "Connection: Keep-Alive" << crlf;
+  else
+    ss << "Connection: Close" << crlf;
 
   if (bodylen >= 0) ss << "Content-Length: " << bodylen << crlf;
 
@@ -1430,7 +1434,7 @@ int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *hea
   return 0;
 }
 
-int XrdHttpProtocol::StartChunkedResp(int code, const char *desc, const char *header_to_add) {
+int XrdHttpProtocol::StartChunkedResp(int code, const char *desc, const char *header_to_add, bool keepalive) {
   const std::string crlf = "\r\n";
 
   std::stringstream ss;
@@ -1440,7 +1444,7 @@ int XrdHttpProtocol::StartChunkedResp(int code, const char *desc, const char *he
   ss << "Transfer-Encoding: chunked";
 
   TRACEI(RSP, "Starting chunked response");
-  return StartSimpleResp(code, desc, ss.str().c_str(), -1);
+  return StartSimpleResp(code, desc, ss.str().c_str(), -1, keepalive);
 }
 
 int XrdHttpProtocol::ChunkResp(const char *body, long long bodylen) {
@@ -1468,14 +1472,14 @@ int XrdHttpProtocol::ChunkResp(const char *body, long long bodylen) {
 /// Header_to_add is a set of header lines each CRLF terminated to be added to the header
 /// Returns 0 if OK
 
-int XrdHttpProtocol::SendSimpleResp(int code, const char *desc, const char *header_to_add, const char *body, long long bodylen) {
+int XrdHttpProtocol::SendSimpleResp(int code, const char *desc, const char *header_to_add, const char *body, long long bodylen, bool keepalive) {
 
   long long content_length = bodylen;
   if (bodylen <= 0) {
     content_length = body ? strlen(body) : 0;
   }
 
-  if (StartSimpleResp(code, desc, header_to_add, content_length) < 0)
+  if (StartSimpleResp(code, desc, header_to_add, content_length, keepalive) < 0)
     return -1;
 
   //

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -134,7 +134,7 @@ private:
   static int InitSecurity();
 
   /// Start a response back to the client
-  int StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen);
+  int StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen, bool keepalive);
 
   /// Send some generic data to the client
   int SendData(const char *body, int bodylen);
@@ -229,11 +229,11 @@ private:
   int BuffgetLine(XrdOucString &dest);
 
   /// Sends a basic response. If the length is < 0 then it is calculated internally
-  int SendSimpleResp(int code, const char *desc, const char *header_to_add, const char *body, long long bodylen);
+  int SendSimpleResp(int code, const char *desc, const char *header_to_add, const char *body, long long bodylen, bool keepalive);
 
   /// Starts a chunked response; body of request is sent over multiple parts using the SendChunkResp
   //  API.
-  int StartChunkedResp(int code, const char *desc, const char *header_to_add);
+  int StartChunkedResp(int code, const char *desc, const char *header_to_add, bool keepalive);
 
   /// Send a (potentially partial) body in a chunked response; invoking with NULL body
   //  indicates that this is the last chunk in the response.
@@ -267,8 +267,6 @@ private:
   /// connection being established
   bool ssldone;
 
-  
-  
   static XrdCryptoFactory *myCryptoFactory;
 protected:
 

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -106,10 +106,9 @@ private:
   void mapXrdErrorToHttpStatus();
 public:
 
-  XrdHttpReq(XrdHttpProtocol *protinstance) {
+  XrdHttpReq(XrdHttpProtocol *protinstance) : keepalive(true) {
 
     prot = protinstance;
-    keepalive = false;
     length = 0;
     //xmlbody = 0;
     depth = 0;


### PR DESCRIPTION
Additionally, if the client is making a HTTP/1.0 request, make sure
to disable keepalive by default.

Fix #809 

@ffurano 