### PR TITLE
[XrdHttp] Reset filesize when the XrdHttpReq object is used.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2456,8 +2456,6 @@ void XrdHttpReq::reset() {
   //                bool final //!< true -> final result
 
 
-  keepalive = false;
-  length = 0;
   //xmlbody = 0;
   depth = 0;
   xrdresp = kXR_noResponsesYet;
@@ -2476,6 +2474,7 @@ void XrdHttpReq::reset() {
   headerok = false;
   keepalive = true;
   length = 0;
+  filesize = 0;
   depth = 0;
   sendcontinue = false;
 


### PR DESCRIPTION
The `filesize` member was not being reset between requests.  If it is non-zero, the `XrdHttpReq` object uses the size when parsing header to potentially reduce the total read size (preventing it from going past the EOF).

Unfortunately, since the `filesize` was set to the size of the *previous* file transfer, this could cause the total response size to be less than the request, resulting in a shorter-than-expected response to the client.