### PR TITLE
Fixes for XrdHttp request state issues

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -692,6 +692,7 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
 
     if (!CurrentReq.headerok) {
       TRACEI(REQ, " rc:" << rc << "Header not yet complete.");
+      CurrentReq.reqstate--;
       // Waiting for more data
       return 1;
     }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -72,13 +72,13 @@ static XrdOucString convert_digest_name(const std::string &rfc_name)
     return "md5";
   } else if (!strcasecmp(rfc_name.c_str(), "adler32")) {
     return "adler32";
-  } else if (strcasecmp(rfc_name.c_str(), "SHA")) {
+  } else if (!strcasecmp(rfc_name.c_str(), "SHA")) {
     return "sha1";
-  } else if (strcasecmp(rfc_name.c_str(), "SHA-256")) {
+  } else if (!strcasecmp(rfc_name.c_str(), "SHA-256")) {
     return "sha256";
-  } else if (strcasecmp(rfc_name.c_str(), "SHA-512")) {
+  } else if (!strcasecmp(rfc_name.c_str(), "SHA-512")) {
     return "sha512";
-  } else if (strcasecmp(rfc_name.c_str(), "UNIXcksum")) {
+  } else if (!strcasecmp(rfc_name.c_str(), "UNIXcksum")) {
     return "cksum";
   }
   return "unknown";


### PR DESCRIPTION
This fixes two problems in the XrdHttp request state:

1.  The callback counter was incorrectly incremented when partial headers were received, meaning the state machine was invalid.
2.  The return code for `strcasecmp` was incorrectly checked, making the code often assume `sha1` was requested.