### PR TITLE
Update xrdfs.1 - document 'BackUpExists' stat flag

### DIFF
--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -84,7 +84,7 @@ flags may be combined together using '|' or '&'
 .br
 Available flags:
 \fBXBitSet\fR, \fBIsDir\fR, \fBOther\fR, \fBOffline\fR, \fBPOSCPending\fR,
-\fBIsReadable\fR, \fBIsWriteable\fR
+\fBIsReadable\fR, \fBIsWriteable\fR, \fBBackUpExists\fR
 
 .RE
 \fBstatvfs\fR \fI<path>\fR


### PR DESCRIPTION
trivial: "BackUpExists" (i.e file is stored on archival media) is implemented but not in the manpage.