### PR TITLE
Do not increment reqstate when headers are incomplete.

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -750,6 +750,7 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
 
     if (!CurrentReq.headerok) {
       TRACEI(REQ, " rc:" << rc << "Header not yet complete.");
+      CurrentReq.reqstate--;
       // Waiting for more data
       return 1;
     }


### PR DESCRIPTION
If the server got incomplete headers (I was able to reliably trigger this with connection reuse), the `reqstate` variable was still incremented.

This resulted in the request state becoming inconsistent - notably, for master, we saw `HEAD` requests believed they always included a checksum.  There are likely other strange XrdHttp behaviors that could have been triggered due to the same bug, hence the request for backport to the stable branch.

(cherry picked from commit 88dad6ab1a1062749ba5e9ca5e0e9b98acbcddab; backport of relevant fix in #822)