### PR TITLE
[Pfc] Couple of fixes from extended testing

### DIFF
--- a/src/XrdFileCache/XrdFileCache.cc
+++ b/src/XrdFileCache/XrdFileCache.cc
@@ -708,7 +708,7 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
    int res = m_output_fs->Stat(i_name.c_str(), &sbuff);
    if (res == 0)
    {
-      TRACE(Dump, "Cache::Prefetch defer open " << f_name);
+      TRACE(Dump, "Cache::Prepare defer open " << f_name);
       return 1;
    }
    else

--- a/src/XrdFileCache/XrdFileCache.cc
+++ b/src/XrdFileCache/XrdFileCache.cc
@@ -71,16 +71,17 @@ XrdOucCache2 *XrdOucGetCache2(XrdSysLogger *logger,
                               const char   *config_filename,
                               const char   *parameters)
 {
-   XrdSysError err(0, "");
-   err.logger(logger);
-   err.Emsg("Retrieve", "Retrieving a caching proxy factory.");
-   Cache &factory = Cache::GetInstance();
-   if (! factory.Config(logger, config_filename, parameters))
+   XrdSysError err(logger, "");
+   err.Say("++++++ Proxy file cache initialization started.");
+
+   Cache &factory = Cache::CreateInstance(logger);
+
+   if (! factory.Config(config_filename, parameters))
    {
-      err.Emsg("Retrieve", "Error - unable to create a factory.");
+      err.Say("Config Proxy file cache initialization failed.");
       return NULL;
    }
-   err.Emsg("Retrieve", "Success - returning a factory.");
+   err.Say("------ Proxy file cache initialization completed.");
 
    pthread_t tid1;
    XrdSysThread::Run(&tid1, ProcessWriteTaskThread, (void*)(&factory), 0, "XrdFileCache WriteTasks ");
@@ -90,8 +91,7 @@ XrdOucCache2 *XrdOucGetCache2(XrdSysLogger *logger,
 
    pthread_t tid;
    XrdSysThread::Run(&tid, PurgeThread, NULL, 0, "XrdFileCache Purge");
-   
-   
+
    return &factory;
 }
 }
@@ -119,10 +119,16 @@ void Configuration::calculate_fractional_usages(long long  du,      long long  f
 
 //==============================================================================
 
+Cache &Cache::CreateInstance(XrdSysLogger *logger)
+{
+   assert (m_factory == NULL);
+   m_factory = new Cache(logger);
+   return *m_factory;
+}
+
 Cache &Cache::GetInstance()
 {
-   if (m_factory == NULL)
-      m_factory = new Cache();
+   assert (m_factory != NULL);
    return *m_factory;
 }
 
@@ -147,10 +153,10 @@ bool Cache::Decide(XrdOucCacheIO* io)
    return true;
 }
 
-Cache::Cache() :
+Cache::Cache(XrdSysLogger *logger) :
    XrdOucCache(),
-   m_log(0, "XrdFileCache_"),
-   m_trace(0),
+   m_log(logger, "XrdFileCache_"),
+   m_trace(new XrdSysTrace("XrdFileCache", logger)),
    m_traceID("Manager"),
    m_prefetch_condVar(0),
    m_RAMblocks_used(0),
@@ -158,8 +164,7 @@ Cache::Cache() :
    m_in_purge(false),
    m_active_cond(0)
 {
-   m_trace = new XrdSysTrace("XrdFileCache");
-   // default log level is Warning
+   // Default log level is Warning.
    m_trace->What = 2;
 }
 

--- a/src/XrdFileCache/XrdFileCache.hh
+++ b/src/XrdFileCache/XrdFileCache.hh
@@ -128,7 +128,7 @@ public:
    //---------------------------------------------------------------------
    //! Constructor
    //---------------------------------------------------------------------
-   Cache();
+   Cache(XrdSysLogger *logger);
 
    //---------------------------------------------------------------------
    //! Obtain a new IO object that fronts existing XrdOucCacheIO.
@@ -176,15 +176,19 @@ public:
    //---------------------------------------------------------------------
    //! \brief Parse configuration file
    //!
-   //! @param logger             xrootd logger
    //! @param config_filename    path to configuration file
    //! @param parameters         optional parameters to be passed
    //!
    //! @return parse status
    //---------------------------------------------------------------------
-   bool Config(XrdSysLogger *logger, const char *config_filename, const char *parameters);
+   bool Config(const char *config_filename, const char *parameters);
 
    //---------------------------------------------------------------------
+   //! Singleton creation.
+   //---------------------------------------------------------------------
+   static Cache &CreateInstance(XrdSysLogger *logger);
+
+  //---------------------------------------------------------------------
    //! Singleton access.
    //---------------------------------------------------------------------
    static Cache &GetInstance();
@@ -250,9 +254,8 @@ private:
 
    bool cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name);
 
-   static Cache     *m_factory;         //!< this object
-   static 
-   XrdScheduler     *schedP;
+   static Cache        *m_factory;      //!< this object
+   static XrdScheduler *schedP;
 
    XrdSysError       m_log;             //!< XrdFileCache namespace logger
    XrdSysTrace      *m_trace;

--- a/src/XrdFileCache/XrdFileCachePurge.cc
+++ b/src/XrdFileCache/XrdFileCachePurge.cc
@@ -270,7 +270,7 @@ void Cache::Purge()
       if (bytesToRemove > 0 || enforce_age_based_purge)
       {
          // Make a sorted map of file paths sorted by access time.
-         FPurgeState purgeState(bytesToRemove * 5 / 4); // prepare 20% more volume than required
+         FPurgeState purgeState(2 * bytesToRemove); // prepare twice more volume than required
 
          if (m_configuration.is_age_based_purge_in_effect())
          {
@@ -328,6 +328,8 @@ void Cache::Purge()
 
          // Loop over map and remove files with oldest values of access time.
          struct stat fstat;
+         int         protected_cnt = 0;
+         long long   protected_sum = 0;
          for (FPurgeState::map_i it = purgeState.fmap.begin(); it != purgeState.fmap.end(); ++it)
          {
             // Finish when enough space has been freed but not while purging of cold files is in progress.
@@ -340,7 +342,12 @@ void Cache::Purge()
             std::string dataPath = infoPath.substr(0, infoPath.size() - strlen(XrdFileCache::Info::m_infoExtension));
 
             if (IsFileActiveOrPurgeProtected(dataPath))
+            {
+               ++protected_cnt;
+               protected_sum += it->second.nBytes;
+               TRACE(Debug, trc_pfx << "File is active or purge-protected: " << dataPath << " size: " << it->second.nBytes);
                continue;
+            }
 
             // remove info file
             if (oss->Stat(infoPath.c_str(), &fstat) == XrdOssOK)
@@ -363,9 +370,12 @@ void Cache::Purge()
                ++deleted_file_count;
 
                oss->Unlink(dataPath.c_str());
-               TRACE(Dump, trc_pfx << "Removed file: '" << dataPath << "' size: " << it->second.nBytes <<
-                     ", time: " << it->first);
+               TRACE(Dump, trc_pfx << "Removed file: '" << dataPath << "' size: " << it->second.nBytes << ", time: " << it->first);
             }
+         }
+         if (protected_cnt > 0)
+         {
+            TRACE(Info, trc_pfx << "Encountered " << protected_cnt << " protected files, sum of their size: " << protected_sum);
          }
       }
 
@@ -376,7 +386,9 @@ void Cache::Purge()
          m_in_purge = false;
       }
 
-      TRACE(Info, trc_pfx << "Finished, removed " << deleted_file_count << " data files, total size " << bytesToRemove_at_start - bytesToRemove << " B.");
+      TRACE(Info, trc_pfx << "Finished, removed " << deleted_file_count << " data files, total size " <<
+            bytesToRemove_at_start - bytesToRemove << ", bytes to remove at end: " << bytesToRemove);
+
       sleep(m_configuration.m_purgeInterval);
    }
 }


### PR DESCRIPTION
* Make sure not to call XrdOucStream::GetWord() again after it returns 0.
* Fix logging initialization to survive log rotation.
* Fix logic for purging below nominal file usage when file usage limits are in force.
* Add traces to Purge() about files not removed due to activity protections.