### PR TITLE
Support multiple IO objects working with the same file

### DIFF
--- a/src/XrdFileCache/XrdFileCache.hh
+++ b/src/XrdFileCache/XrdFileCache.hh
@@ -236,11 +236,11 @@ public:
    
    File* GetFile(const std::string&, IO*, long long off = 0, long long filesize = 0);
 
-   void ReleaseFile(File*);
+   void  ReleaseFile(File*, IO*);
 
-   void ScheduleFileSync(File* f) { schedule_file_sync(f, false); }
+   void ScheduleFileSync(File* f) { schedule_file_sync(f, false, false); }
 
-   void FileSyncDone(File*);
+   void FileSyncDone(File*, bool high_debug);
    
    XrdSysTrace* GetTrace() { return m_trace; }
 
@@ -270,9 +270,10 @@ private:
 
    Configuration m_configuration;           //!< configurable parameters
 
-   XrdSysCondVar m_prefetch_condVar;        //!< central lock for this class
+   XrdSysCondVar m_prefetch_condVar;        //!< lock for vector of prefetching files
+   bool          m_prefetch_enabled;        //!< set to true when prefetching is enabled
 
-   XrdSysMutex m_RAMblock_mutex;            //!< central lock for this class
+   XrdSysMutex m_RAMblock_mutex;            //!< lock for allcoation of RAM blocks
    int         m_RAMblocks_used;
    bool        m_isClient;                  //!< True if running as client
 
@@ -298,10 +299,10 @@ private:
    bool          m_in_purge;
    XrdSysCondVar m_active_cond;
 
-   void inc_ref_cnt(File*, bool lock);
-   void dec_ref_cnt(File*);
+   void inc_ref_cnt(File*, bool lock, bool high_debug);
+   void dec_ref_cnt(File*, bool high_debug);
 
-   void schedule_file_sync(File*, bool ref_cnt_already_set);
+   void schedule_file_sync(File*, bool ref_cnt_already_set, bool high_debug);
 
    // prefetching
    typedef std::vector<File*>  PrefetchList;

--- a/src/XrdFileCache/XrdFileCacheFile.hh
+++ b/src/XrdFileCache/XrdFileCacheFile.hh
@@ -62,31 +62,37 @@ public:
    std::vector<char>   m_buff;
    long long           m_offset;
    File               *m_file;
-   bool                m_prefetch;
-   int                 m_refcnt;
-   int                 m_errno;                         // stores negative errno
-   bool                m_downloaded;
+   IO                 *m_io;            // IO that handled current request, used for == / != comparisons only
 
-   Block(File *f, long long off, int size, bool m_prefetch) :
-      m_offset(off), m_file(f), m_prefetch(m_prefetch), m_refcnt(0),
-      m_errno(0), m_downloaded(false)
+   int                 m_refcnt;
+   int                 m_errno;         // stores negative errno
+   bool                m_downloaded;
+   bool                m_prefetch;
+
+   Block(File *f, IO *io, long long off, int size, bool m_prefetch) :
+      m_offset(off), m_file(f), m_io(io), m_refcnt(0),
+      m_errno(0), m_downloaded(false), m_prefetch(m_prefetch)
    {
       m_buff.resize(size);
    }
 
-   char*     get_buff(long long pos = 0) { return &m_buff[pos]; }
-   int       get_size()   { return (int) m_buff.size(); }
-   long long get_offset() { return m_offset; }
+   char*     get_buff(long long pos = 0) { return &m_buff[pos];        }
+   int       get_size()                  { return (int) m_buff.size(); }
+   long long get_offset()                { return m_offset;            }
+
+   IO*  get_io() const { return m_io; }
 
    bool is_finished() { return m_downloaded || m_errno != 0; }
    bool is_ok()       { return m_downloaded; }
    bool is_failed()   { return m_errno != 0; }
 
-   void set_error_and_free(int err)
+   void set_downloaded()    { m_downloaded = true; }
+   void set_error(int err)  { m_errno      = err;  }
+
+   void reset_error_and_set_io(IO *io)
    {
-      m_errno = err;
-      std::vector<char> x;
-      m_buff.swap(x);
+      m_errno = 0;
+      m_io    = io;
    }
 };
 
@@ -96,8 +102,10 @@ class BlockResponseHandler : public XrdOucCacheIOCB
 {
 public:
    Block *m_block;
+   bool   m_for_prefetch;
 
-   BlockResponseHandler(Block *b) : m_block(b) {}
+   BlockResponseHandler(Block *b, bool prefetch) :
+      m_block(b), m_for_prefetch(prefetch) {}
 
    virtual void Done(int result);
 };
@@ -128,7 +136,7 @@ public:
    //------------------------------------------------------------------------
    //! Constructor.
    //------------------------------------------------------------------------
-   File(IO *io, const std::string &path, long long offset, long long fileSize);
+   File(const std::string &path, long long offset, long long fileSize);
 
    //------------------------------------------------------------------------
    //! Destructor.
@@ -140,9 +148,10 @@ public:
    bool Open();
 
    //! Vector read from disk if block is already downloaded, else ReadV from client.
-   int ReadV (const XrdOucIOVec *readV, int n);
+   int ReadV(IO *io, const XrdOucIOVec *readV, int n);
 
-   int Read(char* buff, long long offset, int size);
+   //! Normal read.
+   int Read (IO *io, char* buff, long long offset, int size);
 
    //----------------------------------------------------------------------
    //! \brief Data and cinfo files are open.
@@ -153,7 +162,7 @@ public:
    //! \brief Initiate close. Return true if still IO active.
    //! Used in XrdPosixXrootd::Close()
    //----------------------------------------------------------------------
-   bool ioActive();
+   bool ioActive(IO *io);
    
    //----------------------------------------------------------------------
    //! \brief Flags that detach stats should be written out in final sync.
@@ -177,7 +186,7 @@ public:
    //----------------------------------------------------------------------
    Stats& GetStats() { return m_stats; }
 
-   void ProcessBlockResponse(Block* b, int res);
+   void ProcessBlockResponse(BlockResponseHandler* brh, int res);
    void WriteBlockToDisk(Block* b);
 
    void Prefetch();
@@ -193,8 +202,10 @@ public:
 
    long long GetFileSize() { return m_fileSize; }
 
-   IO*  SetIO(IO* io);
-   void ReleaseIO();
+   void AddIO(IO *io);
+   int  GetPrefetchCountOnIO(IO *io);
+   void StopPrefetchingOnIO(IO *io);
+   void RemoveIO(IO *io);
 
    // These three methods are called under Cache's m_active lock
    int get_ref_cnt() { return   m_ref_cnt; }
@@ -208,14 +219,29 @@ private:
    
    bool           m_is_open;            //!< open state
 
-   IO            *m_io;                 //!< original data source
    XrdOssDF      *m_output;             //!< file handle for data file on disk
    XrdOssDF      *m_infoFile;           //!< file handle for data-info file on disk
    Info           m_cfi;                //!< download status of file blocks and access statistics
 
    std::string    m_filename;           //!< filename of data file on disk
-   long long      m_offset;             //!< offset of cached file for block-based operation
+   long long      m_offset;             //!< offset of cached file for block-based / hdfs operation
    long long      m_fileSize;           //!< size of cached disk file for block-based operation
+
+   // IO objects attached to this file.
+
+   struct IODetails
+   {
+      int    m_active_prefetches;
+      bool   m_allow_prefetching;
+
+      IODetails() : m_active_prefetches(0), m_allow_prefetching(true) {}
+   };
+
+   typedef std::map<IO*, IODetails> IoMap_t;
+   typedef IoMap_t::iterator        IoMap_i;
+
+   IoMap_t    m_io_map;
+   IoMap_i    m_current_io; //!< IO object to be used for prefetching.
 
    // fsync
    std::vector<int>  m_writes_during_sync;
@@ -236,13 +262,13 @@ private:
 
    XrdSysCondVar m_downloadCond;
 
-   Stats m_stats;                   //!< cache statistics, used in IO detach
+   Stats m_stats;                      //!< cache statistics, used in IO detach
 
    PrefetchState_e m_prefetchState;
 
    int   m_prefetchReadCnt;
    int   m_prefetchHitCnt;
-   float m_prefetchScore;              //cached
+   float m_prefetchScore;              // cached
    
    bool  m_detachTimeIsLogged;
 
@@ -255,12 +281,14 @@ private:
                 long long &off,        // offset in user buffer
                 long long &blk_off,    // offset in block
                 long long &size);
-   // Read
-   Block* PrepareBlockRequest(int i, bool prefetch);
-   
-   void   ProcessBlockRequests(BlockList_t& blks);
 
-   int    RequestBlocksDirect(DirectResponseHandler *handler, IntList_t& blocks,
+   // Read
+   Block* PrepareBlockRequest(int i, IO *io, bool prefetch);
+   
+   void   ProcessBlockRequest (Block       *b,    bool prefetch);
+   void   ProcessBlockRequests(BlockList_t& blks, bool prefetch);
+
+   int    RequestBlocksDirect(IO *io, DirectResponseHandler *handler, IntList_t& blocks,
                               char* buff, long long req_off, long long req_size);
 
    int    ReadBlocksFromDisk(IntList_t& blocks,
@@ -268,13 +296,13 @@ private:
 
    // VRead
    bool VReadValidate     (const XrdOucIOVec *readV, int n);
-   bool VReadPreProcess   (const XrdOucIOVec *readV, int n,
+   bool VReadPreProcess   (IO *io, const XrdOucIOVec *readV, int n,
                            ReadVBlockListRAM&  blks_to_process,
                            ReadVBlockListDisk& blks_on_disk,
                            std::vector<XrdOucIOVec>& chunkVec);
    int  VReadFromDisk     (const XrdOucIOVec *readV, int n,
                            ReadVBlockListDisk& blks_on_disk);
-   int  VReadProcessBlocks(const XrdOucIOVec *readV, int n,
+   int  VReadProcessBlocks(IO *io, const XrdOucIOVec *readV, int n,
                            std::vector<ReadVChunkListRAM>& blks_to_process,
                            std::vector<ReadVChunkListRAM>& blks_rocessed);
 
@@ -283,6 +311,8 @@ private:
    void inc_ref_count(Block*);
    void dec_ref_count(Block*);
    void free_block(Block*);
+
+   bool select_current_io_or_disable_prefetching(bool skip_current);
 
    int  offsetIdx(int idx);
 };

--- a/src/XrdFileCache/XrdFileCacheIO.hh
+++ b/src/XrdFileCache/XrdFileCacheIO.hh
@@ -39,8 +39,6 @@ public:
 
    virtual void Update(XrdOucCacheIO2 &iocp);
 
-   virtual void RelinquishFile(File*) = 0;
-
    XrdSysTrace* GetTrace() { return m_cache.GetTrace(); }
 
    XrdOucCacheIO2* GetInput();

--- a/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
+++ b/src/XrdFileCache/XrdFileCacheIOEntireFile.hh
@@ -90,8 +90,6 @@ public:
 
    virtual long long FSize();
 
-   virtual void RelinquishFile(File*);
-
 private:
    XrdSysMutex  m_mutex;
    File        *m_file;

--- a/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
+++ b/src/XrdFileCache/XrdFileCacheIOFileBlock.hh
@@ -70,8 +70,6 @@ public:
 
    virtual long long FSize();
 
-   virtual void RelinquishFile(File*);
-
 private:
    long long                  m_blocksize;       //!< size of file-block
    std::map<int, File*>       m_blocks;          //!< map of created blocks

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -367,14 +367,6 @@ bool Info::Write(XrdOssDF* fp, const std::string &fname)
 
 //------------------------------------------------------------------------------
 
-void Info::WriteIOStatDetach(Stats& s)
-{
-   m_store.m_astats.back().DetachTime  = time(0);
-   m_store.m_astats.back().BytesDisk   = s.m_BytesDisk;
-   m_store.m_astats.back().BytesRam    = s.m_BytesRam;
-   m_store.m_astats.back().BytesMissed = s.m_BytesMissed;
-}
-
 void Info::WriteIOStatAttach()
 {
    m_store.m_accessCnt++;
@@ -384,6 +376,21 @@ void Info::WriteIOStatAttach()
    AStat as;
    as.AttachTime = time(0);
    m_store.m_astats.push_back(as);
+}
+
+void Info::WriteIOStat(Stats& s)
+{
+   m_store.m_astats.back().BytesDisk   = s.m_BytesDisk;
+   m_store.m_astats.back().BytesRam    = s.m_BytesRam;
+   m_store.m_astats.back().BytesMissed = s.m_BytesMissed;
+}
+
+void Info::WriteIOStatDetach(Stats& s)
+{
+   m_store.m_astats.back().DetachTime  = time(0);
+   m_store.m_astats.back().BytesDisk   = s.m_BytesDisk;
+   m_store.m_astats.back().BytesRam    = s.m_BytesRam;
+   m_store.m_astats.back().BytesMissed = s.m_BytesMissed;
 }
 
 void Info::WriteIOStatSingle(long long bytes_disk)

--- a/src/XrdFileCache/XrdFileCacheInfo.hh
+++ b/src/XrdFileCache/XrdFileCacheInfo.hh
@@ -147,7 +147,11 @@ public:
    //---------------------------------------------------------------------
    void WriteIOStatAttach();
 
+   //! Write bytes missed, hits, and disk
    //---------------------------------------------------------------------
+   void WriteIOStat(Stats& s);
+
+  //---------------------------------------------------------------------
    //! Write close time together with bytes missed, hits, and disk
    //---------------------------------------------------------------------
    void WriteIOStatDetach(Stats& s);

--- a/src/XrdFileCache/XrdFileCacheTrace.hh
+++ b/src/XrdFileCache/XrdFileCacheTrace.hh
@@ -10,13 +10,29 @@
 #define TRACE_Debug    4
 #define TRACE_Dump     5
 
-
 #define TRACE_STR_None     ""
 #define TRACE_STR_Error    "error "
 #define TRACE_STR_Warning  "warning "
 #define TRACE_STR_Info     "info "
 #define TRACE_STR_Debug    "debug "
 #define TRACE_STR_Dump     "dump "
+
+#define TRACE_STR_0        ""
+#define TRACE_STR_1        "error "
+#define TRACE_STR_2        "warning "
+#define TRACE_STR_3        "info "
+#define TRACE_STR_4        "debug "
+#define TRACE_STR_5        "dump "
+
+namespace
+{
+  const char* TraceInt2Str(int lvl)
+  {
+    static const char* t_strings[] = { "", "error ", "warning ", "info ", "debug ", "dump " };
+
+    return t_strings[lvl];
+  }
+}
 
 #ifndef NODEBUG
 
@@ -33,10 +49,14 @@
    if (XRD_TRACE What >= TRACE_ ## act) \
    {XRD_TRACE Beg(0, m_traceID) << TRACE_STR_ ## act  << x; XRD_TRACE End(); }
 
+#define TRACE_INT(act, x) \
+   if (XRD_TRACE What >= act) \
+   {XRD_TRACE Beg(0, m_traceID) << TraceInt2Str(act) << x; XRD_TRACE End(); }
+
 #define TRACE_TEST(act, x) \
    XRD_TRACE Beg("", m_traceID) << TRACE_STR_ ## act  << x; XRD_TRACE End(); 
 
-#define TRACE_PC(act, pre_code, x)           \
+#define TRACE_PC(act, pre_code, x) \
    if (XRD_TRACE What >= TRACE_ ## act) \
    {pre_code; XRD_TRACE Beg(0, m_traceID) << TRACE_STR_ ## act  <<x; XRD_TRACE End(); }
 

--- a/src/XrdFileCache/XrdFileCacheVRead.cc
+++ b/src/XrdFileCache/XrdFileCacheVRead.cc
@@ -13,17 +13,17 @@
 
 namespace XrdFileCache
 {
-// a list of IOVec chuncks that match a given block index
-// first element is block index, the following vector elements are chunk readv indicies
-struct  ReadVChunkListDisk
+// A list of IOVec chuncks that match a given block index.
+// arr vector holds chunk readv indicies.
+struct ReadVChunkListDisk
 {
    ReadVChunkListDisk(int i) : block_idx(i) {}
 
-   int block_idx;
+   int              block_idx;
    std::vector<int> arr;
 };
 
-struct  ReadVChunkListRAM
+struct ReadVChunkListRAM
 {
    ReadVChunkListRAM(Block*b, std::vector <int>* iarr) : block(b), arr(iarr) {}
 
@@ -77,11 +77,11 @@ using namespace XrdFileCache;
 
 //------------------------------------------------------------------------------
 
-int File::ReadV(const XrdOucIOVec *readV, int n)
+int File::ReadV(IO *io, const XrdOucIOVec *readV, int n)
 {
    if ( ! isOpen())
    {
-      return m_io->GetInput()->ReadV(readV, n);
+      return io->GetInput()->ReadV(readV, n);
    }
 
    TRACEF(Dump, "ReadV for " << n << " chunks.");
@@ -104,7 +104,7 @@ int File::ReadV(const XrdOucIOVec *readV, int n)
 
    // TODO The following call never fails (other than with out of mem exception).
    // This should be implemented in PrepareBlockRequest().
-   if ( ! VReadPreProcess(readV, n, blocks_to_process, blocks_on_disk, chunkVec))
+   if ( ! VReadPreProcess(io, readV, n, blocks_to_process, blocks_on_disk, chunkVec))
    {
       bytesRead = -1;
       errno = ENOMEM;
@@ -117,7 +117,7 @@ int File::ReadV(const XrdOucIOVec *readV, int n)
       if ( ! chunkVec.empty())
       {
          direct_handler = new DirectResponseHandler(1);
-         m_io->GetInput()->ReadV(*direct_handler, &chunkVec[0], chunkVec.size());
+         io->GetInput()->ReadV(*direct_handler, &chunkVec[0], chunkVec.size());
       }
    }
 
@@ -139,7 +139,7 @@ int File::ReadV(const XrdOucIOVec *readV, int n)
    // read from cached blocks
    if (bytesRead >= 0)
    {
-      int br = VReadProcessBlocks(readV, n, blocks_to_process.bv, blks_processed);
+      int br = VReadProcessBlocks(io, readV, n, blocks_to_process.bv, blks_processed);
       if (br < 0)
       {
          bytesRead = br;
@@ -179,8 +179,9 @@ int File::ReadV(const XrdOucIOVec *readV, int n)
    {
       XrdSysCondVarHelper _lck(m_downloadCond);
 
-      // decrease ref count on the remaining blocks
-      // this happens in case read process has been broke due to previous errors
+      // Decrease ref count on the remaining blocks.
+      // This happens when read process aborts due to encountered errors.
+      // [ See better implementation of the whole process in File::Read(). ]
       for (std::vector<ReadVChunkListRAM>::iterator i = blocks_to_process.bv.begin(); i != blocks_to_process.bv.end(); ++i)
          dec_ref_count(i->block);
 
@@ -208,7 +209,7 @@ bool File::VReadValidate(const XrdOucIOVec *vr, int n)
    for (int i = 0; i < n; ++i)
    {
       if (vr[i].offset < 0 || vr[i].offset >= m_fileSize ||
-                         vr[i].offset + vr[i].size > m_fileSize)
+          vr[i].offset + vr[i].size > m_fileSize)
       {
          return false;
       }
@@ -218,7 +219,7 @@ bool File::VReadValidate(const XrdOucIOVec *vr, int n)
 
 //------------------------------------------------------------------------------
 
-bool File::VReadPreProcess(const XrdOucIOVec *readV, int n,
+bool File::VReadPreProcess(IO *io, const XrdOucIOVec *readV, int n,
                            ReadVBlockListRAM        &blocks_to_process,
                            ReadVBlockListDisk       &blocks_on_disk,
                            std::vector<XrdOucIOVec> &chunkVec)
@@ -254,7 +255,7 @@ bool File::VReadPreProcess(const XrdOucIOVec *readV, int n,
          {
             if (Cache::GetInstance().RequestRAMBlock())
             {
-               Block *b = PrepareBlockRequest(block_idx, false);
+               Block *b = PrepareBlockRequest(block_idx, io, false);
                // TODO this can not fail (other than out of memory which we don't handle).
                if (! b) return false;
                inc_ref_count(b);
@@ -266,8 +267,8 @@ bool File::VReadPreProcess(const XrdOucIOVec *readV, int n,
             else
             {
                long long off;      // offset in user buffer
-               long long blk_off;      // offset in block
-               long long size;      // size to copy
+               long long blk_off;  // offset in block
+               long long size;     // size to copy
                const long long BS = m_cfi.GetBufferSize();
                overlap(block_idx, BS, readV[iov_idx].offset, readV[iov_idx].size, off, blk_off, size);
                chunkVec.push_back(XrdOucIOVec2(readV[iov_idx].data+off, BS*block_idx + blk_off,size));
@@ -280,7 +281,7 @@ bool File::VReadPreProcess(const XrdOucIOVec *readV, int n,
 
    m_downloadCond.UnLock();
 
-   ProcessBlockRequests(blks_to_request);
+   ProcessBlockRequests(blks_to_request, false);
 
    return true;
 }
@@ -325,20 +326,31 @@ int File::VReadFromDisk(const XrdOucIOVec *readV, int n, ReadVBlockListDisk& blo
 
 //------------------------------------------------------------------------------
 
-int File::VReadProcessBlocks(const XrdOucIOVec *readV, int n,
+int File::VReadProcessBlocks(IO *io, const XrdOucIOVec *readV, int n,
                              std::vector<ReadVChunkListRAM>& blocks_to_process,
                              std::vector<ReadVChunkListRAM>& blocks_processed)
 {
    int bytes_read = 0;
-   while ((! blocks_to_process.empty()) && (bytes_read >= 0))
+   while ( ! blocks_to_process.empty() && bytes_read >= 0)
    {
       std::vector<ReadVChunkListRAM> finished;
+      BlockList_t                    to_reissue;
       {
          XrdSysCondVarHelper _lck(m_downloadCond);
+
          std::vector<ReadVChunkListRAM>::iterator bi = blocks_to_process.begin();
          while (bi != blocks_to_process.end())
          {
-            if (bi->block->is_finished())
+            if (bi->block->is_failed() && bi->block->get_io() != io)
+            {
+               TRACEF(Info, "File::VReadProcessBlocks() requested block " << bi->block << " failed with another io " <<
+                      bi->block->get_io() << " - reissuing request with my io " << io);
+
+               bi->block->reset_error_and_set_io(io);
+               to_reissue.push_back(bi->block);
+               ++bi;
+            }
+            else if (bi->block->is_finished())
             {
                finished.push_back(ReadVChunkListRAM(bi->block, bi->arr));
                // Here we rely on the fact that std::vector does not reallocate on erase!
@@ -350,12 +362,15 @@ int File::VReadProcessBlocks(const XrdOucIOVec *readV, int n,
             }
          }
 
-         if (finished.empty())
+         if (finished.empty() && to_reissue.empty())
          {
             m_downloadCond.Wait();
             continue;
          }
       }
+
+      ProcessBlockRequests(to_reissue, false);
+      to_reissue.clear();
 
       std::vector<ReadVChunkListRAM>::iterator bi = finished.begin();
       while (bi != finished.end())
@@ -378,6 +393,8 @@ int File::VReadProcessBlocks(const XrdOucIOVec *readV, int n,
          {
             bytes_read = -1;
             errno = -bi->block->m_errno;
+            TRACEF(Error, "File::VReadProcessBlocks() io " << io << ", block "<< bi->block <<
+                   " finished with error " << errno << " " << strerror(errno));
             break;
          }
 


### PR DESCRIPTION
This is needed for n2n mapped files and for forwarding-mode
proxies.

Access stats are still collected on per file basis. If several IOs all
read from the same file at overlapping times, these will all be
reported as a single access. This can be improved if needed.

When a block fetch fails on certain IO, other IOs will reissue the
block request. The offending IO will get the error code result
associated with its request. When prefetching, the bad IO will be
removed from the prefetch IO map so it doesn't cause trouble again.