### PR TITLE
[CMake] Add XrdSecsss/XrdSecsssID.hh to private headers

### DIFF
--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -127,6 +127,7 @@ set( XROOTD_PRIVATE_HEADERS
   XrdOfs/XrdOfsHandle.hh
   XrdOfs/XrdOfsTrace.hh
   XrdOfs/XrdOfsTPCInfo.hh
+  XrdSecsss/XrdSecsssID.hh
   XrdSsi/XrdSsiAtomics.hh
   XrdSsi/XrdSsiCluster.hh
   XrdSsi/XrdSsiEntity.hh


### PR DESCRIPTION
Exporting the XrdSecsssID.hh header to allow usage of the XrdSecsss Registry from plugins.