### PR TITLE
Always fall back to reverse DNS if trusted

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3127,12 +3127,10 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
    if (!ServerCertNameOK(hs->Chain->End()->Subject(), Entity.host, emsg) &&
        !hs->Chain->End()->MatchesSAN(Entity.host)) {
       if ((expectedHost == NULL) && TrustDNS && Entity.addrInfo) {
-         char canonname[256];
-         if (Entity.addrInfo->Format(canonname, 256, XrdNetAddrInfo::fmtName, XrdNetAddrInfo::noPort) > 0) {
-            expectedHost = strdup(canonname);
-            if (!ServerCertNameOK(hs->Chain->End()->Subject(), Entity.host, emsg)) {
+         const char *name = Entity.addrInfo->Name();
+         expectedHost = strdup(name);
+         if ((name == NULL) || !ServerCertNameOK(hs->Chain->End()->Subject(), expectedHost, emsg)) {
                return -1;
-            }
          }
       }
       return -1;

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -390,7 +390,8 @@ private:
    XrdCryptoRSA    *sessionKsig;   // RSA key to sign
    XrdCryptoRSA    *sessionKver;   // RSA key to verify
    X509Chain       *proxyChain;    // Chain with the delegated proxy on servers
-   bool             srvMode;       // TRUE if server mode 
+   bool             srvMode;       // TRUE if server mode
+   char            *expectedHost;  // Expected hostname if TrustDNS is enabled.
 
    // Temporary Handshake local info
    gsiHSVars     *hs;
@@ -426,7 +427,7 @@ private:
    static bool    VerifyCA(int opt, X509Chain *cca, XrdCryptoFactory *cf);
    static int     VerifyCRL(XrdCryptoX509Crl *crl, XrdCryptoX509 *xca, XrdOucString crldir,
                            XrdCryptoFactory *CF, int hashalg);
-   bool           ServerCertNameOK(const char *subject, String &e);
+   bool           ServerCertNameOK(const char *subject, const char *hname, String &e);
    static XrdSutCacheEntry *GetSrvCertEnt(XrdSutCERef   &gcref,
                                        XrdCryptoFactory *cf,
                                        time_t timestamp, String &cal);


### PR DESCRIPTION
Whenever reverse DNS is trusted, this enables the "historical" configuration where the IP address of the connected socket is considered for reverse resolution (and the remote server's DN is compared against the resulting hostname).

IMHO, this is significantly more dangerous than "traditional' reliance on reverse DNS for non-Xrootd cases.  Any attacker that is performing a MITM is able to force the client to accept any valid host certificate.

So, if the attacker controlling DNS could force `foo.example.com` to resolve to attacker-controlled IP address `1.2.3.4` with reverse resolution of `badguy.io`, the client would accept the connection as long as `badguy.io` has a certificate from a valid authority.

Fix #841