### PR TITLE
Allow user to control OpenSSL's verify depth

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1064,6 +1064,7 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
       else if TS_Xeq("key", xsslkey);
       else if TS_Xeq("cadir", xsslcadir);
       else if TS_Xeq("cipherfilter", xsslcipherfilter);
+      else if TS_Xeq("verifydepth", xsslverifydepth);
       else if TS_Xeq("gridmap", xgmap);
       else if TS_Xeq("cafile", xsslcafile);
       else if TS_Xeq("secretkey", xsecretkey);

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -90,7 +90,7 @@ char *XrdHttpProtocol::secretkey = 0;
 char *XrdHttpProtocol::gridmap = 0;
 XrdOucGMap *XrdHttpProtocol::servGMap = 0;  // Grid mapping service
 
-int XrdHttpProtocol::sslverifydepth = 9;
+int XrdHttpProtocol::sslverifydepth = 12;
 SSL_CTX *XrdHttpProtocol::sslctx = 0;
 BIO *XrdHttpProtocol::sslbio_err = 0;
 XrdCryptoFactory *XrdHttpProtocol::myCryptoFactory = 0;


### PR DESCRIPTION
Additionally, this increases the default depth.  We have observed cases "in the wild" where the default value is too low.