### PR TITLE
[POSIX] Avoid SEGV due to race condition between open() and close().

### DIFF
--- a/src/XrdPosix/XrdPosixCallBack.hh
+++ b/src/XrdPosix/XrdPosixCallBack.hh
@@ -59,7 +59,7 @@ virtual     ~XrdPosixCallBack() {}
 };
 
 //-----------------------------------------------------------------------------
-//! @brief An abstract class to define a callback for open file requests.
+//! @brief An abstract class to define a callback for file I/O requests.
 //!
 //! This abstract class defines the callback interface for Fsync(), Pread(),
 //! Pwrite(), and VRead(). Async I/O is not supported for Read(), Readv(),

--- a/src/XrdPosix/XrdPosixFile.hh
+++ b/src/XrdPosix/XrdPosixFile.hh
@@ -47,7 +47,6 @@
 #include "XrdPosix/XrdPosixMap.hh"
 #include "XrdPosix/XrdPosixObject.hh"
 
-#include "Xrd/XrdJob.hh"
 /******************************************************************************/
 /*                    X r d P o s i x F i l e   C l a s s                     */
 /******************************************************************************/
@@ -57,8 +56,7 @@ class XrdPosixPrepIO;
 
 class XrdPosixFile : public XrdPosixObject, 
                      public XrdOucCacheIO2,
-                     public XrdCl::ResponseHandler,
-                     public XrdJob
+                     public XrdCl::ResponseHandler
 {
 public:
 
@@ -130,12 +128,11 @@ static void          DelayedDestroy(XrdPosixFile *fp);
 
        bool          Stat(XrdCl::XRootDStatus &Status, bool force=false);
 
-       int           Sync() {return XrdPosixMap::Result(clFile.Sync());}
+       int           Sync();
 
        void          Sync(XrdOucCacheIOCB &iocb);
 
-       int           Trunc(long long Offset)
-                          {return XrdPosixMap::Result(clFile.Truncate((uint64_t)Offset));}
+       int           Trunc(long long Offset);
 
        void          UpdtSize(size_t newsz)
                               {updMutex.Lock();
@@ -152,8 +149,6 @@ static void          DelayedDestroy(XrdPosixFile *fp);
 
        void          Write(XrdOucCacheIOCB &iocb, char *buff, long long offs,
                            int wlen);
-
-       void          DoIt();
 
        size_t        mySize;
        time_t        myMtime;

--- a/src/XrdPosix/XrdPosixFileRH.cc
+++ b/src/XrdPosix/XrdPosixFileRH.cc
@@ -121,6 +121,7 @@ void XrdPosixFileRH::HandleResponse(XrdCl::XRootDStatus *status,
 
 // Now schedule this callback
 //
+   theFile->unRef();
    if (XrdPosixGlobals::schedP) XrdPosixGlobals::schedP->Schedule(this);
       else {pthread_t tid;
             XrdSysThread::Run(&tid, callDoIt, this, 0, "PosixFileRH");

--- a/src/XrdPosix/XrdPosixPrepIO.cc
+++ b/src/XrdPosix/XrdPosixPrepIO.cc
@@ -33,6 +33,20 @@
 #include "XrdPosix/XrdPosixTrace.hh"
 
 /******************************************************************************/
+/*                               D i s a b l e                                */
+/******************************************************************************/
+  
+void XrdPosixPrepIO::Disable()
+{
+   EPNAME("PrepIODisable");
+   XrdPosixObjGuard objGuard(fileP);
+
+   DEBUG("Disabling defered open "<<fileP->Origin());
+
+   openRC = -ESHUTDOWN;
+}
+  
+/******************************************************************************/
 /*                                  I n i t                                   */
 /******************************************************************************/
   
@@ -51,13 +65,13 @@ bool XrdPosixPrepIO::Init(XrdOucCacheIOCB *iocbP)
        DMSG("Init", iCalls <<" unexpected PrepIO calls!");
       }
 
-// Check if the file is already opened. This caller may be vestigial
-//
-   if (fileP->clFile.IsOpen()) return true;
-
 // Do not try to open the file if there was previous error
 //
    if (openRC) return false;
+
+// Check if the file is already opened. This caller may be vestigial
+//
+   if (fileP->clFile.IsOpen()) return true;
 
 // Open the file. It is too difficult to do an async open here as there is a
 // possible pending async request and doing both is not easy at all.

--- a/src/XrdPosix/XrdPosixPrepIO.hh
+++ b/src/XrdPosix/XrdPosixPrepIO.hh
@@ -41,6 +41,8 @@ XrdOucCacheIO *Base()   {return this;} // Already defined
 
 XrdOucCacheIO *Detach() {return this;} // Already defined
 
+void        Disable();
+
 long long   FSize() {return (Init() ? fileP->FSize() : openRC);}
 
 int         Fstat(struct stat &buf)

--- a/src/XrdPosix/XrdPosixXrootd.cc
+++ b/src/XrdPosix/XrdPosixXrootd.cc
@@ -264,7 +264,7 @@ int XrdPosixXrootd::Close(int fildes)
 // Close the file if there is no active I/O (possible caching). Delete the
 // object if the close was successful (it might not be).
 //
-   if (!fP->Refs() && !(fP->XCio->ioActive()))
+   if (!(fP->XCio->ioActive()) && !fP->Refs())
       {if ((ret = fP->Close(Status))) {delete fP; fP = 0;}
           else {DEBUG(Status.ToString().c_str() <<" closing " <<fP->Origin());}
       } else ret = true;


### PR DESCRIPTION
This should protect against a SEGV observed under load for file caches.

This is a backport of ae1fcd1142a7570dd97473edb54555d63b5377f0, originally authored by @abh3.

Note: I'm not sure if there will be further releases in the 4.8.x series, but I wanted to make sure we at least had a PR we can point sites at if they had questions about this issue.