### PR TITLE
Utilize pipelining support in libcurl

### DIFF
--- a/src/XrdTpc.cmake
+++ b/src/XrdTpc.cmake
@@ -14,6 +14,24 @@ if( BUILD_TPC )
   # The XrdHttp library
   #-----------------------------------------------------------------------------
   include_directories( ${CURL_INCLUDE_DIRS} )
+
+  # On newer versions of libcurl, we can use pipelining of requests.
+  include (CheckCSourceCompiles)
+  SET( CMAKE_REQUIRED_INCLUDES "${CURL_INCLUDE_DIRS}" )
+  check_c_source_compiles("#include <curl/multi.h>
+
+  int main(int argc, char** argv)
+  {
+    (void)argv;
+    int foo = CURLMOPT_MAX_HOST_CONNECTIONS;
+    return 0;
+  }
+  " CURL_PIPELINING
+  )
+  set(XRD_COMPILE_DEFS "XRD_CHUNK_RESP")
+  if ( CURL_PIPELINING )
+    set(XRD_COMPILE_DEFS ${XRD_COMPILE_DEFS} "USE_PIPELINING")
+  endif ()
   
   add_library(
     ${LIB_XRD_TPC}
@@ -46,7 +64,7 @@ if( BUILD_TPC )
     INTERFACE_LINK_LIBRARIES ""
     LINK_INTERFACE_LIBRARIES ""
     LINK_FLAGS "${TPC_LINK_FLAGS}"
-    COMPILE_DEFINITIONS "XRD_CHUNK_RESP")
+    COMPILE_DEFINITIONS "${XRD_COMPILE_DEFS}")
 
   #-----------------------------------------------------------------------------
   # Install

--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -238,3 +238,8 @@ int State::AvailableBuffers() const
 {
     return m_stream->AvailableBuffers();
 }
+
+void State::DumpBuffers() const
+{
+    m_stream->DumpBuffers();
+}

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -67,6 +67,8 @@ public:
 
     int AvailableBuffers() const;
 
+    void DumpBuffers() const;
+
     // Returns true if at least one byte of the response has been received,
     // but not the entire contents of the response.
     bool BodyTransferInProgress() const {return m_offset && (m_offset != m_content_length);}

--- a/src/XrdTpc/XrdTpcStream.cc
+++ b/src/XrdTpc/XrdTpcStream.cc
@@ -1,7 +1,10 @@
 
+#include <sstream>
+
 #include "XrdTpcStream.hh"
 
 #include "XrdSfs/XrdSfsInterface.hh"
+#include "XrdSys/XrdSysError.hh"
 
 using namespace TPC;
 
@@ -92,6 +95,25 @@ Stream::Write(off_t offset, const char *buf, size_t size)
 
     return retval;
 }
+
+
+void
+Stream::DumpBuffers() const
+{
+    m_log.Emsg("Stream::DumpBuffers", "Beginning dump of stream buffers.");
+    size_t idx = 0;
+    for (std::vector<Entry*>::const_iterator entry_iter = m_buffers.begin();
+         entry_iter!= m_buffers.end();
+         entry_iter++) {
+        std::stringstream ss;
+        ss << "Buffer " << idx << ": Offset=" << (*entry_iter)->GetOffset() << ", Size="
+           << (*entry_iter)->GetSize() << ", Capacity=" << (*entry_iter)->GetCapacity();
+        m_log.Emsg("Stream::DumpBuffers", ss.str().c_str());
+        idx ++;
+    }
+    m_log.Emsg("Stream::DumpBuffers", "Finish dump of stream buffers.");
+}
+
 
 int
 Stream::Read(off_t offset, char *buf, size_t size)

--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -15,14 +15,16 @@
 struct stat;
 
 class XrdSfsFile;
+class XrdSysError;
 
 namespace TPC {
 class Stream {
 public:
-    Stream(std::unique_ptr<XrdSfsFile> fh, size_t max_blocks, size_t buffer_size)
+    Stream(std::unique_ptr<XrdSfsFile> fh, size_t max_blocks, size_t buffer_size, XrdSysError &log)
         : m_avail_count(max_blocks),
           m_fh(std::move(fh)),
-          m_offset(0)
+          m_offset(0),
+          m_log(log)
     {
         m_buffers.reserve(max_blocks);
         for (size_t idx=0; idx < max_blocks; idx++) {
@@ -39,6 +41,8 @@ public:
     int Write(off_t offset, const char *buffer, size_t size);
 
     size_t AvailableBuffers() const {return m_avail_count;}
+
+    void DumpBuffers() const;
 
 private:
 
@@ -102,6 +106,10 @@ private:
             m_size = other.m_size;
         }
 
+        off_t GetOffset() const {return m_offset;}
+        size_t GetCapacity() const {return m_capacity;}
+        size_t GetSize() const {return m_size;}
+
     private:
 
         Entry(const Entry&) = delete;
@@ -120,5 +128,6 @@ private:
     std::unique_ptr<XrdSfsFile> m_fh;
     off_t m_offset;
     std::vector<Entry*> m_buffers;
+    XrdSysError &m_log;
 };
 }

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -498,7 +498,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         curl_easy_setopt(curl, CURLOPT_CAPATH, m_cadir.c_str());
     }
     curl_easy_setopt(curl, CURLOPT_URL, resource.c_str());
-    Stream stream(std::move(fh), streams, m_block_size);
+    Stream stream(std::move(fh), streams * m_pipelining_multiplier, m_block_size, m_log);
     State state(0, stream, curl, false);
     state.CopyHeaders(req);
 

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -430,7 +430,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     }
     curl_easy_setopt(curl, CURLOPT_URL, resource.c_str());
 
-    Stream stream(std::move(fh), 0, 0);
+    Stream stream(std::move(fh), 0, 0, m_log);
     State state(0, stream, curl, true);
     state.CopyHeaders(req);
 

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -75,5 +75,14 @@ private:
     std::unique_ptr<XrdSfsFileSystem> m_sfs;
     void *m_handle_base;
     void *m_handle_chained;
+
+    // 16 blocks in flight at 16 MB each, meaning that there will be up to 256MB
+    // in flight; this is equal to the bandwidth delay product of a 200ms transcontinental
+    // connection at 10Gbps.
+#ifdef USE_PIPELINING
+    static const int m_pipelining_multiplier = 16;
+#else
+    static const int m_pipelining_multiplier = 1;
+#endif
 };
 }


### PR DESCRIPTION
This allows more requests to be in-flight to the server than the number of concurrent TCP connections.