### PR TITLE
Return correct content-range header

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1925,7 +1925,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                 char buf[64];
                 
                 XrdOucString s = "Content-Range: bytes ";
-                sprintf(buf, "%lld-%lld/%d", rwOps[0].bytestart, rwOps[0].byteend, cnt);
+                sprintf(buf, "%lld-%lld/%lld", rwOps[0].bytestart, rwOps[0].byteend, filesize);
                 s += buf;
                 
                 


### PR DESCRIPTION
According to the HTTP spec, the response from a "Range" request should have a
"content-range" header in the form of "range_begin-range_end/doc_length". But
xrootd currently returns the length of the range intead of the range of the whole
file. Pass in the length of the file and additionally change the printf string since the
file size is stored in a long long