### PR TITLE
xrdhttp: expose query string in external req handler

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -70,7 +70,7 @@ verb(req->requestverb), headers(req->allheaders) {
   resource = req->resource.c_str();
   int envlen = 0;
   
-  query = req->opaque ? req->opaque->Env(envlen) : "";
+  headers["xrd-http-query"] = req->opaque?req->opaque->Env(envlen):"";
   
   // These fields usually identify the client that connected
 

--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -68,7 +68,7 @@ XrdHttpExtReq::XrdHttpExtReq(XrdHttpReq *req, XrdHttpProtocol *pr): prot(pr),
 verb(req->requestverb), headers(req->allheaders) {
   // Here we fill the request summary with all the fields we can
   resource = req->resource.c_str();
-  int envlen=0;
+  int envlen = 0;
   
   query = req->opaque ? req->opaque->Env(envlen) : "";
   

--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -70,7 +70,7 @@ verb(req->requestverb), headers(req->allheaders) {
   resource = req->resource.c_str();
   int envlen=0;
   
-  query = req->opaque?req->opaque->Env(envlen):"";
+  query = req->opaque ? req->opaque->Env(envlen) : "";
   
   // These fields usually identify the client that connected
 

--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -25,6 +25,7 @@
 #include "XrdHttpExtHandler.hh"
 #include "XrdHttpReq.hh"
 #include "XrdHttpProtocol.hh"
+#include "XrdOuc/XrdOucEnv.hh"
 
 /// Sends a basic response. If the length is < 0 then it is calculated internally
 int XrdHttpExtReq::SendSimpleResp(int code, const char* desc, const char* header_to_add, const char* body, long long int bodylen)
@@ -67,6 +68,9 @@ XrdHttpExtReq::XrdHttpExtReq(XrdHttpReq *req, XrdHttpProtocol *pr): prot(pr),
 verb(req->requestverb), headers(req->allheaders) {
   // Here we fill the request summary with all the fields we can
   resource = req->resource.c_str();
+  int envlen=0;
+  
+  query = req->opaque?req->opaque->Env(envlen):"";
   
   // These fields usually identify the client that connected
 

--- a/src/XrdHttp/XrdHttpExtHandler.hh
+++ b/src/XrdHttp/XrdHttpExtHandler.hh
@@ -49,7 +49,7 @@ private:
 public:
   XrdHttpExtReq(XrdHttpReq *req, XrdHttpProtocol *pr);
   
-  std::string verb, resource;
+  std::string verb, resource, query;
   std::map<std::string, std::string> &headers;
   
   std::string clientdn, clienthost, clientgroups;

--- a/src/XrdHttp/XrdHttpExtHandler.hh
+++ b/src/XrdHttp/XrdHttpExtHandler.hh
@@ -49,7 +49,7 @@ private:
 public:
   XrdHttpExtReq(XrdHttpReq *req, XrdHttpProtocol *pr);
   
-  std::string verb, resource, query;
+  std::string verb, resource;
   std::map<std::string, std::string> &headers;
   
   std::string clientdn, clienthost, clientgroups;

--- a/src/XrdVersionPlugin.hh
+++ b/src/XrdVersionPlugin.hh
@@ -96,7 +96,7 @@
         XrdVERSIONPLUGIN_Rule(DoNotChk,  4,  0, XrdgetProtocol                )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdgetProtocolPort            )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdHttpGetSecXtractor         )\
-        XrdVERSIONPLUGIN_Rule(Required,  4,  8, XrdHttpGetExtHandler          )\
+        XrdVERSIONPLUGIN_Rule(Required,  4,  9, XrdHttpGetExtHandler          )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdSysLogPInit                )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdOssGetStorageSystem        )\
         XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdOssStatInfoInit            )\


### PR DESCRIPTION
I integrated XrdHttp into EOS/MGM, but I missed access to the query CGI in the external handler. Would be great to have this added to 4.9, otherwise this external handler is really sort of useless. Otherwise performance looks great!