### PR TITLE
Add padding support in ciphers

### DIFF
--- a/src/XrdCrypto/XrdCryptoCipher.cc
+++ b/src/XrdCrypto/XrdCryptoCipher.cc
@@ -40,7 +40,7 @@
 #include "XrdCrypto/XrdCryptoCipher.hh"
 
 //_____________________________________________________________________________
-bool XrdCryptoCipher::Finalize(char *, int, const char *)
+bool XrdCryptoCipher::Finalize(bool, char *, int, const char *)
 {
    // Finalize key computation (key agreement)
    ABSTRACTMETHOD("XrdCryptoCipher::Finalize");

--- a/src/XrdCrypto/XrdCryptoCipher.hh
+++ b/src/XrdCrypto/XrdCryptoCipher.hh
@@ -51,7 +51,9 @@ public:
    virtual ~XrdCryptoCipher() {}
 
    // Finalize key computation (key agreement)
-   virtual bool Finalize(char *pub, int lpub, const char *t);
+   virtual bool Finalize(bool padded, char *pub, int lpub, const char *t);
+   bool Finalize(char *pub, int lpub, const char *t)
+               { return Finalize(false, pub, lpub, t); }
 
    // Validity
    virtual bool IsValid();

--- a/src/XrdCrypto/XrdCryptoFactory.cc
+++ b/src/XrdCrypto/XrdCryptoFactory.cc
@@ -110,6 +110,15 @@ bool XrdCryptoFactory::SupportedCipher(const char *)
 }
 
 //______________________________________________________________________________
+bool XrdCryptoFactory::HasPaddingSupport()
+{
+   // Returns true id specified cipher is supported by the implementation
+
+   ABSTRACTMETHOD("XrdCryptoFactory::PaddingSupport");
+   return 0;
+}
+
+//______________________________________________________________________________
 XrdCryptoCipher *XrdCryptoFactory::Cipher(const char *, int)
 {
    // Return an instance of an implementation of XrdCryptoCipher.
@@ -130,6 +139,15 @@ XrdCryptoCipher *XrdCryptoFactory::Cipher(const char *, int, const char *,
 
 //______________________________________________________________________________
 XrdCryptoCipher *XrdCryptoFactory::Cipher(XrdSutBucket *)
+{
+   // Return an instance of an implementation of XrdCryptoCipher.
+
+   ABSTRACTMETHOD("XrdCryptoFactory::Cipher");
+   return 0;
+}
+
+//______________________________________________________________________________
+XrdCryptoCipher *XrdCryptoFactory::Cipher(bool, int, char *, int, const char *)
 {
    // Return an instance of an implementation of XrdCryptoCipher.
 

--- a/src/XrdCrypto/XrdCryptoFactory.hh
+++ b/src/XrdCrypto/XrdCryptoFactory.hh
@@ -140,11 +140,13 @@ public:
 
    // Cipher constructors
    virtual bool SupportedCipher(const char *t);
+   virtual bool HasPaddingSupport();
    virtual XrdCryptoCipher *Cipher(const char *t, int l = 0);
    virtual XrdCryptoCipher *Cipher(const char *t, int l, const char *k, 
                                    int liv, const char *iv);
    virtual XrdCryptoCipher *Cipher(XrdSutBucket *b);
    virtual XrdCryptoCipher *Cipher(int bits, char *pub, int lpub, const char *t = 0);
+   virtual XrdCryptoCipher *Cipher(bool padded, int bits, char *pub, int lpub, const char *t);
    virtual XrdCryptoCipher *Cipher(const XrdCryptoCipher &c);
 
    // MsgDigest constructors

--- a/src/XrdCrypto/XrdCryptosslCipher.hh
+++ b/src/XrdCrypto/XrdCryptosslCipher.hh
@@ -67,12 +67,14 @@ public:
    XrdCryptosslCipher(const char *t, int l, const char *k,
                                      int liv, const char *iv);
    XrdCryptosslCipher(XrdSutBucket *b);
-   XrdCryptosslCipher(int len, char *pub, int lpub, const char *t);
+   XrdCryptosslCipher(bool padded, int len, char *pub, int lpub, const char *t);
+   XrdCryptosslCipher(int len, char *pub, int lpub, const char *t)
+                     : XrdCryptosslCipher(false,len,pub,lpub,t) { }
    XrdCryptosslCipher(const XrdCryptosslCipher &c);
    virtual ~XrdCryptosslCipher();
 
    // Finalize key computation (key agreement)
-   bool Finalize(char *pub, int lpub, const char *t);
+   bool Finalize(bool padded, char *pub, int lpub, const char *t);
    void Cleanup();
 
    // Validity

--- a/src/XrdCrypto/XrdCryptosslFactory.cc
+++ b/src/XrdCrypto/XrdCryptosslFactory.cc
@@ -185,6 +185,17 @@ bool XrdCryptosslFactory::SupportedCipher(const char *t)
 }
 
 //______________________________________________________________________________
+bool XrdCryptosslFactory::HasPaddingSupport()
+{
+   // Returns true if cipher padding is supported
+#if OPENSSL_VERSION_NUMBER < 0x10002000L
+   return false;
+#else
+   return true;
+#endif
+}
+
+//______________________________________________________________________________
 XrdCryptoCipher *XrdCryptosslFactory::Cipher(const char *t, int l)
 {
    // Return an instance of a ssl implementation of XrdCryptoCipher.
@@ -232,12 +243,28 @@ XrdCryptoCipher *XrdCryptosslFactory::Cipher(XrdSutBucket *b)
 }
 
 //______________________________________________________________________________
+XrdCryptoCipher *XrdCryptosslFactory::Cipher(bool padded, int b, char *p,
+                                             int l, const char *t)
+{
+   // Return an instance of a Ssl implementation of XrdCryptoCipher.
+
+   XrdCryptoCipher *cip = new XrdCryptosslCipher(padded, b,p,l,t);
+   if (cip) {
+      if (cip->IsValid())
+         return cip;
+      else
+         delete cip;
+   }
+   return (XrdCryptoCipher *)0;
+}
+
+//______________________________________________________________________________
 XrdCryptoCipher *XrdCryptosslFactory::Cipher(int b, char *p,
                                              int l, const char *t)
 {
    // Return an instance of a Ssl implementation of XrdCryptoCipher.
 
-   XrdCryptoCipher *cip = new XrdCryptosslCipher(b,p,l,t);
+   XrdCryptoCipher *cip = new XrdCryptosslCipher(false,b,p,l,t);
    if (cip) {
       if (cip->IsValid())
          return cip;

--- a/src/XrdCrypto/XrdCryptosslFactory.hh
+++ b/src/XrdCrypto/XrdCryptosslFactory.hh
@@ -62,11 +62,13 @@ public:
 
    // Cipher constructors
    bool SupportedCipher(const char *t);
+   bool HasPaddingSupport();
    XrdCryptoCipher *Cipher(const char *t, int l = 0);
    XrdCryptoCipher *Cipher(const char *t, int l, const char *k,
                                           int liv, const char *iv);
    XrdCryptoCipher *Cipher(XrdSutBucket *b);
    XrdCryptoCipher *Cipher(int bits, char *pub, int lpub, const char *t = 0);
+   XrdCryptoCipher *Cipher(bool padded, int bits, char *pub, int lpub, const char *t = 0);
    XrdCryptoCipher *Cipher(const XrdCryptoCipher &c);
 
    // MsgDigest constructors

--- a/src/XrdCrypto/XrdCryptosslRSA.cc
+++ b/src/XrdCrypto/XrdCryptosslRSA.cc
@@ -260,6 +260,7 @@ int XrdCryptosslRSA::ImportPublic(const char *pub, int lpub)
    // bytes.
    // Return 0 in case of success, -1 in case of failure
 
+   int rc = -1;
    if (fEVP)
       EVP_PKEY_free(fEVP);
    fEVP = 0;
@@ -281,12 +282,12 @@ int XrdCryptosslRSA::ImportPublic(const char *pub, int lpub)
    // Read pub key from BIO
    if ((keytmp = PEM_read_bio_PUBKEY(bpub, 0, 0, 0))) {
       fEVP = keytmp;
-      BIO_free(bpub);
       // Update status
       status = kPublic;
-      return 0;
+      rc = 0;
    }
-   return -1;
+   BIO_free(bpub);
+   return rc;
 }
 
 //_____________________________________________________________________________

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3228,24 +3228,6 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
                      <<std::flush;
           }
       }
-/* Below is the original SAN checking code that didn't follow the RFC!
-
-   // First, check the DN against the client-provided hostname.
-   // On failure, we will iterate through the alternate names in the cert.
-   // If that fails, we will do a reverse DNS lookup of the IP address.
-   if (!ServerCertNameOK(hs->Chain->End()->Subject(), Entity.host, emsg) &&
-       !hs->Chain->End()->MatchesSAN(Entity.host, hasSAN)) {
-      if ((expectedHost == NULL) && TrustDNS && Entity.addrInfo) {
-         const char *name = Entity.addrInfo->Name();
-         DEBUG("TrustDNS fallback; checking cert is for host "
-               <<(name ? name : "???"));
-         if ((name == NULL)
-         || !ServerCertNameOK(hs->Chain->End()->Subject(), name, emsg)) {
-               return -1;
-         }
-      } else return -1;
-   }
-*/
 
    //
    // Extract the server key

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -121,7 +121,12 @@ static const char *gGSErrStr[] = {
 
 // One day in secs
 static const int kOneDay = 86400; 
+// Default proxy location template
 static const char *gUsrPxyDef = "/tmp/x509up_u";
+// Tag for pad support
+static const char *gNoPadTag = "nopad";
+// static const char *gPadTag = "&pad";
+
 
 /******************************************************************************/
 /*                     S t a t i c   C l a s s   D a t a                      */
@@ -258,6 +263,7 @@ void gsiHSVars::Dump(XrdSecProtocolgsi *p)
    PRINT("Crypto mod:          "<<CryptoMod);
    PRINT("Remote version:      "<<RemVers);
    PRINT("Ref cipher:          "<<Rcip);
+   PRINT("Cipher padding:      "<<HasPad);
    PRINT("Bucket for exp cert: "<<Cbck);
    PRINT("Handshake ID:        "<<ID);
    PRINT("Cache reference:     "<<Cref);
@@ -569,15 +575,16 @@ char *XrdSecProtocolgsi::Init(gsiOptions opt, XrdOucErrInfo *erp)
          DefCrypto = opt.clist;
       //
       // List of crypto modules
-      String cryptlist(DefCrypto,0,-1,64);
+      String cryptlist;
+      String crypts(DefCrypto,0,-1,64);
       // 
       // Load crypto modules
       XrdSutPFEntry ent;
       XrdCryptoFactory *cf = 0;
-      if (cryptlist.length()) {
+      if (crypts.length()) {
          String ncpt = "";
          int from = 0;
-         while ((from = cryptlist.tokenize(ncpt, from, '|')) != -1) {
+         while ((from = crypts.tokenize(ncpt, from, '|')) != -1) {
             if (ncpt.length() > 0 && ncpt[0] != '-') {
                // Try loading 
                if ((cf = XrdCryptoFactory::GetCryptoFactory(ncpt.c_str()))) {
@@ -592,7 +599,6 @@ char *XrdSecProtocolgsi::Init(gsiOptions opt, XrdOucErrInfo *erp)
                      PRINT("ref cipher for module "<<ncpt<<
                            " cannot be instantiated : disable");
                      from -= ncpt.length();
-                     cryptlist.erase(ncpt);
                   } else {
                      ncrypt++;
                      if (ncrypt >= XrdCryptoMax) {
@@ -600,12 +606,14 @@ char *XrdSecProtocolgsi::Init(gsiOptions opt, XrdOucErrInfo *erp)
                               << XrdCryptoMax <<") reached ");
                         break;
                      }
+                     if (cryptlist.length()) cryptlist += ":";
+                     cryptlist += ncpt;
+                     if (!cf->HasPaddingSupport()) cryptlist += gNoPadTag;
                   }
                } else {
                   PRINT("cannot instantiate crypto factory "<<ncpt<<
                            ": disable");
                   from -= ncpt.length();
-                  cryptlist.erase(ncpt);
                }
             }
          }
@@ -1406,7 +1414,7 @@ XrdSecCredentials *XrdSecProtocolgsi::getCredentials(XrdSecParameters *parm,
    const char *stepstr = 0;
    char *bpub = 0;
    int lpub = 0;
-   String CryptList = "";
+   String CryptoMod = "";
    String Host = "";
    String RemID = "";
    String Emsg;
@@ -1477,7 +1485,9 @@ XrdSecCredentials *XrdSecProtocolgsi::getCredentials(XrdSecParameters *parm,
       //
       // Add bucket with cryptomod to the global list
       // (This must be always visible from now on)
-      if (bpar->AddBucket(hs->CryptoMod,kXRS_cryptomod) != 0)
+      CryptoMod = hs->CryptoMod;
+      if (hs->RemVers >= XrdSecgsiVersDHsigned && !(hs->HasPad)) CryptoMod =+ gNoPadTag;
+      if (bpar->AddBucket(CryptoMod,kXRS_cryptomod) != 0)
          return ErrC(ei,bpar,bmai,0,
               kGSErrCreateBucket,XrdSutBuckStr(kXRS_cryptomod),stepstr);
       //
@@ -1716,6 +1726,7 @@ int XrdSecProtocolgsi::Authenticate(XrdSecCredentials *cred,
    const char *stepstr = 0;
    String Message;
    String CryptList;
+   String Ciphers;
    String Host;
    String SrvPuKExp;
    String Salt;
@@ -1788,10 +1799,10 @@ int XrdSecProtocolgsi::Authenticate(XrdSecCredentials *cred,
       if (!(bpub = hs->Rcip->Public(lpub))) 
          return ErrS(hs->ID,ei,bpar,bmai,0, kGSErrNoPublic,
                                          "session",stepstr);
-      bck = new XrdSutBucket(bpub,lpub,kXRS_puk);
 
       // If client supports decoding of signed DH, do sign them
       if (hs->RemVers >= XrdSecgsiVersDHsigned) {
+         bck = new XrdSutBucket(bpub,lpub,kXRS_cipher);
          if (sessionKsig) {
             //
             // Encrypt server DH public parameters with server key
@@ -1802,6 +1813,9 @@ int XrdSecProtocolgsi::Authenticate(XrdSecCredentials *cred,
             return ErrS(hs->ID,ei,bpar,bmai,0, kGSErrExportPuK,
                                  "server signing key undefined!",stepstr);
          }
+      } else {
+         // Previous naming
+         bck = new XrdSutBucket(bpub,lpub,kXRS_puk);
       }
 
       //
@@ -3111,9 +3125,14 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
                break;
          cip = "";
       }
-      if (cip.length() > 0)
-         // COmmunicate to server
-         br->UpdateBucket(cip, kXRS_cipher_alg);
+      // Must have a common cipher algorithm
+      if (cip.length() <= 0) {
+         emsg = "no common cipher algorithm";
+         hs->Chain = 0;
+         return -1;
+      }
+      // Communicate to server
+      br->UpdateBucket(cip, kXRS_cipher_alg);
    } else {
       NOTIFY("WARNING: list of ciphers supported by server missing"
             " - using default");
@@ -3235,24 +3254,34 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
       emsg = "server certificate contains an invalid key";
       return -1;
    }
-
-   // move this part to here, after sessionKver set, in order to verify the signature of DH parameters
-   // Extract server public part for session cipher
-   if (!(bck = br->GetBucket(kXRS_puk))) {
-      emsg = "server public part for session cipher missing";
-      hs->Chain = 0;
-      return -1;
-   }
+   // Move next part to here, after sessionKver set, in order to
+   // verify the signature of DH parameters
 
    //
    // If client supports decoding of signed DH, do sign them
    if (hs->RemVers >= XrdSecgsiVersDHsigned) {
+
+      // Extract server public part for session cipher
+      if (!(bck = br->GetBucket(kXRS_cipher))) {
+         emsg = "server public part for session cipher missing";
+         hs->Chain = 0;
+         return -1;
+      }
+
       // Encrypt server DH public parameters with server key
       if (sessionKver->DecryptPublic(*bck) <= 0) {
          emsg = "decrypting server DH public parameters";
          return -1;
       }
    } else {
+
+      // Extract server public part for session cipher
+      if (!(bck = br->GetBucket(kXRS_puk))) {
+         emsg = "server public part for session cipher missing";
+         hs->Chain = 0;
+         return -1;
+      }
+
       // If the server doesn't provide signed DH parameter, disable proxy delegation
       if (hs->Options & (kOptsFwdPxy | kOptsSigReq)) {
          hs->Options &= ~(kOptsFwdPxy | kOptsSigReq);
@@ -3265,7 +3294,7 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
    // Initialize session cipher
    SafeDelete(sessionKey);
    if (!(sessionKey =
-         sessionCF->Cipher(0,bck->buffer,bck->size,cip.c_str()))) {
+         sessionCF->Cipher(hs->HasPad, 0,bck->buffer,bck->size,cip.c_str())) || !(sessionKey->IsValid())) {
       PRINT("could not instantiate session cipher "
             "using cipher public info from server");
       emsg = "could not instantiate session cipher ";
@@ -3273,7 +3302,11 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
    }
 
    // Deactivate what not needed any longer
-   br->Deactivate(kXRS_puk);
+   if (hs->RemVers >= XrdSecgsiVersDHsigned) {
+      br->Deactivate(kXRS_cipher);
+   } else {
+      br->Deactivate(kXRS_puk);
+   }
    br->Deactivate(kXRS_x509);
 
    //
@@ -3513,6 +3546,7 @@ int XrdSecProtocolgsi::ServerDoCertreq(XrdSutBuffer *br, XrdSutBuffer **bm,
       cmsg += cmod;
       return -1;
    }
+
    //
    // Get version run by client, if there
    if (br->UnmarshalBucket(kXRS_version,hs->RemVers) != 0) {
@@ -3673,7 +3707,7 @@ int XrdSecProtocolgsi::ServerDoCert(XrdSutBuffer *br,  XrdSutBuffer **bm,
       }
       //
       // Instantiate the session cipher 
-      if (!(sessionKey->Finalize(bck->buffer,bck->size,cip.c_str()))) {
+      if (!(sessionKey->Finalize(hs->HasPad,bck->buffer,bck->size,cip.c_str()))) {
          cmsg = "cannot finalize session cipher";
          hs->Chain = 0;
          return -1;
@@ -4878,11 +4912,22 @@ int XrdSecProtocolgsi::ParseCrypto(String clist)
       // Check this module
       if (hs->CryptoMod.length() > 0) {
          DEBUG("found module: "<<hs->CryptoMod);
+         // Padding support?
+         bool otherHasPad = true;
+         if (hs->RemVers >= XrdSecgsiVersDHsigned) {
+            if (hs->CryptoMod.endswith(gNoPadTag)) {
+               otherHasPad = false;
+               hs->CryptoMod.replace(gNoPadTag, "");
+            }
+         } else {
+            otherHasPad = false;
+         }
          // Load the crypto factory
          if ((sessionCF = 
               XrdCryptoFactory::GetCryptoFactory(hs->CryptoMod.c_str()))) {
             sessionCF->SetTrace(GSITrace->What);
             if (QTRACE(Debug)) sessionCF->Notify();
+            if (otherHasPad && sessionCF->HasPaddingSupport()) hs->HasPad = 1;
             int fid = sessionCF->ID();
             int i = 0;
             // Retrieve the index in local table
@@ -4902,7 +4947,11 @@ int XrdSecProtocolgsi::ParseCrypto(String clist)
                }
             }
             // On servers the ref cipher should be defined at this point
+#if 0
             hs->Rcip = refcip[i];
+#else
+            hs->Rcip = sessionCF->Cipher(hs->HasPad, 0,0,0);
+#endif
             // we are done
             return 0;
          }

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3699,12 +3699,7 @@ int XrdSecProtocolgsi::ServerDoCert(XrdSutBuffer *br,  XrdSutBuffer **bm,
          hs->Chain = 0;
          return -1;
       }
-      // Prepare cipher agreement: get a copy of the reference cipher
-      if (!(sessionKey = sessionCF->Cipher(*(hs->Rcip)))) {
-         cmsg = "cannot get reference cipher";
-         hs->Chain = 0;
-         return -1;
-      }
+      sessionKey = hs->Rcip;
       //
       // Instantiate the session cipher 
       if (!(sessionKey->Finalize(hs->HasPad,bck->buffer,bck->size,cip.c_str()))) {
@@ -3827,6 +3822,7 @@ int XrdSecProtocolgsi::ServerDoCert(XrdSutBuffer *br,  XrdSutBuffer **bm,
          cmsg = "client public key does not match the one from the bucket!";
          return -1;
       }
+      delete ckey;
    } else {
       // For old clients, set the client public key from the certificate
       sessionKver = ckey;

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -489,11 +489,12 @@ private:
 
 class gsiHSVars {
 public:
-   int               Iter;          // iteration number
+   int               Iter;          // Iteration number
    time_t            TimeStamp;     // Time of last call
-   String            CryptoMod;     // crypto module in use
+   String            CryptoMod;     // Crypto module in use
    int               RemVers;       // Version run by remote counterpart
-   XrdCryptoCipher  *Rcip;          // reference cipher
+   XrdCryptoCipher  *Rcip;          // Reference cipher
+   bool              HasPad;        // Whether padding is supported
    XrdSutBucket     *Cbck;          // Bucket with the certificate in export form
    String            ID;            // Handshake ID (dummy for clients)
    XrdSutPFEntry    *Cref;          // Cache reference
@@ -509,7 +510,7 @@ public:
    XrdSutBuffer     *Parms;         // Buffer with server parms on first iteration 
 
    gsiHSVars() { Iter = 0; TimeStamp = -1; CryptoMod = "";
-                 RemVers = -1; Rcip = 0;
+                 RemVers = -1; Rcip = 0; HasPad = 0;
                  Cbck = 0;
                  ID = ""; Cref = 0; Pent = 0; Chain = 0; Crl = 0; PxyChain = 0;
                  RtagOK = 0; Tty = 0; LastStep = 0; Options = 0; HashAlg = 0; Parms = 0;}


### PR DESCRIPTION
Support is is automatically detected (assuming the supports means openssl v >= 1.0.2), also when talking to old clients/servers 