### PR TITLE
Report the correct protocol name to the bridge.

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -914,9 +914,9 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
   // for authorization in the paths that it manages
   if (!Bridge && !FindMatchingExtHandler(CurrentReq)) {
     if (SecEntity.name)
-      Bridge = XrdXrootd::Bridge::Login(&CurrentReq, Link, &SecEntity, SecEntity.name, "XrdHttp");
+      Bridge = XrdXrootd::Bridge::Login(&CurrentReq, Link, &SecEntity, SecEntity.name, ishttps ? "https" : "http");
     else
-      Bridge = XrdXrootd::Bridge::Login(&CurrentReq, Link, &SecEntity, "unknown", "XrdHttp");
+      Bridge = XrdXrootd::Bridge::Login(&CurrentReq, Link, &SecEntity, "unknown", ishttps ? "https" : "http");
       
     if (!Bridge) {
       TRACEI(REQ, " Authorization failed.");


### PR DESCRIPTION
Tell the bridge whether the connection came in using HTTPS or HTTP; this way, monitoring packets can differentiate the two protocol types.