### PR TITLE
[TPC] Ensure file is closed prior to sending response to client

### DIFF
--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -372,7 +372,12 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         ss << "failure: Remote side failed with status code " << state.GetStatusCode();
         m_log.Emsg(log_prefix, "Remote server failed request", ss.str().c_str());
     } else {
-        ss << "success: Created";
+        if (!handles[0]->Finalize()) {
+            ss << "failure: Failed to finalize and close file handle.";
+            m_log.Emsg(log_prefix, "Failed to finalize file handle");
+        } else {
+            ss << "success: Created";
+        }
     }
 
     if ((retval = req.ChunkResp(ss.str().c_str(), 0))) {

--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -243,3 +243,9 @@ void State::DumpBuffers() const
 {
     m_stream->DumpBuffers();
 }
+
+bool State::Finalize()
+{
+    return m_stream->Finalize();
+}
+

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -81,6 +81,15 @@ public:
     // constructor once C++11 is allowed in XRootD.
     void Move (State &other);
 
+    // Flush and finalize a transfer state.  Eventually calls close() on the underlying
+    // file handle, which should hopefully synchronize the file metadata across
+    // all readers (even other load-balanced servers on the same distributed file
+    // system).
+    //
+    // Returns true on success; false otherwise.  Failures can happen, for example, if
+    // not all buffers have been reordered by the underlying stream.
+    bool Finalize();
+
 private:
     bool InstallHandlers(CURL *curl);
 


### PR DESCRIPTION
Previously, the underlying OFS file handle was not closed until the destructor on the XrdTpcStream object was called - this occurs _after_ the response was sent to a client.

In this case, subsequent operations may be done while the file is still open for writing, which may mean data has not been written out from the client cache to the distributed file system.  If the subsequent operation (such as `stat`) is load-balanced to a different data server, then the second operation may observe an incomplete file.

The fix is to explicitly cause the file handle to be closed prior to sending the response to the client.  Then, as long as the filesystem has open-to-close consistency (which NFS and HDFS do have -- a much looser consistency requirement than POSIX), this should remove the possibility of reading an incomplete file.

This bug was revealed while testing load-balanced Xrootd on top of a HDFS filesystem at Nebraska.  Depending on how often the race condition was triggered, it caused failure rates of up to 10%.