### PR TITLE
XrdHttp: add the used protocol (https/http) as a special header i

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -84,6 +84,7 @@ verb(req->requestverb), headers(req->allheaders) {
   int envlen = 0;
   
   headers["xrd-http-query"] = req->opaque?req->opaque->Env(envlen):"";
+  headers["xrd-http-prot"] = prot->isHTTPS()?"https":"http";
   
   // These fields usually identify the client that connected
 

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -124,6 +124,9 @@ public:
   /// Authentication area
   XrdSecEntity SecEntity;
 
+  /// called via https
+  bool isHTTPS() { return ishttps; }
+
 private:
 
 


### PR DESCRIPTION
There is only a 'getter' function added to the header file and I am not sure, if this breaks ABI compatibility of the shared library. This could be postponed to version 5. It is important to know, if a call comes via a 'secure' connection or not in the plug-in.