### PR TITLE
[pfc] Fix crash when all remaining IO objects disconnect within a short time frame.

### DIFF
--- a/src/XrdFileCache/XrdFileCacheFile.hh
+++ b/src/XrdFileCache/XrdFileCacheFile.hh
@@ -241,7 +241,8 @@ private:
    typedef IoMap_t::iterator        IoMap_i;
 
    IoMap_t    m_io_map;
-   IoMap_i    m_current_io; //!< IO object to be used for prefetching.
+   IoMap_i    m_current_io;     //!< IO object to be used for prefetching.
+   int        m_ios_in_detach;  //!< Number of IO objects to which we replied false to ioActive() and will be removed soon.
 
    // fsync
    std::vector<int>  m_writes_during_sync;


### PR DESCRIPTION
Account for IO objects that are known to be detached soon when deciding whether to hold on the last IO that is still active.