### PR TITLE
Fix compilation errors

### DIFF
--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -95,6 +95,7 @@ target_link_libraries(
   XrdXml
   XrdUtils
   pthread
+  ${EXTRA_LIBS}
   ${CMAKE_DL_LIBS})
 
 set_target_properties(

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -116,7 +116,7 @@ void Print::printFile(const std::string& path)
    size_t startIdx = cfi.GetAccessCnt() < cfi.GetMaxNumAccess() ? 0 : cfi.GetAccessCnt() - cfi.GetMaxNumAccess();
    for (std::vector<Info::AStat>::const_iterator it = store.m_astats.begin(); it != store.m_astats.end(); ++it)
    {
-      printf("access %zu: ", startIdx++);
+      printf("access %lu: ", (unsigned long)startIdx++);
       char as[500];
       strftime(as, 500, "%c", localtime(&(it->AttachTime)));
 

--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -498,7 +498,7 @@ Handler::GenerateMacaroonResponse(XrdHttpExtReq &req, const std::string &resourc
     std::vector<char> macaroon_resp; macaroon_resp.reserve(size_hint);
     if (macaroon_serialize(mac_with_date, &macaroon_resp[0], size_hint, &mac_err))
     {
-        printf("Returned macaroon_serialize code: %lu\n", size_hint);
+        printf("Returned macaroon_serialize code: %zu\n", size_hint);
         return req.SendSimpleResp(500, NULL, NULL, "Internal error serializing macaroon", 0);
     }
 

--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -498,7 +498,7 @@ Handler::GenerateMacaroonResponse(XrdHttpExtReq &req, const std::string &resourc
     std::vector<char> macaroon_resp; macaroon_resp.reserve(size_hint);
     if (macaroon_serialize(mac_with_date, &macaroon_resp[0], size_hint, &mac_err))
     {
-        printf("Returned macaroon_serialize code: %zu\n", size_hint);
+        printf("Returned macaroon_serialize code: %lu\n", (unsigned long)size_hint);
         return req.SendSimpleResp(500, NULL, NULL, "Internal error serializing macaroon", 0);
     }
 

--- a/src/XrdOfs/XrdOfsTPC.hh
+++ b/src/XrdOfs/XrdOfsTPC.hh
@@ -88,10 +88,10 @@ struct  iParm {char *Pgm;
                int   Strm;
                int   SMax;
                int   Xmax;
-               char  Grab;
-               char  xEcho;
-               char  autoRM;
-               char  oidsOK;
+               signed char Grab;
+               signed char xEcho;
+               signed char autoRM;
+               signed char oidsOK;
                      iParm() : Pgm(0), Ckst(0), cpath(0), fCreds(0),
                                Dflttl(-1), Maxttl(-1),
                                Logok(-1), Strm(-1), SMax(64), Xmax(-1), Grab(0),


### PR DESCRIPTION
Compilation fails on 32 bit architectures:
```
/builddir/build/BUILD/xrootd-4.9.0/src/XrdMacaroons/XrdMacaroonsHandler.cc: In member function 'int Macaroons::Handler::GenerateMacaroonResponse(XrdHttpExtReq&, const string&, const std::vector<std::__cxx11::basic_string<char> >&, ssize_t, bool)':
/builddir/build/BUILD/xrootd-4.9.0/src/XrdMacaroons/XrdMacaroonsHandler.cc:501:16: error: format '%lu' expects argument of type 'long unsigned int', but argument 2 has type 'size_t' {aka 'unsigned int'} [-Werror=format=]
         printf("Returned macaroon_serialize code: %lu\n", size_hint);
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  ~~~~~~~~~
```

Compilation fails on architectures where "char" is unsigned by default (ppc64, ppc64le, arm, aarch64, s390x):
```
/builddir/build/BUILD/xrootd-4.9.0/src/XrdOfs/XrdOfsTPC.cc: In static member function 'static void XrdOfsTPC::Init(XrdOfsTPC::iParm&)':
/builddir/build/BUILD/xrootd-4.9.0/src/XrdOfs/XrdOfsTPC.cc:453:21: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  453 |    if (Parms.Grab   <  0) errMon = Parms.Grab;
      |        ~~~~~~~~~~~~~^~~~
/builddir/build/BUILD/xrootd-4.9.0/src/XrdOfs/XrdOfsTPC.cc:454:21: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  454 |    if (Parms.xEcho  >= 0) doEcho = Parms.xEcho != 0;
      |        ~~~~~~~~~~~~~^~~~
/builddir/build/BUILD/xrootd-4.9.0/src/XrdOfs/XrdOfsTPC.cc:455:21: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  455 |    if (Parms.autoRM >= 0) autoRM = Parms.autoRM != 0;
      |        ~~~~~~~~~~~~~^~~~
```
Linking fails on ppc64, ppc64le and aarch64:
```
/usr/bin/ld: XrdCl/libXrdCl.so.2.0.0: undefined reference to `aio_read64'
/usr/bin/ld: XrdCl/libXrdCl.so.2.0.0: undefined reference to `aio_fsync64'
/usr/bin/ld: XrdCl/libXrdCl.so.2.0.0: undefined reference to `aio_write64'
/usr/bin/ld: XrdCl/libXrdCl.so.2.0.0: undefined reference to `aio_return64'
collect2: error: ld returned 1 exit status
```
