### PR TITLE
XrdHttp does not support chunked encoding; respond appropriately.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -215,6 +215,8 @@ int XrdHttpReq::parseLine(char *line, int len) {
 
     } else if (!strcmp(key, "Expect") && strstr(val, "100-continue")) {
       sendcontinue = true;
+    } else if (!strcasecmp(key, "Transfer-Encoding") && strstr(val, "chunked")) {
+      m_transfer_encoding_chunked = true;
     } else {
       // Some headers need to be translated into "local" cgi info. In theory they should already be quoted
       std::map< std:: string, std:: string > ::iterator it = prot->hdr2cgimap.find(key);
@@ -2069,6 +2071,12 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
     {
       if (!fopened) {
 
+        // We do not support chunked transfer encoding.
+        if (m_transfer_encoding_chunked) {
+          prot->SendSimpleResp(501, "Not Implemented", NULL, NULL, 0, false);
+          return -1;
+        }
+
         if (xrdresp != kXR_ok) {
 
           prot->SendSimpleResp(httpStatusCode, NULL, NULL,
@@ -2478,6 +2486,7 @@ void XrdHttpReq::reset() {
   depth = 0;
   sendcontinue = false;
 
+  m_transfer_encoding_chunked = false;
 
   /// State machine to talk to the bridge
   reqstate = 0;

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -80,6 +80,9 @@ private:
   int httpStatusCode;
   std::string httpStatusText;
 
+  // Whether transfer encoding was requested.
+  bool m_transfer_encoding_chunked;
+
   int parseContentRange(char *);
   int parseHost(char *);
   int parseRWOp(char *);


### PR DESCRIPTION
This is the first step in fixing #915 - we should at least respond correctly when we don't support something!