### PR TITLE
Log user caveats with macaroon generation.

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -106,6 +106,7 @@ Handler::~Handler()
 
 std::string
 Handler::GenerateID(const XrdSecEntity &entity, const std::string &activities,
+                    const std::vector<std::string> &other_caveats,
                     const std::string &before)
 {
     uuid_t uu;
@@ -123,7 +124,15 @@ Handler::GenerateID(const XrdSecEntity &entity, const std::string &activities,
     if (entity.role) {ss << "role=" << entity.role << ", ";}
     if (entity.grps) {ss << "groups=" << entity.grps << ", ";}
     if (entity.endorsements) {ss << "endorsements=" << entity.endorsements << ", ";}
-    if (activities.size()) {ss << "activity=" << activities << ", ";}
+    if (activities.size()) {ss << "base_activities=" << activities << ", ";}
+
+    for (std::vector<std::string>::const_iterator iter = other_caveats.begin();
+         iter != other_caveats.end();
+         iter++)
+    {
+        ss << "user_caveat=" << *iter << ", ";
+    }
+
     ss << "expires=" << before;
 
     m_log->Emsg("MacaroonGen", ss.str().c_str());
@@ -416,7 +425,7 @@ Handler::GenerateMacaroonResponse(XrdHttpExtReq &req, const std::string &resourc
     std::string utc_time_caveat = ss.str();
 
     std::string activities = GenerateActivities(req);
-    std::string macaroon_id = GenerateID(req.GetSecEntity(), activities, utc_time_str);
+    std::string macaroon_id = GenerateID(req.GetSecEntity(), activities, other_caveats, utc_time_str);
     enum macaroon_returncode mac_err;
 
     struct macaroon *mac = macaroon_create(reinterpret_cast<const unsigned char*>(m_location.c_str()),

--- a/src/XrdMacaroons/XrdMacaroonsHandler.hh
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.hh
@@ -48,7 +48,7 @@ public:
         std::string &location, std::string &secret, ssize_t &max_duration);
 
 private:
-    std::string GenerateID(const XrdSecEntity &, const std::string &, const std::string &);
+    std::string GenerateID(const XrdSecEntity &, const std::string &, const std::vector<std::string> &, const std::string &);
     std::string GenerateActivities(const XrdHttpExtReq &) const;
 
     int ProcessOAuthConfig(XrdHttpExtReq &req);


### PR DESCRIPTION
Fixes #921 

With this, if the user specifies additional limitations (such as limits on activities) as part of the macaroon request, the corresponding log line is:

```
190314 13:02:46 133614 sysMacaroonGen: \
ID=893f6d10-4b91-4f00-8c5e-5fd0d9fcecf8, host=[<ipv6 address>], \
base_activities=activity:READ_METADATA, user_caveat=activity:READ, expires=2019-03-14T18:12:46Z
```