### PR TITLE
Do not accept more data than specified in the HTTP request.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1264,12 +1264,14 @@ int XrdHttpReq::ProcessHTTPReq() {
           xrdreq.write.requestid = htons(kXR_write);
           memcpy(xrdreq.write.fhandle, fhandle, 4);
 
+          long long bytes_to_read = min(static_cast<long long>(prot->BuffUsed()),
+                                        length - writtenbytes);
 
           xrdreq.write.offset = htonll(writtenbytes);
-          xrdreq.write.dlen = htonl(prot->BuffUsed());
+          xrdreq.write.dlen = htonl(bytes_to_read);
 
-          TRACEI(REQ, "Writing " << prot->BuffUsed());
-          if (!prot->Bridge->Run((char *) &xrdreq, prot->myBuffStart, prot->BuffUsed())) {
+          TRACEI(REQ, "Writing " << bytes_to_read);
+          if (!prot->Bridge->Run((char *) &xrdreq, prot->myBuffStart, bytes_to_read)) {
             prot->SendSimpleResp(404, NULL, NULL, (char *) "Could not run write request.", 0, false);
             return -1;
           }


### PR DESCRIPTION
This fixes a potentially bad bug if pipelining is in use: in the callback for `PUT`, we write out ALL data present in the socket, regardless if it belongs to the current HTTP request - or is the beginning of the next pipelined request!

Things were handled correctly before if there was no pipelining (or the client didn't send too much data or the extra data the client sent happened to be split over multiple TCP packets).

Fixes #916 
