### PR TITLE
[Server] Save the proper ReqID for async responses on close

### DIFF
--- a/src/XrdXrootd/XrdXrootdProtocol.cc
+++ b/src/XrdXrootd/XrdXrootdProtocol.cc
@@ -467,7 +467,8 @@ int XrdXrootdProtocol::Process2()
           case kXR_writev:   return do_WriteV();
           case kXR_sync:     ReqID.setID(Request.header.streamid);
                              return do_Sync();
-          case kXR_close:    return do_Close();
+          case kXR_close:    ReqID.setID(Request.header.streamid);
+                             return do_Close();
           case kXR_truncate: ReqID.setID(Request.header.streamid);
                              if (!Request.header.dlen) return do_Truncate();
                              break;


### PR DESCRIPTION
I've implemented async response on close in EOS but this doesn't work with 4.9.0 due to the wrong request ID being sent by the server in the final close response.