### PR TITLE
Create macaroon with proper caveats and path.

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsHandler.hh
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.hh
@@ -48,8 +48,8 @@ public:
         std::string &location, std::string &secret, ssize_t &max_duration);
 
 private:
-    std::string GenerateID(const XrdSecEntity &, const std::string &, const std::vector<std::string> &, const std::string &);
-    std::string GenerateActivities(const XrdHttpExtReq &) const;
+    std::string GenerateID(const std::string &, const XrdSecEntity &, const std::string &, const std::vector<std::string> &, const std::string &);
+    std::string GenerateActivities(const XrdHttpExtReq &, const std::string &) const;
 
     int ProcessOAuthConfig(XrdHttpExtReq &req);
     int ProcessTokenRequest(XrdHttpExtReq& req);


### PR DESCRIPTION
The new OAuth2-style of macaroon requests caused incorrect caveats to be requested - permissions were broken up across multiple caveats instead of in a single request.

Further, it requested the macaroon for the wrong path (the OAuth2 token issuer path) and this is fixed too.

Relatively safe, should be backported to 4.9.1.