### PR TITLE
XrdHttp: High memory usage apparently from cached XrdHttpProtocol objects

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -251,6 +251,12 @@ XrdProtocol *XrdHttpProtocol::Match(XrdLink *lp) {
   else
     hp->ishttps = myishttps;
 
+  // Allocate 1MB buffer from pool
+  if (!hp->myBuff) {
+    hp->myBuff = BPool->Obtain(1024 * 1024);
+  }
+  hp->myBuffStart = hp->myBuffEnd = hp->myBuff->buff;
+
   // Bind the protocol to the link and return the protocol
   //
   hp->Link = lp;
@@ -1797,10 +1803,11 @@ void XrdHttpProtocol::Reset() {
   CurrentReq.reset();
   CurrentReq.reqstate = 0;
 
-  if (!myBuff) {
-    myBuff = BPool->Obtain(1024 * 1024);
+  if (myBuff) {
+    BPool->Release(myBuff);
+    myBuff = 0;
   }
-  myBuffStart = myBuffEnd = myBuff->buff;
+  myBuffStart = myBuffEnd = 0;
 
   DoingLogin = false;
 


### PR DESCRIPTION
We're seeing climbing xrootd memory usage on a local redirector. From some initial debugging, it seems due to XrdHttpProtocol buffers. This patch frees the 1MB buffer when the XrdHttpProtocol objects are idle.

The HTTP protocol handler keeps a stack of idle XrdHttpProtocol objects in ProtStack. The stack depth is limited to ConnMax/3, and ConnMax is set to RLIMIT_NOFILE. Each idle handler holds a 1MB buffer. When LimitNOFILE is increased to 65k for better concurrency, it's possible to have ~21k XrdHttpProtocol objects in ProtStack for a total of ~21GB RAM allocated to buffers. This seems unexpectedly high, especially for redirectors.

Rather than adding another configuration knob to limit the memory usage, we could free the 1MB buffer when the object is idle. With XrdBuffManager already caching blocks of RAM, I'd hope there isn't too much overhead or fragmentation.

To show the high RAM usage, open a large number of concurrent HTTP connections:

    ab -n 2000 -c 2000 https://xrootd.example.edu:1094/file
