### PR TITLE
[XrdTpc] Only use Curl's low-speed-limit with libcurl v7.38 and later

### DIFF
--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -70,10 +70,15 @@ bool State::InstallHandlers(CURL *curl) {
     }
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 
-    // Require a minimum speed from the transfer: must move at least 1MB every 2 minutes
-    // (roughly 8KB/s).
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 2*60);
-    curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1024*1024);
+    // Only use low-speed limits with libcurl v7.38 or later.
+    // Older versions have poor transfer performance, corrected in curl commit cacdc27f.
+    curl_version_info_data *curl_ver = curl_version_info(CURLVERSION_NOW);
+    if (curl_ver->age > 0 && curl_ver->version_num >= 0x072600) {
+        // Require a minimum speed from the transfer: must move at least 1MB every 2 minutes
+        // (roughly 8KB/s).
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 2*60);
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 1024*1024);
+    }
     return true;
 }
 


### PR DESCRIPTION
Curl's detection of low-speed transfers creates a flood of timeout calls which significantly slows large transfers and increases CPU usage. This is fixed in https://github.com/curl/curl/commit/cacdc27f52 which is unfortunately not present on EL7.

This PR checks the curl version and only enables the low-speed detection when libcurl is new enough to have the fix.

Trying this patch on a production EL7 xrootd server which handles TPC requests, there was a significant drop in xrootd CPU usage: from ~100% busy, down to ~5%.

To see if the system is likely being affected, look for the function `Curl_speedcheck` appearing frequently in the gstack output for `xrootd`.