### PR TITLE
Allow admin to customize default macaroons authz.

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsAuthz.hh
+++ b/src/XrdMacaroons/XrdMacaroonsAuthz.hh
@@ -34,11 +34,17 @@ public:
     }
 
 private:
+    XrdAccPrivs OnMissing(const XrdSecEntity     *Entity,
+                          const char             *path,
+                          const Access_Operation  oper,
+                                XrdOucEnv        *env);
+
     ssize_t m_max_duration;
     XrdAccAuthorize *m_chain;
     XrdSysError m_log;
     std::string m_secret;
     std::string m_location;
+    int m_authz_behavior;
 };
 
 }

--- a/src/XrdMacaroons/XrdMacaroonsHandler.hh
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.hh
@@ -29,11 +29,18 @@ public:
         m_chain(chain),
         m_log(log)
     {
-        if (!Config(config, myEnv, m_log, m_location, m_secret, m_max_duration))
+        AuthzBehavior behavior;
+        if (!Config(config, myEnv, m_log, m_location, m_secret, m_max_duration, behavior))
         {
             throw std::runtime_error("Macaroon handler config failed.");
         }
     }
+
+    enum AuthzBehavior {
+        PASSTHROUGH,
+        ALLOW,
+        DENY
+    };
 
     virtual ~Handler();
 
@@ -45,7 +52,8 @@ public:
     // Static configuration method; made static to allow Authz object to reuse
     // this code.
     static bool Config(const char *config, XrdOucEnv *env, XrdSysError *log,
-        std::string &location, std::string &secret, ssize_t &max_duration);
+        std::string &location, std::string &secret, ssize_t &max_duration,
+        AuthzBehavior &behavior);
 
 private:
     std::string GenerateID(const std::string &, const XrdSecEntity &, const std::string &, const std::vector<std::string> &, const std::string &);


### PR DESCRIPTION
With this, the admin can set a new `macaroons.onmissing` configuration flag to allow the authorization plugin to always allow in the case when no macaroon exists.

This is useful for EOS as EOS does not utilize the XRootD authorization system and will apply its own authorizations downstream of this plugin.

Additionally, this fixes a memory leak of the macaroon object that occurs on successful validation.