### PR TITLE
[XrdMacaroons] Fix default for `macaroons.onmissing`

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsAuthz.cc
+++ b/src/XrdMacaroons/XrdMacaroonsAuthz.cc
@@ -111,7 +111,7 @@ Authz::Authz(XrdSysLogger *log, char const *config, XrdAccAuthorize *chain)
     m_log(log, "macarons_"),
     m_authz_behavior(static_cast<int>(Handler::AuthzBehavior::PASSTHROUGH))
 {
-    Handler::AuthzBehavior behavior;
+    Handler::AuthzBehavior behavior(Handler::AuthzBehavior::PASSTHROUGH);
     if (!Handler::Config(config, nullptr, &m_log, m_location, m_secret, m_max_duration, behavior))
     {
         throw std::runtime_error("Macaroon authorization config failed.");

--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -540,6 +540,7 @@ Handler::GenerateMacaroonResponse(XrdHttpExtReq &req, const std::string &resourc
         printf("Returned macaroon_serialize code: %lu\n", (unsigned long)size_hint);
         return req.SendSimpleResp(500, NULL, NULL, "Internal error serializing macaroon", 0);
     }
+    macaroon_destroy(mac_with_date);
 
     json_object *response_obj = json_object_new_object();
     if (!response_obj)


### PR DESCRIPTION
When testing 4.9.1-rc1, @jthiltges reported that `macaroons.onmissing` had undefined behavior if it was not set in the configuration file (unfortunately, the undefined behavior for my test platforms was the same as the expected behavior ... but not in production!).

Since I was hitting the codebase with valgrind, this PR also fixes two minor memory leaks and one uninitialized read.

@simonmichal - please backport for 4.9.1 final!