### PR TITLE
Fixup fallthrough statements.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1191,8 +1191,8 @@ int XrdHttpReq::ProcessHTTPReq() {
             // We want to be invoked again after this request is finished
             return 0;
           }
-          // fallthrough
         }
+        // fallthrough
         default: // Read() or Close()
         {
 
@@ -2159,9 +2159,9 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               return -1;
             }
 
-            // Remaining case: reqstate == 2 and we didn't ask for a digest (should be a read);
-            // fallthrough
+            // Remaining case: reqstate == 2 and we didn't ask for a digest (should be a read).
           }
+          // fallthrough
           default: //read or readv
           {
 


### PR DESCRIPTION
Apparently GCC only can handle the `fallthrough` comment (and skip a warning) if it is the last statement before the next case.

Fixes build failures due to #902 on GCC7+ platforms such as Fedora and latest Debian.