### PR TITLE
[XrdHttp] Don't add blank header if m_digest_header is empty

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2098,7 +2098,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               if (rwOps.size() == 0) {
                 // Full file.
                 
-                prot->SendSimpleResp(200, NULL, m_digest_header.c_str(), NULL, filesize, keepalive);
+                prot->SendSimpleResp(200, NULL, m_digest_header.empty() ? NULL : m_digest_header.c_str(), NULL, filesize, keepalive);
                 return 0;
               } else
                 if (rwOps.size() == 1) {


### PR DESCRIPTION
Testing 4.9.1-rc2, @matyasselmeci noted that HTTP output prepends a `\r\n` to the expected contents.

@bbockelm was able to isolate the issue and suggested the patch in this PR.

This would be helpful to have in RC3. @simonmichal

Example:
xrootd-4.9.1-0.1.rc1.osg34.el7.x86_64
```
$ curl -s -k -E /tmp/cert.pem 'https://xrootd.example.edu:1094/hello_world.txt' | hexdump -C
00000000  68 65 6c 6c 6f 20 77 6f  72 6c 64 21 0a           |hello world!.|
0000000d
```

xrootd-4.9.1-0.2.rc2.osg34.el7.x86_64
```
$ curl -s -k -E /tmp/cert.pem 'https://xrootd.example.edu:1094/hello_world.txt' | hexdump -C
00000000  0d 0a 68 65 6c 6c 6f 20  77 6f 72 6c 64           |..hello world|
0000000d
```
