### PR TITLE
DM-18697: Disable python bindings

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -11,7 +11,7 @@ config()
         rm -rf ${BUILDDIR}
         mkdir ${BUILDDIR}
         cd ${BUILDDIR}
-        cmake ${PKGDIR} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${PREFIX} -DENABLE_PERL=FALSE
+        cmake ${PKGDIR} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${PREFIX} -DENABLE_PYTHON=FALSE
 }
 
 build()


### PR DESCRIPTION
Also remove perl bindings option since that option no longer exists.

Disable python bindings because we do not use them and currently they do not work on macOS because clang is used to compile the C++ files and Apple Clang no longer allows that.