### PR TITLE
[XCache]  Implement write-queue number of blocks / threads config options. 

### DIFF
--- a/src/XrdFileCache/XrdFileCache.hh
+++ b/src/XrdFileCache/XrdFileCache.hh
@@ -67,6 +67,8 @@ struct Configuration
       m_bufferSize(1024*1024),
       m_RamAbsAvailable(0),
       m_NRamBuffers(-1),
+      m_wqueue_blocks(1),
+      m_wqueue_threads(1),
       m_prefetch_max_blocks(10),
       m_hdfsbsize(128*1024*1024),
       m_flushCnt(100)
@@ -98,6 +100,8 @@ struct Configuration
    long long m_bufferSize;              //!< prefetch buffer size, default 1MB
    long long m_RamAbsAvailable;         //!< available from configuration
    int       m_NRamBuffers;             //!< number of total in-memory cache blocks, cached
+   int       m_wqueue_blocks;           //!< maximum number of blocks written per write-queue loop
+   int       m_wqueue_threads;          //!< number of threads writing blocks to disk
    int       m_prefetch_max_blocks;     //!< maximum number of blocks to prefetch per file
 
    long long m_hdfsbsize;               //!< used with m_hdfsmode, default 128MB
@@ -280,12 +284,12 @@ private:
 
    struct WriteQ
    {
-      WriteQ() : condVar(0), size(0), writes_between_purges(0) {}
+      WriteQ() : condVar(0), writes_between_purges(0), size(0) {}
 
       XrdSysCondVar     condVar;      //!< write list condVar
-      size_t            size;         //!< cache size of a container
       std::list<Block*> queue;        //!< container
       long long         writes_between_purges; //!< upper bound on amount of bytes written between two purge passes
+      int               size;         //!< current size of write queue
    };
 
    WriteQ m_writeQ;

--- a/src/XrdFileCache/XrdFileCacheConfiguration.cc
+++ b/src/XrdFileCache/XrdFileCacheConfiguration.cc
@@ -316,6 +316,7 @@ bool Cache::Config(const char *config_filename, const char *parameters)
                       "       pfc.blocksize %lld\n"
                       "       pfc.prefetch %d\n"
                       "       pfc.ram %.fg\n"
+                      "       pfc.writequeue %d %d\n"
                       "       # Total available disk: %lld\n"
                       "       pfc.diskusage %lld %lld files %lld %lld %lld purgeinterval %d purgecoldfiles %d\n"
                       "       pfc.spaces %s %s\n"
@@ -324,7 +325,9 @@ bool Cache::Config(const char *config_filename, const char *parameters)
                       config_filename,
                       m_configuration.m_bufferSize,
                       m_configuration.m_prefetch_max_blocks,
-                      rg, sP.Total,
+                      rg,
+                      m_configuration.m_wqueue_blocks, m_configuration.m_wqueue_threads,
+                      sP.Total,
                       m_configuration.m_diskUsageLWM, m_configuration.m_diskUsageHWM,
                       m_configuration.m_fileUsageBaseline, m_configuration.m_fileUsageNominal, m_configuration.m_fileUsageMax,
                       m_configuration.m_purgeInterval, m_configuration.m_purgeColdFilesAge,
@@ -476,6 +479,17 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
       long long minRAM = m_isClient ? 256 * 1024 * 1024 : 1024 * 1024 * 1024;
       long long maxRAM = 256 * minRAM;
       if ( XrdOuca2x::a2sz(m_log, "get RAM available", cwg.GetWord(), &m_configuration.m_RamAbsAvailable, minRAM, maxRAM))
+      {
+         return false;
+      }
+   }
+   else if ( part == "writequeue")
+   {
+      if (XrdOuca2x::a2i(m_log, "Error getting pfc.writequeue num-blocks", cwg.GetWord(), &m_configuration.m_wqueue_blocks, 1, 1024))
+      {
+         return false;
+      }
+      if (XrdOuca2x::a2i(m_log, "Error getting pfc.writequeue num-threads", cwg.GetWord(), &m_configuration.m_wqueue_threads, 1, 16))
       {
          return false;
       }

--- a/src/XrdFileCache/XrdFileCacheConfiguration.cc
+++ b/src/XrdFileCache/XrdFileCacheConfiguration.cc
@@ -489,7 +489,7 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
       {
          return false;
       }
-      if (XrdOuca2x::a2i(m_log, "Error getting pfc.writequeue num-threads", cwg.GetWord(), &m_configuration.m_wqueue_threads, 1, 16))
+      if (XrdOuca2x::a2i(m_log, "Error getting pfc.writequeue num-threads", cwg.GetWord(), &m_configuration.m_wqueue_threads, 1, 64))
       {
          return false;
       }


### PR DESCRIPTION
pfc.writequeue max-num-blocks-per-loop num-threads

Where:
- max-num-blocks-per-loop Number of blocks taken off the write queue and written to disk in a single iteration of the disk-writer loop.
- num-threads Number of threads that perform writing of cache blocks to disk.

Defaults:  pfc.writequeue 1 1
