### PR TITLE
Allow cms.dfs retries to be set to 0.

### DIFF
--- a/src/XrdCms/XrdCmsBaseFS.hh
+++ b/src/XrdCms/XrdCmsBaseFS.hh
@@ -133,7 +133,7 @@ static const int dfltStgTries = 3;
 
        void             SetTries(bool xdfs, int tcnt)
                                 {if (xdfs) dfsMaxTries = 
-                                           (tcnt < 1 ? dfltDfsTries : tcnt);
+                                           (tcnt < 0 ? dfltDfsTries : tcnt);
                                     else   stgMaxTries =
                                            (tcnt < 1 ? dfltStgTries : tcnt);
                                 }

--- a/src/XrdCms/XrdCmsConfig.cc
+++ b/src/XrdCms/XrdCmsConfig.cc
@@ -1648,7 +1648,7 @@ int XrdCmsConfig::xdfs(XrdSysError *eDest, XrdOucStream &CFile)
 {
     int Opts = XrdCmsBaseFS::DFSys | (isProxy ? XrdCmsBaseFS::Immed : 0)
              | (!isManager && isServer ? XrdCmsBaseFS::Servr: 0);
-    int Hold = 0, limCent = 0, limFix = 0, limV = 0, qMax = 0, rTry = 0;
+    int Hold = 0, limCent = 0, limFix = 0, limV = 0, qMax = 0, rTry = -1;
     char *val;
 
 // If we are a meta-manager or a peer, ignore this option

--- a/src/XrdCms/XrdCmsConfig.cc
+++ b/src/XrdCms/XrdCmsConfig.cc
@@ -1701,7 +1701,7 @@ do{     if (!strcmp("mdhold",  val))
    else if (!strcmp("retries", val))
            {if (!(val = CFile.GetWord()))
                {eDest->Emsg("Config","retries value not specified.");    return 1;}
-            if (XrdOuca2x::a2i(*eDest, "retries value", val, &rTry, 1))  return 1;
+            if (XrdOuca2x::a2i(*eDest, "retries value", val, &rTry, 0))  return 1;
            }
    else {eDest->Emsg("Config", "invalid dfs option '",val,"'."); return 1;}
   } while((val = CFile.GetWord()));


### PR DESCRIPTION
@abh3 I would like to test this as a temporary fix to avoid duplicating entries in a cache cluster. Can you please review this and think through if this is sufficient and not too dangerous?

I plan to combine it with a static redirect to federation on ENOENT.