### PR TITLE
Always query dual stack for HTTP TPC.

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -181,6 +181,8 @@ int TPCHandler::OpenWaitStall(XrdSfsFile &fh, const std::string &resource,
 {
     int open_result;
     while (1) {
+        int orig_ucap = fh.error.getUCap();
+        fh.error.setUCap(orig_ucap | XrdOucEI::uIPv64);
         open_result = fh.open(resource.c_str(), mode, openMode, &sec,
                               authz.empty() ? NULL: authz.c_str());
         if ((open_result == SFS_STALL) || (open_result == SFS_STARTED)) {


### PR DESCRIPTION
If we open a file using the SFS interface, the OFS plugin will, by default, only query for servers that support IPv6.  If a cluster only has IPv4 addresses, then this will always fail.

This changes the default to dual-stack: the transfer can be serviced by a server that speaks either IPv4 or IPv6 (or both!).  This is likely the best we can do as we have no indication of whether the source side is IPv4, IPv6, or dual stack itself.

Fixes #968