### PR TITLE
Include provided opaque information in the redirection

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -84,6 +84,7 @@ verb(req->requestverb), headers(req->allheaders) {
   int envlen = 0;
   
   headers["xrd-http-query"] = req->opaque?req->opaque->Env(envlen):"";
+  headers["xrd-http-fullresource"] = req->resourceplusopaque.c_str();
   headers["xrd-http-prot"] = prot->isHTTPS()?"https":"http";
   
   // These fields usually identify the client that connected

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -662,7 +662,7 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
     redirdest += buf;
   }
 
-  redirdest += resource.c_str();
+  redirdest += resourceplusopaque.c_str();
   
   // Here we put back the opaque info, if any
   if (vardata) {

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -924,8 +924,26 @@ int XrdHttpReq::ProcessHTTPReq() {
 
   kXR_int32 l;
 
-  
-  
+  /// If we have to add extra header information, add it here.
+  if (!hdr2cgistr.empty()) {
+    const char *p = strchr(resourceplusopaque.c_str(), '?');
+    if (p) {
+      resourceplusopaque.append("&");
+    } else {
+      resourceplusopaque.append("?");
+    }
+
+    char *q = quote(hdr2cgistr.c_str());
+    resourceplusopaque.append(q);
+    TRACEI(DEBUG, "Appended header fields to opaque info: '" << hdr2cgistr << "'");
+    free(q);
+
+    // Once we've appended the authorization to the full resource+opaque string,
+    // reset the authz to empty: this way, any operation that triggers repeated ProcessHTTPReq
+    // calls won't also trigger multiple copies of the authz.
+    hdr2cgistr = "";
+    }
+
   // Verify if we have an external handler for this request
   if (reqstate == 0) {
     XrdHttpExtHandler *exthandler = prot->FindMatchingExtHandler(*this);
@@ -939,27 +957,7 @@ int XrdHttpReq::ProcessHTTPReq() {
       return 1; // There was an error and a response was sent
     }
   }
-  
-  /// If we have to add extra header information, add it here.
-  if (!hdr2cgistr.empty()) {
-    const char *p = strchr(resourceplusopaque.c_str(), '?');
-    if (p) {
-      resourceplusopaque.append("&");
-    } else {
-      resourceplusopaque.append("?");
-    }
-    
-    char *q = quote(hdr2cgistr.c_str());
-    resourceplusopaque.append(q);
-    TRACEI(DEBUG, "Appended header fields to opaque info: '" << hdr2cgistr << "'");
-    free(q);
-    
-    // Once we've appended the authorization to the full resource+opaque string,
-    // reset the authz to empty: this way, any operation that triggers repeated ProcessHTTPReq
-    // calls won't also trigger multiple copies of the authz.
-    hdr2cgistr = "";
-    }
-  
+
   //
   // Here we process the request locally
   //

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -163,7 +163,7 @@ std::string TPCHandler::GetAuthz(XrdHttpExtReq &req) {
     return authz;
 }
 
-int TPCHandler::RedirectTransfer(XrdHttpExtReq &req, XrdOucErrInfo &error) {
+int TPCHandler::RedirectTransfer(const std::string &redirect_resource, XrdHttpExtReq &req, XrdOucErrInfo &error) {
     int port;
     const char *host = error.getErrText(port);
     if ((host == NULL) || (*host == '\0') || (port == 0)) {
@@ -171,7 +171,7 @@ int TPCHandler::RedirectTransfer(XrdHttpExtReq &req, XrdOucErrInfo &error) {
         return req.SendSimpleResp(500, NULL, NULL, msg, 0);
     }
     std::stringstream ss;
-    ss << "Location: http" << (m_desthttps ? "s" : "") << "://" << host << ":" << port << "/" << req.resource;
+    ss << "Location: http" << (m_desthttps ? "s" : "") << "://" << host << ":" << port << "/" << redirect_resource;
     return req.SendSimpleResp(307, NULL, const_cast<char *>(ss.str().c_str()), NULL, 0);
 }
 
@@ -418,6 +418,12 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
         char msg[] = "Failed to initialize internal transfer resources";
         return req.SendSimpleResp(500, NULL, NULL, msg, 0);
     }
+    auto query_header = req.headers.find("xrd-http-fullresource");
+    std::string redirect_resource = req.resource;
+    if (query_header != req.headers.end()) {
+        redirect_resource = query_header->second;
+    }
+
     char *name = req.GetSecEntity().name;
     AtomicBeg(m_monid_mutex);
     uint64_t file_monid = AtomicInc(m_monid);
@@ -434,7 +440,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     int open_results = OpenWaitStall(*fh, full_url, SFS_O_RDONLY, 0644,
                                      req.GetSecEntity(), authz);
     if (SFS_REDIRECT == open_results) {
-        return RedirectTransfer(req, fh->error);
+        return RedirectTransfer(redirect_resource, req, fh->error);
     } else if (SFS_OK != open_results) {
         int code;
         char msg_generic[] = "Failed to open local resource";
@@ -476,6 +482,11 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
             char msg[] = "Failed to initialize internal transfer file handle";
             return req.SendSimpleResp(500, NULL, NULL, msg, 0);
     }
+    auto query_header = req.headers.find("xrd-http-fullresource");
+    std::string redirect_resource = req.resource;
+    if (query_header != req.headers.end()) {
+        redirect_resource = query_header->second;
+    }
     std::string authz = GetAuthz(req);
     XrdSfsFileOpenMode mode = SFS_O_CREAT;
     auto overwrite_header = req.headers.find("Overwrite");
@@ -504,7 +515,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     int open_result = OpenWaitStall(*fh, full_url, mode|SFS_O_WRONLY, 0644,
                                     req.GetSecEntity(), authz);
     if (SFS_REDIRECT == open_result) {
-        return RedirectTransfer(req, fh->error);
+        return RedirectTransfer(redirect_resource, req, fh->error);
     } else if (SFS_OK != open_result) {
         int code;
         char msg_generic[] = "Failed to open local resource";

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -31,7 +31,7 @@ private:
 
     static std::string GetAuthz(XrdHttpExtReq &req);
 
-    int RedirectTransfer(XrdHttpExtReq &req, XrdOucErrInfo &error);
+    int RedirectTransfer(const std::string &redirect_resource, XrdHttpExtReq &req, XrdOucErrInfo &error);
 
     int OpenWaitStall(XrdSfsFile &fh, const std::string &resource, int mode,
                       int openMode, const XrdSecEntity &sec,


### PR DESCRIPTION
If opaque information is given by the user as part of the URL (i.e., `GET /foo?bar=1`), then include this opaque information in the redirection string.

Previously, opaque information was dropped and only the resource was used.  This is problematic in cases where the opaque information contains important authorization details (think: signed URLs).

Additionally, the TPC handler is updated to perform correctly in this situation.

With this PR, if `http.header2cgi Authorization authz` is set in the configuration, the token will be moved from the headers to the opaque information _and_ now included in the redirect.  Thus, clients which drop the `Authorization:` header upon redirect (this includes the latest versions of `curl`!) will now work by default with an Xrootd cluster.

Fixes behavior observed in the WLCG DOMA testing.