### PR TITLE
[XrdSecgsi] Make proxy cache path aware.

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3096,7 +3096,7 @@ int XrdSecProtocolgsi::ClientDoInit(XrdSutBuffer *br, XrdSutBuffer **bm,
                    UsrProxy.c_str(), PxyValid.c_str(),
                    DepLength, DefBits};
    ProxyOut_t po = {hs->PxyChain, sessionKsig, hs->Cbck };
-   if (QueryProxy(1, &cachePxy, "Proxy:0",
+   if (QueryProxy(1, &cachePxy, UsrProxy.c_str(),
                   sessionCF, hs->TimeStamp, &pi, &po) != 0) {
       emsg = "error getting user proxies";
       hs->Chain = 0;


### PR DESCRIPTION
This aims at fixing #976.

@gganis : I think we can simply use `UsrProxy` as the tag used to query proxy cache. Alternatively, we could hash the proxy location and create a tag like `Proxy: + hash` (alternative version in the comments). Please let me know which one suits us better!

Michal