### PR TITLE
Ubuntu disco CI build - part 3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,13 @@ stages:
     - gdebi -n xrootd-build-deps-depends*.deb
     - version=`./genversion.sh --print-only`
     - dch --create -v `echo $version | sed 's/^v\(.*\)/\1/'` --package xrootd --urgency low --distribution ${DIST} -M "This package is built and released automatically. For important notices and releases subscribe to our maling lists or visit our website."
-    - dpkg-buildpackage -b -us -uc -tc --buildinfo-option="-udeb_packages" --changes-option="-udeb_packages"
+    - dpkg_version=`dpkg-query --showformat='${Version}' --show dpkg`
+    - dpkg --compare-versions $dpkg_version "ge" "1.18.11"
+    - if [ $? -eq "0" ]; then
+        dpkg-buildpackage -b -us -uc -tc --buildinfo-option="-udeb_packages" --changes-option="-udeb_packages" ;
+      else
+        dpkg-buildpackage -b -us -uc -tc --changes-option="-udeb_packages" ;
+      fi
     - mkdir ${DIST}/
     - cp deb_packages/*.deb ${DIST}/
     - if [[ $DEBUG = "true" ]] ; then cp deb_packages/*.ddeb ${DIST}/; fi


### PR DESCRIPTION
Perform a version compare on the dpkg package and include the  "--buildinfo-option" argument only if dpkg version >= 1.1.8.11 (first version which introduced "--buildinfo-option")