### PR TITLE
[CI] Capture exit code of "dpkg --compare-versions" into variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,8 +17,8 @@ stages:
     - version=`./genversion.sh --print-only`
     - dch --create -v `echo $version | sed 's/^v\(.*\)/\1/'` --package xrootd --urgency low --distribution ${DIST} -M "This package is built and released automatically. For important notices and releases subscribe to our maling lists or visit our website."
     - dpkg_version=`dpkg-query --showformat='${Version}' --show dpkg`
-    - dpkg --compare-versions $dpkg_version "ge" "1.18.11"
-    - if [ $? -eq "0" ]; then
+    - rc=0 ; dpkg --compare-versions $dpkg_version "ge" "1.18.11" || rc=$?
+    - if [ $rc -eq "0" ]; then
         dpkg-buildpackage -b -us -uc -tc --buildinfo-option="-udeb_packages" --changes-option="-udeb_packages" ;
       else
         dpkg-buildpackage -b -us -uc -tc --changes-option="-udeb_packages" ;


### PR DESCRIPTION
Previous commit failed because "dpkg --compare-versions" sets the exit code to 1 when the condition is not met. However, the CI environment exists on any non-zero exit code.

Exit code of "dpkg --compare-versions" should now be captured into the **rc** variable.