### PR TITLE
Deny write access to a file in initial Prepare() call.

### DIFF
--- a/src/XrdFileCache/XrdFileCache.cc
+++ b/src/XrdFileCache/XrdFileCache.cc
@@ -742,6 +742,13 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
    std::string f_name = url.GetPath();
    std::string i_name = f_name + ".cinfo";
 
+   // Do not allow write access.
+   if (oflags & (O_WRONLY | O_RDWR))
+   {
+      TRACE(Warning, "Cache::Prepare write access requested on file " << f_name << ". Denying access.");
+      return -ENOTSUP;
+   }
+
    // Intercept xrdpfc_command requests.
    if (m_configuration.m_allow_xrdpfc_command && strncmp("/xrdpfc_command/", f_name.c_str(), 16) == 0)
    {


### PR DESCRIPTION
This addresses #663.

Note that Write() calls in IO object were already failing with errno = ENOTSUP.

Write access into cache is not supported. If one really wants to open files with write access using the cache as the entry point, they should setup static redirect on write to a suitable location / service. 