### PR TITLE
Review and correct error handling in POSIX and XCache, implement XCache::Unlink()

### DIFF
--- a/src/XrdFileCache/XrdFileCacheIO.hh
+++ b/src/XrdFileCache/XrdFileCacheIO.hh
@@ -30,12 +30,11 @@ public:
 
    using XrdOucCacheIO2::Trunc;
 
-   virtual int Trunc(long long Offset) { errno = ENOTSUP; return -1; }
+   virtual int Trunc(long long Offset) { return -ENOTSUP; }
 
    using XrdOucCacheIO2::Write;
 
-   virtual int Write(char *Buffer, long long Offset, int Length)
-   { errno = ENOTSUP; return -1; }
+   virtual int Write(char *Buffer, long long Offset, int Length) { return -ENOTSUP; }
 
    virtual void Update(XrdOucCacheIO2 &iocp);
 

--- a/src/XrdFileCache/XrdFileCacheInfo.cc
+++ b/src/XrdFileCache/XrdFileCacheInfo.cc
@@ -61,7 +61,7 @@ struct FpHelper
          if (warnp)
          {
             TRACE(Warning, f_ttext << " off=" << f_off << " size=" << size
-                                   << " ret=" << ret << " error=" << ((ret < 0) ? strerror(errno) : "<no error>"));
+                                   << " ret=" << ret << " error=" << ((ret < 0) ? strerror(-ret) : "<no error>"));
          }
          return true;
       }
@@ -81,7 +81,7 @@ struct FpHelper
       if (ret != size)
       {
          TRACE(Warning, f_ttext << " off=" << f_off << " size=" << size
-                                << " ret=" << ret << " error=" << ((ret < 0) ? strerror(errno) : "<no error>"));
+                                << " ret=" << ret << " error=" << ((ret < 0) ? strerror(ret) : "<no error>"));
          return true;
       }
       f_off += ret;
@@ -334,9 +334,10 @@ bool Info::Write(XrdOssDF* fp, const std::string &fname)
    std::string trace_pfx("Info:::Write() ");
    trace_pfx += fname + " ";
 
-   if (XrdOucSxeq::Serialize(fp->getFD(), XrdOucSxeq::noWait))
+   int rc;
+   if ((rc = XrdOucSxeq::Serialize(fp->getFD(), XrdOucSxeq::noWait)))
    {
-      TRACE(Error, trace_pfx << " lock failed " << strerror(errno));
+      TRACE(Error, trace_pfx << " lock failed " << strerror(rc));
       return false;
    }
 

--- a/src/XrdFileCache/XrdFileCachePrint.cc
+++ b/src/XrdFileCache/XrdFileCachePrint.cc
@@ -77,7 +77,7 @@ void Print::printFile(const std::string& path)
 
    int cntd = 0;
    for (int i = 0; i < cfi.GetSizeInBits(); ++i)
-      if (cfi.TestBit(i)) cntd++;
+      if (cfi.TestBitWritten(i)) cntd++;
 
    const Info::Store& store = cfi.RefStoredData();
    char   creationBuff[1000];
@@ -107,7 +107,7 @@ void Print::printFile(const std::string& path)
       {
          if (i % 64 == 0)
             printf("\n%*d ", n_db, i);
-         printf("%c", cfi.TestBit(i) ? 'x' : '.');
+         printf("%c", cfi.TestBitWritten(i) ? 'x' : '.');
       }
       printf("\n");
    }

--- a/src/XrdFileCache/XrdFileCachePurge.cc
+++ b/src/XrdFileCache/XrdFileCachePurge.cc
@@ -114,7 +114,8 @@ void FillFileMapRecurse(XrdOssDF* iOssDF, const std::string& path, FPurgeState& 
             // We could also check if it is currently opened with Cache::HaveActiveFileWihtLocalPath()
             // This is not really necessary because we do that check before unlinking the file
             Info cinfo(Cache::GetInstance().GetTrace());
-            if (fh->Open(np.c_str(), O_RDONLY, 0600, env) == XrdOssOK && cinfo.Read(fh, np))
+            int open_rs;
+            if ((open_rs = fh->Open(np.c_str(), O_RDONLY, 0600, env)) == XrdOssOK && cinfo.Read(fh, np))
             {
                time_t accessTime;
                if (cinfo.GetLatestDetachTime(accessTime))
@@ -151,7 +152,7 @@ void FillFileMapRecurse(XrdOssDF* iOssDF, const std::string& path, FPurgeState& 
             }
             else
             {
-               TRACE(Warning, "FillFileMapRecurse() can't open or read " << np << ", err " << strerror(errno)
+               TRACE(Warning, "FillFileMapRecurse() can't open or read " << np << ", open exit status " << strerror(-open_rs)
                                                                          << "; purging.");
                XrdOss* oss = Cache::GetInstance().GetOss();
                oss->Unlink(np.c_str());

--- a/src/XrdFileCache/XrdFileCacheTrace.hh
+++ b/src/XrdFileCache/XrdFileCacheTrace.hh
@@ -33,7 +33,7 @@
 #define XRD_TRACE GetTrace()->
 #endif
 
-#define ERRNO_AND_ERRSTR ", errno=" << errno << ", err=" << strerror(errno)
+#define ERRNO_AND_ERRSTR(err_code) ", err_code=" << err_code << ", err_str=" << strerror(err_code)
 
 #define TRACE(act, x) \
    if (XRD_TRACE What >= TRACE_ ## act) \
@@ -61,7 +61,7 @@
 
 #else
 
-#define ERRNO_AND_ERRSTR
+#define ERRNO_AND_ERRSTR(err_code)
 #define TRACE(act,x)
 #define TRACE_PC(act, pre_code, x)
 #define TRACEIO(act, x)

--- a/src/XrdPosix/XrdPosixAdmin.cc
+++ b/src/XrdPosix/XrdPosixAdmin.cc
@@ -56,7 +56,7 @@ XrdCl::URL *XrdPosixAdmin::FanOut(int &num)
 //
    xStatus = Xrd.DeepLocate(Url.GetPathWithParams(),XrdCl::OpenFlags::None,info);
    if (!xStatus.IsOK())
-      {num = XrdPosixMap::Result(xStatus);
+      {num = XrdPosixMap::Result(xStatus, false);
        return 0;
       }
 

--- a/src/XrdPosix/XrdPosixFileRH.cc
+++ b/src/XrdPosix/XrdPosixFileRH.cc
@@ -101,9 +101,9 @@ void XrdPosixFileRH::HandleResponse(XrdCl::XRootDStatus *status,
                                     XrdCl::AnyObject    *response)
 {
 
-// Determine ending status.
+// Determine ending status. Note: error indicated as result set to -errno.
 //
-        if (!(status->IsOK())) result = -XrdPosixMap::Result(*status);
+        if (!(status->IsOK())) result = XrdPosixMap::Result(*status, false);
    else if (typeIO == nonIO) result = 0;
    else if (typeIO == isRead)
            {XrdCl::ChunkInfo *cInfo = 0;
@@ -119,7 +119,7 @@ void XrdPosixFileRH::HandleResponse(XrdCl::XRootDStatus *status,
    delete status;
    delete response;
 
-// Now schedule this callback
+// Now schedule our XrdOucCacheIOCB callback
 //
    theFile->unRef();
    if (XrdPosixGlobals::schedP) XrdPosixGlobals::schedP->Schedule(this);

--- a/src/XrdPosix/XrdPosixMap.cc
+++ b/src/XrdPosix/XrdPosixMap.cc
@@ -92,7 +92,7 @@ int XrdPosixMap::mapCode(int rc)
         case XrdCl::errQueryNotSupported:  return ENOTSUP;
         case XrdCl::errOperationExpired:   return ESTALE;
         case XrdCl::errNoMoreFreeSIDs:     return ENOSR;
-//      case XrdCl::errInvalidRedirectURL: return ?????;
+        case XrdCl::errInvalidRedirectURL: return ESPIPE;
         case XrdCl::errInvalidResponse:    return EBADMSG;
         case XrdCl::errNotFound:           return EIDRM;
         case XrdCl::errCheckSumError:      return EILSEQ;
@@ -126,7 +126,7 @@ XrdCl::Access::Mode XrdPosixMap::Mode2Access(mode_t mode)
 /*                                R e s u l t                                 */
 /******************************************************************************/
   
-int XrdPosixMap::Result(const XrdCl::XRootDStatus &Status)
+int XrdPosixMap::Result(const XrdCl::XRootDStatus &Status, bool retneg1)
 {
    std::string eText;
    int eNum;
@@ -154,5 +154,5 @@ int XrdPosixMap::Result(const XrdCl::XRootDStatus &Status)
 // Return
 //
    errno = eNum;
-   return -1;
+   return (retneg1 ? -1 : -eNum);
 }

--- a/src/XrdPosix/XrdPosixMap.hh
+++ b/src/XrdPosix/XrdPosixMap.hh
@@ -44,7 +44,8 @@ static mode_t              Flags2Mode(dev_t *rdv, uint32_t flags);
 
 static XrdCl::Access::Mode Mode2Access(mode_t mode);
 
-static int                 Result(const XrdCl::XRootDStatus &Status);
+static int                 Result(const XrdCl::XRootDStatus &Status,
+                                  bool retneg1=false);
 
 static void                SetDebug(bool dbg) {Debug = dbg;}
 

--- a/src/XrdPosix/XrdPosixPrepIO.cc
+++ b/src/XrdPosix/XrdPosixPrepIO.cc
@@ -85,8 +85,7 @@ bool XrdPosixPrepIO::Init(XrdOucCacheIOCB *iocbP)
 // Make sure all went well
 //
    if (!Status.IsOK())
-      {XrdPosixMap::Result(Status);
-       openRC = -errno;
+      {openRC = XrdPosixMap::Result(Status, false);
        if (DEBUGON && errno != ENOENT && errno != ELOOP)
           {std::string eTxt = Status.ToString();
            DEBUG(eTxt<<" deferred open "<<fileP->Origin());

--- a/src/XrdPosix/XrdPosixXrootd.cc
+++ b/src/XrdPosix/XrdPosixXrootd.cc
@@ -387,6 +387,7 @@ int     XrdPosixXrootd::Fstat(int fildes, struct stat *buf)
 int XrdPosixXrootd::Fsync(int fildes)
 {
    XrdPosixFile *fp;
+   int rc;
 
 // Find the file object
 //
@@ -394,7 +395,7 @@ int XrdPosixXrootd::Fsync(int fildes)
 
 // Do the sync
 //
-   if (fp->XCio->Sync() < 0) return Fault(fp, errno);
+   if ((rc = fp->XCio->Sync()) < 0) return Fault(fp, -rc);
    fp->UnLock();
    return 0;
 }
@@ -421,6 +422,7 @@ void XrdPosixXrootd::Fsync(int fildes, XrdPosixCallBackIO *cbp)
 int XrdPosixXrootd::Ftruncate(int fildes, off_t offset)
 {
    XrdPosixFile *fp;
+   int rc;
 
 // Find the file object
 //
@@ -428,7 +430,7 @@ int XrdPosixXrootd::Ftruncate(int fildes, off_t offset)
 
 // Do the trunc
 //
-   if (fp->XCio->Trunc(offset) < 0) return Fault(fp, errno);
+   if ((rc = fp->XCio->Trunc(offset)) < 0) return Fault(fp, -rc);
    fp->UnLock();
    return 0;
 }
@@ -723,7 +725,7 @@ ssize_t XrdPosixXrootd::Pread(int fildes, void *buf, size_t nbyte, off_t offset)
 //
    offs = static_cast<long long>(offset);
    bytes = fp->XCio->Read((char *)buf, offs, (int)iosz);
-   if (bytes < 0) return Fault(fp,errno);
+   if (bytes < 0) return Fault(fp,-bytes);
 
 // All went well
 //
@@ -788,7 +790,7 @@ ssize_t XrdPosixXrootd::Pwrite(int fildes, const void *buf, size_t nbyte, off_t 
 //
    offs = static_cast<long long>(offset);
    bytes = fp->XCio->Write((char *)buf, offs, (int)iosz);
-   if (bytes < 0) return Fault(fp, errno);
+   if (bytes < 0) return Fault(fp,-bytes);
 
 // All went well
 //
@@ -853,7 +855,7 @@ ssize_t XrdPosixXrootd::Read(int fildes, void *buf, size_t nbyte)
 // Issue the read
 //
    bytes = fp->XCio->Read((char *)buf,fp->Offset(),(int)iosz);
-   if (bytes < 0) return Fault(fp, errno);
+   if (bytes < 0) return Fault(fp,-bytes);
 
 // All went well
 //
@@ -900,7 +902,7 @@ ssize_t XrdPosixXrootd::VRead(int fildes, const XrdOucIOVec *readV, int n)
 
 // Issue the read
 //
-   if ((bytes = fp->XCio->ReadV(readV, n)) < 0) return Fault(fp, errno);
+   if ((bytes = fp->XCio->ReadV(readV, n)) < 0) return Fault(fp,-bytes);
 
 // Return bytes read
 //
@@ -1356,7 +1358,7 @@ ssize_t XrdPosixXrootd::Write(int fildes, const void *buf, size_t nbyte)
 // Issue the write
 //
    bytes = fp->XCio->Write((char *)buf,fp->Offset(),(int)iosz);
-   if (bytes < 0) return Fault(fp, errno);
+   if (bytes < 0) return Fault(fp,-bytes);
 
 // All went well
 //


### PR DESCRIPTION
* [XCache] Implement Cache::Unlink(); use it for handling of FSync errors, too.
  - Unlink removes specified data file and corresponding cinfo file.
  - If a file is currently open, it is put into shutdown mode.
    All new Read requests on File fail immediately with ENOENT error code.

* [POSIX] Correct inconsitent errno handling.

* [XCache] Review error handling and bring error codes in sync with POSIX changes.