### PR TITLE
Fix two problems with RFC-3230 handling in xrootd:

### DIFF
--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -215,8 +215,12 @@ public:
   /// The destination field specified in the req
   std::string destination;
 
-  /// The requested digest type
+  /// The Want-Digest request header value (e.g., "MD5, ADLER32;q=0.8")
   std::string m_req_digest;
+
+  /// The xrootd name for the selected digest
+  std::string m_selected_digest;
+
   /// The checksum algorithm is specified as part of the opaque data in the URL.
   /// Hence, when a digest is generated to satisfy a request, we cache the tweaked
   /// URL in this data member.


### PR DESCRIPTION
First, the Digest response header copies the supplied Want-Digest
request header value.  A request with:

    Want-Digest: MD5,ADLER32

would yield a response like:

    Digest: MD5,ADLER32=<md5-value>

where the correct response would be:

    Digest: MD5=<md5-value>

Second, the method that calculates whether the response should be
encoded in hexadecimal or base64 expects an algorithm name, but is given
the Want-Digest request header value.  If the client makes a request with:

    Want-Digest: MD5, ADLER32

then the response is incorrectly encoded using hexadecimal.