### PR TITLE
[XrdHttp] Fix one-byte overrun in Tobase64()

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1754,7 +1754,7 @@ XrdHttpReq::PostProcessChecksum(std::string &digest_header) {
         free(digest_binary_value);
         return -1;
       }
-      char *digest_base64_value = (char *)malloc(digest_length);
+      char *digest_base64_value = (char *)malloc(digest_length + 1);
       // Binary length is precisely half the size of the hex-encoded digest_value; hence, divide length by 2.
       Tobase64(digest_binary_value, digest_length/2, digest_base64_value);
       free(digest_binary_value);


### PR DESCRIPTION
The allocated target buffer for base64 output is sometimes too short, leading to an overrun. (And I suspect it's causing memory corruption with eventual misbehavior and segfaults.)

A hex string may be the same length as the base64 representation. To allow for a terminating null on the base64 string, we need to allocate an additional byte.
```
string abcd
   hex 61626364
base64 YWJjZA==
```