### PR TITLE
Fix redirection handling

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -688,7 +688,7 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
     redirdest += buf;
   }
 
-  redirdest += resourceplusopaque.c_str();
+  redirdest += resource.c_str();
   
   // Here we put back the opaque info, if any
   if (vardata) {

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -899,7 +899,7 @@ void XrdHttpReq::parseResource(char *res) {
     buf = unquote(p + 1);
     opaque = new XrdOucEnv(buf);
     resourceplusopaque.append('?');
-    resourceplusopaque.append(buf);
+    resourceplusopaque.append(p + 1);
     free(buf);
   }
   

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -226,6 +226,7 @@ public:
 
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;
+  bool m_appended_hdr2cgistr;
   
   //
   // Area for coordinating request and responses to/from the bridge


### PR DESCRIPTION
There were a few issues with redirection handling:
- Opaque data in the original URL was being added twice; once quoted and once unquoted.
- The second copy of opaque data duplicated the `?` character
- The `resourceplusopaque` member did not quote arguments in all cases.