### PR TITLE
Use an FHS 3.0 compliant pidpath

### DIFF
--- a/packaging/common/xrootd-clustered.cfg
+++ b/packaging/common/xrootd-clustered.cfg
@@ -50,7 +50,7 @@ frm.xfr.copycmd /bin/cp /dev/null $PFN
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # More configuration files can be added in /etc/xrootd/config.d/
 # For example /etc/xrootd/config.d/10-mygrid.cfg and 

--- a/packaging/common/xrootd-http.cfg
+++ b/packaging/common/xrootd-http.cfg
@@ -22,7 +22,7 @@ all.export /tmp
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # Load the http protocol, indicate that it should be seved on port 80.
 # The socket bound to port 80 has to be preallocated by the systemd

--- a/packaging/common/xrootd-standalone.cfg
+++ b/packaging/common/xrootd-standalone.cfg
@@ -22,7 +22,7 @@ all.export /tmp
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # More configuration files can be added in /etc/xrootd/config.d/                                                                                                             
 # For example /etc/xrootd/config.d/10-mygrid.cfg and                                                                                                                         


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard#FHS_compliance

> Modern Linux distributions include a /run directory as a temporary
filesystem (tmpfs) which stores volatile runtime data, following the
FHS version 3.0. According to the FHS version 2.3, this data should be
stored in /var/run but this was a problem in some cases because this
directory isn't always available at early boot. As a result, these
programs have had to resort to trickery, such as using /dev/.udev,
/dev/.mdadm, /dev/.systemd or /dev/.mount directories, even though the
device directory isn't intended for such data. Among other advantages,
this makes the system easier to use normally with the root filesystem
mounted read-only.