### PR TITLE
Use common filesystem loader

### DIFF
--- a/src/XrdXrootd/XrdXrootdConfig.cc
+++ b/src/XrdXrootd/XrdXrootdConfig.cc
@@ -135,7 +135,7 @@ int XrdXrootdProtocol::Configure(char *parms, XrdProtocol_Config *pi)
 
    extern XrdSfsFileSystem *XrdXrootdloadFileSystem(XrdSysError *, 
                                                     XrdSfsFileSystem *,
-                                                    char *, int,
+                                                    const char *, int,
                                                     const char *, XrdOucEnv *);
    extern XrdSfsFileSystem *XrdDigGetFS
                             (XrdSfsFileSystem *nativeFS,

--- a/src/XrdXrootd/XrdXrootdLoadLib.cc
+++ b/src/XrdXrootd/XrdXrootdLoadLib.cc
@@ -42,7 +42,7 @@
 
 XrdSfsFileSystem *XrdXrootdloadFileSystem(XrdSysError *eDest,
                                           XrdSfsFileSystem *prevFS,
-                                          char *fslib, int fsver,
+                                          const char *fslib, int fsver,
                                           const char *cfn, XrdOucEnv *envP)
 {
    static XrdVERSIONINFODEF(myVersion, XrdOfsLoader, XrdVNUMBER, XrdVERSION);


### PR DESCRIPTION
When the TPC library was maintained out-of-tree, we had to stick to the public interfaces.  This forced the filesystem loader code to duplicate a lot of logic (not necessarily 100% correct).

With this change, the plugin will make a call directly into the internal function that does the SFS loading elsewhere in Xrootd.

@abh3 - if you are OK with the approach and implementation, there's another place where we can remove code in `XrdMacaroons`.

Fixes #1034 