### PR TITLE
Fix linking for libXrdCmsRedirectLocal-4.so on macOS

### DIFF
--- a/src/XrdPlugins.cmake
+++ b/src/XrdPlugins.cmake
@@ -157,7 +157,9 @@ add_library(
   XrdCms/XrdCmsRedirLocal.cc XrdCms/XrdCmsRedirLocal.hh )
 
 target_link_libraries(
-  ${LIB_XRD_CMSREDIRL} )
+  ${LIB_XRD_CMSREDIRL}
+  XrdServer
+  XrdUtils )
 
 set_target_properties(
   ${LIB_XRD_CMSREDIRL}


### PR DESCRIPTION
Building the latest RC failed on macOS with the error listed below. This is fixed by this patch.

You can see the result of building with/without this patch in the last two builds of: https://github.com/conda-forge/xrootd-feedstock/pull/11

```
[ 10%] Linking CXX shared module libXrdCmsRedirectLocal-4.so
ld: warning: -pie being ignored. It is only used when linking a main executable
Undefined symbols for architecture x86_64:
  "XrdNetAddr::Set(char const*, int)", referenced from:
      XrdCmsRedirLocal::Locate(XrdOucErrInfo&, char const*, int, XrdOucEnv*) in XrdCmsRedirLocal.cc.o
  "XrdNetAddr::XrdNetAddr(int)", referenced from:
      XrdCmsRedirLocal::Locate(XrdOucErrInfo&, char const*, int, XrdOucEnv*) in XrdCmsRedirLocal.cc.o
  "XrdOucStream::GetFirstWord(int)", referenced from:
      XrdCmsRedirLocal::loadConfig(char const*) in XrdCmsRedirLocal.cc.o
  "XrdOucStream::Close(int)", referenced from:
      XrdCmsRedirLocal::loadConfig(char const*) in XrdCmsRedirLocal.cc.o
  "XrdOucStream::Attach(int, int)", referenced from:
      XrdCmsRedirLocal::loadConfig(char const*) in XrdCmsRedirLocal.cc.o
  "XrdOucStream::GetWord(int)", referenced from:
      XrdCmsRedirLocal::loadConfig(char const*) in XrdCmsRedirLocal.cc.o
  "XrdOucStream::XrdOucStream(XrdSysError*, char const*, XrdOucEnv*, char const*)", referenced from:
      XrdCmsRedirLocal::loadConfig(char const*) in XrdCmsRedirLocal.cc.o
  "XrdNetAddrInfo::isPrivate()", referenced from:
      XrdCmsRedirLocal::Locate(XrdOucErrInfo&, char const*, int, XrdOucEnv*) in XrdCmsRedirLocal.cc.o
  "XrdOucBuffPool::BuffSlot::Recycle(XrdOucBuffer*)", referenced from:
      XrdCmsRedirLocal::Locate(XrdOucErrInfo&, char const*, int, XrdOucEnv*) in XrdCmsRedirLocal.cc.o
  "XrdCmsFinderRMT::XrdCmsFinderRMT(XrdSysLogger*, int, int)", referenced from:
      _XrdCmsGetClient in XrdCmsRedirLocal.cc.o
      XrdCmsRedirLocal::XrdCmsRedirLocal(XrdSysLogger*, int, int, XrdOss*) in XrdCmsRedirLocal.cc.o
      XrdCmsRedirLocal::XrdCmsRedirLocal(XrdSysLogger*, int, int, XrdOss*) in XrdCmsRedirLocal.cc.o
ld: symbol(s) not found for architecture x86_64
clang-4.0: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/CMakeFiles/XrdCmsRedirectLocal-4.dir/build.make:84: src/libXrdCmsRedirectLocal-4.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:1864: src/CMakeFiles/XrdCmsRedirectLocal-4.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```