### PR TITLE
[Python] Initialize bytesRead in Read() calls

### DIFF
--- a/bindings/python/src/PyXRootDFile.cc
+++ b/bindings/python/src/PyXRootDFile.cc
@@ -193,7 +193,7 @@ namespace PyXRootD
     }
 
     else {
-      uint32_t bytesRead;
+      uint32_t bytesRead = 0;
       async( status = self->file->Read( offset, size, buffer, bytesRead, timeout ) );
       pyresponse = PyBytes_FromStringAndSize( buffer, bytesRead );
       delete[] buffer;
@@ -363,7 +363,7 @@ namespace PyXRootD
     XrdCl::XRootDStatus status;
     XrdCl::Buffer      *buffer;
     XrdCl::Buffer      *temp;
-    uint32_t            bytesRead;
+    uint32_t            bytesRead = 0;
 
     temp = new XrdCl::Buffer( size );
     status = self->file->Read( offset, size, temp->GetBuffer(), bytesRead );


### PR DESCRIPTION
If the `XrdCl::File::Read()` call fails, `bytesRead` is not initialized. This leads to a segfault when the buffer is passed to Python `PyBytes_FromStringAndSize()`

Valgrind output for xrootd-4.10.0-1.osg34.el7.x86_64:
```
2019-10-03 19:00:56 ==31606== Conditional jump or move depends on uninitialised value(s)
2019-10-03 19:00:56 ==31606==    at 0x4EC9D64: PyString_FromStringAndSize (in /usr/lib64/libpython2.7.so.1.0)
2019-10-03 19:00:56 ==31606==    by 0x117C57B8: PyXRootD::File::Read(PyXRootD::File*, _object*, _object*) (PyXRootDFile.cc:198)
2019-10-03 19:00:56 ==31606==    by 0x4F1BD3F: PyEval_EvalFrameEx (in /usr/lib64/libpython2.7.so.1.0)
```