### PR TITLE
Extend the urlencoding function to /r and /n

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -690,8 +690,10 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
   
   // Here we put back the opaque info, if any
   if (vardata) {
+    char *newvardata = quote(vardata);
     redirdest += "?&";
-    redirdest += vardata;
+    redirdest += newvardata;
+    free(newvardata);
   }
   
   // Shall we put also the opaque data of the request? Maybe not

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -375,6 +375,14 @@ char *quote(const char *str) {
         strcpy(r + j, "%2F");
         j += 3;
         break;
+      case '\n':
+        strcpy(r + j, "%0C");
+        j += 3;
+        break;
+      case '\r':
+        strcpy(r + j, "%0A");
+        j += 3;
+        break;
       default:
         r[j++] = c;
     }


### PR DESCRIPTION
Urlencode the opaque info that is propagated into a redirection response