### PR TITLE
drop default 'all.export /tmp' in standalone cfg

### DIFF
--- a/packaging/common/xrootd-standalone.cfg
+++ b/packaging/common/xrootd-standalone.cfg
@@ -16,7 +16,7 @@
 # The export directive indicates which paths are to be exported. While the
 # default is '/tmp', we indicate it anyway to show you this directive.
 #
-all.export /tmp
+#all.export /tmp
 
 # The adminpath and pidpath variables indicate where the pid and various
 # IPC files should be placed


### PR DESCRIPTION
Including the default `all.export /tmp` interferes with other packages that drop cfg files under `/etc/xrootd/config.d` to set `all.export` paths.

By commenting out the default `all.export /tmp`, the default behavior will be the same, but other packages will be able to install config.d files to specify other `all.export` paths, without automatically including the default `/tmp`.

(The same is true for the other config files, but for now we are mainly interested in the standalone config.)