### PR TITLE
Use discovered OpenSSL linker libraries

### DIFF
--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -100,7 +100,7 @@ target_link_libraries(
   z
   ${EXTRA_LIBS}
   ${CMAKE_DL_LIBS}
-  ssl)
+  ${OPENSSL_LIBRARIES})
 
 set_target_properties(
   XrdCl

--- a/src/XrdUtils.cmake
+++ b/src/XrdUtils.cmake
@@ -219,8 +219,7 @@ target_link_libraries(
   XrdUtils
   pthread
   ${CMAKE_DL_LIBS}
-  ssl
-  crypto
+  ${OPENSSL_LIBRARIES}
   ${SOCKET_LIBRARY}
   ${SENDFILE_LIBRARY}
   ${EXTRA_LIBS} )

--- a/src/api_test/CMakeLists.txt
+++ b/src/api_test/CMakeLists.txt
@@ -27,8 +27,7 @@ add_executable(
 target_link_libraries(
   xrdsrv
   XrdUtils
-  ssl
-  crypto
+  ${OPENSSL_LIBRARIES}
   pthread )
   
 


### PR DESCRIPTION
This PR resolves for me compilation issues with OpenSSL 1.1 on MacOS.