### PR TITLE
adding XrdSfsGPFile.hh to XrdHeaders.cmake

### DIFF
--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -103,6 +103,7 @@ if( NOT XRDCL_ONLY )
     XrdSfs/XrdSfsDio.hh
     XrdSfs/XrdSfsXio.hh
     XrdSfs/XrdSfsFlags.hh
+    XrdSfs/XrdSfsGPFile.hh
     XrdSfs/XrdSfsInterface.hh
     XrdXrootd/XrdXrootdMonData.hh
     XrdXrootd/XrdXrootdBridge.hh


### PR DESCRIPTION
When trying to build the xrootd-hdfs plugin (https://github.com/opensciencegrid/xrootd-hdfs) we got the following error[1], we saw that the the file: XrdSfs/XrdSfsGPFile.hh is not installed with the xrootd-server-devel package as one would expect. I think the file is missing in the XrdHeaders.cmake file

[1]
`usr/bin/c++   -std=gnu++11 -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches   -m64 -mtune=generic  -Wall -Werror -O2 -g -DNDEBUG  -Wl,--no-undefined CMakeFiles/xrootd_hdfs_envcheck.dir/src/XrdHdfsEnvCheck.cc.o  -o xrootd_hdfs_envcheck -rdynamic 
In file included from /builddir/build/BUILD/xrootd-hdfs-2.1.7/src/XrdHdfsChecksumCalc.cc:10:0:
/usr/include/xrootd/XrdSfs/XrdSfsInterface.hh:42:34: fatal error: XrdSfs/XrdSfsGPFile.hh: No such file or directory
 #include "XrdSfs/XrdSfsGPFile.hh"
`