### PR TITLE
Remove duplicate version of `quote` function.

### DIFF
--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -35,7 +35,8 @@
  * 
  */
 
-
+#include "XProtocol/XPtypes.hh"
+#include "XrdSec/XrdSecEntity.hh"
 
 #ifndef XRDHTTPUTILS_HH
 #define	XRDHTTPUTILS_HH

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -68,47 +68,6 @@ static std::string prepareURL(XrdHttpExtReq &req) {
 }
 
 
-static char *quote(const char *str) {
-  int l = strlen(str);
-  char *r = (char *) malloc(l*3 + 1);
-  r[0] = '\0';
-  int i, j = 0;
-
-  for (i = 0; i < l; i++) {
-    char c = str[i];
-
-    switch (c) {
-      case ' ':
-        strcpy(r + j, "%20");
-        j += 3;
-        break;
-      case '[':
-        strcpy(r + j, "%5B");
-        j += 3;
-        break;
-      case ']':
-        strcpy(r + j, "%5D");
-        j += 3;
-        break;
-      case ':':
-        strcpy(r + j, "%3A");
-        j += 3;
-        break;
-      case '/':
-        strcpy(r + j, "%2F");
-        j += 3;
-        break;
-      default:
-        r[j++] = c;
-    }
-  }
-
-  r[j] = '\0';
-
-  return r;
-}
-
-
 bool TPCHandler::MatchesPath(const char *verb, const char *path) {
     return !strcmp(verb, "COPY") || !strcmp(verb, "OPTIONS");
 }

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -6,6 +6,7 @@
 #include "XrdSys/XrdSysPthread.hh"
 
 #include "XrdHttp/XrdHttpExtHandler.hh"
+#include "XrdHttp/XrdHttpUtils.hh"
 
 class XrdOucErrInfo;
 class XrdOucStream;


### PR DESCRIPTION
The `quote` function was copy-pasted into the standalone xrootd-http-tpc package before that package was integrated back into the mainline `xrootd` source code.  Now that XrdTpc is in the same source repo, there's no need for this duplicate function.

Remove it!

@ffurano 