### PR TITLE
Initial code to internally proxy security credentials with a macaroon.

### DIFF
--- a/src/XrdHttp.cmake
+++ b/src/XrdHttp.cmake
@@ -17,12 +17,18 @@ if( BUILD_HTTP )
   # The XrdHttp library
   #-----------------------------------------------------------------------------
   include_directories( ${OPENSSL_INCLUDE_DIR} )
-  
+
+if( BUILD_MACAROONS )
+  set( MACAROON_FILES XrdMacaroons/XrdMacaroonsAuthz.cc XrdMacaroons/XrdMacaroonsAuthz.hh
+    XrdMacaroons/XrdMacaroonsConfigure.cc )
+endif()
+
   # Note this is marked as a shared library as XrdHttp plugins are expected to
   # link against this for the XrdHttpExt class implementations.
   add_library(
     ${LIB_XRD_HTTP_UTILS}
     SHARED
+    ${MACAROON_FILES}
     XrdHttp/XrdHttpProtocol.cc    XrdHttp/XrdHttpProtocol.hh
     XrdHttp/XrdHttpReq.cc         XrdHttp/XrdHttpReq.hh
                                   XrdHttp/XrdHttpSecXtractor.hh
@@ -36,12 +42,18 @@ if( BUILD_HTTP )
     MODULE
     XrdHttp/XrdHttpModule.cc )
 
+if( BUILD_MACAROONS )
+  include_directories(${MACAROONS_INCLUDES} ${UUID_INCLUDE_DIRS})
+endif()
+
   target_link_libraries(
     ${LIB_XRD_HTTP_UTILS}
     XrdServer
     XrdUtils
     ${CMAKE_DL_LIBS}
     pthread
+    ${MACAROONS_LIB}
+    ${UUID_LIBRARIES}
     ${OPENSSL_LIBRARIES}
     ${OPENSSL_CRYPTO_LIBRARY} )
 

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -166,6 +166,7 @@ private:
   static int xsslkey(XrdOucStream &Config);
   static int xsecxtractor(XrdOucStream &Config);
   static int xexthandler(XrdOucStream & Config, const char *ConfigFN, XrdOucEnv *myEnv);
+  static int xproxymacaroon(XrdOucStream & Config, const char *ConfigFN, XrdOucEnv *myEnv);
   static int xsslcadir(XrdOucStream &Config);
   static int xsslcipherfilter(XrdOucStream &Config);
   static int xdesthttps(XrdOucStream &Config);
@@ -317,6 +318,10 @@ protected:
   //
   // Processing configuration values
   //
+
+  /// XrdMacaroonAuthz handler (type-erased) for signing
+  /// tokens.
+  static void *m_macaroon_authz;
 
   /// Timeout for reading the handshake
   static int hailWait;

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -227,7 +227,8 @@ public:
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;
   bool m_appended_hdr2cgistr;
-  
+  bool m_authz_header;
+
   //
   // Area for coordinating request and responses to/from the bridge
   //

--- a/src/XrdMacaroons/XrdMacaroonsAuthz.hh
+++ b/src/XrdMacaroons/XrdMacaroonsAuthz.hh
@@ -20,6 +20,11 @@ public:
                                const Access_Operation  oper,
                                      XrdOucEnv        *env);
 
+    bool Sign(const XrdSecEntity *Entity,
+              const char         *path,
+                    XrdOucEnv    *env,
+                    std::string  &result);
+
     virtual int Audit(const int accok, const XrdSecEntity *Entity,
                       const char *path, const Access_Operation oper,
                       XrdOucEnv *Env)
@@ -38,6 +43,12 @@ private:
                           const char             *path,
                           const Access_Operation  oper,
                                 XrdOucEnv        *env);
+
+    std::string
+    GenerateID(const std::string &resource,
+                      const XrdSecEntity &entity,
+                      const std::string &activities,
+                      const std::string &before);
 
     ssize_t m_max_duration;
     XrdAccAuthorize *m_chain;

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -39,12 +39,16 @@ XrdVERSIONINFO(XrdHttpGetExtHandler, HttpTPC);
 // header (which will later be used for XrdSecEntity).  The latter copy is only done if
 // the Authorization header is not already present.
 static std::string prepareURL(XrdHttpExtReq &req) {
-  std::map<std::string, std::string>::const_iterator iter = req.headers.find("xrd-http-query");
+  std::map<std::string, std::string>::const_iterator iter = req.headers.find("xrd-http-fullresource");
   if (iter == req.headers.end() || iter->second.empty()) {return req.resource;}
 
   auto has_authz_header = req.headers.find("Authorization") != req.headers.end();
 
-  std::istringstream requestStream(iter->second);
+  const char *query_start = strchr(iter->second.c_str(), '?');
+  if (!query_start) {query_start = "";}
+  else {query_start++;}
+
+  std::istringstream requestStream(query_start);
   std::string token;
   std::stringstream result;
   bool found_first_header = false;
@@ -184,7 +188,9 @@ std::string TPCHandler::GetAuthz(XrdHttpExtReq &req) {
         ss << "authz=" << quoted_url;
         free(quoted_url);
         authz = ss.str();
+        return authz;
     }
+
     return authz;
 }
 


### PR DESCRIPTION
This causes HTTP requests coming in using an X509 proxy to generate a new macaroon used internally.  Since the macaroon serializes the security session, this avoids problems to forward authorization if this is a gateway.