### PR TITLE
Use uuid.h from libuuid for Macaroons

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -4,7 +4,7 @@
 #include <string>
 #include <iostream>
 
-#include "uuid.h"
+#include <uuid/uuid.h>
 #include "json.h"
 #include "macaroons.h"
 


### PR DESCRIPTION
This PR aligns the usage of uuid.h header in the [XrdMacaroonsHandler.cc](https://github.com/xrootd/xrootd/blob/master/src/XrdMacaroons/XrdMacaroonsHandler.cc#L7) with [XrdClFileStateHandler.cc](https://github.com/xrootd/xrootd/blob/master/src/XrdCl/XrdClFileStateHandler.cc#L45). I believe the libuuid version should be used in both cases.

Cheers,
Nikola