### PR TITLE
[XrdHttp] Enable elliptic-curve support for OpenSSL 1.0.2+

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1758,7 +1758,13 @@ int XrdHttpProtocol::InitSecurity() {
   }
 
   // Use default cipherlist filter if none is provided
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+  // For OpenSSL v1.0.2+ (EL7+), use recommended cipher list from Mozilla
+  // https://ssl-config.mozilla.org/#config=intermediate&openssl=1.0.2k&guideline=5.4
   if (!sslcipherfilter) sslcipherfilter = (char *) "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
+#else
+  if (!sslcipherfilter) sslcipherfilter = (char *) "ALL:!LOW:!EXP:!MD5:!MD2";
+#endif
   /* Apply the cipherlist filtering. */
   if (!SSL_CTX_set_cipher_list(sslctx, sslcipherfilter)) {
     TRACE(EMSG, " Error setting the cipherlist filter.");

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1766,6 +1766,12 @@ int XrdHttpProtocol::InitSecurity() {
     exit(1);
   }
 
+#if SSL_CTRL_SET_ECDH_AUTO
+    // Enable elliptic-curve support
+    // not needed in OpenSSL 1.1.0+
+    SSL_CTX_set_ecdh_auto(sslctx, 1);
+#endif
+
   //SSL_CTX_set_purpose(sslctx, X509_PURPOSE_ANY);
   SSL_CTX_set_mode(sslctx, SSL_MODE_AUTO_RETRY);
 


### PR DESCRIPTION
ECC support is automatically enabled in OpenSSL 1.1+, but must be initialized in 1.0.

From quick testing on CentOS 7, this seems to resolve #1149 for me. Results from HTTPS connections to various versions:

* 4.11.2:
    * Protocol  : TLSv1.2
    * Cipher    : AES256-GCM-SHA384
* 4.11.3rc1:
    * Client: `SSL routines:ssl3_read_bytes:sslv3 alert handshake failure:ssl/record/rec_layer_s3.c:1543:SSL alert number 40`
    * Server: `SSL routines:ssl3_get_client_hello:no shared cipher:s3_srvr.c:1435`
* 4.11.3rc1 with this PR:
    * Protocol  : TLSv1.2
    * Cipher    : ECDHE-RSA-AES256-GCM-SHA384