### PR TITLE
Improve HTTP-TPC error messages.

### DIFF
--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -61,6 +61,8 @@ public:
 
     int GetStatusCode() const {return m_status_code;}
 
+    std::string GetErrorMessage() const {return m_error_buf;}
+
     void ResetAfterRequest();
 
     CURL *GetHandle() const {return m_curl;}
@@ -118,6 +120,7 @@ private:
     struct curl_slist *m_headers; // any headers we set as part of the libcurl request.
     std::vector<std::string> m_headers_copy; // Copies of custom headers.
     std::string m_resp_protocol;  // Response protocol in the HTTP status line.
+    std::string m_error_buf;  // Any error associated with a response.
 };
 
 };

--- a/src/XrdTpc/XrdTpcStream.cc
+++ b/src/XrdTpc/XrdTpcStream.cc
@@ -60,6 +60,12 @@ Stream::Write(off_t offset, const char *buf, size_t size)
         buffer_accepted = true;
         if (retval != SFS_ERROR) {
             m_offset += retval;
+        } else {
+            std::stringstream ss;
+            const char *msg = m_fh->error.getErrText();
+            if (!msg || (*msg == '\0')) {msg = "(no error message provided)";}
+            ss << m_fh->error.getErrText() << " (code=" << m_fh->error.getErrInfo() << ")";
+            m_error_buf = ss.str();
         }
         // If there are no in-use buffers, then we don't need to
         // do any accounting.

--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <vector>
+#include <string>
 
 #include <cstring>
 
@@ -54,6 +55,8 @@ public:
     //
     // Returns true on success; false otherwise.
     bool Finalize();
+
+    std::string GetErrorMessage() const {return m_error_buf;}
 
 private:
 
@@ -141,5 +144,6 @@ private:
     off_t m_offset;
     std::vector<Entry*> m_buffers;
     XrdSysError &m_log;
+    std::string m_error_buf;
 };
 }


### PR DESCRIPTION
Importantly, if the passive endpoint provides a reasonable error messages, this is now passed along to the TPC client.