### PR TITLE
Have HTTP-TPC reuse the SFS from the environment.

### DIFF
--- a/src/XrdTpc/XrdTpcConfigure.cc
+++ b/src/XrdTpc/XrdTpcConfigure.cc
@@ -4,101 +4,14 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 
+#include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOuc/XrdOucStream.hh"
 #include "XrdOuc/XrdOucPinPath.hh"
 #include "XrdSfs/XrdSfsInterface.hh"
 
-extern XrdSfsFileSystem *XrdSfsGetDefaultFileSystem(XrdSfsFileSystem *native_fs,
-                                                    XrdSysLogger     *lp,
-                                                    const char       *configfn,
-                                                    XrdOucEnv        *EnvInfo);
-
 
 using namespace TPC;
 
-
-static XrdSfsFileSystem *load_sfs(void *handle, bool alt, XrdSysError &log, const std::string &libpath, const char *configfn, XrdOucEnv &myEnv, XrdSfsFileSystem *prior_sfs) {
-    XrdSfsFileSystem *sfs = NULL;
-    if (alt) {
-        XrdSfsFileSystem2_t ep = (XrdSfsFileSystem *(*)(XrdSfsFileSystem *, XrdSysLogger *, const char *, XrdOucEnv *))
-                      (dlsym(handle, "XrdSfsGetFileSystem2"));
-        if (ep == NULL) {
-            log.Emsg("Config", "Failed to load XrdSfsGetFileSystem2 from library ", libpath.c_str(), dlerror());
-            return NULL;
-        }
-        sfs = ep(prior_sfs, log.logger(), configfn, &myEnv);
-    } else {
-        XrdSfsFileSystem_t ep = (XrdSfsFileSystem *(*)(XrdSfsFileSystem *, XrdSysLogger *, const char *))
-                              (dlsym(handle, "XrdSfsGetFileSystem"));
-        if (ep == NULL) {
-            log.Emsg("Config", "Failed to load XrdSfsGetFileSystem from library ", libpath.c_str(), dlerror());
-            return NULL;
-        }
-        sfs = ep(prior_sfs, log.logger(), configfn);
-    }
-    if (!sfs) {
-        log.Emsg("Config", "Failed to initialize filesystem library for TPC handler from ", libpath.c_str());
-        return NULL;
-    }
-    return sfs;
-}
-
-
-bool TPCHandler::ConfigureFSLib(XrdOucStream &Config, std::string &path1, bool &path1_alt, std::string &path2, bool &path2_alt) {
-    char *val;
-    if (!(val = Config.GetWord())) {
-        m_log.Emsg("Config", "fslib not specified");
-        return false;
-    }
-    if (!strcmp("throttle", val)) {
-        path2 = "libXrdThrottle.so";
-        if (!(val = Config.GetWord())) {
-            m_log.Emsg("Config", "fslib throttle target library not specified");
-            return false;
-        }
-    }
-    else if (!strcmp("-2", val)) {
-        path2_alt = true;
-        if (!(val = Config.GetWord())) {
-            m_log.Emsg("Config", "fslib library not specified");
-            return false;
-        }
-        path2 = val;
-    }
-    else {
-        path2 = val;
-    }
-    if (!(val = Config.GetWord()) || !strcmp("default", val)) {
-        // There is not a second path specified or we requested the default path.
-        // Configuration of the form "xrootd.fslib /some/path.so"
-        // or                        "xrootd.fslib /some/path.so default"
-        if ((path2 == "libXrdThrottle.so") || val) {
-            // Default path specified as base or no default path specified, but chaining
-            // with the throttle plugin.
-            // Configuration of the form "xrootd.fslib throttle"
-            //                        or "xrootd.fslib throttle default"
-            path1 = "default";
-        } else {
-            // Only one path was specified - only load base.
-            // Configuration of the form "xrootd.fslib /some/base_path.so"
-            path1 = path2;
-            path2 = "";
-            path1_alt = path2_alt;
-        }
-    } else if (!strcmp("-2", val)) {
-        // Configuration of the form  "xrootd.fslib /some/path.so -2 /some/base_path.so"
-        path1_alt = true;
-        if (!(val = Config.GetWord())) {
-            m_log.Emsg("Config", "fslib base library not specified");
-            return false;
-        }
-        path1 = val;
-    } else {
-        // Configuration of the form "xrootd.fslib /some/path.so /some/base_path.so"
-        path1 = val;
-    }
-    return true;
-}
 
 bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
 {
@@ -115,20 +28,8 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
     static const char *cvec[] = { "*** http tpc plugin config:", 0 };
     Config.Capture(cvec);
     const char *val;
-    std::string path2, path1 = "default";
-    bool path1_alt = false, path2_alt = false;
     while ((val = Config.GetMyFirstWord())) {
-        if (!strcmp("xrootd.fslib", val)) {
-            if (!ConfigureFSLib(Config, path1, path1_alt, path2, path2_alt)) {
-                Config.Close();
-                m_log.Emsg("Config", "Failed to parse the xrootd.fslib directive");
-                return false;
-            }
-            m_log.Emsg("Config", "xrootd.fslib line successfully processed by TPC handler.  Base library:", path1.c_str());
-            if (path2.size()) {
-                m_log.Emsg("Config", "Chained library:", path2.c_str());
-            }
-        } else if (!strcmp("http.desthttps", val)) {
+        if (!strcmp("http.desthttps", val)) {
             if (!(val = Config.GetWord())) {
                 Config.Close();
                 m_log.Emsg("Config", "http.desthttps value not specified");
@@ -154,45 +55,14 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
     }
     Config.Close();
 
-    XrdSfsFileSystem *base_sfs = NULL;
-    if (path1 == "default") {
-        m_log.Emsg("Config", "Loading the default filesystem");
-        base_sfs = XrdSfsGetDefaultFileSystem(NULL, m_log.logger(), configfn, myEnv);
-        m_log.Emsg("Config", "Finished loading the default filesystem");
+    void *sfs_raw_ptr;
+    if ((sfs_raw_ptr = myEnv->GetPtr("XrdSfsFileSystem*"))) {
+        m_sfs = static_cast<XrdSfsFileSystem*>(sfs_raw_ptr);
+        m_log.Emsg("Config", "Using filesystem object from the framework.");
+        return true;
     } else {
-        char resolvePath[2048];
-        bool usedAltPath{true};
-        if (!XrdOucPinPath(path1.c_str(), usedAltPath, resolvePath, 2048)) {
-            m_log.Emsg("Config", "Failed to locate appropriately versioned base filesystem library for ", path1.c_str());
-            return false;
-        }
-        m_handle_base = dlopen(resolvePath, RTLD_LOCAL|RTLD_NOW);
-        if (m_handle_base == NULL) {
-            m_log.Emsg("Config", "Failed to base plugin ", resolvePath, dlerror());
-            return false;
-        }
-        base_sfs = load_sfs(m_handle_base, path1_alt, m_log, path1, configfn, *myEnv, NULL);
-    }
-    if (!base_sfs) {
-        m_log.Emsg("Config", "Failed to initialize filesystem library for TPC handler from ", path1.c_str());
+        m_log.Emsg("Config", "No filesystem object available to HTTP-TPC subsystem.  Internal error.");
         return false;
     }
-    XrdSfsFileSystem *chained_sfs = NULL;
-    if (!path2.empty()) {
-        char resolvePath[2048];
-        bool usedAltPath{true};
-        if (!XrdOucPinPath(path2.c_str(), usedAltPath, resolvePath, 2048)) {
-            m_log.Emsg("Config", "Failed to locate appropriately versioned chained filesystem library for ", path2.c_str());
-            return false;
-        }
-        m_handle_chained = dlopen(resolvePath, RTLD_LOCAL|RTLD_NOW);
-        if (m_handle_chained == NULL) {
-            m_log.Emsg("Config", "Failed to chained plugin ", resolvePath, dlerror());
-            return false;
-        }
-        chained_sfs = load_sfs(m_handle_chained, path2_alt, m_log, path2, configfn, *myEnv, base_sfs);
-    }
-    m_sfs.reset(chained_sfs ? chained_sfs : base_sfs);
-    m_log.Emsg("Config", "Successfully configured the filesystem object for TPC handler");
     return true;
 }

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -105,22 +105,13 @@ int TPCHandler::ProcessReq(XrdHttpExtReq &req) {
 }
 
 TPCHandler::~TPCHandler() {
-    m_sfs = NULL;  // NOTE: must delete the SFS here as we may unload the destructor from memory below!
-    if (m_handle_base) {
-        dlclose(m_handle_base);
-        m_handle_base = NULL;
-    }
-    if (m_handle_chained) {
-        dlclose(m_handle_chained);
-        m_handle_chained = NULL;
-    }
+    m_sfs = NULL;
 }
 
 TPCHandler::TPCHandler(XrdSysError *log, const char *config, XrdOucEnv *myEnv) :
         m_desthttps(false),
         m_log(*log),
-        m_handle_base(NULL),
-        m_handle_chained(NULL)
+        m_sfs(NULL)
 {
     if (!Configure(config, myEnv)) {
         throw std::runtime_error("Failed to configure the HTTP third-party-copy handler.");

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -73,9 +73,7 @@ private:
     static XrdSysMutex m_monid_mutex;
     static uint64_t m_monid;
     XrdSysError &m_log;
-    std::unique_ptr<XrdSfsFileSystem> m_sfs;
-    void *m_handle_base;
-    void *m_handle_chained;
+    XrdSfsFileSystem *m_sfs;
 
     // 16 blocks in flight at 16 MB each, meaning that there will be up to 256MB
     // in flight; this is equal to the bandwidth delay product of a 200ms transcontinental


### PR DESCRIPTION
The XRootD framework now exports the global SFS object to the environment (which is available to the HTTP-TPC plugin).  This switches HTTP-TPC to use that object instead of loading a separate copy of the filesystem.