### PR TITLE
Fix MKCOL response when we have an EEXIST.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -943,6 +943,9 @@ void XrdHttpReq::mapXrdErrorToHttpStatus() {
       case kXR_isDirectory:
         httpStatusCode = 409; httpStatusText = "Resource is a directory";
         break;
+      case kXR_InvalidRequest:
+        httpStatusCode = 405; httpStatusText = "Method is not allowed";
+        break;
       default:
         break;
     }


### PR DESCRIPTION
Per the WebDAV spec, the correct MKCOL response for when a collection already exists is 405.

Without this fix, `gfal-mkdir` interprets the `EEXISTS` response to `MKCOL` as a file-not-found.  This causes the client to attempt to make the parent directory.

This fixes a race condition in FTS that we've been triggering on occasion with this pattern:
```
- Client 1 does a stat on path `/foo/bar`; file-not-found is returned
- Client 2 does a stat on path `/foo/bar`; file-not-found is returned
- Client 1 does a mkdir on path `/foo/bar`; successful!
- Client 2 does a mkdir on path `/foo/bar`; file-not-found is returned (due to this bug).
- Client 2 does a mkdir on path `/foo`; permission denied is returned.
- Client 2 tells the user the permission is denied.
```
So client 2 returns a permission problem because it can't make a top-level directory when, in reality, the path it wants already exists!

@simonmichal - please consider this for backport.  It's causing transfer failures in production and should be a relatively safe, simple backport.
@ffurano - please review