### PR TITLE
Workaround an incorrect error code from the Xrootd bridge.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2621,6 +2621,12 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
     {
 
       if (xrdresp != kXR_ok) {
+        // Workaround for the cmsd not sending the right error code -- we need to examine the
+        // text.  See GH issue #1167.  In R5, we simply fix the error code.
+        if (httpStatusText == "Unable to create new file; file already exists.\n")
+        {
+            httpStatusCode = 405;
+        }
         prot->SendSimpleResp(httpStatusCode, NULL, NULL,
                              httpStatusText.c_str(), httpStatusText.length(), false);
         return -1;


### PR DESCRIPTION
This avoids the issue in #1167, which causes the wrong error code
to be given for a known error text.  This simply looks for the known
error text and corrects the HTTP status code.

The root cause is already fixed in R5 -- this is just a minimal workaround for stable.