### PR TITLE
Initialize the XrdAccEntityInfo structure.

### DIFF
--- a/src/XrdAcc/XrdAccEntity.hh
+++ b/src/XrdAcc/XrdAccEntity.hh
@@ -42,7 +42,12 @@ struct XrdAccEntityInfo
        const char *vorg;
        const char *role;
        const char *grup;
-                   XrdAccEntityInfo() {}
+                   XrdAccEntityInfo() :
+                       name(NULL),
+                       host(NULL),
+                       vorg(NULL),
+                       role(NULL),
+                       grup(NULL) {}
                   ~XrdAccEntityInfo() {}
       };
 
@@ -91,7 +96,7 @@ struct EntityAttr
       {const char *vorg;
        const char *role;
        const char *grup;
-                   EntityAttr() {}
+                   EntityAttr() : vorg(NULL), role(NULL), grup(NULL) {}
                   ~EntityAttr() {}
       };
 


### PR DESCRIPTION
When one `vorg` is provided and no groups are provided, the `grup` data memeber may be uninitialized on use.  This has resulted in periodic segfaults on the SciTokens ACC provider; I'm guessing that `grup` quite often has an initial value of `nullptr`, even when uninitialized.

I suspect this hasn't been observed for the VOMS provider because all VOMS server implementations create at least one group; hence this case is never hit.