### PR TITLE
Reload certificate store once an hour.

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -638,9 +638,17 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
           BIO_set_nbio(sbio, 1);
           ssl = SSL_new(sslctx);
 
+          // On newer versions of OpenSSL, we use the periodically
+          // updated store `verify_store` with the `x509_store_lock`
+          // held; older OpenSSL versions are missing `SSL_set1_*_cert_store`,
+          // so we simply rely on the global one in SSL_CTX.  The latter
+          // doesn't refresh the verify store, which causes issues with some
+          // plugins.
+#if OPENSSL_VERSION_NUMBER >= 0x010100000L
           XrdSysRWLockHelper scopedLock(x509_store_lock, true);
           SSL_set1_verify_cert_store(ssl, verify_store);
           SSL_set1_chain_cert_store(ssl, verify_store);
+#endif
 
         }
 
@@ -1631,6 +1639,7 @@ extern "C" int verify_callback(int ok, X509_STORE_CTX * store) {
 }
 
 /// Initialization of the ssl security
+//  Only scheduled on sufficiently new OpenSSL.
 
 class XrdCertStoreJob : XrdJob
 {
@@ -1750,6 +1759,10 @@ int XrdHttpProtocol::InitSecurity() {
     }
   }
 
+  // Initialize a store for use on individual SSL objects and schedule
+  // a periodic update.  These separate stores are only usable on versions
+  // of OpenSSL 1.1.0 or later.
+#if OPENSSL_VERSION_NUMBER >= 0x010100000L
   {
     XrdSysRWLockHelper scopedLock(x509_store_lock, false);
     verify_store = PrepareStore();
@@ -1757,8 +1770,8 @@ int XrdHttpProtocol::InitSecurity() {
       exit(1);
     }
   }
-
   new XrdCertStoreJob(Sched, 3600);
+#endif
 
   // Use default cipherlist filter if none is provided
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1788,6 +1788,13 @@ int XrdHttpProtocol::InitSecurity() {
     exit(1);
   }
 
+  // NOTE(bbockelm): OpenSSL docs note that peer_chain is not available
+  // in reused sessions.  We should build a session cache, but we just
+  // disable sessions for now.  The session cache breaks X509 auth that
+  // is built-in to XrdHttp.
+  SSL_CTX_set_session_cache_mode(sslctx, SSL_SESS_CACHE_OFF);
+  SSL_CTX_set_options(sslctx, SSL_OP_NO_TICKET);
+
 #if SSL_CTRL_SET_ECDH_AUTO
     // Enable elliptic-curve support
     // not needed in OpenSSL 1.1.0+

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -94,6 +94,8 @@ char *XrdHttpProtocol::gridmap = 0;
 XrdOucGMap *XrdHttpProtocol::servGMap = 0;  // Grid mapping service
 
 int XrdHttpProtocol::sslverifydepth = 9;
+XrdSysRWLock XrdHttpProtocol::x509_store_lock;
+X509_STORE *XrdHttpProtocol::verify_store = NULL;
 SSL_CTX *XrdHttpProtocol::sslctx = 0;
 BIO *XrdHttpProtocol::sslbio_err = 0;
 XrdHttpSecXtractor *XrdHttpProtocol::secxtractor = 0;
@@ -635,6 +637,11 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
           sbio = CreateBIO(Link);
           BIO_set_nbio(sbio, 1);
           ssl = SSL_new(sslctx);
+
+          XrdSysRWLockHelper scopedLock(x509_store_lock, true);
+          SSL_set1_verify_cert_store(ssl, verify_store);
+          SSL_set1_chain_cert_store(ssl, verify_store);
+
         }
 
       if (!ssl) {
@@ -1625,6 +1632,56 @@ extern "C" int verify_callback(int ok, X509_STORE_CTX * store) {
 
 /// Initialization of the ssl security
 
+class XrdCertStoreJob : XrdJob
+{
+public:
+
+  void DoIt() {XrdHttpProtocol::PeriodicUpdate();
+               Sched->Schedule((XrdJob *)this, time(0)+iVal);
+              }
+
+  XrdCertStoreJob(XrdScheduler *schP, int iV)
+                  : XrdJob("cert store updater"),
+                       Sched(schP), iVal(iV)
+                    {Sched->Schedule((XrdJob *)this, time(0)+iVal);}
+  ~XrdCertStoreJob() {}
+private:
+
+  XrdScheduler *Sched;
+  int           iVal;
+};
+
+void XrdHttpProtocol::PeriodicUpdate() {
+
+    X509_STORE *new_store = PrepareStore();
+    TRACE(EMSG, "Updating new cert store");
+    if (new_store) {
+      XrdSysRWLockHelper scopedLock(x509_store_lock, false);
+      X509_STORE_free(verify_store);
+      verify_store = new_store;
+    }
+}
+
+X509_STORE *XrdHttpProtocol::PrepareStore() {
+  X509_STORE *store = X509_STORE_new();
+
+  if (!store) {
+    eDest.Say(" error: failed to allocate new certificate store");
+    return NULL;
+  }
+
+  X509_STORE_set_depth(store, sslverifydepth);
+  X509_STORE_set_flags(store, X509_V_FLAG_ALLOW_PROXY_CERTS);
+
+  if (!X509_STORE_load_locations(store, sslcafile, sslcadir)) {
+    TRACE(EMSG, " Error setting the ca file or directory.");
+    ERR_print_errors(sslbio_err);
+    return NULL;
+  }
+
+  return store;
+}
+
 int XrdHttpProtocol::InitSecurity() {
   
   static const char *eText = XrdTlsContext::Init();
@@ -1692,6 +1749,16 @@ int XrdHttpProtocol::InitSecurity() {
       exit(1);
     }
   }
+
+  {
+    XrdSysRWLockHelper scopedLock(x509_store_lock, false);
+    verify_store = PrepareStore();
+    if (!verify_store) {
+      exit(1);
+    }
+  }
+
+  new XrdCertStoreJob(Sched, 3600);
 
   // Use default cipherlist filter if none is provided
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -127,6 +127,9 @@ public:
   /// called via https
   bool isHTTPS() { return ishttps; }
 
+  /// Handle periodic refresh of the CRLs
+  static void PeriodicUpdate();
+
 private:
 
 
@@ -135,6 +138,9 @@ private:
 
   /// Initialization of the ssl security things
   static int InitSecurity();
+
+  /// Generate a new cert store.
+  static X509_STORE *PrepareStore();
 
   /// Start a response back to the client
   int StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen, bool keepalive);
@@ -253,6 +259,10 @@ private:
   
   /// Global, static SSL context
   static SSL_CTX *sslctx;
+
+  /// Current X509_STORE and associated locks.
+  static X509_STORE *verify_store;
+  static XrdSysRWLock x509_store_lock;
 
   /// Private SSL context
   SSL *ssl;


### PR DESCRIPTION
This triggers a reload of the cert store used for chain building and certificate verification (CRLs) once an hour.

Fixes #750 