### PR TITLE
Disable session cache (stable)

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1782,6 +1782,13 @@ int XrdHttpProtocol::InitSecurity() {
     exit(1);
   }
 
+  // NOTE(bbockelm): OpenSSL docs note that peer_chain is not available
+  // in reused sessions.  We should build a session cache, but we just
+  // disable sessions for now.  The session cache breaks X509 auth that
+  // is built-in to XrdHttp.
+  SSL_CTX_set_session_cache_mode(sslctx, SSL_SESS_CACHE_OFF);
+  SSL_CTX_set_options(sslctx, SSL_OP_NO_TICKET);
+
 #if SSL_CTRL_SET_ECDH_AUTO
     // Enable elliptic-curve support
     // not needed in OpenSSL 1.1.0+


### PR DESCRIPTION
The session cache breaks the built-in X509 client authentication; disable it until we have the time to implement a real cache.

Doing this as a one-off against the stable branch as master has significantly diverged in how it handles the `SSL_CTX`.

Builds fine on CentOS 6; from some sleuthing, it seems this API was present in OpenSSL 1.0.2.