### PR TITLE
Install missing in installation directory header file XrdCl/XrdClOptional.hh

### DIFF
--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -171,6 +171,7 @@ install(
     XrdClStatus.hh
     XrdClURL.hh
     XrdClXRootDResponses.hh
+    XrdClOptional.hh
     XrdClPlugInInterface.hh
     XrdClPlugInManager.hh
     XrdClPropertyList.hh

--- a/utils/xrootd-config
+++ b/utils/xrootd-config
@@ -39,7 +39,7 @@ Generic options
 
 Compilation support options
   --cflags      print pre-processor and compiler flags
-  --plugin-vesion print plug-in version suffix
+  --plugin-version print plug-in version suffix
 
 Install directories XRootD was configured to
   --prefix


### PR DESCRIPTION
cc: @bbockelm 
(seen in https://github.com/bbockelm/xrdcl-authz-plugin)
```
[ 75%] Building CXX object CMakeFiles/XrdClAuthzPlugin-.dir/src/XrdClAuthzPlugin.cc.o
In file included from /home/oksana/CERN_sources/xrdcl-authz-plugin/src/XrdClAuthzPlugin.cc:4:
/home/oksana/CERN/xrootd-HEAD/include/xrootd/XrdCl/XrdClPlugInInterface.hh:30:10: fatal error: XrdCl/XrdClOptional.hh: No such file or directory
   30 | #include "XrdCl/XrdClOptional.hh"
```