### PR TITLE
Make the xrdmapc help text and manpage match the code.

### DIFF
--- a/docs/man/xrdmapc.1
+++ b/docs/man/xrdmapc.1
@@ -16,9 +16,9 @@ The \fBxrdmapc\fR utility queries the XRootD redirector (status/subscribers/path
 when specified, uses <host>:<port> to determine the locations of path and does optional verification.
 
 .SH OPTIONS
-\fB-1\fR | \fB--list\fR [\fB\fR\fIall\fR|\fIm\fR|\fIs\fR]
+\fB-l\fR | \fB--list\fR [\fB\fR\fIall\fR|\fIm\fR|\fIs\fR]
 .RS 5
-'all' lists managers and servers (default), 'm' lists only managers and 's' lists only servers.
+\&'all' lists managers and servers (default), 'm' lists only managers and 's' lists only servers.
 
 .RE
 \fB-q\fR | \fB--quiet\fR
@@ -47,7 +47,7 @@ Errors yield an error message and a non-zero exit status.
 LGPL
 
 .SH SUPPORT LEVEL
-The \fBxrdcp\fR command is supported by the xrootd collaboration.
+The \fBxrdmapc\fR command is supported by the xrootd collaboration.
 Contact information can be found at:
 
 .ce

--- a/src/XrdApps/XrdMapCluster.cc
+++ b/src/XrdApps/XrdMapCluster.cc
@@ -455,7 +455,7 @@ void Usage(const char *emsg)
         <<"<opt>: [--help] [--list {all|m|s}] [--quiet] [--refresh] [--verify]" <<endl;
    if (!emsg)
       {cerr <<
-"--list    | -1 'all' lists managers and servers (default), 'm' lists only\n"
+"--list    | -l 'all' lists managers and servers (default), 'm' lists only\n"
 "               managers and 's' lists only servers.\n"
 "--quiet   | -q does not print error messages to cerr; errors appear inline.\n"
 "--refresh | -r does not use cached information but will refresh the cache.\n"


### PR DESCRIPTION
The short option for --list is -l, not -1. The code that defines the
option is src/XrdApps/XrdMapCluster.cc line 481:

      {OPT_TYPE "list",      1, 0, (int)'l'},

$ xrdmapc -1
xrdmapc: Invalid option, '-1'.
$ xrdmapc -l
xrdmapc: '-l' argument missing.

Add a zero-width space (\&) before 'all' at the start of the line, so
that the apostrophe at the start of the line is not interpreted as a
macro.

Fixes rpmlint warning:

$ rpmlint xrootd-client
xrootd-client.x86_64: W: manual-page-warning /usr/share/man/man1/xrdmapc.1.gz 21: warning: macro `all'' not defined
1 packages and 0 specfiles checked; 0 errors, 1 warnings.

Also fixes broken rendering of the man page where the line with the
unknown macro is ignored.

Original:

OPTIONS

       -1 | --list [all|m|s]

       -q | --quiet
            Does not print error messages to cerr; errors appear inline.

Updated:

OPTIONS

       -l | --list [all|m|s]
            'all' lists managers and servers (default), 'm' lists only man‐
            agers and 's' lists only servers.

       -q | --quiet
            Does not print error messages to cerr; errors appear inline.