### PR TITLE
[pfc] g-stream file_close & write queue mem handling

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -373,8 +373,13 @@ char* Cache::RequestRAM(long long size)
       else
       {
          m_RAM_mutex.UnLock();
-         char *buf = 0;
-         posix_memalign((void**) &buf, s_block_align, (size_t) size);
+         char *buf;
+         if (posix_memalign((void**) &buf, s_block_align, (size_t) size))
+         {
+            // Report out of mem? Probably should report it at least the first time,
+            // then periodically.
+            return 0;
+         }
          return buf;
       }
    }

--- a/src/XrdPfc/XrdPfcIOFileBlock.hh
+++ b/src/XrdPfc/XrdPfcIOFileBlock.hh
@@ -67,7 +67,7 @@ private:
    XrdSysMutex                m_mutex;           //!< map mutex
    struct stat               *m_localStat;
    Info                       m_info;
-   XrdOssDF*                  m_infoFile;
+   XrdOssDF*                  m_info_file;
 
    void  GetBlockSizeFromPath();
    int   initLocalStat();

--- a/src/XrdPfc/XrdPfcInfo.cc
+++ b/src/XrdPfc/XrdPfcInfo.cc
@@ -143,15 +143,15 @@ void Info::SetAllBitsSynced()
 void Info::SetBufferSize(long long bs)
 {
    // Needed only info is created first time in File::Open()
-   m_store.m_bufferSize = bs;
+   m_store.m_buffer_size = bs;
 }
 
 //------------------------------------------------------------------------------s
 
 void Info::SetFileSize(long long fs)
 {
-   m_store.m_fileSize = fs;
-   ResizeBits((m_store.m_fileSize - 1) / m_store.m_bufferSize + 1);
+   m_store.m_file_size = fs;
+   ResizeBits((m_store.m_file_size - 1) / m_store.m_buffer_size + 1);
    m_store.m_creationTime = time(0);
 }
 
@@ -213,7 +213,7 @@ bool Info::Read(XrdOssDF* fp, const std::string &fname)
       }
    }
 
-   if (r.Read(m_store.m_bufferSize)) return false;
+   if (r.Read(m_store.m_buffer_size)) return false;
 
    long long fs;
    if (r.Read(fs)) return false;
@@ -300,8 +300,8 @@ bool Info::Write(XrdOssDF* fp, const std::string &fname)
 
    m_store.m_version = s_defaultVersion;
    if (w.Write(m_store.m_version))    return false;
-   if (w.Write(m_store.m_bufferSize)) return false;
-   if (w.Write(m_store.m_fileSize))   return false;
+   if (w.Write(m_store.m_buffer_size)) return false;
+   if (w.Write(m_store.m_file_size))   return false;
 
    if (w.WriteRaw(m_store.m_buff_synced, GetSizeInBytes())) return false;
 
@@ -456,6 +456,10 @@ bool Info::GetLatestDetachTime(time_t& t) const
    return t != 0;
 }
 
+const Info::AStat* Info::GetLastAccessStats() const
+{
+   return m_store.m_astats.empty() ? 0 : & m_store.m_astats.back();
+}
 
 //==============================================================================
 // Support for reading of previous cinfo versions
@@ -478,7 +482,7 @@ bool Info::ReadV2(XrdOssDF* fp, const std::string &fname)
    FpHelper r(fp, 0, m_trace, m_traceID, trace_pfx + "oss read failed");
 
    if (r.Read(m_store.m_version))    return false;
-   if (r.Read(m_store.m_bufferSize)) return false;
+   if (r.Read(m_store.m_buffer_size)) return false;
 
    long long fs;
    if (r.Read(fs)) return false;
@@ -553,7 +557,7 @@ bool Info::ReadV1(XrdOssDF* fp, const std::string &fname)
    FpHelper r(fp, 0, m_trace, m_traceID, trace_pfx + "oss read failed");
 
    if (r.Read(m_store.m_version)) return false;
-   if (r.Read(m_store.m_bufferSize)) return false;
+   if (r.Read(m_store.m_buffer_size)) return false;
 
    long long fs;
    if (r.Read(fs)) return false;

--- a/src/XrdPfc/XrdPfcInfo.hh
+++ b/src/XrdPfc/XrdPfcInfo.hh
@@ -48,7 +48,7 @@ class Stats;
 class Info
 {
 public:
-   // !Access statistics
+   //! Access statistics
    struct AStat
    {
       time_t    AttachTime;       //!< open time
@@ -71,15 +71,15 @@ public:
    struct Store
    {
       int                m_version;                //!< info version
-      long long          m_bufferSize;             //!< prefetch buffer size
-      long long          m_fileSize;               //!< number of file blocks
+      long long          m_buffer_size;             //!< prefetch buffer size
+      long long          m_file_size;               //!< number of file blocks
       unsigned char     *m_buff_synced;            //!< disk written state vector
       char               m_cksum[16];              //!< cksum of downloaded information
       time_t             m_creationTime;           //!< time the info file was created
       size_t             m_accessCnt;              //!< total access count for the file
       std::vector<AStat> m_astats;                 //!< access records
 
-      Store () : m_version(1), m_bufferSize(-1), m_fileSize(0), m_buff_synced(0), m_creationTime(0), m_accessCnt(0) {}
+      Store () : m_version(1), m_buffer_size(-1), m_file_size(0), m_buff_synced(0), m_creationTime(0), m_accessCnt(0) {}
    };
 
 
@@ -128,7 +128,7 @@ public:
    void SetFileSize(long long);
 
    //---------------------------------------------------------------------
-   //! \brief Reserve buffer for fileSize/bufferSize bytes
+   //! \brief Reserve buffer for file_size / buffer_size bytes
    //!
    //! @param n number of file blocks
    //---------------------------------------------------------------------
@@ -216,6 +216,11 @@ public:
    bool GetLatestDetachTime(time_t& t) const;
 
    //---------------------------------------------------------------------
+   //! Get latest access stats
+   //---------------------------------------------------------------------
+   const AStat* GetLastAccessStats() const;
+
+   //---------------------------------------------------------------------
    //! Get prefetch buffer size
    //---------------------------------------------------------------------
    long long GetBufferSize() const;
@@ -253,7 +258,7 @@ public:
    //---------------------------------------------------------------------
    //! Get number of accesses
    //---------------------------------------------------------------------
-   size_t GetAccessCnt() { return m_store.m_accessCnt; }
+   size_t GetAccessCnt() const { return m_store.m_accessCnt; }
 
    //---------------------------------------------------------------------
    //! Get version
@@ -362,7 +367,7 @@ inline int Info::GetNDownloadedBlocks() const
 
 inline long long Info::GetNDownloadedBytes() const
 {
-   return m_store.m_bufferSize * GetNDownloadedBlocks();
+   return m_store.m_buffer_size * GetNDownloadedBlocks();
 }
 
 inline int Info::GetLastDownloadedBlock() const
@@ -377,9 +382,9 @@ inline long long Info::GetExpectedDataFileSize() const
 {
    int last_block = GetLastDownloadedBlock();
    if (last_block == m_sizeInBits - 1)
-      return m_store.m_fileSize;
+      return m_store.m_file_size;
    else
-      return (last_block + 1) * m_store.m_bufferSize;
+      return (last_block + 1) * m_store.m_buffer_size;
 }
 
 inline int Info::GetSizeInBytes() const
@@ -397,7 +402,7 @@ inline int Info::GetSizeInBits() const
 
 inline long long Info::GetFileSize() const
 {
-   return m_store.m_fileSize;
+   return m_store.m_file_size;
 }
 
 inline bool Info::IsComplete() const
@@ -422,7 +427,7 @@ inline void Info::UpdateDownloadCompleteStatus()
 
 inline long long Info::GetBufferSize() const
 {
-   return m_store.m_bufferSize;
+   return m_store.m_buffer_size;
 }
 
 }

--- a/src/XrdPfc/XrdPfcStats.hh
+++ b/src/XrdPfc/XrdPfcStats.hh
@@ -25,7 +25,7 @@
 namespace XrdPfc
 {
 //----------------------------------------------------------------------------
-//! Statistics of disk cache utilisation.
+//! Statistics of cache utilisation by a File object.
 //----------------------------------------------------------------------------
 class Stats
 {


### PR DESCRIPTION
- Implement pfc g-stream file_close reporting.
- Align buffers to page size.
- Reuse 5% of ram of buffers.
- Collect statistics of ram / write queue usage in bytes.