### PR TITLE
No version in cfg

### DIFF
--- a/packaging/common/xrootd-filecache-clustered.cfg
+++ b/packaging/common/xrootd-filecache-clustered.cfg
@@ -67,7 +67,7 @@ all.role server
 # For xrootd, load the proxy plugin and the disk caching plugin.
 #
 ofs.osslib   libXrdPss.so
-pss.cachelib libXrdPfc.so
+pss.cachelib default
 
 # The server needs to write to disk, stage not relevant
 #

--- a/packaging/common/xrootd-filecache-standalone.cfg
+++ b/packaging/common/xrootd-filecache-standalone.cfg
@@ -20,7 +20,7 @@ all.export  /test/
 # Load the proxy plugin and the disk caching plugin.
 #
 ofs.osslib   libXrdPss.so
-pss.cachelib libXrdPfc.so
+pss.cachelib default
 
 # Tell the proxy where the data is coming from (arbitrary).
 #

--- a/packaging/common/xrootd-http.cfg
+++ b/packaging/common/xrootd-http.cfg
@@ -33,7 +33,7 @@ all.pidpath /var/run/xrootd
 # In order to start the xrdhttp.socket run:
 #	systemctl start xrdhttp@http.socket
 #
-xrd.protocol XrdHttp:80 /usr/lib64/libXrdHttp-4.so
+xrd.protocol XrdHttp:80 /usr/lib64/libXrdHttp.so
 # More configuration files can be added in /etc/xrootd/config.d/                                                                                                            
 # For example /etc/xrootd/config.d/10-mygrid.cfg and                                                                                                                        
 # /etc/xrootd/config.d/98-mysite-specifics.cfg                                                                                                                             

--- a/src/XrdHttp/xrootd-http-rdr.cf
+++ b/src/XrdHttp/xrootd-http-rdr.cf
@@ -5,7 +5,7 @@
 
 
 if exec xrootd
-   xrd.protocol XrdHttp /usr/lib64/libXrdHttp.so.1
+   xrd.protocol XrdHttp /usr/lib64/libXrdHttp.so
 fi
 
 # Regular SSL stuff ... adjust as needed

--- a/src/XrdHttp/xrootd-http.cf
+++ b/src/XrdHttp/xrootd-http.cf
@@ -7,7 +7,7 @@
 
 
 if exec xrootd
-   xrd.protocol XrdHttp /usr/local/lib/libXrdHttp-4.so
+   xrd.protocol XrdHttp /usr/lib64/libXrdHttp.so
 fi
 
 http.cert /etc/grid-security/hostcert.pem
@@ -15,7 +15,7 @@ http.key /etc/grid-security/hostkey.pem
 http.cadir /etc/grid-security/certificates
 #http.secretkey CHANGEME
 #http.gridmap /etc/grid-security/mapfile
-#http.secxtractor /usr/lib64/libXrdHttpVOMS-4.so
+#http.secxtractor /usr/lib64/libXrdHttpVOMS.so
 #http.selfhttps2http yes
 
 # As an example of preloading files, let's preload in memory


### PR DESCRIPTION
Don't use versioned plugin names in configuration.
Using libXrdXxxx-4.so doesn't make sense for xrootd 5.

Use "pss.cachelib default" in the filecache configuration files.
This way the config files can be used by both the xrootd 5 server and the xrootd 4 server provided by the xrootd-compat package.
