### PR TITLE
Use existing library to extract DN from peer chain

### DIFF
--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -377,6 +377,34 @@ int XrdCryptosslX509ChainToFile(XrdCryptoX509Chain *ch, const char *fn)
 }
 
 //____________________________________________________________________________
+int XrdCryptosslX509ParseStack(STACK_OF(X509*) st_x509, XrdCryptoX509Chain *chain)
+{
+   EPNAME("X509ParseStack");
+
+   int nci = 0;
+   // Make sure we got a chain where to add the certificates
+   if (!chain) {
+      DEBUG("chain undefined: can do nothing");
+      return nci;
+   }
+
+   for (int i=0; i < sk_X509_num(st_x509); i++) {
+      X509 *cert = sk_X509_value(st_x509, i);
+      XrdCryptoX509 *c = new XrdCryptosslX509(cert);
+      if (c) {
+         chain->PushBack(c);
+      } else {
+         DEBUG("could not create certificate: memory exhausted?");
+         chain->Reorder();
+         return nci;
+      }
+      nci ++;
+   }
+   chain->Reorder();
+   return nci;
+}
+
+//____________________________________________________________________________
 int XrdCryptosslX509ParseFile(const char *fname,
                               XrdCryptoX509Chain *chain)
 {

--- a/src/XrdCrypto/XrdCryptosslAux.hh
+++ b/src/XrdCrypto/XrdCryptosslAux.hh
@@ -60,6 +60,8 @@ int XrdCryptosslX509ChainToFile(XrdCryptoX509Chain *c, const char *fn);
 int XrdCryptosslX509ParseFile(const char *fname, XrdCryptoX509Chain *c);
 // certificates from bucket parsing
 int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *c);
+// certificates from STACK_OF(X509*)
+int XrdCryptosslX509ParseStack(STACK_OF(X509*) st_x509, XrdCryptoX509Chain *c);
 //
 // Function to convert from ASN1 time format into UTC since Epoch (Jan 1, 1970) 
 time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1);


### PR DESCRIPTION
OpenSSL libraries don't understand proxy certificates and pull out the wrong subject for the use with the gridmap.  We can use the existing Xrootd libraries instead.

Fixes #1221 