### PR TITLE
Client (proxy) certificate handing in XrdHttp

### DIFF
--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -13,6 +13,10 @@ Version 4.12.1
 + **Major bug fixes**
   * **[XrdXrootdVoms]** Fix run-time lib dependencies.
 
++ **Minor bug fixes**
+  * **[xrdcp]** Don't create unwanted dir if --recursive option was used and the
+                source is a file.
+
 --------------
 Version 4.12.0
 --------------

--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -687,6 +687,7 @@ int main( int argc, char **argv )
   // If we're doing remote recursive copy, chain all the files (if it's a
   // directory)
   //----------------------------------------------------------------------------
+  bool srcIsDir = config.srcFile->Protocol == XrdCpFile::isDir;
   if( config.Want( XrdCpConfig::DoRecurse ) &&
       config.srcFile->Protocol == XrdCpFile::isXroot )
   {
@@ -697,6 +698,7 @@ int main( int argc, char **argv )
     XRootDStatus st = fs->Stat( source.GetPath(), statInfo );
     if( st.IsOK() && statInfo->TestFlags( StatInfo::IsDir ) )
     {
+      srcIsDir = true;
       //------------------------------------------------------------------------
       // Recursively index the remote directory
       //------------------------------------------------------------------------
@@ -758,7 +760,7 @@ int main( int argc, char **argv )
     //--------------------------------------------------------------------------
     std::string target = dest;
     // if this is a recursive copy make sure we preserve the directory structure
-    if( config.Want( XrdCpConfig::DoRecurse ) )
+    if( config.Want( XrdCpConfig::DoRecurse ) && srcIsDir )
     {
       // get the source directory
       std::string srcDir( sourceFile->Path, sourceFile->Doff );

--- a/src/XrdCrypto/XrdCryptoFactory.cc
+++ b/src/XrdCrypto/XrdCryptoFactory.cc
@@ -315,6 +315,16 @@ XrdCryptoX509ParseFile_t XrdCryptoFactory::X509ParseFile()
 }
 
 //______________________________________________________________________________
+XrdCryptoX509ParseStack_t XrdCryptoFactory::X509ParseStack()
+{
+   // Return an instance of an implementation of a function
+   // to parse a file supposed to contain for X509 certificates.
+
+   ABSTRACTMETHOD("XrdCryptoFactory::X509ParseStack");
+   return 0;
+}
+
+//______________________________________________________________________________
 XrdCryptoX509ParseBucket_t XrdCryptoFactory::X509ParseBucket()
 {
    // Return an instance of an implementation of a function

--- a/src/XrdCrypto/XrdCryptoFactory.hh
+++ b/src/XrdCrypto/XrdCryptoFactory.hh
@@ -79,6 +79,11 @@ typedef int (*XrdCryptoX509ChainToFile_t)(XrdCryptoX509Chain *, const char *);
 // certificates from file parsing
 typedef int (*XrdCryptoX509ParseFile_t)(const char *fname,
                                         XrdCryptoX509Chain *);
+
+// certificates from STACK_OF(X509*)
+typedef int (*XrdCryptoX509ParseStack_t)(void* ssl_conn,
+                                         XrdCryptoX509Chain *c);
+
 // certificates from bucket parsing
 typedef int (*XrdCryptoX509ParseBucket_t)(XrdSutBucket *,
                                           XrdCryptoX509Chain *);
@@ -173,6 +178,7 @@ public:
    virtual XrdCryptoX509VerifyCert_t X509VerifyCert();
    virtual XrdCryptoX509VerifyChain_t X509VerifyChain();
    virtual XrdCryptoX509ParseFile_t X509ParseFile();
+   virtual XrdCryptoX509ParseStack_t X509ParseStack();
    virtual XrdCryptoX509ParseBucket_t X509ParseBucket();
    virtual XrdCryptoX509ExportChain_t X509ExportChain();
    virtual XrdCryptoX509ChainToFile_t X509ChainToFile();

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -43,6 +43,7 @@
 #include "XrdCrypto/XrdCryptosslX509.hh"
 #include "XrdCrypto/XrdCryptosslTrace.hh"
 #include <openssl/pem.h>
+#include <openssl/ssl.h>
 
 // Error code from verification set by verify callback function
 static int gErrVerifyChain = 0;
@@ -377,9 +378,15 @@ int XrdCryptosslX509ChainToFile(XrdCryptoX509Chain *ch, const char *fn)
 }
 
 //____________________________________________________________________________
-int XrdCryptosslX509ParseStack(STACK_OF(X509*) st_x509, XrdCryptoX509Chain *chain)
+int XrdCryptosslX509ParseStack(void* ssl_conn, XrdCryptoX509Chain *chain)
 {
    EPNAME("X509ParseStack");
+   SSL* ssl = (SSL*) ssl_conn;
+   STACK_OF(X509) *st_x509 = SSL_get_peer_cert_chain(ssl);
+
+   if (!st_x509) {
+     return 0;
+   }
 
    int nci = 0;
    // Make sure we got a chain where to add the certificates

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -377,6 +377,34 @@ int XrdCryptosslX509ChainToFile(XrdCryptoX509Chain *ch, const char *fn)
 }
 
 //____________________________________________________________________________
+int XrdCryptosslX509ParseStack(STACK_OF(X509*) st_x509, XrdCryptoX509Chain *chain)
+{
+   EPNAME("X509ParseStack");
+
+   int nci = 0;
+   // Make sure we got a chain where to add the certificates
+   if (!chain) {
+      DEBUG("chain undefined: can do nothing");
+      return nci;
+   }
+
+   for (int i=0; i < sk_X509_num(st_x509); i++) {
+      X509 *cert = sk_X509_value(st_x509, i);
+      XrdCryptoX509 *c = new XrdCryptosslX509(cert);
+      if (c) {
+         chain->PushBack(c);
+      } else {
+         DEBUG("could not create certificate: memory exhausted?");
+         chain->Reorder();
+         return nci;
+      }
+      nci ++;
+   }
+   chain->Reorder();
+   return nci;
+}
+
+//____________________________________________________________________________
 int XrdCryptosslX509ParseFile(const char *fname,
                               XrdCryptoX509Chain *chain)
 {

--- a/src/XrdCrypto/XrdCryptosslAux.hh
+++ b/src/XrdCrypto/XrdCryptosslAux.hh
@@ -60,6 +60,8 @@ int XrdCryptosslX509ChainToFile(XrdCryptoX509Chain *c, const char *fn);
 int XrdCryptosslX509ParseFile(const char *fname, XrdCryptoX509Chain *c);
 // certificates from bucket parsing
 int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *c);
+// certificates from STACK_OF(X509*)
+int XrdCryptosslX509ParseStack(STACK_OF(X509*) st_x509, XrdCryptoX509Chain *c);
 //
 // Function to convert from ASN1 time format into UTC since Epoch (Jan 1, 1970) 
 time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1);

--- a/src/XrdCrypto/XrdCryptosslAux.hh
+++ b/src/XrdCrypto/XrdCryptosslAux.hh
@@ -61,7 +61,7 @@ int XrdCryptosslX509ParseFile(const char *fname, XrdCryptoX509Chain *c);
 // certificates from bucket parsing
 int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *c);
 // certificates from STACK_OF(X509*)
-int XrdCryptosslX509ParseStack(STACK_OF(X509*) st_x509, XrdCryptoX509Chain *c);
+int XrdCryptosslX509ParseStack(void* ssl_conn, XrdCryptoX509Chain *c);
 //
 // Function to convert from ASN1 time format into UTC since Epoch (Jan 1, 1970) 
 time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1);

--- a/src/XrdCrypto/XrdCryptosslFactory.cc
+++ b/src/XrdCrypto/XrdCryptosslFactory.cc
@@ -478,6 +478,15 @@ XrdCryptoX509ParseFile_t XrdCryptosslFactory::X509ParseFile()
 }
 
 //______________________________________________________________________________
+XrdCryptoX509ParseStack_t XrdCryptosslFactory::X509ParseStack()
+{
+   // Return an instance of an implementation of a function
+   // to parse a file supposed to contain for X509 certificates.
+
+   return &XrdCryptosslX509ParseStack;
+}
+
+//______________________________________________________________________________
 XrdCryptoX509ParseBucket_t XrdCryptosslFactory::X509ParseBucket()
 {
    // Return an instance of an implementation of a function

--- a/src/XrdCrypto/XrdCryptosslFactory.hh
+++ b/src/XrdCrypto/XrdCryptosslFactory.hh
@@ -95,6 +95,7 @@ public:
    XrdCryptoX509VerifyCert_t X509VerifyCert();
    XrdCryptoX509VerifyChain_t X509VerifyChain();
    XrdCryptoX509ParseFile_t X509ParseFile();
+   XrdCryptoX509ParseStack_t X509ParseStack();
    XrdCryptoX509ParseBucket_t X509ParseBucket();
    XrdCryptoX509ExportChain_t X509ExportChain();
    XrdCryptoX509ChainToFile_t X509ChainToFile();


### PR DESCRIPTION
This includes the changes in #1223, fixes the linking issues and exposes the functionality to the XrdHttp plugin. Moreover it also deals with simple client certificates that are not handled by SSL_get_peer_cert_chain.