### PR TITLE
Fixed TaskWrapper template specialization

### DIFF
--- a/src/XrdCl/XrdClOperationHandlers.hh
+++ b/src/XrdCl/XrdClOperationHandlers.hh
@@ -276,7 +276,7 @@ namespace XrdCl
   //! @arg Return   : type of the value returned by the task
   //----------------------------------------------------------------------------
   template<typename Return>
-  class TaskWrapper<void, Return>
+  class TaskWrapper<void, Return>: public ResponseHandler
   {
     public:
 


### PR DESCRIPTION
This PR fixes a bug in XrdCl::TaskWrapper template specialization which disallows creation of std::packaged_tasks for operations which do not require arguments.

# Steps to reproduce
Add the following code to the `tests/XrdClTests/OperationsWorkflowTest.cc` file:

```
void WorkflowTest::MkDirAsyncTest() {
  using namespace XrdCl;

  FileSystem fs{"/"};

  std::packaged_task<void(XrdCl::XRootDStatus & st)> mkdirTask{
    [](XrdCl::XRootDStatus &st) {
        if (!st.IsOK())
          throw XrdCl::PipelineException(st);
    }};

  auto &&t = Async(MkDir(fs, "MkDirAsyncTest", XrdCl::MkDirFlags::None,
            XrdCl::Access::Mode::UR | XrdCl::Access::Mode::UW |
                XrdCl::Access::Mode::UX | XrdCl::Access::Mode::GR |
                XrdCl::Access::Mode::GW | XrdCl::Access::Mode::GX) >> mkdirTask);

  CPPUNIT_ASSERT(t.get().status == stOK);
}
```

Compilation of this test fails with:
```
[ 93%] Building CXX object tests/XrdClTests/CMakeFiles/XrdClTests.dir/OperationsWorkflowTest.cc.o
[ 94%] Built target xrdfs
[ 95%] Built target XrdClTestMonitor-5
In file included from /mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/src/XrdCl/XrdClOperations.hh:35,
                 from /mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/tests/XrdClTests/OperationsWorkflowTest.cc:30:
/mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/src/XrdCl/XrdClOperationHandlers.hh: In instantiation of ‘static XrdCl::ResponseHandler* XrdCl::Resp<void>::Create(std::packaged_task<Return(XrdCl::XRootDStatus&)>&) [with Return = void]’:
/mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/src/XrdCl/XrdClOperations.hh:518:53:   required from ‘Derived<true> XrdCl::ConcreteOperation<Derived, HasHndl, HdlrFactory, Args>::operator>>(Hdlr&&) [with Hdlr = std::packaged_task<void(XrdCl::XRootDStatus&)>&; Derived = XrdCl::MkDirImpl; bool HasHndl = false; HdlrFactory = XrdCl::Resp<void>; Args = {XrdCl::Arg<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, XrdCl::Arg<XrdCl::MkDirFlags::Flags>, XrdCl::Arg<XrdCl::Access::Mode>}]’
/mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/tests/XrdClTests/OperationsWorkflowTest.cc:896:71:   required from here
/mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/src/XrdCl/XrdClOperationHandlers.hh:708:30: error: cannot convert ‘XrdCl::TaskWrapper<void, void>*’ to ‘XrdCl::ResponseHandler*’
  708 |         return make_finalized( new TaskWrapper<void, Return>( std::move( task ) ) );
      |                ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                              |
      |                              XrdCl::TaskWrapper<void, void>*
/mnt/docker/onedata/VFS-6474-add-xrootd/xrootd/src/XrdCl/XrdClOperationHandlers.hh:591:60: note:   initializing argument 1 of ‘XrdCl::FinalizeHandler* XrdCl::make_finalized(XrdCl::ResponseHandler*)’
  591 |   inline FinalizeHandler* make_finalized( ResponseHandler *handler )
      |                                           ~~~~~~~~~~~~~~~~~^~~~~~~
make[2]: *** [tests/XrdClTests/CMakeFiles/XrdClTests.dir/build.make:193: tests/XrdClTests/CMakeFiles/XrdClTests.dir/OperationsWorkflowTest.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1126: tests/XrdClTests/CMakeFiles/XrdClTests.dir/all] Error 2
make: *** [Makefile:141: all] Error 2


```


The PR contains the above mentioned test which compiles fine with the fix (I do not know if it actually passes...)