### PR TITLE
[Xrootd HTTP] Allow redirect to local filesystem when using HTTP

### DIFF
--- a/src/XrdCms/XrdCmsRedirLocal.cc
+++ b/src/XrdCms/XrdCmsRedirLocal.cc
@@ -35,7 +35,8 @@ XrdCmsRedirLocal::XrdCmsRedirLocal(XrdSysLogger *Logger, int opMode, int myPort,
                          XrdOss *theSS) : XrdCmsClient(amLocal) {
   nativeCmsFinder = new XrdCmsFinderRMT(Logger, opMode, myPort);
   this->theSS = theSS;
-  readOnlyredirect = false;
+  readOnlyredirect = true;
+  httpRedirect = true;
 }
 //------------------------------------------------------------------------------
 //! Destructor
@@ -64,14 +65,24 @@ void XrdCmsRedirLocal::loadConfig(const char *filename) {
   while ((word = Config.GetFirstWord(true))) { //get word in lower case
     // search for readonlyredirect,
     // which only allows read calls to be redirected to local
-    if (strcmp(word, "XrdCmsRedirLocal.readonlyredirect") == 0){
-      // get next word in lower case
+    if (strcmp(word, "xrdcmsredirlocal.readonlyredirect") == 0){
       std::string readWord = std::string(Config.GetWord(true));//to lower case
-      if(readWord.find("true") != string::npos){
+      if (readWord.find("true") != string::npos){
         readOnlyredirect = true;
       }
       else {
         readOnlyredirect = false;
+      }
+    }
+    // search for httpredirect,
+    // which allows http(s) calls to be redirected to local
+    else if (strcmp(word, "xrdcmsredirlocal.httpredirect") == 0){
+      std::string readWord = std::string(Config.GetWord(true));//to lower case
+      if(readWord.find("true") != string::npos){
+        httpRedirect = true;
+      }
+      else {
+        httpRedirect = false;
       }
     }
   }
@@ -80,8 +91,12 @@ void XrdCmsRedirLocal::loadConfig(const char *filename) {
 
 //------------------------------------------------------------------------------
 //! Preconditions:
-//! Client Protocol Version is >= 784
+//! Writing must be enabled  via xrdcmsredirlocal.readonlyredirect false
+//! Client has urlRedirSupport
+//! Client has localredirect capability
 //! Flag is one of: SFS_O_RDONLY, SFS_O_RDWR, SFS_O_WRONLY, SFS_O_CREAT, SFS_O_TRUNC
+//! [Only HTTP] Flag may also be SFS_O_STAT in case of read access
+//! [Only HTTP] xrdcmsredirlocal.httpRedirect is true in the config
 //! Locate the file, get Client IP and target IP.
 //! 1) If both are private, redirect to local does apply.
 //!    set ErrInfo of param Resp and return SFS_REDIRECT.
@@ -98,40 +113,53 @@ int XrdCmsRedirLocal::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
                         XrdOucEnv *EnvInfo) {
   int rcode = 0;
   if (nativeCmsFinder) {
+    string dialect = EnvInfo->secEnv()->addrInfo->Dialect();
+    const string httpDialects = "https";
     // get regular target host
     rcode = nativeCmsFinder->Locate(Resp, path, flags, EnvInfo);
+    // check if http redirect to local filesystem is allowed
+    if (httpDialects.find(dialect) != string::npos && !httpRedirect)
+      return rcode;
+
     // define target host from locate result
     XrdNetAddr target(-1); // port is necessary, but can be any
     target.Set(Resp.getErrText());
     // does the target host have a private IP?
     if (!target.isPrivate())
       return rcode;
-
     // does the client host have a private IP?
     if (!EnvInfo->secEnv()->addrInfo->isPrivate())
       return rcode;
 
-    // get client url redirect capability
-    int urlRedirSupport = Resp.getUCap();
-    urlRedirSupport &= XrdOucEI::uUrlOK;
-    if (!urlRedirSupport)
-      return rcode;
+    // as we can't rely on the flags from http clients, we do not perform the below
+    if (httpDialects.find(dialect) == string::npos)
+    {
+      // get client url redirect capability
+      int urlRedirSupport = Resp.getUCap();
+      urlRedirSupport &= XrdOucEI::uUrlOK;
+      if (!urlRedirSupport && httpDialects.find(dialect) == string::npos)
+        return rcode;
 
-    // get client localredirect capability
-    int clientLRedirSupport = Resp.getUCap();
-    clientLRedirSupport &= XrdOucEI::uLclF;
-    if (!clientLRedirSupport)
-      return rcode;
+      // get client localredirect capability
+      int clientLRedirSupport = Resp.getUCap();
+      clientLRedirSupport &= XrdOucEI::uLclF;
+      if (!clientLRedirSupport)
+        return rcode;
+    }
 
-    // only allow simple (but most prominent) operations to avoid complications
-    // RDONLY, WRONLY, RDWR, CREAT, TRUNC are allowed
-    if (flags > 0x202)
-      return rcode;
-    // always use native function if readOnlyredirect is configured and a
-    // non readonly flag is passed
-    if (readOnlyredirect && !(flags == SFS_O_RDONLY))
-      return rcode;
-
+    // http gets SFS_O_STAT flag when opening to read, instead of SFS_O_RDONLY
+    // in case of http dialect and stat, we do not perform the checks below
+    if (!(httpDialects.find(dialect) != string::npos && flags == 0x20000000))
+    {
+      // only allow simple (but most prominent) operations to avoid complications
+      // RDONLY, WRONLY, RDWR, CREAT, TRUNC are allowed
+      if (flags > 0x202)
+        return rcode;
+      // always use native function if readOnlyredirect is configured and a
+      // non readonly flag is passed
+      if (readOnlyredirect && !(flags == SFS_O_RDONLY))
+        return rcode;
+    }
     // passed all checks, now to actual business
     // build a buffer with a total acceptable buffer length,
     // which must have a larger capacity than localroot and filename concatenated
@@ -140,8 +168,16 @@ int XrdCmsRedirLocal::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
     char *buff = new char[maxPathLength];
     // prepend oss.localroot
     const char *ppath = theSS->Lfn2Pfn(path, buff, maxPathLength, rc);
-    // set info which will be sent to client
-    Resp.setErrInfo(-1, ppath);
+    if (httpDialects.find(dialect) != string::npos)
+    {
+      // set info which will be sent to client
+      // eliminate the resource name so we it is not doubled in XrdHttpReq::Redir.
+      Resp.setErrInfo(-1, string(ppath).substr(0, string(ppath).find(path)).c_str());
+    }
+    else{
+      // set info which will be sent to client
+      Resp.setErrInfo(-1, ppath);
+    }
     delete[] buff;
     return SFS_REDIRECT;
   }

--- a/src/XrdCms/XrdCmsRedirLocal.cc
+++ b/src/XrdCms/XrdCmsRedirLocal.cc
@@ -167,7 +167,7 @@ int XrdCmsRedirLocal::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
     int maxPathLength = 4096;
     char *buff = new char[maxPathLength];
     // prepend oss.localroot
-    const char *ppath = theSS->Lfn2Pfn(path, buff, maxPathLength, rc);
+    const char *ppath = ("file://" + string(theSS->Lfn2Pfn(path, buff, maxPathLength, rc))).c_str();
     if (httpDialects.find(dialect) != string::npos)
     {
       // set info which will be sent to client

--- a/src/XrdCms/XrdCmsRedirLocal.hh
+++ b/src/XrdCms/XrdCmsRedirLocal.hh
@@ -76,6 +76,7 @@ public:
   XrdCmsClient *nativeCmsFinder;
   XrdOss *theSS;
   bool readOnlyredirect;
+  bool httpRedirect;
 };
 
 #endif // XRDCMSREDIRPLUGIN_HH_

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -661,6 +661,13 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
   else
     redirdest = "Location: http://";
   
+  // port -1 signals redirect to local filesystem
+  // switch to file:// protocol
+  if (port == -1)
+  {
+    TRACE(REQ, " XrdHttpReq::Redir Switching to file:// ");
+    redirdest = "Location: file://";
+  }
   // Beware, certain Ofs implementations (e.g. EOS) add opaque data directly to the host name
   // This must be correctly treated here and appended to the opaque info
   // that we may already have
@@ -681,7 +688,7 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
   else
     redirdest += hname;
 
-  if (port) {
+  if (port > 0) {
     sprintf(buf, ":%d", port);
     redirdest += buf;
   }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -661,12 +661,14 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
   else
     redirdest = "Location: http://";
   
-  // port -1 signals redirect to local filesystem
-  // switch to file:// protocol
-  if (port == -1)
+  // port < 0 signals switch to full URL
+  if (port < 0)
   {
-    TRACE(REQ, " XrdHttpReq::Redir Switching to file:// ");
-    redirdest = "Location: file://";
+    if (string(hname).find("file://") != string::npos)
+    {
+      TRACE(REQ, " XrdHttpReq::Redir Switching to file:// ");
+      redirdest = "Location: "; // "file://" already contained in hname
+    }
   }
   // Beware, certain Ofs implementations (e.g. EOS) add opaque data directly to the host name
   // This must be correctly treated here and appended to the opaque info

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -664,7 +664,7 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
   // port < 0 signals switch to full URL
   if (port < 0)
   {
-    if (string(hname).find("file://") != string::npos)
+    if (strncmp(hname, "file://", 7) == 0)
     {
       TRACE(REQ, " XrdHttpReq::Redir Switching to file:// ");
       redirdest = "Location: "; // "file://" already contained in hname


### PR DESCRIPTION
With these changes, an HTTP-client can be redirected to the file://-protocol by the xrootd redirector employing the XrdCmsRedirLocal-plugin.

The plug-in must be configured to allow HTTP redirects to local filesystem via the xrdcmsredirlocal.httpredirect true option.
Otherwise, default redirect behaviour is used.

Only minimal changes to other sources than the plug-in necessary.