### PR TITLE
[TPC] Fix potential null pointer dereference on Push.

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -523,7 +523,6 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     rec.log_prefix = "PushRequest";
     rec.local = req.resource;
     rec.remote = resource;
-    rec.name = req.GetSecEntity().name;
     char *name = req.GetSecEntity().name;
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PUSH_START", "Starting a push request");


### PR DESCRIPTION
If name in the SecEntity is a nullptr,
we must not try to derefence it.

Fixes: #1249