### PR TITLE
Fix XrdOucUtils::Sanitize not sanitizing the first character in the string

### DIFF
--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -820,7 +820,6 @@ void XrdOucUtils::Sanitize(char *str, char subc)
           else if (*str == ' ') *str = subc;
        char *blank = rindex(str, ' ');
        if (blank) while(*blank == ' ') *blank-- = 0;
-       str++;
        while(*str)
             {if (!isalnum(*str) && index("_-.", *str) == 0) *str = subc;
              str++;

--- a/src/XrdXrootd/XrdXrootdTransit.cc
+++ b/src/XrdXrootd/XrdXrootdTransit.cc
@@ -231,7 +231,6 @@ void XrdXrootdTransit::Init(XrdXrootd::Bridge::Result *respP, // Private
    XrdNetAddrInfo *addrP;
    const char *who;
    char uname[sizeof(Request.login.username)+1];
-   int n;
 
 // Set standard stuff
 //
@@ -263,10 +262,8 @@ void XrdXrootdTransit::Init(XrdXrootd::Bridge::Result *respP, // Private
 
 // Develop a trace identifier
 //
-   n = strlen(nameP);
-   if (n >= int(sizeof(uname))) n = sizeof(uname)-1;
    strncpy(uname, nameP, sizeof(uname)-1);
-   uname[n] = 0;
+   uname[sizeof(uname)-1] = 0;
    XrdOucUtils::Sanitize(uname);
    linkP->setID(uname, mySID);
 

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -889,7 +889,7 @@ int XrdXrootdProtocol::do_Login()
 // Unmarshall the pid and construct username using the POSIX.1-2008 standard
 //
    pid = (int)ntohl(Request.login.pid);
-   strncpy(uname, (const char *)Request.login.username, sizeof(uname)-2);
+   strncpy(uname, (const char *)Request.login.username, sizeof(uname)-1);
    uname[sizeof(uname)-1] = 0;
    XrdOucUtils::Sanitize(uname);
 


### PR DESCRIPTION
The method skips to the second character in the string after checking that it is not a -, without checking that it belongs to the allowed set of characters.