### PR TITLE
No XrdSysDNS in xrootd 5 - remove include

### DIFF
--- a/src/XrdApps/XrdClProxyPlugin/ProxyPrefixPlugin.cc
+++ b/src/XrdApps/XrdClProxyPlugin/ProxyPrefixPlugin.cc
@@ -25,7 +25,6 @@
 #include "ProxyPrefixPlugin.hh"
 #include "ProxyPrefixFile.hh"
 #include "XrdVersion.hh"
-#include "XrdSys/XrdSysDNS.hh"
 #include "XrdCl/XrdClDefaultEnv.hh"
 #include "XrdCl/XrdClLog.hh"
 #include <stdlib.h>


### PR DESCRIPTION
The XrdSysDNS is not in xrootd 5. The XrdSysDNS.cc is still in the source tree, but is not compiled so it is not available in any library, and the XrdSysDNS.hh header is not installed.
This PR removes the one remaining include of the header (outside of XrdClient which is also not part of xrootd 5).
The XrdSysDNS is not used here so the include can be removed without any other changes.
