### PR TITLE
Add forward declaration to fix one definition rule (ODR) violation

### DIFF
--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -11,6 +11,7 @@
 class XrdSfsFile;
 class XrdHttpExtReq;
 typedef void CURL;
+struct curl_slist;
 
 namespace TPC {
 class Stream;


### PR DESCRIPTION
```
/builddir/build/BUILD/xrootd-5.0.0/src/XrdTpc/XrdTpcState.hh:18:7: error: type 'struct State' violates the C++ One Definition Rule [-Werror=odr]
   18 | class State {
      |       ^
/builddir/build/BUILD/xrootd-5.0.0/src/XrdTpc/XrdTpcState.hh:18:7: note: a different type is defined in another translation unit
   18 | class State {
      |       ^
/builddir/build/BUILD/xrootd-5.0.0/src/XrdTpc/XrdTpcState.hh:126:24: note: the first difference of corresponding definitions is field 'm_headers'
  126 |     struct curl_slist *m_headers; // any headers we set as part of the libcurl request.
      |                        ^
/builddir/build/BUILD/xrootd-5.0.0/src/XrdTpc/XrdTpcState.hh:126:24: note: a field of same name but different type is defined in another translation unit
  126 |     struct curl_slist *m_headers; // any headers we set as part of the libcurl request.
      |                        ^
/builddir/build/BUILD/xrootd-5.0.0/src/XrdTpc/XrdTpcState.hh:126:12: note: type name 'TPC::curl_slist' should match type name 'curl_slist'
  126 |     struct curl_slist *m_headers; // any headers we set as part of the libcurl request.
      |            ^
/usr/include/curl/curl.h:2474:8: note: the incompatible type is defined here
 2474 | struct curl_slist {
      |        ^
lto1: all warnings being treated as errors
lto-wrapper: fatal error: /usr/bin/g++ returned 1 exit status
compilation terminated.
```
