### PR TITLE
Fix 32 bit compilation

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -650,7 +650,7 @@ void Cache::dec_ref_cnt(File* f, bool high_debug)
                                "\"b_hit\":%lld,\"b_miss\":%lld,\"b_bypass\":%lld}",
                                f->GetLocalPath().c_str(), f->GetFileSize(), f->GetBlockSize(),
                                f->GetNBlocks(), f->GetNDownloadedBlocks(),
-                               f->GetAccessCnt(), (long long) as->AttachTime, (long long) as->DetachTime,
+                               (unsigned long) f->GetAccessCnt(), (long long) as->AttachTime, (long long) as->DetachTime,
                                as->BytesHit, as->BytesMissed, as->BytesBypassed
            );
            bool suc = false;


### PR DESCRIPTION
/builddir/build/BUILD/xrootd-5.0.1/src/XrdPfc/XrdPfc.cc:649:50: error: format '%lu' expects argument of type 'long unsigned int', but argument 9 has type 'size_t' {aka 'unsigned int'} [-Werror=format=]
