### PR TITLE
Fix ARM, PPC and S390X compilation (char is unsigned by default)

### DIFF
--- a/src/Xrd/XrdProtLoad.cc
+++ b/src/Xrd/XrdProtLoad.cc
@@ -164,7 +164,7 @@ int XrdProtLoad::Port(const char *lname, const char *pname,
 int XrdProtLoad::Process(XrdLink *lp)
 {
      XrdProtocol *pp = 0;
-     char *pVec = myProt;
+     signed char *pVec = myProt;
      int i = 0;
 
 // Try to find a protocol match for this connection

--- a/src/Xrd/XrdProtLoad.hh
+++ b/src/Xrd/XrdProtLoad.hh
@@ -74,6 +74,6 @@ static bool           ProtoTLS[ProtoMax];   // ->Supported protocol objects TLS
 static int            ProtoCnt;             // Number in table (at least 1)
 
        int            myPort;
-       char           myProt[ProtoMax+2];   // My protocols
+       signed char    myProt[ProtoMax+2];   // My protocols
 };
 #endif


### PR DESCRIPTION
~~~~
/builddir/build/BUILD/xrootd-5.0.1/src/Xrd/XrdProtLoad.cc:172:16: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  172 |    while(*pVec != -2)
      |          ~~~~~~^~~~~
/builddir/build/BUILD/xrootd-5.0.1/src/Xrd/XrdProtLoad.cc:173:20: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  173 |         {if (*pVec == -1)
      |              ~~~~~~^~~~~
~~~~