### PR TITLE
Fix null pointer dereference

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3937,7 +3937,7 @@ int XrdSecProtocolgsi::ServerDoSigpxy(XrdSutBuffer *br,  XrdSutBuffer **bm,
    if (!(bck = (*bm)->GetBucket(kXRS_x509))) {
       cmsg = "buffer with requested info missing";
       // Is there a message from the client?
-      if (!(bck = (*bm)->GetBucket(kXRS_message))) {
+      if ((bck = (*bm)->GetBucket(kXRS_message))) {
          // Yes: decode it and print it
          String m;
          bck->ToString(m);


### PR DESCRIPTION
The if statement says "if (!bck)", but the code then dereferences bck.
It looks like the code was meant to say "if (bck)".

Issue found by the gcc maintainers in Fedora when trying out gcc 11,
which reports a new error diagnostic:

error: 'this' pointer null [-Werror=nonnull]

Full error message:
````
/builddir/build/BUILD/xrootd-5.0.1/src/XrdSecgsi/XrdSecProtocolgsi.cc: In member function 'XrdSecProtocolgsi::ServerDoSigpxy(XrdSutBuffer*, XrdSutBuffer**, XrdOucString&)':
/builddir/build/BUILD/xrootd-5.0.1/src/XrdSecgsi/XrdSecProtocolgsi.cc:3943:23: error: 'this' pointer null [-Werror=nonnull]
 3943 |          bck->ToString(m);
      |          ~~~~~~~~~~~~~^~~
In file included from /builddir/build/BUILD/xrootd-5.0.1/src/./XrdCrypto/XrdCryptoBasic.hh:40,
                 from /builddir/build/BUILD/xrootd-5.0.1/src/./XrdCrypto/XrdCryptoMsgDigest.hh:39,
                 from /builddir/build/BUILD/xrootd-5.0.1/src/XrdSecgsi/XrdSecProtocolgsi.cc:55:
/builddir/build/BUILD/xrootd-5.0.1/src/./XrdSut/XrdSutBucket.hh:60:9: note: in a call to non-static member function 'XrdSutBucket::ToString(XrdOucString&)'
   60 |    void ToString(XrdOucString &s);
      |         ^~~~~~~~
````
This should also be fixed in xrootd 4.