### PR TITLE
[CI] Let publish:koji jobs use the updated kojicli image to fix unexp…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -785,11 +785,9 @@ publish:weekly:
 
 publish:koji:centos8:
   stage: post:publish
-  image: gitlab-registry.cern.ch/linuxsupport/cc7-base
+  image: gitlab-registry.cern.ch/linuxsupport/rpmci/kojicli
   script:
-    - yum install --nogpg -y sssd-client koji
-    - mkdir ~/.koji
-    - echo -e '[koji]\nserver = https://kojihub.cern.ch/kojihub\nweburl = https://koji.cern.ch/\ntopurl = https://koji.cern.ch/kojifiles\nkrb_canon_host = no\nkrb_rdns = False\n' >> ~/.koji/config
+    - yum install --nogpg -y sssd-client
     - kinit stci@CERN.CH -k -t /stci.krb5/stci.keytab
     - path=/eos/project/s/storage-ci/www/xrootd/release/centos-8-x86_64/$CI_COMMIT_TAG/source/
     - if [[ $CI_COMMIT_TAG != *rc* ]] ; then koji build eos8 $path/*.src.rpm ; else stat $path/*.src.rpm ; fi
@@ -803,11 +801,9 @@ publish:koji:centos8:
 
 publish:koji:cc7:
   stage: post:publish
-  image: gitlab-registry.cern.ch/linuxsupport/cc7-base
+  image: gitlab-registry.cern.ch/linuxsupport/rpmci/kojicli
   script:
-    - yum install --nogpg -y sssd-client koji
-    - mkdir ~/.koji
-    - echo -e '[koji]\nserver = https://kojihub.cern.ch/kojihub\nweburl = https://koji.cern.ch/\ntopurl = https://koji.cern.ch/kojifiles\nkrb_canon_host = no\nkrb_rdns = False\n' >> ~/.koji/config
+    - yum install --nogpg -y sssd-client
     - kinit stci@CERN.CH -k -t /stci.krb5/stci.keytab
     - path=/eos/project/s/storage-ci/www/xrootd/release/cc-7-x86_64/$CI_COMMIT_TAG/source/
     - if [[ $CI_COMMIT_TAG != *rc* ]] ; then koji build eos7 $path/*.src.rpm ; else stat $path/*.src.rpm ; fi
@@ -821,11 +817,9 @@ publish:koji:cc7:
 
 publish:koji:slc6:
   stage: post:publish
-  image: gitlab-registry.cern.ch/linuxsupport/cc7-base
+  image: gitlab-registry.cern.ch/linuxsupport/rpmci/kojicli
   script:
-    - yum install --nogpg -y sssd-client koji
-    - mkdir ~/.koji
-    - echo -e '[koji]\nserver = https://kojihub.cern.ch/kojihub\nweburl = https://koji.cern.ch/\ntopurl = https://koji.cern.ch/kojifiles\nkrb_canon_host = no\nkrb_rdns = False\n' >> ~/.koji/config
+    - yum install --nogpg -y sssd-client
     - kinit stci@CERN.CH -k -t /stci.krb5/stci.keytab
     - path=/eos/project/s/storage-ci/www/xrootd/release/slc-6-x86_64/$CI_COMMIT_TAG/source/
     - if [[ $CI_COMMIT_TAG != *rc* ]] ; then koji build eos6 $path/*.src.rpm ; else stat $path/*.src.rpm ; fi


### PR DESCRIPTION
cern koji builds have been failing since ~ xrootd tag 4.12.3 , e.g 
4.12.4 - https://gitlab.cern.ch/dss/xrootd/-/jobs/9854464 
5.0.1  - https://gitlab.cern.ch/dss/xrootd/-/jobs/9611376 
due to https://cern.service-now.com/service-portal-old/view-outage.do?n=OTG0057766
This should fix the problem.