### PR TITLE
XrdHttp: in http mode fail the read if any error comes from the socket, including timeout

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1292,8 +1292,8 @@ int XrdHttpProtocol::getDataOneShot(int blen, bool wait) {
     }
 
     if (rlen < 0) {
-      Link->setEtext("link timeout");
-      return 1;
+      Link->setEtext("link timeout or other error");
+      return -1;
     }
   }
 


### PR DESCRIPTION
XrdHttp: in http mode fail the read if any error comes from the socket, including timeout