### PR TITLE
URI-quote outgoing opaque data for HTTP-TPC

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -163,7 +163,9 @@ int TPCHandler::RedirectTransfer(const std::string &redirect_resource,
     ss << "Location: http" << (m_desthttps ? "s" : "") << "://" << host << ":" << port << "/" << redirect_resource;
 
     if (!opaque.empty()) {
-      ss << "?" << opaque;
+      char *quoted_opaque = nullptr;
+      ss << "?" << (quoted_opaque = quote(opaque.c_str()));
+      free(quoted_opaque);
     }
 
     rec.status = 307;

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -61,7 +61,7 @@ private:
     static std::string GetAuthz(XrdHttpExtReq &req);
 
     // Redirect the transfer according to the contents of an XrdOucErrInfo object.
-    int RedirectTransfer(const std::string &redirect_resource, XrdHttpExtReq &req,
+    int RedirectTransfer(CURL *curl, const std::string &redirect_resource, XrdHttpExtReq &req,
         XrdOucErrInfo &error, TPCLogRecord &);
 
     int OpenWaitStall(XrdSfsFile &fh, const std::string &resource, int mode,


### PR DESCRIPTION
Ensure that we URI-quote the outgoing opaque data when we redirect as part of a HTTP-TPC.

This matches the same quoting strategy for normal HTTP redirects.

Fixes: #1293