### PR TITLE
BUILD: Really pass the user version when building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,18 @@ add_definitions( -DXRDPLUGIN_SOVERSION="${PLUGIN_VERSION}" )
 #-------------------------------------------------------------------------------
 # Generate the version header
 #-------------------------------------------------------------------------------
+if (USER_VERSION)
+  set(XROOTD_VERSION "${USER_VERSION}")
+else ()
 execute_process(
   COMMAND ${CMAKE_SOURCE_DIR}/genversion.sh --print-only ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE XROOTD_VERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE )
+endif()
 
 add_custom_target(
   XrdVersion.hh
-  ${CMAKE_SOURCE_DIR}/genversion.sh ${CMAKE_SOURCE_DIR} )
+  ${CMAKE_SOURCE_DIR}/genversion.sh --version ${XROOTD_VERSION} ${CMAKE_SOURCE_DIR})
 
 # sigh, yet another ugly hack :(
 macro( add_library _target )

--- a/genversion.sh
+++ b/genversion.sh
@@ -137,7 +137,9 @@ if test ! -d ${SOURCEPATH}.git; then
     echo "[!] VERSION_INFO file absent. Unable to determine the version. Using \"unknown\"" 1>&2
   elif test x"`grep Format ${SOURCEPATH}VERSION_INFO`" != x; then
     echo "[!] VERSION_INFO file invalid. Unable to determine the version. Using \"unknown\"" 1>&2
-
+  elif test x$USER_VERSION != x; then
+    echo "[I] Using the user supplied version: ${USER_VERSION}" 1>&2
+    VERSION=${USER_VERSION}
   #-----------------------------------------------------------------------------
   # The version file exists and seems to be valid so we know the version
   #----------------------------------------------------------------------------

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -464,6 +464,7 @@ cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 %if %{?_with_xrdclhttp:1}%{!?_with_xrdclhttp:0}
       -DXRDCLHTTP_SUBMODULE=TRUE \
 %endif
+      -DUSER_VERSION=v%{version} \
       -DUSE_LIBC_SEMAPHORE=%{use_libc_semaphore} ../
 
 make -i VERBOSE=1 %{?_smp_mflags}


### PR DESCRIPTION
I tried building XRootD and passing a custom version number so that it's easier to deploy it locally. But this did not work as expected since the version value embedded in the libraries (that is used for comparing the version of the dynamically loaded plugins) is not the expected one - it still uses the timestamp and git hash value. This pull request fixes that - so not only the RPM name contains the specified version but also the version embedded in the libraries is what one would expect.