### PR TITLE
Add support for buffering even when single-stream TPC

### DIFF
--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -365,6 +365,8 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         throw std::runtime_error("Internal state error in libcurl");
     }
 
+    state.Flush();
+
     rec.bytes_transferred = state.BytesTransferred();
     rec.tpc_status = state.GetStatusCode();
 

--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -189,7 +189,17 @@ size_t State::WriteCB(void *buffer, size_t size, size_t nitems, void *userdata) 
 }
 
 int State::Write(char *buffer, size_t size) {
-    int retval = m_stream->Write(m_start_offset + m_offset, buffer, size);
+    int retval = m_stream->Write(m_start_offset + m_offset, buffer, size, false);
+    if (retval == SFS_ERROR) {
+        m_error_buf = m_stream->GetErrorMessage();
+        return -1;
+    }
+    m_offset += retval;
+    return retval;
+}
+
+int State::Flush() {
+    int retval = m_stream->Write(m_start_offset + m_offset, nullptr, 0, true);
     if (retval == SFS_ERROR) {
         m_error_buf = m_stream->GetErrorMessage();
         return -1;

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -93,6 +93,11 @@ public:
     // not all buffers have been reordered by the underlying stream.
     bool Finalize();
 
+    // Flush the data in memory to disk, even if it may cause unaligned or short
+    // writes.  Typically, only done while shutting down the transfer (note some
+    // backends may be unable to handle unaligned writes unless it's the last write).
+    int Flush();
+
     // Retrieve the description of the remote connection; is of the form:
     //   tcp:129.93.3.4:1234
     //   tcp:[2600:900:6:1301:268a:7ff:fef6:a590]:2345

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -488,6 +488,8 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
     }
     curl_multi_cleanup(multi_handle);
 
+    state.Flush();
+
     rec.bytes_transferred = state.BytesTransferred();
     rec.tpc_status = state.GetStatusCode();
 
@@ -529,6 +531,7 @@ int TPCHandler::RunCurlBasic(CURL *curl, XrdHttpExtReq &req, State &state,
     CURLcode res;
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
+    state.Flush();
     if (res == CURLE_HTTP_RETURNED_ERROR) {
         m_log.Emsg(log_prefix, "Remote server failed request", curl_easy_strerror(res));
         return req.SendSimpleResp(500, NULL, NULL,


### PR DESCRIPTION
Currently, we take a write from `libcurl` and immediately push it down to the underlying filesystem layer.  `libcurl` will issue fairly small writes, especially if the underlying filesystem is actually a remote filesystem (meaning the small write may be performed synchronously instead of just going to the OS page cache).

This code aggregates writes in memory until there's a full 1MB available; the MB is then pushed to the filesystem layer.

Note: as a side-effect of this change, writes become aligned on MB boundaries.  This avoids an issue with `xrootd-ceph` which does not currently support unaligned writes for EC setups.