### PR TITLE
XrdTpc: Close file handle before final HTTP response

### DIFF
--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -366,6 +366,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
     }
 
     state.Flush();
+    state.Finalize();
 
     rec.bytes_transferred = state.BytesTransferred();
     rec.tpc_status = state.GetStatusCode();

--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -192,6 +192,7 @@ int State::Write(char *buffer, size_t size) {
     int retval = m_stream->Write(m_start_offset + m_offset, buffer, size, false);
     if (retval == SFS_ERROR) {
         m_error_buf = m_stream->GetErrorMessage();
+        m_error_code = 1;
         return -1;
     }
     m_offset += retval;
@@ -202,6 +203,7 @@ int State::Flush() {
     int retval = m_stream->Write(m_start_offset + m_offset, nullptr, 0, true);
     if (retval == SFS_ERROR) {
         m_error_buf = m_stream->GetErrorMessage();
+        m_error_code = 2;
         return -1;
     }
     m_offset += retval;
@@ -269,7 +271,12 @@ void State::DumpBuffers() const
 
 bool State::Finalize()
 {
-    return m_stream->Finalize();
+    if (!m_stream->Finalize()) {
+        m_error_buf = m_stream->GetErrorMessage();
+        m_error_code = 3;
+        return false;
+    }
+    return true;
 }
 
 std::string State::GetConnectionDescription()

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -26,6 +26,7 @@ public:
         m_offset(0),
         m_start_offset(0),
         m_status_code(-1),
+        m_error_code(0),
         m_content_length(-1),
         m_stream(NULL),
         m_curl(NULL),
@@ -42,6 +43,7 @@ public:
         m_offset(0),
         m_start_offset(start_offset),
         m_status_code(-1),
+        m_error_code(0),
         m_content_length(-1),
         m_stream(&stream),
         m_curl(curl),
@@ -59,6 +61,8 @@ public:
     off_t BytesTransferred() const {return m_offset;}
 
     off_t GetContentLength() const {return m_content_length;}
+
+    int GetErrorCode() const {return m_error_code;}
 
     int GetStatusCode() const {return m_status_code;}
 
@@ -126,6 +130,7 @@ private:
     off_t m_offset;  // number of bytes we have received.
     off_t m_start_offset;  // offset where we started in the file.
     int m_status_code;  // status code from HTTP response.
+    int m_error_code; // error code from underlying stream operations.
     off_t m_content_length;  // value of Content-Length header, if we received one.
     Stream *m_stream;  // stream corresponding to this transfer.
     CURL *m_curl;  // libcurl handle


### PR DESCRIPTION
This ensures that the underlying file handle is closed before a HTTP response is sent to the client.

It also improves the error message handling such that filesystem errors generate a unique failure message.

Fixes: #1314