### PR TITLE
Pass the environment pointer internally in XrdCksManOss

### DIFF
--- a/src/XrdCks/XrdCksManOss.cc
+++ b/src/XrdCks/XrdCksManOss.cc
@@ -111,7 +111,7 @@ int XrdCksManOss::Calc(const char *Lfn, XrdCksData &Cks, int doSet)
 
 /******************************************************************************/
   
-int XrdCksManOss::Calc(const char *Pfn, time_t &MTime, XrdCksCalc *csP)
+int XrdCksManOss::Calc(const char *Pfn, time_t &MTime, XrdCksCalc *csP, XrdOucEnv *envP)
 {
    class inFile
         {public:
@@ -127,9 +127,12 @@ int XrdCksManOss::Calc(const char *Pfn, time_t &MTime, XrdCksCalc *csP)
    size_t ioSize, calcSize;
    int    rc;
 
+   if (envP) {eDest->Emsg("XrdCksManOss::Calc", "Got envP");}
+   else {eDest->Emsg("XrdCksManOss::Calc", "No envP");}
+
 // Open the input file
 //
-   if ((rc = In.fP->Open(Lfn,O_RDONLY,0,openEnv))) return (rc > 0 ? -rc : rc);
+   if ((rc = In.fP->Open(Lfn,O_RDONLY,0, envP ? *envP : openEnv))) return (rc > 0 ? -rc : rc);
 
 // Get the file characteristics
 //

--- a/src/XrdCks/XrdCksManOss.hh
+++ b/src/XrdCks/XrdCksManOss.hh
@@ -61,7 +61,7 @@ virtual int         Ver( const char *Lfn, XrdCksData &Cks);
 virtual            ~XrdCksManOss() {}
 
 protected:
-virtual int         Calc(const char *Lfn, time_t &MTime, XrdCksCalc *CksObj);
+virtual int         Calc(const char *Lfn, time_t &MTime, XrdCksCalc *CksObj, XrdOucEnv *envP);
 virtual int         ModTime(const char *Pfn, time_t &MTime);
 
 private:

--- a/src/XrdCks/XrdCksManager.cc
+++ b/src/XrdCks/XrdCksManager.cc
@@ -127,7 +127,7 @@ int XrdCksManager::Calc(const char *Pfn, XrdCksData &Cks, int doSet)
 
 // Use the calculator to get and possibly set the checksum
 //
-   if (!(rc = Calc(Pfn, MTime, csP)))
+   if (!(rc = Calc(Pfn, MTime, csP, Cks.envP)))
       {memcpy(Cks.Value, csP->Final(), csIP->Len);
        Cks.fmTime = static_cast<long long>(MTime);
        Cks.csTime = static_cast<int>(time(0) - MTime);
@@ -147,7 +147,7 @@ int XrdCksManager::Calc(const char *Pfn, XrdCksData &Cks, int doSet)
 
 /******************************************************************************/
   
-int XrdCksManager::Calc(const char *Pfn, time_t &MTime, XrdCksCalc *csP)
+int XrdCksManager::Calc(const char *Pfn, time_t &MTime, XrdCksCalc *csP, XrdOucEnv*)
 {
    class ioFD
         {public:

--- a/src/XrdCks/XrdCksManager.hh
+++ b/src/XrdCks/XrdCksManager.hh
@@ -81,7 +81,7 @@ protected:
               Otherwise, it returns -errno. The default implementation uses
               open(), fstat(), mmap(), and unmap() to calculate the results.
 */
-virtual int         Calc(const char *Pfn, time_t &MTime, XrdCksCalc *CksObj);
+virtual int         Calc(const char *Pfn, time_t &MTime, XrdCksCalc *CksObj, XrdOucEnv *envP);
 
 /* ModTime()  returns 0 and places file's modification time in MTime. Otherwise,
               it return -errno. The default implementation uses stat().


### PR DESCRIPTION
With this, if the `XrdCksData` object has an `XrdOucEnv` pointer then we pass it down to the `XrdCksManOss::Calc` interface.