### PR TITLE
Update 4.x -> 5.0 in plugin version table

### DIFF
--- a/src/XrdVersionPlugin.hh
+++ b/src/XrdVersionPlugin.hh
@@ -100,8 +100,8 @@
         XrdVERSIONPLUGIN_Rule(Optional,  5,  0, XrdPfcGetDecision       )\
         XrdVERSIONPLUGIN_Rule(DoNotChk,  5,  0, XrdgetProtocol                )\
         XrdVERSIONPLUGIN_Rule(Required,  5,  0, XrdgetProtocolPort            )\
-        XrdVERSIONPLUGIN_Rule(Required,  4,  0, XrdHttpGetSecXtractor         )\
-        XrdVERSIONPLUGIN_Rule(Required,  4,  8, XrdHttpGetExtHandler          )\
+        XrdVERSIONPLUGIN_Rule(Required,  5,  0, XrdHttpGetSecXtractor         )\
+        XrdVERSIONPLUGIN_Rule(Required,  5,  0, XrdHttpGetExtHandler          )\
         XrdVERSIONPLUGIN_Rule(Required,  5,  0, XrdSysLogPInit                )\
         XrdVERSIONPLUGIN_Rule(Required,  5,  0, XrdOfsAddPrepare              )\
         XrdVERSIONPLUGIN_Rule(Required,  5,  0, XrdOfsFSctl                   )\


### PR DESCRIPTION
XrdHttpGetSecXtractor 4.0 -> 5.0
XrdHttpGetExtHandler 4.8 -> 5.0

Fix issue with 5.0.3 and dmlite where plugin doesn't load with error:
```
Plugin version XrdHttpProtocolTest v5.0.3 is incompatible with domexrdhttp v5.0.2 (must be >= 4.8.x) in exthandlerlib /usr/lib64/libdome-5.so
------ HTTP protocol initialization failed.
201113 13:09:07 3734 XrdProtocol: Protocol XrdHttp could not be loaded
```