### PR TITLE
Fix check on Ver32C return code

### DIFF
--- a/docs/PreReleaseNotes.txt
+++ b/docs/PreReleaseNotes.txt
@@ -23,6 +23,7 @@ Prerelease Notes
   **[Server]** Fix memory leak of 64MB per checksum request. Fixes #1291
 
 + **Minor bug fixes**
+  **[Server]** When requested fully verify supplied checksums in pgwrite.
 
 + **Miscellaneous**
   **[Xcache]** Allow origin location query to be refreshed.

--- a/src/XrdOss/XrdOss.cc
+++ b/src/XrdOss/XrdOss.cc
@@ -225,7 +225,7 @@ ssize_t XrdOssDF::pgWrite(void     *buffer,
 //
    if (csvec && (opts & Verify))
       {uint32_t valcs;
-       if (!XrdOucCRC::Ver32C((void *)buffer, wrlen, csvec, valcs))
+       if (XrdOucCRC::Ver32C((void *)buffer, wrlen, csvec, valcs) >= 0)
           return -EDOM;
       }
 


### PR DESCRIPTION
Changes return code check on Ver32C return code in XrdOssDF::pgWrite.