### PR TITLE
[XCache] Fix options argument to pgwrite.

### DIFF
--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -951,7 +951,7 @@ void File::WriteBlockToDisk(Block* b)
 
    if (m_cfi.IsCkSumCache())
       if (b->has_cksums())
-         retval = m_data_file->pgWrite(b->get_buff(), offset, size, b->ref_cksum_vec().data(), b->ref_cksum_vec().size());
+         retval = m_data_file->pgWrite(b->get_buff(), offset, size, b->ref_cksum_vec().data(), 0);
       else
          retval = m_data_file->pgWrite(b->get_buff(), offset, size, 0, 0);
    else


### PR DESCRIPTION
Last argument of pgWrite() is opts rather than a size. So in this patch I set the opts to 0. I don't think there's any advantage to specify Verify here, since the data are already available to a cache client by reading from RAM so it would be late to discover a mismatch.

The data almost certainly do match their checksums (if present) since they came from pgRead, so either XrdCl verified received checksums or they were generated based on data received over TLS. (I think XrdCl does always verify received checksums, but protocol spec says it only has to verify if the connection is not TLS. If client didn't verify they could conceivably mismatch if origin sent them mismatching).