### PR TITLE
Xcache: segfault during purge and plugin name

### DIFF
--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -357,7 +357,7 @@ bool Cache::Config(const char *config_filename, const char *parameters)
       char csi_conf[128];
       if (snprintf(csi_conf, 128, "space=%s nofill", m_configuration.m_meta_space.c_str()) < 128)
       {
-         ofsCfg->Push(XrdOfsConfigPI::theOssLib, "libXrdOssCsi", csi_conf);
+         ofsCfg->Push(XrdOfsConfigPI::theOssLib, "libXrdOssCsi.so", csi_conf);
       } else {
          TRACE(Error, "Config() buffer too small for libXrdOssCsi params.");
          return false;

--- a/src/XrdPfc/XrdPfcPurge.cc
+++ b/src/XrdPfc/XrdPfcPurge.cc
@@ -564,7 +564,10 @@ void Cache::copy_out_active_stats_and_update_data_fs_state()
 
       for (ActiveMap_i i = m_active.begin(); i != m_active.end(); ++i)
       {
-         updates.insert(std::make_pair(i->first, i->second->DeltaStatsFromLastCall()));
+         if (i->second != 0)
+         {
+            updates.insert(std::make_pair(i->first, i->second->DeltaStatsFromLastCall()));
+         }
       }
    }
 


### PR DESCRIPTION
The plugin loader needs the .so suffix for libXrdOssCsi.so.

I saw a segfault during purge, I've also put one possible fix commit in this PR (see issue #1336).