### PR TITLE
Fix case where 0 streams is requested.

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -701,7 +701,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
                 logTransferEvent(LogMask::Info, rec, "INVALID_REQUEST", msg);
                 return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
             }
-            streams = streams == 0 ? 1 : stream_req;
+            streams = stream_req == 0 ? 1 : stream_req;
         }
     }
     rec.streams = streams;


### PR DESCRIPTION
Fix case where stream_req is 0, which should be interpreted as a single stream. This fixes what is currently a typo in the ternary comparison.