### PR TITLE
Remove obsolete warning overrides

### DIFF
--- a/cmake/XRootDOSDefs.cmake
+++ b/cmake/XRootDOSDefs.cmake
@@ -55,22 +55,6 @@ if( CMAKE_COMPILER_IS_GNUCXX )
   if( GCC_VERSION VERSION_GREATER 4.8.0 )
   	set( XrdClPipelines TRUE )
   endif()
-
-  # gcc 6.0 is more pedantic
-  if( GCC_VERSION VERSION_GREATER 6.0 OR GCC_VERSION VERSION_EQUAL 6.0 )
-    set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=misleading-indentation" )
-  endif()
-  
-  # gcc 9.0 is even more pedantic
-  if( GCC_VERSION VERSION_GREATER 9.0 OR GCC_VERSION VERSION_EQUAL 9.0 )
-      set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=address-of-packed-member" )
-      #-------------------------------------------------------------------------
-      # Althought new compilers are obliged to do copy elision on return 
-      # statement old ones are not, so we turn off the warning. 
-      #-------------------------------------------------------------------------
-      set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=pessimizing-move" )
-  endif()
-
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
The -Wmisleading-indentation warnings were fixed in commit
d24f77c040b0e1ea170fa398ec21767c2ce1ad3a

The -Wpessimizing-move warnings warnings were fixed in commit
5cc51a08090b874d10180e019e6bceb0372e8445

The -Wno-error=address-of-packed-member warnings were false positives
issued by prerelease versions of gcc 9. The compiler has been fixed
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88664