### PR TITLE
[XCache] Improve cinfo consistency, purge file on read size mismatch.

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1010,16 +1010,10 @@ int Cache::Unlink(const char *curl)
 
    // printf("Unlink url=%s\n\t    fname=%s\n", curl, f_name.c_str());
 
-   return UnlinkCommon(f_name, false);
+   return UnlinkFile(f_name, false);
 }
 
-
-int Cache::UnlinkUnlessOpen(const std::string& f_name)
-{
-   return UnlinkCommon(f_name, true);
-}
-
-int Cache::UnlinkCommon(const std::string& f_name, bool fail_if_open)
+int Cache::UnlinkFile(const std::string& f_name, bool fail_if_open)
 {
    ActiveMap_i  it;
    File        *file = 0;

--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -342,9 +342,9 @@ public:
    void Purge();
 
    //---------------------------------------------------------------------
-   //! Remove file from cache unless it is currently open.
+   //! Remove cinfo and data files from cache.
    //---------------------------------------------------------------------
-   int  UnlinkUnlessOpen(const std::string& f_name);
+   int  UnlinkFile(const std::string& f_name, bool fail_if_open);
 
    //---------------------------------------------------------------------
    //! Add downloaded block in write queue.
@@ -401,8 +401,6 @@ private:
    bool xtrace(XrdOucStream &);
 
    bool cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name);
-
-   int  UnlinkCommon(const std::string& f_name, bool fail_if_open);
 
    static Cache     *m_instance;        //!< this object
 

--- a/src/XrdPfc/XrdPfcCommand.cc
+++ b/src/XrdPfc/XrdPfcCommand.cc
@@ -234,7 +234,7 @@ void Cache::ExecuteCommandUrl(const std::string& command_url)
 
          Info myInfo(m_trace, false);
          myInfo.SetBufferSize(block_size);
-         myInfo.SetFileSize(file_size);
+         myInfo.SetFileSizeAndCreationTime(file_size);
          myInfo.SetAllBitsSynced();
 
          for (int i = 0; i < at_count; ++i)
@@ -312,7 +312,7 @@ void Cache::ExecuteCommandUrl(const std::string& command_url)
 
       TRACE(Debug, err_prefix << "file argument '" << f_name << "'.");
 
-      int ret = UnlinkCommon(f_name, true);
+      int ret = UnlinkFile(f_name, true);
 
       TRACE(Info, err_prefix << "returned with status " << ret);
    }

--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -785,12 +785,11 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
          return false;
       }
    }
-   else if ( part == "hdfsmode" || part == "filefragmentmode" )
+   else if ( part == "hdfsmode" )
    {
-      if (part == "filefragmentmode")
-      {
-         m_log.Emsg("Config", "pfc.filefragmentmode is deprecated, please use pfc.hdfsmode instead. Replacing the directive internally.");
-      }
+      m_log.Emsg("Config", "pfc.hdfsmode is currently unsupported.");
+      return false;
+
       m_configuration.m_hdfsmode = true;
 
       const char* params = cwg.GetWord();

--- a/src/XrdPfc/XrdPfcIOFileBlock.cc
+++ b/src/XrdPfc/XrdPfcIOFileBlock.cc
@@ -257,8 +257,8 @@ int IOFileBlock::initLocalStat()
                // The info file is used to get file size on defer open
                // don't initalize buffer, it does not hold useful information in this case
                m_info.SetBufferSize(m_cache.RefConfiguration().m_bufferSize);
-               m_info.DisableDownloadStatus();
-               m_info.SetFileSize(tmpStat.st_size);
+               // m_info.DisableDownloadStatus(); -- this stopped working a while back.
+               m_info.SetFileSizeAndCreationTime(tmpStat.st_size);
                m_info.Write(m_info_file, path.c_str());
                m_info_file->Fsync();
             }

--- a/src/XrdPfc/XrdPfcPrint.cc
+++ b/src/XrdPfc/XrdPfcPrint.cc
@@ -63,7 +63,7 @@ void Print::printFile(const std::string& path)
    XrdOssDF* fh = m_oss->newFile(m_ossUser);
    fh->Open((path).c_str(),O_RDONLY, 0600, m_env);
 
-   XrdSysTrace tr(""); tr.What = 2;
+   XrdSysTrace tr("XrdPfcPrint"); tr.What = 2;
    Info cfi(&tr);
 
    if ( ! cfi.Read(fh, path.c_str()))
@@ -117,7 +117,8 @@ void Print::printFile(const std::string& path)
           "Record", "Attach", "Detach", "Duration", "N_ios", "N_mrg", "B_hit[kB]", "B_miss[kB]", "B_bypass[kB]");
 
    int idx = 1;
-   for (std::vector<Info::AStat>::const_iterator it = store.m_astats.begin(); it != store.m_astats.end(); ++it)
+   const std::vector<Info::AStat> &astats = cfi.RefAStats();
+   for (std::vector<Info::AStat>::const_iterator it = astats.begin(); it != astats.end(); ++it)
    {
       const int MM = 128;
       char s[MM];


### PR DESCRIPTION
- When wrong number of bytes is returned in a block read, assume
  that initial file-size estimate was different than the current
  remote file -- purge the file.

- Make two cinfo checksums: one for the core data and another for downloaded
  state and for access statistics. The logic here is that if core part gets
  corrupted, I could get nonsensical/wrong values for sizes of the following
  arrays and thus I thought it's better to check that first.

- Add checks for corrupt / nonsensical access stats in previous cinfo file
  versions.

- Remove support for cinfo file version 1.

- Do not allow enabling of hdfs mode during configuration parsing:
  this functionality has not been supported for a while and there is
  now a better way of potentially re-implementing it.