### PR TITLE
Use correct size for struct

### DIFF
--- a/src/XrdOuc/XrdOucPsx.cc
+++ b/src/XrdOuc/XrdOucPsx.cc
@@ -703,7 +703,7 @@ bool XrdOucPsx::ParseSet(XrdSysError *Eroute, XrdOucStream &Config)
 {
     char  kword[256], *val;
     int   kval, noGo;
-    static struct {const char *Sopt; const char *Copt; int isT;} Sopts[]  =
+    static struct sopts {const char *Sopt; const char *Copt; int isT;} Sopts[] =
        {
          {"ConnectTimeout",        "ConnectionWindow",1},    // Default  120
          {"ConnectionRetry",       "ConnectionRetry",1},     // Default    5
@@ -732,7 +732,7 @@ bool XrdOucPsx::ParseSet(XrdSysError *Eroute, XrdOucStream &Config)
          {"TransactionTimeout",    "",1},
          {"WorkerThreads",         "WorkerThreads",0}        // Set To    64
        };
-    int i, numopts = sizeof(Sopts)/( sizeof(const char *) );
+    int i, numopts = sizeof(Sopts)/sizeof(struct sopts);
 
     if (!(val = Config.GetWord()))
        {Eroute->Emsg("Config", "setopt keyword not specified"); return false;}


### PR DESCRIPTION
The fix for the gcc 11 compiler warning in commit
8f36753d46c183aa89058219e36e9a2980afd250 is incorrect.
Placing the sizeof statement in parenthesis does not correct the bug,
it just obfuscates the code so that the compiler doesn't see it.

The correct fix is to give the unnamed struct a name so that the
sizeof the struct can be used in the calculation.