### PR TITLE
Rename XrdAccAuthorizeObjectAdd to XrdAccAuthorizeObjAdd

### DIFF
--- a/src/XrdSciTokens/src/XrdAccSciTokens.cc
+++ b/src/XrdSciTokens/src/XrdAccSciTokens.cc
@@ -966,7 +966,7 @@ std::string      cfgSciTokens;
 
 extern "C" {
 
-XrdAccAuthorize *XrdAccAuthorizeObjectAdd(XrdSysLogger *lp,
+XrdAccAuthorize *XrdAccAuthorizeObjAdd(XrdSysLogger *lp,
                                           const char   *cfn,
                                           const char   *parm,
                                        XrdAccAuthorize *accP)


### PR DESCRIPTION
The plugin interface expect XrdAccAuthorizeObjAdd function to
exist.