### PR TITLE
Allow 0 issuers in SciTokens config

### DIFF
--- a/src/XrdSciTokens/src/XrdAccSciTokens.cc
+++ b/src/XrdSciTokens/src/XrdAccSciTokens.cc
@@ -901,7 +901,6 @@ private:
 
         if (issuers.empty()) {
             m_log.Emsg("Reconfig", "No issuers configured.");
-            return false;
         }
 
         pthread_rwlock_wrlock(&m_config_lock);


### PR DESCRIPTION
0 issuers is ok for SciTokens.  No token will be authorized,
but it shouldn't be an error causing xrootd to not start.  A
log message is still reported when 0 issuers are detected.