### PR TITLE
Add UUID library to build xrdpfc_print

### DIFF
--- a/src/XrdPfc.cmake
+++ b/src/XrdPfc.cmake
@@ -77,7 +77,8 @@ target_link_libraries(
   xrdpfc_print
   XrdServer
   XrdCl
-  XrdUtils )
+  XrdUtils
+  ${UUID_LIBRARY} )
 
 #-------------------------------------------------------------------------------
 # Install


### PR DESCRIPTION
This was required in order to build master just now.