### PR TITLE
Use /run instead of /var/run

### DIFF
--- a/packaging/common/cmsd@.service
+++ b/packaging/common/cmsd@.service
@@ -6,7 +6,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/cmsd-%i.pid -n %i
+ExecStart=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/cmsd-%i.pid -n %i
 User=xrootd
 Group=xrootd
 Type=simple

--- a/packaging/common/frm_purged@.service
+++ b/packaging/common/frm_purged@.service
@@ -6,7 +6,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/frm_purged -l /var/log/xrootd/frm_purged.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/frm_purged-%i.pid -n %i
+ExecStart=/usr/bin/frm_purged -l /var/log/xrootd/frm_purged.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/frm_purged-%i.pid -n %i
 User=xrootd
 Group=xrootd
 Type=simple

--- a/packaging/common/frm_xfrd@.service
+++ b/packaging/common/frm_xfrd@.service
@@ -6,7 +6,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/frm_xfrd -l /var/log/xrootd/frm_xfrd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/frm_xfrd-%i.pid -n %i
+ExecStart=/usr/bin/frm_xfrd -l /var/log/xrootd/frm_xfrd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/frm_xfrd-%i.pid -n %i
 User=xrootd
 Group=xrootd
 Type=simple

--- a/packaging/common/xrootd-clustered.cfg
+++ b/packaging/common/xrootd-clustered.cfg
@@ -50,7 +50,7 @@ frm.xfr.copycmd /bin/cp /dev/null $PFN
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # More configuration files can be added in /etc/xrootd/config.d/
 # For example /etc/xrootd/config.d/10-mygrid.cfg and

--- a/packaging/common/xrootd-http.cfg
+++ b/packaging/common/xrootd-http.cfg
@@ -22,7 +22,7 @@ all.export /tmp
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # Load the http protocol, indicate that it should be served on port 80.
 # The socket bound to port 80 has to be preallocated by the systemd

--- a/packaging/common/xrootd-standalone.cfg
+++ b/packaging/common/xrootd-standalone.cfg
@@ -22,7 +22,7 @@
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # More configuration files can be added in /etc/xrootd/config.d/
 # For example /etc/xrootd/config.d/10-mygrid.cfg and

--- a/packaging/common/xrootd@.service
+++ b/packaging/common/xrootd@.service
@@ -6,7 +6,7 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-ExecStart=/usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/xrootd-%i.pid -n %i
+ExecStart=/usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/xrootd-%i.pid -n %i
 User=xrootd
 Group=xrootd
 Type=simple

--- a/packaging/rhel/xrootd.functions
+++ b/packaging/rhel/xrootd.functions
@@ -92,11 +92,11 @@ function checkSanity()
     chown $XROOTD_USER:$XROOTD_GROUP -R /var/spool/xrootd
   fi
 
-  mkdir -p /var/run/xrootd
-  chown $XROOTD_USER:$XROOTD_GROUP -R /var/run/xrootd
-  checkDirectory /var/run/xrootd $XROOTD_USER $XROOTD_GROUP
+  mkdir -p /run/xrootd
+  chown $XROOTD_USER:$XROOTD_GROUP -R /run/xrootd
+  checkDirectory /run/xrootd $XROOTD_USER $XROOTD_GROUP
   if test $? -ne 0; then
-    chown $XROOTD_USER:$XROOTD_GROUP -R /var/run/xrootd
+    chown $XROOTD_USER:$XROOTD_GROUP -R /run/xrootd
   fi
 }
 
@@ -112,7 +112,7 @@ function startDaemon()
   XROOTD_USER=$3
   XROOTD_GROUP=$4
   INSTANCE=$5
-  PIDFILE="/var/run/xrootd/$DAEMON-$INSTANCE.pid"
+  PIDFILE="/run/xrootd/$DAEMON-$INSTANCE.pid"
 
   # check sanity of the installation
   checkSanity $XROOTD_USER $XROOTD_GROUP
@@ -138,7 +138,7 @@ function startDaemon()
 function stopDaemon()
 {
   echo -n "Shutting down xrootd ($1, $5): "
-  PIDFILE="/var/run/xrootd/$1-$5.pid"
+  PIDFILE="/run/xrootd/$1-$5.pid"
   if [ -e $PIDFILE ]; then
     killproc -p $PIDFILE $1
     RETVAL=$?
@@ -155,7 +155,7 @@ function stopDaemon()
 #-------------------------------------------------------------------------------
 function statusOfTheDaemon()
 {
-  PIDFILE="/var/run/xrootd/$1-$5.pid"
+  PIDFILE="/run/xrootd/$1-$5.pid"
   echo -n "[$5] "
   status -p $PIDFILE $1
   return $RETVAL
@@ -166,7 +166,7 @@ function statusOfTheDaemon()
 #-------------------------------------------------------------------------------
 function condrestartDaemon()
 {
-  PIDFILE="/var/run/xrootd/$1-$5.pid"
+  PIDFILE="/run/xrootd/$1-$5.pid"
   status -p $PIDFILE $1 > /dev/null
   if test $? -ne 0; then
      return 0

--- a/packaging/rhel/xrootd.functions-slc4
+++ b/packaging/rhel/xrootd.functions-slc4
@@ -92,11 +92,11 @@ function checkSanity()
     chown $XROOTD_USER:$XROOTD_GROUP -R /var/spool/xrootd
   fi
 
-  mkdir -p /var/run/xrootd
-  chown $XROOTD_USER:$XROOTD_GROUP -R /var/run/xrootd
-  checkDirectory /var/run/xrootd $XROOTD_USER $XROOTD_GROUP
+  mkdir -p /run/xrootd
+  chown $XROOTD_USER:$XROOTD_GROUP -R /run/xrootd
+  checkDirectory /run/xrootd $XROOTD_USER $XROOTD_GROUP
   if test $? -ne 0; then
-    chown $XROOTD_USER:$XROOTD_GROUP -R /var/run/xrootd
+    chown $XROOTD_USER:$XROOTD_GROUP -R /run/xrootd
   fi
 }
 
@@ -111,7 +111,7 @@ function startDaemon()
   XROOTD_USER=$3
   XROOTD_GROUP=$4
   INSTANCE=$5
-  PIDFILE="/var/run/xrootd/$DAEMON-$INSTANCE.pid"
+  PIDFILE="/run/xrootd/$DAEMON-$INSTANCE.pid"
 
   # check sanity of the installation
   checkSanity $XROOTD_USER $XROOTD_GROUP
@@ -140,7 +140,7 @@ function startDaemon()
 function stopDaemon()
 {
   echo -n "Shutting down xrootd ($1, $5): "
-  PIDFILE="/var/run/xrootd/$1-$5.pid"
+  PIDFILE="/run/xrootd/$1-$5.pid"
 
   if test -r "$PIDFILE"; then
     PID=`cat "$PIDFILE"`
@@ -164,7 +164,7 @@ function stopDaemon()
 #-------------------------------------------------------------------------------
 function statusOfTheDaemon()
 {
-  PIDFILE="/var/run/xrootd/$1-$5.pid"
+  PIDFILE="/run/xrootd/$1-$5.pid"
   echo -n "[$5] "
 
   if test -r "$PIDFILE"; then

--- a/packaging/rhel/xrootd.tmpfiles
+++ b/packaging/rhel/xrootd.tmpfiles
@@ -1,1 +1,1 @@
-d /var/run/xrootd - xrootd xrootd -
+d /run/xrootd - xrootd xrootd -

--- a/src/XrdSciTokens/test/config/xrootd-http.cfg
+++ b/src/XrdSciTokens/test/config/xrootd-http.cfg
@@ -22,7 +22,7 @@ all.export /tmp
 # IPC files should be placed
 #
 all.adminpath /var/spool/xrootd
-all.pidpath /var/run/xrootd
+all.pidpath /run/xrootd
 
 # Load the http protocol, indicate that it should be seved on port 80.
 # The socket bound to port 80 has to be preallocated by the systemd

--- a/src/XrdSciTokens/test/test_inside_docker.sh
+++ b/src/XrdSciTokens/test/test_inside_docker.sh
@@ -31,8 +31,8 @@ popd
 rpmbuild --define '_topdir /tmp/rpmbuild' -ba /tmp/rpmbuild/SPECS/xrootd-scitokens.spec
 
 # After building the RPM, try to install it
-# Fix the lock file error on EL7.  /var/lock is a symlink to /var/run/lock
-mkdir -p /var/run/lock
+# Fix the lock file error on EL7.  /var/lock is a symlink to /run/lock
+mkdir -p /run/lock
 
 RPM_LOCATION=/tmp/rpmbuild/RPMS/x86_64
 

--- a/utils/XrdCmsNotify.pm
+++ b/utils/XrdCmsNotify.pm
@@ -167,9 +167,9 @@ sub getConfig {my($iname) = @_;
 # Construct possible pid paths
 #
   if ($iname eq '')
-     {$pp1 = '/tmp/cmsd.pid'; $pp2 = '/var/run/cmsd/cmsd.pid';}
+     {$pp1 = '/tmp/cmsd.pid'; $pp2 = '/run/cmsd/cmsd.pid';}
      else
-     {$pp1 = "/tmp/$iname/cmsd.pid"; $pp2 = "/var/run/cmsd/$iname/cmsd.pid";}
+     {$pp1 = "/tmp/$iname/cmsd.pid"; $pp2 = "/run/cmsd/$iname/cmsd.pid";}
 
 # We will look for the pid file in one of two locations
 #


### PR DESCRIPTION
/var/run is a symlink to /run, so the locations are the same.
However, if /var/run is used in systemd and tmpfiles.d configuration
files, the logs get full of warnings asking for it to be changed, e.g.

xrootd.conf:1: Line references path below legacy directory /var/run/, updating /var/run/xrootd → /run/xrootd; please update the tmpfiles.d/ drop-in file accordingly.