### PR TITLE
build: add 'plugins' phony target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,15 @@ if(NOT (CMAKE_VERSION VERSION_LESS "3.1"))
   cmake_policy(SET CMP0054 OLD)
 endif()
 
+
+#-------------------------------------------------------------------------------
+# A 'plugins' phony target to simplify building build-tree binaries.
+# Plugins are responsible for adding themselves to this target, where
+# appropriate.
+#-------------------------------------------------------------------------------
+ADD_CUSTOM_TARGET(plugins)
+
+
 include( XRootDUtils )
 CheckBuildDirectory()
 

--- a/src/XrdCrypto.cmake
+++ b/src/XrdCrypto.cmake
@@ -4,6 +4,7 @@ include( XRootDCommon )
 # Modules
 #-------------------------------------------------------------------------------
 set( LIB_XRD_CRYPTOSSL     XrdCryptossl-${PLUGIN_VERSION} )
+add_dependencies(plugins ${LIB_XRD_CRYPTOSSL})
 
 #-------------------------------------------------------------------------------
 # Shared library version

--- a/src/XrdSec.cmake
+++ b/src/XrdSec.cmake
@@ -10,6 +10,12 @@ set( LIB_XRD_SEC_PWD    XrdSecpwd-${PLUGIN_VERSION} )
 set( LIB_XRD_SEC_SSS    XrdSecsss-${PLUGIN_VERSION} )
 set( LIB_XRD_SEC_UNIX   XrdSecunix-${PLUGIN_VERSION} )
 
+add_dependencies(plugins ${LIB_XRD_SEC}
+  ${LIB_XRD_SEC_PROT}
+  ${LIB_XRD_SEC_PWD}
+  ${LIB_XRD_SEC_SSS}
+  ${LIB_XRD_SEC_UNIX})
+
 #-------------------------------------------------------------------------------
 # The XrdSec module
 #-------------------------------------------------------------------------------

--- a/src/XrdSecgsi.cmake
+++ b/src/XrdSecgsi.cmake
@@ -8,6 +8,10 @@ set( LIB_XRD_SEC_GSI          XrdSecgsi-${PLUGIN_VERSION} )
 set( LIB_XRD_SEC_GSI_GMAPDN   XrdSecgsiGMAPDN-${PLUGIN_VERSION} )
 set( LIB_XRD_SEC_GSI_AUTHZVO  XrdSecgsiAUTHZVO-${PLUGIN_VERSION} )
 
+add_dependencies(plugins ${LIB_XRD_SEC_GSI}
+  ${LIB_XRD_SEC_GSI_GMAPDN}
+  ${LIB_XRD_SEC_GSI_AUTHZVO})
+
 #-------------------------------------------------------------------------------
 # The XrdSecgsi library
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Motivation:

Commands like 'xrdcp' and 'xrdfs' require plugins to provide some
functionality, perhaps most prominently when authenticating.  However,
the list of required plugins and the names of these plugin's targets
changes over time.

It would be convenient if the build system were to automate building a
useful subset of plugins (perhaps all plugins) by using a constant
(phony) target 'plugins'.  This would facilitate creating build-tree
binaries with a command like:

    make plugins xrdcp xrdfs

Modification:
    
Add support for 'plugins' phony target to which plugins may add
themselves.
    
Add initial support for this 'plugins' target that builds XrdCryptossl,
XrdSecpwd, XrdSecsss, XrdSecunix, XrdSecgsi, XrdSecgsiGMAPDN and
XrdSecgsiAUTHZVO, and any dependencies thereof.

Result:

Is is easier to build functional client applications that run from
within the build-tree.