### PR TITLE
Fix error handling on stream write errors

### DIFF
--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -188,8 +188,8 @@ size_t State::WriteCB(void *buffer, size_t size, size_t nitems, void *userdata) 
     return obj->Write(static_cast<char*>(buffer), size*nitems);
 }
 
-int State::Write(char *buffer, size_t size) {
-    int retval = m_stream->Write(m_start_offset + m_offset, buffer, size, false);
+ssize_t State::Write(char *buffer, size_t size) {
+    ssize_t retval = m_stream->Write(m_start_offset + m_offset, buffer, size, false);
     if (retval == SFS_ERROR) {
         m_error_buf = m_stream->GetErrorMessage();
         m_error_code = 1;
@@ -200,7 +200,7 @@ int State::Write(char *buffer, size_t size) {
 }
 
 int State::Flush() {
-    int retval = m_stream->Write(m_start_offset + m_offset, 0, 0, true);
+    ssize_t retval = m_stream->Write(m_start_offset + m_offset, 0, 0, true);
     if (retval == SFS_ERROR) {
         m_error_buf = m_stream->GetErrorMessage();
         m_error_code = 2;

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -120,7 +120,7 @@ private:
                            void *userdata);
     int Header(const std::string &header);
     static size_t WriteCB(void *buffer, size_t size, size_t nitems, void *userdata);
-    int Write(char *buffer, size_t size);
+    ssize_t Write(char *buffer, size_t size);
     static size_t ReadCB(void *buffer, size_t size, size_t nitems, void *userdata);
     int Read(char *buffer, size_t size);
 

--- a/src/XrdTpc/XrdTpcStream.cc
+++ b/src/XrdTpc/XrdTpcStream.cc
@@ -56,7 +56,7 @@ Stream::Stat(struct stat* buf)
     return m_fh->stat(buf);
 }
 
-int
+ssize_t
 Stream::Write(off_t offset, const char *buf, size_t size, bool force)
 {
 /*

--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -89,8 +89,10 @@ private:
                 size_desired -= (size_desired % (1024*1024));
                 if (!size_desired) {return 0;}
             }
-            int retval = stream.Write(m_offset, &m_buffer[0], size_desired, force);
-            if ((retval == -1) || (static_cast<size_t>(retval) != size_desired)) {
+            ssize_t retval = stream.Write(m_offset, &m_buffer[0], size_desired, force);
+            // Currently the only valid negative value is SFS_ERROR (-1); checking for
+            // all negative values to future-proof the code.
+            if ((retval < 0) || (static_cast<size_t>(retval) != size_desired)) {
                 return -1;
             }
             // If partial data remains, copy it to the beginning of the buffer.

--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -80,7 +80,7 @@ private:
                 if (!size_desired) {return 0;}
             }
             int retval = stream.Write(m_offset, &m_buffer[0], size_desired, force);
-            if (retval < 0 && (static_cast<size_t>(retval) != size_desired)) {
+            if ((retval == -1) || (static_cast<size_t>(retval) != size_desired)) {
                 return -1;
             }
             // If partial data remains, copy it to the beginning of the buffer.

--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -41,7 +41,17 @@ public:
 
     int Read(off_t offset, char *buffer, size_t size);
 
-    int Write(off_t offset, const char *buffer, size_t size, bool force);
+    // Writes a buffer of a given size to an offset.
+    // This will often keep the buffer in memory in to present the underlying
+    // filesystem with a single stream of data (required for HDFS); further,
+    // it will also buffer to align the writes on a 1MB boundary (required
+    // for some RADOS configurations).  When force is set to true, it will
+    // skip the buffering and always write (this should only be done at the
+    // end of a stream!).
+    //
+    // Returns the number of bytes written; on error, returns -1 and sets
+    // the error code and error message for the stream
+    ssize_t Write(off_t offset, const char *buffer, size_t size, bool force);
 
     size_t AvailableBuffers() const {return m_avail_count;}
 


### PR DESCRIPTION
Corrects an error conditional and fixes some missing returns.  This prevents a stack overflow due to recursion when the filesystem write fails.

Fixes #1384 