### PR TITLE
XrdHttp: Fix empty PUT

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1365,8 +1365,9 @@ int XrdHttpReq::ProcessHTTPReq() {
 
 
         // We want to be invoked again after this request is finished
-        // Only if there is data to fetch from the socket
-        if (prot->BuffUsed() > 0)
+        // Only if there is data to fetch from the socket or there will
+        // never be more data
+        if (prot->BuffUsed() > 0 || length == 0)
           return 0;
 
         return 1;


### PR DESCRIPTION
If the remote client is trying to create an empty file, the state machine broke because it was waiting for more bytes from the bridge before advancing the query.

This short-circuits the wait and causes an immediate callback, allowing XrdHttp to immediately close the file.

Fixes #1365 