### PR TITLE
XrdTPC: Refactor stream writes

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -109,6 +109,7 @@ private:
 
     static int m_marker_period;
     static size_t m_block_size;
+    static size_t m_small_block_size;
     bool m_desthttps;
     std::string m_cadir;
     static XrdSysMutex m_monid_mutex;


### PR DESCRIPTION
This removes problematic recursive invocations of the stream writes and fixes some multistream errors that caused too-high concurrency.

The underlying cause of the multistream issue was allowing partial writes of the buffers.  The buffer occupancy is a feedback mechanism to the multistream code to not launch additional requests; the partial write optimization allowed a buffer to look empty when really there was more coming from the request.

Because we aren't allowing partial writes, this also had to allow partial accepts if the incoming curl buffer spanned two internal buffers.  With this, multistream stays megabyte aligned and should still work on RAL's Echo.

Finally, this adds some error messages on conditions considered internal logic errors -- should help with future debugging.