### PR TITLE
XrdTpc: Add a crude timeout mechanism.

### DIFF
--- a/src/XrdTpc/XrdTpcConfigure.cc
+++ b/src/XrdTpc/XrdTpcConfigure.cc
@@ -4,6 +4,7 @@
 #include <dlfcn.h>
 #include <fcntl.h>
 
+#include "XrdOuc/XrdOuca2x.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOuc/XrdOucStream.hh"
 #include "XrdOuc/XrdOucPinPath.hh"
@@ -51,6 +52,17 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
             if (!ConfigureLogger(Config)) {
                 Config.Close();
                 return false;
+            }
+        } else if (!strcmp("tpc.timeout", val)) {
+            if (!(val = Config.GetWord())) {
+                m_log.Emsg("Config","tpc.timeout value not specified.");  return false;
+            }
+            if (XrdOuca2x::a2tm(m_log, "timeout value", val, &m_timeout, 0)) return false;
+                // First byte timeout can be set separately from the continuous timeout.
+            if ((val = Config.GetWord())) {
+                if (XrdOuca2x::a2tm(m_log, "first byte timeout value", val, &m_first_timeout, 0)) return false;
+            } else {
+                m_first_timeout = 2*m_timeout;
             }
         }
     }

--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -317,7 +317,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
     time_t last_advance_time = time(NULL);
     time_t transfer_start = last_advance_time;
     CURLcode res = static_cast<CURLcode>(-1);
-    CURLMcode mres;
+    CURLMcode mres = CURLM_OK;
     do {
         time_t now = time(NULL);
         time_t next_marker = last_marker + m_marker_period;

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -64,9 +64,13 @@ public:
 
     int GetErrorCode() const {return m_error_code;}
 
+    void SetErrorCode(int error_code) {m_error_code = error_code;}
+
     int GetStatusCode() const {return m_status_code;}
 
     std::string GetErrorMessage() const {return m_error_buf;}
+
+    void SetErrorMessage(const std::string &error_msg) {m_error_buf = error_msg;}
 
     void ResetAfterRequest();
 

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -111,6 +111,9 @@ private:
     static size_t m_block_size;
     static size_t m_small_block_size;
     bool m_desthttps;
+    int m_timeout; // the 'timeout interval'; if no bytes have been received during this time period, abort the transfer.
+    int m_first_timeout; // the 'first timeout interval'; the amount of time we're willing to wait to get the first byte.
+                         // Unless explicitly specified, this is 2x the timeout interval.
     std::string m_cadir;
     static XrdSysMutex m_monid_mutex;
     static uint64_t m_monid;


### PR DESCRIPTION
This does not enforce a minimum bandwidth (N MB/s) but rather
aborts the transfer if zero data has moved within a given timeframe.
By default, the transfer has 120 seconds to move the first byte of
data and it must transfer at least 1 byte every 60 seconds thereafter.

This purposely does not do bandwidth minimums as that's built into
future versions of `curl` and I'd prefer to not re-implement it.

The default timeouts can be overridden by setting:

```
tpc.timeout timeout_val [first_byte_timeout_val]
```

where the default is equivalent to:

```
tpc.timeout 60
```

If the `first_byte_timeout_val` is not set, it defaults to 2x the
`timeout_val`.

(Note: I am _not_ targeting the 5.1.0 release for this)