### PR TITLE
XrdMacaroons: Normalize slashes when issuing and authorizing macaroons.

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsHandler.hh
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.hh
@@ -21,6 +21,21 @@ enum LogMask {
     All = 0xff
 };
 
+// 'Normalize' the macaroon path.  This only takes care of double slashes
+// but, as is common in XRootD, it doesn't treat these as a hierarchy.
+// For example, these result in the same path:
+//
+//   /foo/bar -> /foo/bar
+//   //foo////bar -> /foo/bar
+//
+// These are all distinct:
+//
+//   /foo/bar  -> /foo/bar
+//   /foo/bar/ -> /foo/bar/
+//   /foo/baz//../bar -> /foo/baz/../bar
+//
+std::string NormalizeSlashes(const std::string &);
+
 class Handler : public XrdHttpExtHandler {
 public:
     Handler(XrdSysError *log, const char *config, XrdOucEnv *myEnv,


### PR DESCRIPTION
For authorization purposes, there have been many requests to be more lenient about mismatches slashes (that is, macaroon was requested for `/foo//bar` but the user tries to access `/foo/bar`).  This normalizes the slashes when the macaroon is issued and when it is used for authorization.