### PR TITLE
XrdHttp: Fix chunked transfer with 100-continue.

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1369,7 +1369,7 @@ int XrdHttpReq::ProcessHTTPReq() {
         // We want to be invoked again after this request is finished
         // Only if there is data to fetch from the socket or there will
         // never be more data
-        if (prot->BuffUsed() > 0 || length == 0)
+        if (prot->BuffUsed() > 0 || (length == 0 && !sendcontinue))
           return 0;
 
         return 1;


### PR DESCRIPTION
This fixes a bug accidentally created by the fix for empty PUT's.

When the original PUT is given for a 100-continue transfer, the length is _supposed_ to be zero but we need to continue the transfer.

Fixes #1411