### PR TITLE
XrdTpc: Fixup some minor memory bugs

### DIFF
--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -263,7 +263,7 @@ private:
 
 
 int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
-    size_t streams, std::vector<State*> handles, TPCLogRecord &rec)
+    size_t streams, std::vector<State*> &handles, TPCLogRecord &rec)
 {
     int result;
     bool success;
@@ -358,8 +358,8 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
             msg = curl_multi_info_read(multi_handle, &msgq);
             if (msg && (msg->msg == CURLMSG_DONE)) {
                 CURL *easy_handle = msg->easy_handle;
-                mch.FinishCurlXfer(easy_handle);
                 res = msg->data.result;
+                mch.FinishCurlXfer(easy_handle);
                 // If any requests fail, cut off the entire transfer.
                 if (res != CURLE_OK) {
                     break;

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -610,14 +610,14 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PUSH_START", "Starting a push request");
     CURL *curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     if (!curl) {
         char msg[] = "Failed to initialize internal transfer resources";
         rec.status = 500;
         logTransferEvent(LogMask::Error, rec, "PUSH_FAIL", msg);
         return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
     }
-
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+ 
     auto query_header = req.headers.find("xrd-http-fullresource");
     std::string redirect_resource = req.resource;
     if (query_header != req.headers.end()) {
@@ -686,13 +686,13 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PULL_START", "Starting a push request");
     CURL *curl = curl_easy_init();
-    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     if (!curl) {
             char msg[] = "Failed to initialize internal transfer resources";
             rec.status = 500;
             logTransferEvent(LogMask::Error, rec, "PULL_FAIL", msg);
             return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
     }
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     std::unique_ptr<XrdSfsFile> fh(m_sfs->newFile(name, m_monid++));
     if (!fh.get()) {
             curl_easy_cleanup(curl);

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -88,7 +88,7 @@ private:
     int RunCurlWithStreams(XrdHttpExtReq &req, TPC::State &state,
                            size_t streams, TPCLogRecord &rec);
     int RunCurlWithStreamsImpl(XrdHttpExtReq &req, TPC::State &state,
-                           size_t streams, std::vector<TPC::State*> streams_handles,
+                           size_t streams, std::vector<TPC::State*> &streams_handles,
                            TPCLogRecord &rec);
 #else
     int RunCurlBasic(CURL *curl, XrdHttpExtReq &req, TPC::State &state,


### PR DESCRIPTION
This fixes an incorrect copy (which should have been a reference, resulting in a leak) and a use-after-free found by valgrind.  Those are in the multistream code and, I believe, currently rarely used.

It also fixes a potential pointer deref - if libcurl failed to malloc a new handle, then we used the handle before checking for a null pointer.  I also consider this fairly unlikely to occur in reality but a worthwhile fix.