### PR TITLE
delete chunk buffer for VectorReadInfo after copying into python string

### DIFF
--- a/bindings/python/src/Conversions.hh
+++ b/bindings/python/src/Conversions.hh
@@ -270,6 +270,8 @@ namespace PyXRootD
 
           PyObject *buffer = PyBytes_FromStringAndSize( (const char *) chunk.buffer,
                                                         chunk.length );
+          delete[] (char*) chunk.buffer;
+
           PyList_SET_ITEM( pychunks, i,
               Py_BuildValue( "{sOsOsO}",
                   "offset", Py_BuildValue( "k", chunk.offset ),


### PR DESCRIPTION
This should fix #1400. I added a delete after a chunk buffer is copied into a python string in the conversion function for `VectorReadInfo`, analogous to what is done here for `ChunkInfo`:

https://github.com/xrootd/xrootd/blob/551521ea7368e3b2a4c7964325e2e7e3fe7ce047/bindings/python/src/Conversions.hh#L248-L257
