### PR TITLE
[OssCsi] Fix some incorrect conversion of return values

### DIFF
--- a/src/XrdOssCsi/XrdOssCsiFile.cc
+++ b/src/XrdOssCsi/XrdOssCsiFile.cc
@@ -463,13 +463,13 @@ ssize_t XrdOssCsiFile::WriteV(XrdOucIOVec *writeV, int n)
       }
    }
    // standard OSS gives -ESPIPE in case of partial write of an element
-   int ret = successor_->WriteV(writeV, n);
-   if (ret<0)
+   ssize_t wret = successor_->WriteV(writeV, n);
+   if (wret<0)
    {
       rg.ReleaseAll();
       resyncSizes();
    }
-   return ret;
+   return wret;
 }
 
 ssize_t XrdOssCsiFile::pgRead(void *buffer, off_t offset, size_t rdlen, uint32_t *csvec, uint64_t opts)

--- a/src/XrdOssCsi/XrdOssCsiPages.cc
+++ b/src/XrdOssCsi/XrdOssCsiPages.cc
@@ -229,7 +229,7 @@ int XrdOssCsiPages::VerifyRange(XrdOssDF *const fd, const void *buff, const off_
    // if the tag file is missing we don't verify anything
    if (hasMissingTags_)
    {
-      return blen;
+      return 0;
    }
 
    const Sizes_t sizes = rg.getTrackinglens();
@@ -254,7 +254,7 @@ int XrdOssCsiPages::VerifyRange(XrdOssDF *const fd, const void *buff, const off_
       return -EDOM;
    }
 
-   ssize_t vret;
+   int vret;
    if ((offset % XrdSys::PageSize) != 0 || (offset+blen != static_cast<size_t>(trackinglen) && (blen % XrdSys::PageSize) != 0))
    {
       vret = VerifyRangeUnaligned(fd, buff, offset, blen, sizes);
@@ -642,7 +642,7 @@ int XrdOssCsiPages::FetchRange(
       {
          pgDoCalc(buff, offset, blen, csvec);
       }
-      return blen;
+      return 0;
    }
 
    const Sizes_t sizes = rg.getTrackinglens();
@@ -671,10 +671,10 @@ int XrdOssCsiPages::FetchRange(
    {
       // if the crc values are not wanted nor checks against data, then
       // there's nothing more to do here
-      return blen;
+      return 0;
    }
 
-   ssize_t fret;
+   int fret;
    if ((offset % XrdSys::PageSize) != 0 || (offset+blen != static_cast<size_t>(trackinglen) && (blen % XrdSys::PageSize) != 0))
    {
      fret = FetchRangeUnaligned(fd, buff, offset, blen, sizes, csvec, opts);
@@ -708,7 +708,7 @@ int XrdOssCsiPages::StoreRange(XrdOssDF *const fd, const void *buff, const off_t
       {
          pgDoCalc(buff, offset, blen, csvec);
       }
-      return blen;
+      return 0;
    }
 
    const Sizes_t sizes = rg.getTrackinglens();

--- a/src/XrdOssCsi/XrdOssCsiTagstoreFile.cc
+++ b/src/XrdOssCsi/XrdOssCsiTagstoreFile.cc
@@ -71,7 +71,7 @@ int XrdOssCsiTagstoreFile::Open(const char *path, const off_t dsize, const int O
 
    uint32_t magic;
 
-   const int mread = XrdOssCsiTagstoreFile::fullread(*fd_, header_, 0, 20);
+   const ssize_t mread = XrdOssCsiTagstoreFile::fullread(*fd_, header_, 0, 20);
    bool mok = false;
    if (mread >= 0)
    {


### PR DESCRIPTION
Fix some unintended conversion between ssize_t and int when used as return values; and correct meaning of return value of FetchRange & VerifyRange. I'm not aware of any errors being triggered because of these bugs.