### PR TITLE
[XrdTpc] Do not modify curl handle after curl_easy_cleanup()

### DIFF
--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -275,8 +275,10 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
     handles.reserve(concurrency);
     handles.push_back(new State());
     handles[0]->Move(state);
+    std::vector<ManagedCurlHandle> curl_handles;
     for (size_t idx = 1; idx < concurrency; idx++) {
         handles.push_back(handles[0]->Duplicate());
+        curl_handles.emplace_back(handles.back()->GetHandle());
     }
 
     // Create the multi-handle and add in the current transfer to it.

--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -58,12 +58,10 @@ public:
              it != m_active_handles.end();
              it++) {
             curl_multi_remove_handle(m_handle, *it);
-            curl_easy_cleanup(*it);
         }
         for (std::vector<CURL *>::const_iterator it = m_avail_handles.begin();
              it != m_avail_handles.end();
              it++) {
-            curl_easy_cleanup(*it);
         }
         curl_multi_cleanup(m_handle);
     }

--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -59,10 +59,6 @@ public:
              it++) {
             curl_multi_remove_handle(m_handle, *it);
         }
-        for (std::vector<CURL *>::const_iterator it = m_avail_handles.begin();
-             it != m_avail_handles.end();
-             it++) {
-        }
         curl_multi_cleanup(m_handle);
     }
 

--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -257,7 +257,8 @@ private:
 
 
 int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
-    size_t streams, std::vector<State*> &handles, TPCLogRecord &rec)
+    size_t streams, std::vector<State*> &handles,
+    std::vector<ManagedCurlHandle> &curl_handles, TPCLogRecord &rec)
 {
     int result;
     bool success;
@@ -275,7 +276,6 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
     handles.reserve(concurrency);
     handles.push_back(new State());
     handles[0]->Move(state);
-    std::vector<ManagedCurlHandle> curl_handles;
     for (size_t idx = 1; idx < concurrency; idx++) {
         handles.push_back(handles[0]->Duplicate());
         curl_handles.emplace_back(handles.back()->GetHandle());
@@ -492,9 +492,10 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
 int TPCHandler::RunCurlWithStreams(XrdHttpExtReq &req, State &state,
     size_t streams, TPCLogRecord &rec)
 {
+    std::vector<ManagedCurlHandle> curl_handles;
     std::vector<State*> handles;
     try {
-        int retval = RunCurlWithStreamsImpl(req, state, streams, handles, rec);
+        int retval = RunCurlWithStreamsImpl(req, state, streams, handles, curl_handles, rec);
         for (std::vector<State*>::iterator state_iter = handles.begin();
              state_iter != handles.end();
              state_iter++) {

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -3,6 +3,7 @@
  *
  * Helper class for managing the state of a single TPC request.
  */
+#pragma once
 
 #include <memory>
 #include <vector>

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -272,14 +272,12 @@ int TPCHandler::DetermineXferSize(CURL *curl, XrdHttpExtReq &req, State &state,
         ss << "Remote server failed request: " << curl_easy_strerror(res);
         rec.status = 500;
         logTransferEvent(LogMask::Error, rec, "SIZE_FAIL", ss.str());
-        curl_easy_cleanup(curl);
         return req.SendSimpleResp(rec.status, NULL, NULL, const_cast<char *>(curl_easy_strerror(res)), 0);
     } else if (state.GetStatusCode() >= 400) {
         std::stringstream ss;
         ss << "Remote side failed with status code " << state.GetStatusCode();
         rec.status = 500;
         logTransferEvent(LogMask::Error, rec, "SIZE_FAIL", ss.str());
-        curl_easy_cleanup(curl);
         return req.SendSimpleResp(rec.status, NULL, NULL, const_cast<char *>(ss.str().c_str()), 0);
     } else if (res) {
         std::stringstream ss;
@@ -287,7 +285,6 @@ int TPCHandler::DetermineXferSize(CURL *curl, XrdHttpExtReq &req, State &state,
         rec.status = 500;
         logTransferEvent(LogMask::Error, rec, "SIZE_FAIL", ss.str());
         char msg[] = "Unknown internal transfer failure";
-        curl_easy_cleanup(curl);
         return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
     }
     std::stringstream ss;

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -373,7 +373,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
         logTransferEvent(LogMask::Error, rec, "CURL_INIT_FAIL",
             "Failed to initialize a libcurl multi-handle");
         char msg[] = "Failed to initialize internal server memory";
-        curl_easy_cleanup(curl);
         return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
     }
 
@@ -387,7 +386,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
         ss << "Failed to add transfer to libcurl multi-handle: " << curl_multi_strerror(mres);
         logTransferEvent(LogMask::Error, rec, "CURL_INIT_FAIL", ss.str());
         char msg[] = "Failed to initialize internal server handle";
-        curl_easy_cleanup(curl);
         curl_multi_cleanup(multi_handle);
         return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
     }
@@ -395,7 +393,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
     // Start response to client prior to the first call to curl_multi_perform
     int retval = req.StartChunkedResp(201, "Created", "Content-Type: text/plain");
     if (retval) {
-        curl_easy_cleanup(curl);
         curl_multi_cleanup(multi_handle);
         logTransferEvent(LogMask::Error, rec, "RESPONSE_FAIL",
             "Failed to send the initial response to the TPC client");
@@ -425,7 +422,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
             }
             if (SendPerfMarker(req, rec, state)) {
                 curl_multi_remove_handle(multi_handle, curl);
-                curl_easy_cleanup(curl);
                 curl_multi_cleanup(multi_handle);
                 logTransferEvent(LogMask::Error, rec, "PERFMARKER_FAIL",
                     "Failed to send a perf marker to the TPC client");
@@ -438,7 +434,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
                 ss << "Transfer failed because no bytes have been received in " << timeout << " seconds.";
                 state.SetErrorMessage(ss.str());
                 curl_multi_remove_handle(multi_handle, curl);
-                curl_easy_cleanup(curl);
                 curl_multi_cleanup(multi_handle);
                 break;
             }
@@ -465,7 +460,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
                 CURL *easy_handle = msg->easy_handle;
                 res = msg->data.result;
                 curl_multi_remove_handle(multi_handle, easy_handle);
-                curl_easy_cleanup(easy_handle);
             }
         } while (msg);
 
@@ -491,7 +485,6 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
 
         char msg[] = "Internal server error due to libcurl";
         curl_multi_remove_handle(multi_handle, curl);
-        curl_easy_cleanup(curl);
         curl_multi_cleanup(multi_handle);
 
         if ((retval = req.ChunkResp(msg, 0))) {
@@ -511,13 +504,11 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
             CURL *easy_handle = msg->easy_handle;
             res = msg->data.result;
             curl_multi_remove_handle(multi_handle, easy_handle);
-            curl_easy_cleanup(easy_handle);
         }
     } while (msg);
 
     if (!state.GetErrorCode() && res == static_cast<CURLcode>(-1)) { // No transfers returned?!?
         curl_multi_remove_handle(multi_handle, curl);
-        curl_easy_cleanup(curl);
         curl_multi_cleanup(multi_handle);
         char msg[] = "Internal state error in libcurl";
         logTransferEvent(LogMask::Error, rec, "TRANSFER_CURL_ERROR", msg);
@@ -587,7 +578,6 @@ int TPCHandler::RunCurlBasic(CURL *curl, XrdHttpExtReq &req, State &state,
                              const char *log_prefix) {
     CURLcode res;
     res = curl_easy_perform(curl);
-    curl_easy_cleanup(curl);
     state.Flush();
     state.Finalize();
     if (state.GetErrorCode()) {
@@ -627,7 +617,10 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     char *name = req.GetSecEntity().name;
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PUSH_START", "Starting a push request");
-    CURL *curl = curl_easy_init();
+
+    auto curl_deleter = [](CURL *curl) { curl_easy_cleanup(curl); };
+    std::unique_ptr<CURL, decltype(curl_deleter)> curlPtr(curl_easy_init(), curl_deleter);
+    CURL *curl = curlPtr.get();
     if (!curl) {
         char msg[] = "Failed to initialize internal transfer resources";
         rec.status = 500;
@@ -647,7 +640,6 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     AtomicEnd(m_monid_mutex);
     std::unique_ptr<XrdSfsFile> fh(m_sfs->newFile(name, file_monid));
     if (!fh.get()) {
-        curl_easy_cleanup(curl);
         rec.status = 500;
         logTransferEvent(LogMask::Error, rec, "OPEN_FAIL",
             "Failed to initialize internal transfer file handle");
@@ -662,10 +654,8 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
                                      req.GetSecEntity(), authz);
     if (SFS_REDIRECT == open_results) {
         int result = RedirectTransfer(curl, redirect_resource, req, fh->error, rec);
-        curl_easy_cleanup(curl);
         return result;
     } else if (SFS_OK != open_results) {
-        curl_easy_cleanup(curl);
         int code;
         char msg_generic[] = "Failed to open local resource";
         const char *msg = fh->error.getErrText(code);
@@ -701,7 +691,10 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     char *name = req.GetSecEntity().name;
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PULL_START", "Starting a push request");
-    CURL *curl = curl_easy_init();
+
+    auto curl_deleter = [](CURL *curl) { curl_easy_cleanup(curl); };
+    std::unique_ptr<CURL, decltype(curl_deleter)> curlPtr(curl_easy_init(), curl_deleter);
+    CURL *curl = curlPtr.get();
     if (!curl) {
             char msg[] = "Failed to initialize internal transfer resources";
             rec.status = 500;
@@ -711,7 +704,6 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     std::unique_ptr<XrdSfsFile> fh(m_sfs->newFile(name, m_monid++));
     if (!fh.get()) {
-            curl_easy_cleanup(curl);
             char msg[] = "Failed to initialize internal transfer file handle";
              rec.status = 500;
             logTransferEvent(LogMask::Error, rec, "PULL_FAIL", msg);
@@ -737,7 +729,6 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
             } catch (...) { // Handled below
             }
             if (stream_req < 0 || stream_req > 100) {
-                curl_easy_cleanup(curl);
                 char msg[] = "Invalid request for number of streams";
                 rec.status = 500;
                 logTransferEvent(LogMask::Info, rec, "INVALID_REQUEST", msg);
@@ -754,10 +745,8 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
                                     req.GetSecEntity(), authz);
     if (SFS_REDIRECT == open_result) {
         int result = RedirectTransfer(curl, redirect_resource, req, fh->error, rec);
-        curl_easy_cleanup(curl);
         return result;
     } else if (SFS_OK != open_result) {
-        curl_easy_cleanup(curl);
         int code;
         char msg_generic[] = "Failed to open local resource";
         const char *msg = fh->error.getErrText(code);

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -615,8 +615,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PUSH_START", "Starting a push request");
 
-    auto curl_deleter = [](CURL *curl) { curl_easy_cleanup(curl); };
-    std::unique_ptr<CURL, decltype(curl_deleter)> curlPtr(curl_easy_init(), curl_deleter);
+    std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curlPtr(curl_easy_init(), &curl_easy_cleanup);
     CURL *curl = curlPtr.get();
     if (!curl) {
         char msg[] = "Failed to initialize internal transfer resources";
@@ -689,8 +688,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     if (name) rec.name = name;
     logTransferEvent(LogMask::Info, rec, "PULL_START", "Starting a push request");
 
-    auto curl_deleter = [](CURL *curl) { curl_easy_cleanup(curl); };
-    std::unique_ptr<CURL, decltype(curl_deleter)> curlPtr(curl_easy_init(), curl_deleter);
+    std::unique_ptr<CURL, decltype(&curl_easy_cleanup)> curlPtr(curl_easy_init(), &curl_easy_cleanup);
     CURL *curl = curlPtr.get();
     if (!curl) {
             char msg[] = "Failed to initialize internal transfer resources";

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -27,6 +27,13 @@ enum LogMask {
     All     = 0xff
 };
 
+
+struct CurlDeleter {
+    void operator()(CURL *curl);
+};
+using ManagedCurlHandle = std::unique_ptr<CURL, CurlDeleter>;
+
+
 class TPCHandler : public XrdHttpExtHandler {
 public:
     TPCHandler(XrdSysError *log, const char *config, XrdOucEnv *myEnv);

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -102,6 +102,7 @@ private:
                            size_t streams, TPCLogRecord &rec);
     int RunCurlWithStreamsImpl(XrdHttpExtReq &req, TPC::State &state,
                            size_t streams, std::vector<TPC::State*> &streams_handles,
+                           std::vector<ManagedCurlHandle> &curl_handles,
                            TPCLogRecord &rec);
 #else
     int RunCurlBasic(CURL *curl, XrdHttpExtReq &req, TPC::State &state,


### PR DESCRIPTION
When `ProcessPushReq()` and `ProcessPullReq()` leave scope, `TPC::State::~State()` is called. The destructor modifies the curl handle, but the handle may already have been through `curl_easy_cleanup()`, and any further use may cause memory corruption.

Make the curl handle NULL after `curl_easy_cleanup()`.

<details>
<summary>Valgrind output from xrootd-5.1.2-0.experimental.2534824.4ca38eb6.el7.cern.x86_64 and curl-7.29.0-59.el7_9.1.x86_64</summary>

```
-bash-4.2$ valgrind --undef-value-errors=no /usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo -s /var/run/xrootd/xrootd-clustered.pid -n clustered
==20804== Memcheck, a memory error detector
==20804== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==20804== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==20804== Command: /usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-clustered.cfg -k fifo -s /var/run/xrootd/xrootd-clustered.pid -n clustered
==20804==
==20804== Thread 52:
==20804== Invalid write of size 8
==20804==    at 0x127A5173: Curl_setopt (url.c:1098)
==20804==    by 0x127B373A: curl_easy_setopt (easy.c:384)
==20804==    by 0x1608349D: TPC::State::~State() (XrdTpcState.cc:22)
==20804==    by 0x16095C0D: TPC::TPCHandler::ProcessPullReq(std::string const&, XrdHttpExtReq&) (XrdTpcTPC.cc:777)
==20804==    by 0x1609688D: TPC::TPCHandler::ProcessReq(XrdHttpExtReq&) (XrdTpcTPC.cc:147)
==20804==    by 0xB2FFF82: XrdHttpReq::ProcessHTTPReq() (XrdHttpReq.cc:998)
==20804==    by 0xB2F7C7C: XrdHttpProtocol::Process(XrdLink*) (XrdHttpProtocol.cc:854)
==20804==    by 0x51D6AA5: XrdLinkXeq::DoIt() (XrdLinkXeq.cc:319)
==20804==    by 0x51D31D8: XrdLink::setProtocol(XrdProtocol*, bool, bool) (XrdLink.cc:435)
==20804==    by 0x51D9DA5: XrdScheduler::Run() (XrdScheduler.cc:382)
==20804==    by 0x51D9EF8: XrdStartWorking(void*) (XrdScheduler.cc:88)
==20804==    by 0x517F846: XrdSysThread_Xeq (XrdSysPthread.cc:86)
==20804==  Address 0x2334a0f0 is 864 bytes inside a block of size 19,536 free'd
==20804==    at 0x4C2B06D: free (vg_replace_malloc.c:540)
==20804==    by 0x127A40FC: Curl_close (url.c:471)
==20804==    by 0x1609131E: TPC::TPCHandler::RunCurlWithUpdates(void*, XrdHttpExtReq&, TPC::State&, TPC::TPCHandler::TPCLogRecord&) (XrdTpcTPC.cc:514)
==20804==    by 0x16095F40: TPC::TPCHandler::ProcessPullReq(std::string const&, XrdHttpExtReq&) (XrdTpcTPC.cc:784)
==20804==    by 0x1609688D: TPC::TPCHandler::ProcessReq(XrdHttpExtReq&) (XrdTpcTPC.cc:147)
==20804==    by 0xB2FFF82: XrdHttpReq::ProcessHTTPReq() (XrdHttpReq.cc:998)
==20804==    by 0xB2F7C7C: XrdHttpProtocol::Process(XrdLink*) (XrdHttpProtocol.cc:854)
==20804==    by 0x51D6AA5: XrdLinkXeq::DoIt() (XrdLinkXeq.cc:319)
==20804==    by 0x51D31D8: XrdLink::setProtocol(XrdProtocol*, bool, bool) (XrdLink.cc:435)
==20804==    by 0x51D9DA5: XrdScheduler::Run() (XrdScheduler.cc:382)
==20804==    by 0x51D9EF8: XrdStartWorking(void*) (XrdScheduler.cc:88)
==20804==    by 0x517F846: XrdSysThread_Xeq (XrdSysPthread.cc:86)
==20804==  Block was alloc'd at
==20804==    at 0x4C2C089: calloc (vg_replace_malloc.c:762)
==20804==    by 0x127A4369: Curl_open (url.c:604)
==20804==    by 0x127B3663: curl_easy_init (easy.c:358)
==20804==    by 0x160952C0: TPC::TPCHandler::ProcessPullReq(std::string const&, XrdHttpExtReq&) (XrdTpcTPC.cc:704)
==20804==    by 0x1609688D: TPC::TPCHandler::ProcessReq(XrdHttpExtReq&) (XrdTpcTPC.cc:147)
==20804==    by 0xB2FFF82: XrdHttpReq::ProcessHTTPReq() (XrdHttpReq.cc:998)
==20804==    by 0xB2F7C7C: XrdHttpProtocol::Process(XrdLink*) (XrdHttpProtocol.cc:854)
==20804==    by 0x51D6AA5: XrdLinkXeq::DoIt() (XrdLinkXeq.cc:319)
==20804==    by 0x51D31D8: XrdLink::setProtocol(XrdProtocol*, bool, bool) (XrdLink.cc:435)
==20804==    by 0x51D9DA5: XrdScheduler::Run() (XrdScheduler.cc:382)
==20804==    by 0x51D9EF8: XrdStartWorking(void*) (XrdScheduler.cc:88)
==20804==    by 0x517F846: XrdSysThread_Xeq (XrdSysPthread.cc:86)
==20804==
```
</details>