### PR TITLE
Fix memleak in SecEntity.host

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -746,6 +746,7 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
         nfo = CurrentReq.opaque->Get("xrdhttphost");
         if (nfo) {
           TRACEI(DEBUG, " Setting host: " << nfo);
+          if (SecEntity.host) free(SecEntity.host);
           SecEntity.host = unquote(nfo);
           TRACEI(REQ, " Setting host: " << SecEntity.host);
         }


### PR DESCRIPTION
Memory for SecEntity.host is already allocated by `GetClientIPStr` at
https://github.com/xrootd/xrootd/blob/1578f628946f04c439321c4a342d26b6da9bc973/src/XrdHttp/XrdHttpProtocol.cc#L474-L477