### PR TITLE
[XrdCl] Remove more ugly hack

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -3,11 +3,8 @@
 #-------------------------------------------------------------------------------
 %if %{?rhel:1}%{!?rhel:0}
     # starting with rhel 7 we have systemd and macaroons,
-    # also glibc semaphores are fixed
-    %if %{rhel} >= 7
         %define use_systemd 1
         %define have_macaroons 1
-		%define use_libc_semaphore 1
 
         %if %{rhel} == 7
 			# we build both python2 and python3 bindings for EPEL7
@@ -20,15 +17,6 @@
 			%define python3only 1
 			%define python2and3 0
         %endif
-    %else
-        %define use_systemd 0
-        %define have_macaroons 0
- 		%define use_libc_semaphore 0
-		# we only build python2 bindings for EPEL<=6
-		%define python2only 1
-		%define python3only 0
-		%define python2and3 0
-    %endif
 %else
     # do we have macaroons ?
     %if %{?fedora}%{!?fedora:0} >= 28
@@ -42,12 +30,6 @@
     %else
         %define use_systemd 0
     %endif
-	# can we use glibc semaphores ?
-	%if %{?fedora}%{!?fedora:0} >= 22
-	    %define use_libc_semaphore 1
-	%else
-	    %define use_libc_semaphore 0
-	%endif
     # we only build python3 bindings for fedora
 	%define python2only 0
 	%define python3only 1
@@ -609,7 +591,7 @@ cmake  \
 %if %{?_with_xrdclhttp:1}%{!?_with_xrdclhttp:0}
       -DXRDCLHTTP_SUBMODULE=TRUE \
 %endif
-      -DUSE_LIBC_SEMAPHORE=%{use_libc_semaphore} ../
+      ../
 
 make -i VERBOSE=1 %{?_smp_mflags}
 popd

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -90,7 +90,6 @@ add_library(
   XrdClJobManager.cc             XrdClJobManager.hh
                                  XrdClResponseJob.hh
   XrdClFileTimer.cc              XrdClFileTimer.hh
-                                 XrdClUglyHacks.hh
                                  XrdClPlugInInterface.hh
   XrdClPlugInManager.cc          XrdClPlugInManager.hh
                                  XrdClPropertyList.hh

--- a/src/XrdCl/XrdClChannel.cc
+++ b/src/XrdCl/XrdClChannel.cc
@@ -128,7 +128,7 @@ namespace
       FilterHandler(const FilterHandler &other);
       FilterHandler &operator = (const FilterHandler &other);
 
-      XrdSysSemaphore     *pSem;
+      XrdSysSemaphore      *pSem;
       XrdCl::MessageFilter *pFilter;
       XrdCl::Message       *pMsg;
       XrdCl::XRootDStatus   pStatus;
@@ -179,7 +179,7 @@ namespace
       StatusHandler(const StatusHandler &other);
       StatusHandler &operator = (const StatusHandler &other);
 
-      XrdSysSemaphore    *pSem;
+      XrdSysSemaphore     *pSem;
       XrdCl::XRootDStatus  pStatus;
       XrdCl::Message      *pMsg;
   };

--- a/src/XrdCl/XrdClCheckSumManager.cc
+++ b/src/XrdCl/XrdClCheckSumManager.cc
@@ -28,6 +28,7 @@
 #include "XrdCks/XrdCksCalccrc32.hh"
 #include "XrdCks/XrdCksCalcadler32.hh"
 #include "XrdSys/XrdSysE2T.hh"
+#include "XrdSys/XrdSysPthread.hh"
 #include "XrdVersion.hh"
 
 #include <sys/types.h>

--- a/src/XrdCl/XrdClClassicCopyJob.cc
+++ b/src/XrdCl/XrdClClassicCopyJob.cc
@@ -38,6 +38,7 @@
 #include "XrdCl/XrdClXRootDTransport.hh"
 #include "XrdClXCpCtx.hh"
 #include "XrdSys/XrdSysE2T.hh"
+#include "XrdSys/XrdSysPthread.hh"
 
 #include <memory>
 #include <mutex>

--- a/src/XrdCl/XrdClCopyProcess.cc
+++ b/src/XrdCl/XrdClCopyProcess.cc
@@ -35,6 +35,7 @@
 #include "XrdCl/XrdClJobManager.hh"
 #include "XrdCl/XrdClRedirectorRegistry.hh"
 #include "XrdCl/XrdClConstants.hh"
+#include "XrdSys/XrdSysPthread.hh"
 
 #include <sys/time.h>
 
@@ -50,7 +51,7 @@ namespace
                      XrdCl::CopyProgressHandler *progress,
                      uint16_t                    currentJob,
                      uint16_t                    totalJobs,
-                     XrdSysSemaphore           *sem = 0 ):
+                     XrdSysSemaphore            *sem = 0 ):
         pJob(job), pProgress(progress), pCurrentJob(currentJob),
         pTotalJobs(totalJobs), pSem(sem),
         pRetryCnt( XrdCl::DefaultRetryWrtAtLBLimit )
@@ -162,7 +163,7 @@ namespace
       XrdCl::CopyProgressHandler *pProgress;
       uint16_t                    pCurrentJob;
       uint16_t                    pTotalJobs;
-      XrdSysSemaphore           *pSem;
+      XrdSysSemaphore            *pSem;
       int                         pRetryCnt;
   };
 };

--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -44,8 +44,9 @@
 
 #include "XrdOuc/XrdOucCRC.hh"
 
-#include "XrdSys/XrdSysPageSize.hh"
 #include "XrdSys/XrdSysKernelBuffer.hh"
+#include "XrdSys/XrdSysPageSize.hh"
+#include "XrdSys/XrdSysPthread.hh"
 
 #include <sstream>
 #include <memory>

--- a/src/XrdCl/XrdClSyncQueue.hh
+++ b/src/XrdCl/XrdClSyncQueue.hh
@@ -99,7 +99,7 @@ namespace XrdCl
     protected:
       std::queue<Item>  pQueue;
       XrdSysMutex       pMutex;
-      XrdSysSemaphore        *pSem;
+      XrdSysSemaphore  *pSem;
   };
 }
 

--- a/src/XrdCl/XrdClThirdPartyCopyJob.cc
+++ b/src/XrdCl/XrdClThirdPartyCopyJob.cc
@@ -32,6 +32,7 @@
 #include "XrdCl/XrdClRedirectorRegistry.hh"
 #include "XrdCl/XrdClDlgEnv.hh"
 #include "XrdOuc/XrdOucTPC.hh"
+#include "XrdSys/XrdSysPthread.hh"
 #include "XrdSys/XrdSysTimer.hh"
 
 #include <iostream>
@@ -700,7 +701,7 @@ namespace XrdCl
     // Do the copy and follow progress
     //--------------------------------------------------------------------------
     TPCStatusHandler  statusHandler;
-    XrdSysSemaphore        *sem  = statusHandler.GetXrdSysSemaphore();
+    XrdSysSemaphore  *sem  = statusHandler.GetXrdSysSemaphore();
     StatInfo         *info   = 0;
 
     uint16_t tpcTimeout = 0;

--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -43,6 +43,7 @@
 
 #include "XrdSys/XrdSysPlatform.hh" // same as above
 #include "XrdSys/XrdSysAtomics.hh"
+#include "XrdSys/XrdSysPthread.hh"
 #include <memory>
 #include <sstream>
 #include <numeric>

--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -62,7 +62,6 @@ set( XROOTD_PUBLIC_HEADERS
   XrdSys/XrdSysError.hh
   XrdSys/XrdSysFD.hh
   XrdSys/XrdSysHeaders.hh
-  XrdSys/XrdSysLinuxSemaphore.hh
   XrdSys/XrdSysLogger.hh
   XrdSys/XrdSysLogPI.hh
   XrdSys/XrdSysPageSize.hh


### PR DESCRIPTION
- Remove references to removed XrdClUglyHacks.hh and XrdSysLinuxSemaphore.hh in CMakeLists.txt files.
- Add #include "XrdSys/XrdSysPthread.hh" where classes from the file is used, and it was previously included recursively by a removed include of XrdClUglyHacks.hhl.
- Remove semaphore selection from spec file.
- Fix some alignments in variable declarations. 