### PR TITLE
Fix compilation failure on 32 bit (ix86/arm32)

### DIFF
--- a/src/XrdSfs/XrdSfsInterface.cc
+++ b/src/XrdSfs/XrdSfsInterface.cc
@@ -149,7 +149,7 @@ XrdSfsXferSize XrdSfsFile::pgWrite(XrdSfsFileOffset   offset,
 
        if (XrdOucPgrwUtils::csVer(buffer,offset,wrlen,csvec,badoff,badlen) >= 0)
           {char eMsg[512];
-           snprintf(eMsg, sizeof(eMsg),"Checksum error at offset %ld.",badoff);
+           snprintf(eMsg, sizeof(eMsg),"Checksum error at offset %ld.",(long)badoff);
            error.setErrInfo(EDOM, eMsg);
            return SFS_ERROR;
           }


### PR DESCRIPTION
error: format '%ld' expects argument of type 'long int', but argument
4 has type 'ssize_t' {aka 'int'} [-Werror=format=]