### PR TITLE
[XrdCl] Only use the passwd file if a valid entry is found

### DIFF
--- a/src/XrdCl/XrdClPlugInManager.cc
+++ b/src/XrdCl/XrdClPlugInManager.cc
@@ -228,7 +228,7 @@ namespace XrdCl
 
       XrdSysPwd pwdHandler;
       passwd *pwd = pwdHandler.Get( getuid() );
-      if( !pwd )
+      if( pwd )
       {
         std::string userPlugIns = pwd->pw_dir;
         userPlugIns += "/.xrootd/client.plugins.d";


### PR DESCRIPTION
When using XRootD 5.2 in CERN OpenShift I've seen the following segfault in gfal2:

```
[2021-05-25 12:29:06.201028 +0000][Debug  ][Utility           ] Initializing xrootd client version: v5.2.0
[2021-05-25 12:29:06.201312 +0000][Warning][Utility           ] Unable to process global config file: [ERROR] OS Error: no such file or directory
[2021-05-25 12:29:06.201378 +0000][Debug  ][Utility           ] Unable to find user home directory.
[2021-05-25 12:29:06.201553 +0000][Debug  ][PlugInMgr         ] Initializing plug-in manager...
[2021-05-25 12:29:06.201563 +0000][Debug  ][PlugInMgr         ] No default plug-in, loading plug-in configs...
[2021-05-25 12:29:06.201585 +0000][Debug  ][PlugInMgr         ] Processing plug-in definitions in /etc/xrootd/client.plugins.d...
[2021-05-25 12:29:06.201596 +0000][Debug  ][PlugInMgr         ] Unable to process directory /etc/xrootd/client.plugins.d: [ERROR] OS Error: no such file or directory

Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007f60553dd5d8 in XrdCl::PlugInManager::ProcessEnvironmentSettings() () from /tmp/env/lib/gfal2-plugins//../libXrdCl.so.3
```

The issue is that the user ID is randomised and is therefore missing from the `/etc/passwd` file and it looks like 597509497b59608bf8c0f104bdec5d1b2a5c29b2 forgot to invert the if condition. Presumably this also causes another bug with user plugins being ignored.