### PR TITLE
Clear OpenSSL error queue ahead of SSL_read/write/accept()

### DIFF
--- a/src/XrdTls/XrdTlsSocket.cc
+++ b/src/XrdTls/XrdTlsSocket.cc
@@ -265,7 +265,8 @@ XrdTls::RC XrdTlsSocket::Connect(const char *thehost, std::string *eWhy)
 
 // Do the connect.
 //
-do{int rc = SSL_connect( pImpl->ssl );
+do{if (pImpl->isClient) ERR_clear_error();
+   int rc = SSL_connect( pImpl->ssl );
    if (rc == 1) break;
 
    ssler = Diagnose("TLS_Connect", rc, XrdTls::dbgSOK);
@@ -640,7 +641,8 @@ XrdTls::RC XrdTlsSocket::Read( char *buffer, size_t size, int &bytesRead )
     // have to explicitly call SSL_connect or SSL_do_handshake.
     //------------------------------------------------------------------------
 
- do{int rc = SSL_read( pImpl->ssl, buffer, size );
+ do{if (pImpl->isClient) ERR_clear_error();
+    int rc = SSL_read( pImpl->ssl, buffer, size );
 
     // Note that according to SSL whenever rc > 0 then SSL_ERROR_NONE can be
     // returned to the caller. So, we short-circuit all the error handling.
@@ -785,7 +787,8 @@ XrdTls::RC XrdTlsSocket::Write( const char *buffer, size_t size,
     // have to explicitly call SSL_connect or SSL_do_handshake.
     //------------------------------------------------------------------------
 
- do{int rc = SSL_write( pImpl->ssl, buffer, size );
+ do{if (pImpl->isClient) ERR_clear_error();
+    int rc = SSL_write( pImpl->ssl, buffer, size );
 
     // Note that according to SSL whenever rc > 0 then SSL_ERROR_NONE can be
     // returned to the caller. So, we short-circuit all the error handling.


### PR DESCRIPTION
- Clear the OpenSSL error queue to avoid reporting errors from other SSL operations, such as reading CRLs
- Log queued OpenSSL errors if present