### PR TITLE
Clear the OpenSSL error queue in XrdCryptosslX509ParseBucket()

### DIFF
--- a/src/XrdCl/XrdClXRootDTransport.cc
+++ b/src/XrdCl/XrdClXRootDTransport.cc
@@ -2241,13 +2241,11 @@ namespace XrdCl
                     "[%s] Authenticated with %s.", hsData->streamName.c_str(),
                     protocolName.c_str() );
 
-        if( info->encrypted || ( info->serverFlags & kXR_gotoTLS ) ||
-            ( info->serverFlags & kXR_tlsLogin ) )
-          //--------------------------------------------------------------------
-          // Clear the SSL error queue of the calling thread, as there might be
-          // some leftover from the authentication!
-          //--------------------------------------------------------------------
-          Tls::ClearErrorQueue();
+        //--------------------------------------------------------------------
+        // Clear the SSL error queue of the calling thread, as there might be
+        // some leftover from the authentication!
+        //--------------------------------------------------------------------
+        Tls::ClearErrorQueue();
 
         return XRootDStatus();
       } 
@@ -2311,13 +2309,11 @@ namespace XrdCl
     MarshallRequest( msg );
     delete credentials;
 
-    if( info->encrypted || ( info->serverFlags & kXR_gotoTLS ) ||
-        ( info->serverFlags & kXR_tlsLogin ) )
-      //------------------------------------------------------------------------
-      // Clear the SSL error queue of the calling thread, as there might be
-      // some leftover from the authentication!
-      //------------------------------------------------------------------------
-      Tls::ClearErrorQueue();
+    //------------------------------------------------------------------------
+    // Clear the SSL error queue of the calling thread, as there might be
+    // some leftover from the authentication!
+    //------------------------------------------------------------------------
+    Tls::ClearErrorQueue();
 
     return XRootDStatus( stOK, suContinue );
   }
@@ -2425,6 +2421,7 @@ namespace XrdCl
     info->authProtocol = 0;
     info->authParams   = 0;
     info->authEnv      = 0;
+    Tls::ClearErrorQueue();
     return Status();
   }
 

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -43,6 +43,7 @@
 #include "XrdCrypto/XrdCryptosslX509.hh"
 #include "XrdCrypto/XrdCryptosslTrace.hh"
 #include "XrdTls/XrdTlsPeerCerts.hh"
+#include <openssl/err.h>
 #include <openssl/pem.h>
 
 // Error code from verification set by verify callback function
@@ -605,6 +606,7 @@ int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *chain)
    if (BIO_write(bmem,(const void *)(b->buffer),b->size) != b->size) {
       DEBUG("problems writing data to BIO");
       BIO_free(bmem);
+      ERR_clear_error();
       return nci;
    }
 
@@ -621,10 +623,16 @@ int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *chain)
       } else {
          DEBUG("could not create certificate: memory exhausted?");
          BIO_free(bmem);
+         ERR_clear_error();
          return nci;
       }
       // reset cert otherwise the next one is not fetched
       xcer = 0;
+   }
+
+   // Clear OpenSSL error queue from PEM_read_bio_X509() loop end condition
+   if (ERR_GET_REASON(ERR_peek_last_error()) == PEM_R_NO_START_LINE) {
+      ERR_clear_error();
    }
 
    // If we found something, and we are asked to extract a key,
@@ -689,6 +697,13 @@ int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *chain)
 
    // Cleanup
    BIO_free(bmem);
+
+   // Report and clear any other OpenSSL errors on the queue
+   char eBuff[120]; int eCode;
+   while ((eCode = ERR_get_error())) {
+      ERR_error_string_n(eCode, eBuff, sizeof(eBuff));
+      DEBUG("TLS error: " << eBuff);
+   }
 
    // We are done
    return nci;

--- a/src/XrdTls/XrdTlsSocket.cc
+++ b/src/XrdTls/XrdTlsSocket.cc
@@ -265,8 +265,7 @@ XrdTls::RC XrdTlsSocket::Connect(const char *thehost, std::string *eWhy)
 
 // Do the connect.
 //
-do{if (pImpl->isClient) ERR_clear_error();
-   int rc = SSL_connect( pImpl->ssl );
+do{int rc = SSL_connect( pImpl->ssl );
    if (rc == 1) break;
 
    ssler = Diagnose("TLS_Connect", rc, XrdTls::dbgSOK);
@@ -641,8 +640,7 @@ XrdTls::RC XrdTlsSocket::Read( char *buffer, size_t size, int &bytesRead )
     // have to explicitly call SSL_connect or SSL_do_handshake.
     //------------------------------------------------------------------------
 
- do{if (pImpl->isClient) ERR_clear_error();
-    int rc = SSL_read( pImpl->ssl, buffer, size );
+ do{int rc = SSL_read( pImpl->ssl, buffer, size );
 
     // Note that according to SSL whenever rc > 0 then SSL_ERROR_NONE can be
     // returned to the caller. So, we short-circuit all the error handling.
@@ -787,8 +785,7 @@ XrdTls::RC XrdTlsSocket::Write( const char *buffer, size_t size,
     // have to explicitly call SSL_connect or SSL_do_handshake.
     //------------------------------------------------------------------------
 
- do{if (pImpl->isClient) ERR_clear_error();
-    int rc = SSL_write( pImpl->ssl, buffer, size );
+ do{int rc = SSL_write( pImpl->ssl, buffer, size );
 
     // Note that according to SSL whenever rc > 0 then SSL_ERROR_NONE can be
     // returned to the caller. So, we short-circuit all the error handling.


### PR DESCRIPTION
Regarding the OpenSSL `ERR_clear_error()` overhead introduced in #1464:

This PR should clear the OpenSSL error queue in `XrdCryptosslX509ParseBucket()`, along with reverting the `ERR_clear_error()` calls in `XrdTlsSocket`.

So far, I'm unable to reproduce the TLS error on our local xcache with this patch (on the latest experimental, xrootd-5.2.1-0.experimental.2679300.76d03f61). This certainly could use some thorough testing to confirm. @osschar 