### PR TITLE
Fix linking XrdSecztn when building for macOS

### DIFF
--- a/src/XrdSecztn.cmake
+++ b/src/XrdSecztn.cmake
@@ -14,7 +14,7 @@ add_library(
 
 target_link_libraries(
   ${LIB_XRD_SEC_ZTN}
-# XrdUtils
+  XrdUtils
   )
 
 set_target_properties(


### PR DESCRIPTION
It's not clear to me why this was commented but this fixes the issue in https://github.com/conda-forge/xrootd-feedstock/pull/45 where building with scitoken support for macOS fails with the below linker error (for both x86 and arm64).
```cpp
Undefined symbols for architecture arm64:
  "XrdSysE2T(int)", referenced from:
      XrdSecProtocolztn::readFail(XrdOucErrInfo*, char const*, int) in XrdSecProtocolztn.cc.o
  "XrdOucString::find(char, int, bool)", referenced from:
      XrdSecProtocolztn::findToken(XrdOucErrInfo*, std::__1::vector<XrdOucString, std::__1::allocator<XrdOucString> >&, bool&) in XrdSecProtocolztn.cc.o
  "XrdOucString::endswith(char const*)", referenced from:
      XrdSecProtocolztn::findToken(XrdOucErrInfo*, std::__1::vector<XrdOucString, std::__1::allocator<XrdOucString> >&, bool&) in XrdSecProtocolztn.cc.o
  "XrdOucString::XrdOucString(char const*, int)", referenced from:
      XrdSecProtocolztn::getCredentials(XrdSecBuffer*, XrdOucErrInfo*) in XrdSecProtocolztn.cc.o
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
  "XrdOucString::~XrdOucString()", referenced from:
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
  "XrdOucString::operator=(char const*)", referenced from:
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
  "XrdOucString::operator+=(char const*)", referenced from:
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
  "XrdSecEntity::XrdSecEntity(char const*)", referenced from:
      XrdSecProtocolztn::XrdSecProtocolztn(char const*, XrdOucErrInfo*, bool&) in XrdSecProtocolztn.cc.o
      _XrdSecProtocolztnObject in XrdSecProtocolztn.cc.o
  "XrdSecEntity::~XrdSecEntity()", referenced from:
      XrdSecProtocolztn::XrdSecProtocolztn(char const*, XrdOucErrInfo*, bool&) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::~XrdSecProtocolztn() in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::~XrdSecProtocolztn() in XrdSecProtocolztn.cc.o
  "XrdNetAddrInfo::isUsingTLS()", referenced from:
      _XrdSecProtocolztnObject in XrdSecProtocolztn.cc.o
  "XrdOucBuffPool::BuffSlot::Recycle(XrdOucBuffer*)", referenced from:
      XrdSecProtocolztn::XrdSecProtocolztn(char const*, XrdOucErrInfo*, bool&) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::retToken(XrdOucErrInfo*, char const*, int) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::getCredentials(XrdSecBuffer*, XrdOucErrInfo*) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::getToken(XrdOucErrInfo*, XrdSecBuffer*) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::readFail(XrdOucErrInfo*, char const*, int) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::Authenticate(XrdSecBuffer*, XrdSecBuffer**, XrdOucErrInfo*) in XrdSecProtocolztn.cc.o
      XrdSecProtocolztn::SendAI(XrdOucErrInfo*, XrdSecBuffer**) in XrdSecProtocolztn.cc.o
      ...
  "XrdOucPinLoader::Resolve(char const*, int)", referenced from:
      (anonymous namespace)::getLinkage(XrdOucErrInfo*, char const*) in XrdSecProtocolztn.cc.o
  "XrdOucPinLoader::XrdOucPinLoader(char*, int, XrdVersionInfo*, char const*, char const*)", referenced from:
      (anonymous namespace)::getLinkage(XrdOucErrInfo*, char const*) in XrdSecProtocolztn.cc.o
  "XrdOucPinLoader::~XrdOucPinLoader()", referenced from:
      (anonymous namespace)::getLinkage(XrdOucErrInfo*, char const*) in XrdSecProtocolztn.cc.o
  "XrdOucTokenizer::Attach(char*)", referenced from:
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
  "XrdOucTokenizer::GetLine()", referenced from:
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
  "XrdOucTokenizer::GetToken(char**, int)", referenced from:
      _XrdSecProtocolztnInit in XrdSecProtocolztn.cc.o
ld: symbol(s) not found for architecture arm64
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [src/CMakeFiles/XrdSecztn-5.dir/build.make:113: src/libXrdSecztn-5.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:1497: src/CMakeFiles/XrdSecztn-5.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```