### PR TITLE
Fix compilation failure on 32 bit (ix86/arm32)

### DIFF
--- a/src/XrdOfs/XrdOfs.cc
+++ b/src/XrdOfs/XrdOfs.cc
@@ -129,7 +129,7 @@ bool VerPgw(const char *buf, ssize_t off, size_t len, const uint32_t* csv,
    if (!XrdOucPgrwUtils::csVer(dInfo, badoff, badlen))
       {char eMsg[512];
        int n;
-       n=snprintf(eMsg,sizeof(eMsg),"Checksum error at offset %ld.",badoff);
+       n = snprintf(eMsg, sizeof(eMsg), "Checksum error at offset %lld.", (long long) badoff);
        error.setErrInfo(EDOM, eMsg);
        eMsg[n-1] = 0;
        OfsEroute.Emsg(epname, eMsg, "aborted pgwrite to", oh->Name());

--- a/src/XrdSfs/XrdSfsInterface.cc
+++ b/src/XrdSfs/XrdSfsInterface.cc
@@ -143,7 +143,7 @@ XrdSfsXferSize XrdSfsFile::pgWrite(XrdSfsFileOffset   offset,
 
        if (!XrdOucPgrwUtils::csVer(dInfo, badoff, badlen))
           {char eMsg[512];
-           snprintf(eMsg, sizeof(eMsg),"Checksum error at offset %ld.",(long)badoff);
+           snprintf(eMsg, sizeof(eMsg), "Checksum error at offset %lld.", (long long) badoff);
            error.setErrInfo(EDOM, eMsg);
            return SFS_ERROR;
           }


### PR DESCRIPTION
src/XrdOfs/XrdOfs.cc:
error: format '%ld' expects argument of type 'long int',
but argument 4 has type 'off_t' {aka 'long long int'} [-Werror=format=]

src/XrdSfs/XrdSfsInterface.cc:
Type changed from ssize_t (32/64 bits) to off_t (64 bits)
Change cast from (long) to (long long) and format from %ld to %lld