### PR TITLE
Obfuscate paths hidden into error strings

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -639,7 +639,7 @@ bool XrdHttpReq::Error(XrdXrootd::Bridge::Context &info, //!< the result context
 
   xrdresp = kXR_error;
   xrderrcode = (XErrorCode) ecode;
-  this->etext = etext_;
+  obfuscatepath(this->etext, etext_);
 
 
   if (PostProcessHTTPReq()) reset();

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -439,5 +439,32 @@ char *escapeXML(const char *str) {
 
 
 
+// If the text contains a path then it will not be seen as such by wannabe security tests
+// Returns the number of chars that have been substituted
+int obfuscatepath(std::string &strout, const char *strin) {
+  int l = strlen(strin);
+  strout.clear();
+  int i, j = 0;
+
+  for (i = 0; i < l; i++) {
+    const char c = strin[i];
+
+    switch (c) {
+      case '/':
+        strout.append(" / ");
+        j++;
+        break;
+      case '\\':
+        strout.append(" \\ ");
+        j++;
+        break;
+      default:
+        strout.push_back(c);
+    }
+  }
+
+
+  return j;
+}
 
 

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -89,5 +89,10 @@ char *unquote(char *str);
 // Escape a string and return a new one
 char *escapeXML(const char *str);
 
+
+// If the text contains a path then it will not be seen as such by wannabe security tests
+// // Returns the number of chars that have been substituted
+int obfuscatepath(std::string &, const char *);
+ 
 #endif	/* XRDHTTPUTILS_HH */
 


### PR DESCRIPTION
Workaround for "security" tests