### PR TITLE
python bindings: catch ReferenceError error when finalizing File's

### DIFF
--- a/bindings/python/libs/client/finalize.py
+++ b/bindings/python/libs/client/finalize.py
@@ -42,7 +42,10 @@ def finalize():
      # If this isn't done, there will be no running threads to process requests
      # after this function returns so the interpreter will deadlock.
      for obj in gc.get_objects():
-         if isinstance(obj, File) and obj.is_open():
-             obj.close()
+        try:
+            if isinstance(obj, File) and obj.is_open():
+                obj.close()
+        except ReferenceError:
+            pass
 
      client.__XrdCl_Stop_Threads()


### PR DESCRIPTION
The finalize method in `bindings/python/libs/client/finalize.py` iterates over all references known to the garbage collector, even those not created by the xrootd bindings. This does not work correctly when the target of a weak reference has been already
collected.

This pr catches this exception, e.g.:

Traceback (most recent call last):
  File
  ".../envs/topcoffea-env/lib/python3.8/site-packages/XRootD/client/finalize.py",
  line 46, in finalize
      if isinstance(obj, File) and obj.is_open():
ReferenceError: weakly-referenced object no longer exists