### PR TITLE
Link libXrdServer to libatomic on riscv64 

### DIFF
--- a/src/XrdServer.cmake
+++ b/src/XrdServer.cmake
@@ -185,13 +185,18 @@ add_library(
   XrdDig/XrdDigConfig.cc        XrdDig/XrdDigConfig.hh
   XrdDig/XrdDigFS.cc            XrdDig/XrdDigFS.hh )
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
+  SET(ATOMIC_LIBS -latomic)
+endif()
+
 target_link_libraries(
   XrdServer
   XrdUtils
   ${CMAKE_DL_LIBS}
   pthread
   ${EXTRA_LIBS}
-  ${SOCKET_LIBRARY} )
+  ${SOCKET_LIBRARY}
+  ${ATOMIC_LIBS} )
 
 set_target_properties(
   XrdServer


### PR DESCRIPTION
Link libXrdServer to libatomic on riscv64 to avoid undefined references:
```
/usr/bin/ld: libXrdServer.so.3.0.0: undefined reference to `__atomic_fetch_or_1'
/usr/bin/ld: libXrdServer.so.3.0.0: undefined reference to `__atomic_fetch_sub_1'
/usr/bin/ld: libXrdServer.so.3.0.0: undefined reference to `__atomic_fetch_and_1'
/usr/bin/ld: libXrdServer.so.3.0.0: undefined reference to `__atomic_fetch_add_1'
collect2: error: ld returned 1 exit status
```
