### PR TITLE
Use -pthread

### DIFF
--- a/cmake/XRootDSystemCheck.cmake
+++ b/cmake/XRootDSystemCheck.cmake
@@ -98,6 +98,12 @@ check_include_file( et/com_err.h HAVE_ET_COM_ERR_H )
 compiler_define_if_found( HAVE_ET_COM_ERR_H HAVE_ET_COM_ERR_H )
 
 #-------------------------------------------------------------------------------
+# Check for pthreads
+#-------------------------------------------------------------------------------
+set( THREADS_PREFER_PTHREAD_FLAG TRUE )
+find_package( Threads )
+
+#-------------------------------------------------------------------------------
 # Check for the atomics
 #-------------------------------------------------------------------------------
 if (CMAKE_CROSSCOMPILING)

--- a/src/XrdApps.cmake
+++ b/src/XrdApps.cmake
@@ -28,7 +28,7 @@ if( NOT XRDCL_ONLY )
     xrdadler32
     XrdPosix
     XrdUtils
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${ZLIB_LIBRARY} )
 
 
@@ -66,7 +66,7 @@ if( NOT XRDCL_ONLY )
     XrdAppUtils
     XrdUtils
     ${EXTRA_LIBS}
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${SOCKET_LIBRARY} )
 
   #-----------------------------------------------------------------------------
@@ -79,7 +79,7 @@ if( NOT XRDCL_ONLY )
   target_link_libraries(
     wait41
     XrdUtils
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${EXTRA_LIBS} )
 
   #-----------------------------------------------------------------------------

--- a/src/XrdApps.cmake
+++ b/src/XrdApps.cmake
@@ -29,7 +29,7 @@ if( NOT XRDCL_ONLY )
     XrdPosix
     XrdUtils
     ${CMAKE_THREAD_LIBS_INIT}
-    ${ZLIB_LIBRARY} )
+    ${ZLIB_LIBRARIES} )
 
 
   #-----------------------------------------------------------------------------

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -115,7 +115,7 @@ target_link_libraries(
   XrdUtils
   ${CMAKE_THREAD_LIBS_INIT}
   ${UUID_LIBRARY}
-  z
+  ${ZLIB_LIBRARIES}
   ${EXTRA_LIBS}
   ${CMAKE_DL_LIBS}
   ${OPENSSL_LIBRARIES}

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -113,7 +113,7 @@ target_link_libraries(
   XrdCl
   XrdXml
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${UUID_LIBRARY}
   z
   ${EXTRA_LIBS}
@@ -144,7 +144,7 @@ add_executable(
 
 target_link_libraries(
   xrdfs
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   XrdCl
   XrdUtils
   ${READLINE_LIBRARY}

--- a/src/XrdCrypto.cmake
+++ b/src/XrdCrypto.cmake
@@ -99,7 +99,7 @@ if( BUILD_CRYPTO )
     ${LIB_XRD_CRYPTOSSL}
     XrdCrypto
     XrdUtils
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${OPENSSL_LIBRARIES} )
 
   set_target_properties(

--- a/src/XrdDaemons.cmake
+++ b/src/XrdDaemons.cmake
@@ -16,7 +16,7 @@ target_link_libraries(
   XrdServer
   XrdUtils
   ${CMAKE_DL_LIBS}
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY} )
 
@@ -57,7 +57,7 @@ target_link_libraries(
   cmsd
   XrdServer
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY} )
 

--- a/src/XrdFfs.cmake
+++ b/src/XrdFfs.cmake
@@ -25,7 +25,7 @@ target_link_libraries(
   XrdCl
   XrdPosix
   XrdUtils
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   XrdFfs
@@ -47,7 +47,7 @@ if( BUILD_FUSE )
     xrootdfs
     XrdFfs
     XrdPosix
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${FUSE_LIBRARIES} )
 endif()
 

--- a/src/XrdFrm.cmake
+++ b/src/XrdFrm.cmake
@@ -40,7 +40,7 @@ target_link_libraries(
   XrdFrm
   XrdServer
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${READLINE_LIBRARY}
   ${NCURSES_LIBRARY}
   ${EXTRA_LIBS}
@@ -59,7 +59,7 @@ target_link_libraries(
   XrdFrm
   XrdServer
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY} )
 
@@ -75,7 +75,7 @@ target_link_libraries(
   XrdFrm
   XrdServer
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY} )
 
@@ -91,7 +91,7 @@ target_link_libraries(
   XrdFrm
   XrdServer
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY} )
 

--- a/src/XrdHttp.cmake
+++ b/src/XrdHttp.cmake
@@ -43,7 +43,7 @@ if( BUILD_HTTP )
     XrdUtils
     XrdCrypto
     ${CMAKE_DL_LIBS}
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${OPENSSL_LIBRARIES}
     ${OPENSSL_CRYPTO_LIBRARY} )
 

--- a/src/XrdOssCsi.cmake
+++ b/src/XrdOssCsi.cmake
@@ -31,7 +31,7 @@ target_link_libraries(
   ${LIB_XRD_OSSCSI}
   XrdUtils
   XrdServer
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   ${LIB_XRD_OSSCSI}

--- a/src/XrdPfc.cmake
+++ b/src/XrdPfc.cmake
@@ -37,7 +37,7 @@ target_link_libraries(
   XrdCl
   XrdUtils
   XrdServer
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   ${LIB_XRD_FILECACHE}

--- a/src/XrdPlugins.cmake
+++ b/src/XrdPlugins.cmake
@@ -61,7 +61,7 @@ target_link_libraries(
   ${LIB_XRD_BWM}
   XrdServer
   XrdUtils
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   ${LIB_XRD_BWM}

--- a/src/XrdPlugins.cmake
+++ b/src/XrdPlugins.cmake
@@ -117,7 +117,7 @@ add_library(
 target_link_libraries(
   ${LIB_XRD_ZCRC32}
   XrdUtils
-  ${ZLIB_LIBRARY} )
+  ${ZLIB_LIBRARIES} )
 
 set_target_properties(
   ${LIB_XRD_ZCRC32}

--- a/src/XrdPosix.cmake
+++ b/src/XrdPosix.cmake
@@ -37,7 +37,7 @@ target_link_libraries(
   XrdPosix
   XrdCl
   XrdUtils
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   XrdPosix

--- a/src/XrdSciTokens.cmake
+++ b/src/XrdSciTokens.cmake
@@ -26,7 +26,7 @@ target_link_libraries(
    XrdUtils
    XrdServer
    dl
-   pthread )
+   ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
    ${LIB_XRD_SCITOKENS}

--- a/src/XrdSciTokens.cmake
+++ b/src/XrdSciTokens.cmake
@@ -25,7 +25,7 @@ target_link_libraries(
    ${SCITOKENS_CPP_LIBRARIES}
    XrdUtils
    XrdServer
-   dl
+   ${CMAKE_DL_LIBS}
    ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(

--- a/src/XrdSec.cmake
+++ b/src/XrdSec.cmake
@@ -35,7 +35,7 @@ add_library(
 target_link_libraries(
   ${LIB_XRD_SEC}
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${CMAKE_DL_LIBS} )
 
 set_target_properties(
@@ -57,13 +57,13 @@ if( BUILD_CRYPTO )
   target_link_libraries(
     ${LIB_XRD_SEC_PROT}
     XrdUtils
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${OPENSSL_CRYPTO_LIBRARY} )
 else()
   target_link_libraries(
     ${LIB_XRD_SEC_PROT}
     XrdUtils
-    pthread )
+    ${CMAKE_THREAD_LIBS_INIT} )
 endif()
 
 set_target_properties(
@@ -85,7 +85,7 @@ target_link_libraries(
   ${LIB_XRD_SEC_PWD}
   XrdCrypto
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${CRYPT_LIBRARY} )
 
 set_target_properties(

--- a/src/XrdSecgsi.cmake
+++ b/src/XrdSecgsi.cmake
@@ -26,7 +26,7 @@ target_link_libraries(
   ${LIB_XRD_SEC_GSI}
   XrdCrypto
   XrdUtils
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   ${LIB_XRD_SEC_GSI}

--- a/src/XrdServer.cmake
+++ b/src/XrdServer.cmake
@@ -185,18 +185,13 @@ add_library(
   XrdDig/XrdDigConfig.cc        XrdDig/XrdDigConfig.hh
   XrdDig/XrdDigFS.cc            XrdDig/XrdDigFS.hh )
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
-  SET(ATOMIC_LIBS -latomic)
-endif()
-
 target_link_libraries(
   XrdServer
   XrdUtils
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
-  ${SOCKET_LIBRARY}
-  ${ATOMIC_LIBS} )
+  ${SOCKET_LIBRARY} )
 
 set_target_properties(
   XrdServer

--- a/src/XrdServer.cmake
+++ b/src/XrdServer.cmake
@@ -193,7 +193,7 @@ target_link_libraries(
   XrdServer
   XrdUtils
   ${CMAKE_DL_LIBS}
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY}
   ${ATOMIC_LIBS} )

--- a/src/XrdSsi.cmake
+++ b/src/XrdSsi.cmake
@@ -74,7 +74,7 @@ XrdSsi/XrdSsiShMat.cc                  XrdSsi/XrdSsiShMat.hh)
 target_link_libraries(
   XrdSsiShMap
   XrdUtils
-  ${ZLIB_LIBRARY}
+  ${ZLIB_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(

--- a/src/XrdSsi.cmake
+++ b/src/XrdSsi.cmake
@@ -52,7 +52,7 @@ target_link_libraries(
   XrdSsiLib
   XrdCl
   XrdUtils
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   XrdSsiLib
@@ -75,7 +75,7 @@ target_link_libraries(
   XrdSsiShMap
   XrdUtils
   ${ZLIB_LIBRARY}
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   XrdSsiShMap

--- a/src/XrdTpc.cmake
+++ b/src/XrdTpc.cmake
@@ -49,7 +49,7 @@ if( BUILD_TPC )
     XrdUtils
     XrdHttpUtils
     ${CMAKE_DL_LIBS}
-    pthread
+    ${CMAKE_THREAD_LIBS_INIT}
     ${CURL_LIBRARIES} )
 
   if( MacOSX )

--- a/src/XrdUtils.cmake
+++ b/src/XrdUtils.cmake
@@ -251,7 +251,7 @@ add_library(
 
 target_link_libraries(
   XrdUtils
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${CMAKE_DL_LIBS}
   ${OPENSSL_LIBRARIES}
   ${SOCKET_LIBRARY}

--- a/src/XrdXml.cmake
+++ b/src/XrdXml.cmake
@@ -48,7 +48,7 @@ target_link_libraries(
   XrdUtils
   ${TINYXML_LIBRARIES}
   ${XRDXML2_LIBRARIES}
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
 
 set_target_properties(
   XrdXml

--- a/tests/XrdCephTests/CMakeLists.txt
+++ b/tests/XrdCephTests/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(
 
 target_link_libraries(
   XrdCephTests
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${CPPUNIT_LIBRARIES}
   ${ZLIB_LIBRARY}
   XrdCephPosix )

--- a/tests/XrdCephTests/CMakeLists.txt
+++ b/tests/XrdCephTests/CMakeLists.txt
@@ -10,7 +10,7 @@ target_link_libraries(
   XrdCephTests
   ${CMAKE_THREAD_LIBS_INIT}
   ${CPPUNIT_LIBRARIES}
-  ${ZLIB_LIBRARY}
+  ${ZLIB_LIBRARIES}
   XrdCephPosix )
 
 #-------------------------------------------------------------------------------

--- a/tests/XrdClTests/CMakeLists.txt
+++ b/tests/XrdClTests/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(
 target_link_libraries(
   XrdClTests
   XrdClTestsHelper
-  pthread
+  ${CMAKE_THREAD_LIBS_INIT}
   ${CPPUNIT_LIBRARIES}
   ${ZLIB_LIBRARY}
   XrdCl )

--- a/tests/XrdClTests/CMakeLists.txt
+++ b/tests/XrdClTests/CMakeLists.txt
@@ -32,7 +32,7 @@ target_link_libraries(
   XrdClTestsHelper
   ${CMAKE_THREAD_LIBS_INIT}
   ${CPPUNIT_LIBRARIES}
-  ${ZLIB_LIBRARY}
+  ${ZLIB_LIBRARIES}
   XrdCl )
 
 add_library(

--- a/tests/XrdClTests/tls/CMakeLists.txt
+++ b/tests/XrdClTests/tls/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
   XrdXml
   XrdAppUtils
   dl
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
   
   
 add_executable(
@@ -30,6 +30,6 @@ target_link_libraries(
   xrdsrv-tls
   XrdUtils
   ${OPENSSL_LIBRARIES}
-  pthread )
+  ${CMAKE_THREAD_LIBS_INIT} )
   
 endif()

--- a/tests/XrdClTests/tls/CMakeLists.txt
+++ b/tests/XrdClTests/tls/CMakeLists.txt
@@ -18,7 +18,7 @@ target_link_libraries(
   XrdPosix
   XrdXml
   XrdAppUtils
-  dl
+  ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT} )
   
   

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -9,15 +9,23 @@ add_library(
   CppUnitXrdHelpers.hh)
 
 target_link_libraries(
- XrdClTestsHelper
-  pthread
+  XrdClTestsHelper
+  ${CMAKE_THREAD_LIBS_INIT}
   ${CPPUNIT_LIBRARIES}
   ${ZLIB_LIBRARY}
   XrdCl
   XrdUtils)
 
-add_executable(test-runner TextRunner.cc PathProcessor.hh)
-target_link_libraries(test-runner ${CMAKE_DL_LIBS} ${CPPUNIT_LIBRARIES} pthread)
+add_executable(
+  test-runner
+  TextRunner.cc
+  PathProcessor.hh)
+
+target_link_libraries(
+  test-runner
+  ${CMAKE_DL_LIBS}
+  ${CPPUNIT_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT})
 
 #-------------------------------------------------------------------------------
 # Install

--- a/tests/common/CMakeLists.txt
+++ b/tests/common/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(
   XrdClTestsHelper
   ${CMAKE_THREAD_LIBS_INIT}
   ${CPPUNIT_LIBRARIES}
-  ${ZLIB_LIBRARY}
+  ${ZLIB_LIBRARIES}
   XrdCl
   XrdUtils)
 


### PR DESCRIPTION
This is a follow-up to the discussion in #1506.
Using ${CMAKE_THREAD_LIBS_INIT} everywhere is more consistent than doing a one-off for the one place where it is strictly necessary.
This also avoids that things break elsewhere in the future if some other part of the code starts using new parts of std::atomic that need libatomic.
