### PR TITLE
[Server] Use length returned by read and fix an alignment check in pgRead

### DIFF
--- a/src/XrdOss/XrdOss.cc
+++ b/src/XrdOss/XrdOss.cc
@@ -172,7 +172,7 @@ ssize_t XrdOssDF::pgRead(void     *buffer,
 // Calculate checksums if so wanted
 //
    if (bytes > 0 && csvec) 
-      XrdOucPgrwUtils::csCalc((const char *)buffer, offset, rdlen, csvec);
+      XrdOucPgrwUtils::csCalc((const char *)buffer, offset, bytes, csvec);
 
 // All done
 //

--- a/src/XrdOuc/XrdOucCache.cc
+++ b/src/XrdOuc/XrdOucCache.cc
@@ -44,12 +44,6 @@ int XrdOucCacheIO::pgRead(char                  *buff,
 {
    int bytes;
 
-// Make sure the offset is on a 4K boundary and the size is a multiple of
-// 4k as well (we use simple and for this).
-//
-   if ((offs & XrdSys::PageMask)
-   || (rdlen & XrdSys::PageMask)) return -EINVAL;
-
 // Read the data into the buffer
 //
    bytes = Read(buff, offs, rdlen);
@@ -58,7 +52,7 @@ int XrdOucCacheIO::pgRead(char                  *buff,
 //
    if (bytes > 0 && (opts & forceCS))
        XrdOucPgrwUtils::csCalc((const char *)buff, (ssize_t)offs,
-                               (size_t)rdlen, csvec);
+                               (size_t)bytes, csvec);
 
 // All done
 //


### PR DESCRIPTION
Changes XrdOssDF and XrdOucCacheIO pgRead to use the length returned by read when calculating the checksums, rather than the requested read size. Believed to fix issue #1507 (due to XrdOucCacheIO pgRead).

Also removes an alignment check which may have been inadvertently re-added to XrdOucCacheIO::pgRead during a rebase.