### PR TITLE
Add missing headers to XrdClPipelineSources cmake var

### DIFF
--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -15,9 +15,11 @@ if( XrdClPipelines )
   set( XrdClPipelineSources
        XrdClOperations.cc            XrdClOperations.hh
        XrdClOperationHandlers.hh
+       XrdClOperationTimeout.hh
        XrdClArg.hh
        XrdClFwd.hh
        XrdClParallelOperation.hh
+       XrdClFinalOperation.hh
        XrdClFileOperations.hh
        XrdClFileSystemOperations.hh
        XrdClZipArchive.cc            XrdClZipArchive.hh


### PR DESCRIPTION
Fixes #1519 

I wanted to give this a try. Hopefully it is enough, let me know or feel free to just discard this PR