### PR TITLE
[XrdCmsRedirLocal] Add localroot option for plug-in. Improve fault tolerance of RedirLocal plug-in

### DIFF
--- a/src/XrdCms/XrdCmsRedirLocal.cc
+++ b/src/XrdCms/XrdCmsRedirLocal.cc
@@ -85,6 +85,11 @@ void XrdCmsRedirLocal::loadConfig(const char *filename) {
         httpRedirect = false;
       }
     }
+    // search for localroot,
+    // which manually sets localroot to prepend
+    else if (strcmp(word, "xrdcmsredirlocal.localroot") == 0){
+      localroot = std::string(Config.GetWord(true));//to lower case
+    }
   }
   Config.Close();
 }
@@ -161,13 +166,8 @@ int XrdCmsRedirLocal::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
         return rcode;
     }
     // passed all checks, now to actual business
-    // build a buffer with a total acceptable buffer length,
-    // which must have a larger capacity than localroot and filename concatenated
-    int rc = 0;
-    int maxPathLength = 4096;
-    char *buff = new char[maxPathLength];
-    // prepend oss.localroot
-    std::string ppath = "file://" + std::string(theSS->Lfn2Pfn(path, buff, maxPathLength, rc));
+    // prepend manually configured localroot
+    std::string ppath = "file://" + localroot + path;
     if (strncmp(dialect.c_str(), "http", 4) == 0)
     {
       // set info which will be sent to client
@@ -178,7 +178,6 @@ int XrdCmsRedirLocal::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
       // set info which will be sent to client
       Resp.setErrInfo(-1, ppath.c_str());
     }
-    delete[] buff;
     return SFS_REDIRECT;
   }
   return rcode;

--- a/src/XrdCms/XrdCmsRedirLocal.hh
+++ b/src/XrdCms/XrdCmsRedirLocal.hh
@@ -77,6 +77,7 @@ public:
   XrdOss *theSS;
   bool readOnlyredirect;
   bool httpRedirect;
+  std::string localroot;
 };
 
 #endif // XRDCMSREDIRPLUGIN_HH_

--- a/src/XrdCms/XrdCmsRedirLocal.hh
+++ b/src/XrdCms/XrdCmsRedirLocal.hh
@@ -74,10 +74,10 @@ public:
   //! used to forward requests to CmsFinder with regular implementation
   //---------------------------------------------------------------------------
   XrdCmsClient *nativeCmsFinder;
-  XrdOss *theSS;
   bool readOnlyredirect;
   bool httpRedirect;
   std::string localroot;
+  XrdSysError Say;
 };
 
 #endif // XRDCMSREDIRPLUGIN_HH_


### PR DESCRIPTION
Until now, the plug-in used oss.localroot set in the redirector, to calculate the new paths. This led to conflicts described in issue  #1278 . Adding a config option with a localroot onl for the plug-in, this issue is resolved.

The second commit increases the fault tolerance: Before this commit, if a client is redirected to the local filesystem, but does not find the file there, a redirection loop is started.
Example:
`
Open has returned with status [FATAL] Redirect limit has been reached
Error while opening at 192.168.122.200:1094: [FATAL] Redirect limit has been reached
Redirect trace-back:
	0. Redirected from: root://192.168.122.200:1094//autoTest1 to: file://localhost/xrdmnt//autoTest1
 	1. Retrying: root://192.168.122.200:1094//autoTest1
	2. Redirected from: root://192.168.122.200:1094//autoTest1 to: file://localhost/xrdmnt//xrdmnt/autoTest1
	3. Retrying: root://192.168.122.200:1094//autoTest1
	4. Redirected from: root://192.168.122.200:1094//autoTest1 to: file://localhost/xrdmnt//xrdmnt/xrdmnt/autoTest1
	...
`
With the new changes, the plug-in checks if localroot is in the path AND if the EnvInfo shows that the client has already tried localhost. The result is this:
` Redirect trace-back:
 	0. Redirected from: root://192.168.122.200:1094//autoTest1 to: file://localhost/xrdmnt//autoTest1
 	1. Retrying: root://192.168.122.200:1094//autoTest1
 	2. Waited at server request. Resending: root://192.168.122.200:1094//autoTest1
 	3. Waited at server request. Resending: root://192.168.122.200:1094//autoTest1
 	4. Redirected from: root://192.168.122.200:1094//autoTest1 to: root://192.168.122.202:1094//autoTest1
`

The client tries a second time and gets redirected to the dataserver it would normally have contacted