### PR TITLE
Log davs:// https:// transfer stats in the logs

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -184,6 +184,19 @@ private:
                  : extHName(hName), extHPath(hPath), extHParm(hParm) {}
         ~extHInfo() {}
   };
+
+  struct LogRecord {
+       bool paramsSet;
+       std::string log_prefix;
+       XrdOucString* filename;
+       std::string remote;
+       std::string name;
+       std::string reqtype;
+       int reqstate{-1};
+       int status{-1};
+  };
+  LogRecord rec;
+
   /// Functions related to the configuration
   static int Config(const char *fn, XrdOucEnv *myEnv);
   static const char *Configed();

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -41,6 +41,7 @@
 
 #include "XrdOuc/XrdOucString.hh"
 
+#include "XrdSys/XrdSysError.hh"
 #include "XProtocol/XProtocol.hh"
 #include "XrdXrootd/XrdXrootdBridge.hh"
 
@@ -98,6 +99,9 @@ private:
 
   void getfhandle();
 
+  std::string EnumToString( int enumVal );
+  void logTransferEvent(const int debug, const int retval, const char *message);
+
   // Process the checksum response and return a header that should
   // be included in the response.
   int PostProcessChecksum(std::string &digest_header);
@@ -113,6 +117,7 @@ private:
   void parseResource(char *url);
   // Map an XRootD error code to an appropriate HTTP status code and message
   void mapXrdErrorToHttpStatus();
+
 public:
 
   XrdHttpReq(XrdHttpProtocol *protinstance) : keepalive(true) {

--- a/src/XrdHttp/XrdHttpTrace.hh
+++ b/src/XrdHttp/XrdHttpTrace.hh
@@ -47,6 +47,8 @@
 #define TRACE_ALL       0x0fff
 #define TRACE_AUTH      0x0001
 #define TRACE_DEBUG     0x0002
+#define TRACE_STATS     0x0004
+#define TRACE_STATSALL  0x0008
 #define TRACE_MEM       0x0010
 #define TRACE_REQ       0x0020
 #define TRACE_REDIR     0x0040


### PR DESCRIPTION
This is what it will give in the logs (based on the http.trace flag `stats|statsall`:
```
211013 16:26:47 2630835 http_Req: ALL_STATS_REPORT: retval=501, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=POST, reqstate=0, remote=[2605:d9c0:1:9::1:1]; Request not supported.
211013 16:26:47 2631149 http_Req: ALL_STATS_REPORT: retval=207, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=PROPFIND, reqstate=0, remote=[2605:d9c0:1:9::1:1];
211013 16:26:47 2630834 http_Req: ALL_STATS_REPORT: retval=501, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=POST, reqstate=0, remote=[2605:d9c0:1:9::1:1]; Request not supported.
211013 16:26:47 2630835 http_Req: ALL_STATS_REPORT: retval=207, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=PROPFIND, reqstate=0, remote=[2605:d9c0:1:9::1:1];
211013 16:26:47 2631149 http_Req: ALL_STATS_REPORT: retval=200, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=GET, reqstate=0, remote=[2605:d9c0:1:9::1:1]; STAT
211013 16:26:47 2631149 http_Req: STATS_REPORT: retval=200, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=GET, reqstate=1, remote=[2605:d9c0:1:9::1:1]; OPEN
211013 16:26:47 2631149 http_Req: ALL_STATS_REPORT: retval=200, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=GET, reqstate=1, remote=[2605:d9c0:1:9::1:1]; FINISHED
211013 16:26:55 2631149 http_Req: STATS_REPORT: retval=200, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=GET, reqstate=2032, remote=[2605:d9c0:1:9::1:1]; OPEN-FINISH
211013 16:26:55 2631149 http_Req: STATS_REPORT: retval=200, filename=/store/user/jbalcas/2/3/5.root, user=jbalcas, reqtype=GET, reqstate=2032, remote=[2605:d9c0:1:9::1:1]; FINISH-DONE-OK
```
There might be need to change/add more TRACE - but this can be done later. 

@bbockelm please review. Thanks!