### PR TITLE
Do not hardcode error numbers

### DIFF
--- a/src/XrdPosix/XrdPosixMap.cc
+++ b/src/XrdPosix/XrdPosixMap.cc
@@ -44,6 +44,10 @@
 #define ENOSR ENOSPC
 #endif
 
+#ifndef ECHRNG
+#define ECHRNG EINVAL
+#endif
+
 /******************************************************************************/
 /*                        S t a t i c   M e m b e r s                         */
 /******************************************************************************/
@@ -79,10 +83,6 @@ mode_t XrdPosixMap::Flags2Mode(dev_t *rdv, uint32_t flags)
 /******************************************************************************/
 /* Private:                      m a p C o d e                                */
 /******************************************************************************/
-
-#ifndef ECHRNG
-#define ECHRNG 44
-#endif
 
 int XrdPosixMap::mapCode(int rc)
 {


### PR DESCRIPTION
The error numbers defined on Linux can not be reused on other systems
since this causes clashes.

On Linux ECHRNG is 44, but defining ECHRNG to be 44 on systems that do
not define ECHRNG is not appropriate. On e.g. kFreeBSD this will clash
with ESOCKTNOSUPPORT, which is defined as 44 on that system.