### PR TITLE
Fix build failure on platforms where char is unsigned (ARM, PPC and S390X)

### DIFF
--- a/src/XrdSys/XrdSysTrace.hh
+++ b/src/XrdSys/XrdSysTrace.hh
@@ -116,7 +116,7 @@ const char      *iName;
 short            dPnt;
 short            dFree;
 short            vPnt;
-char             doHex;
+signed char      doHex;
 struct iovec     ioVec[iovMax];
 char             pBuff[pfxMax];
 char             dBuff[txtMax];


### PR DESCRIPTION
~~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:177:22: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  177 |            if (doHex < 0) doHex = 0;
      |                ~~~~~~^~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc: In member function 'XrdSysTrace& XrdSysTrace::operator<<(short int)':
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:232:14: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  232 |    if (doHex < 0) doHex = 0;
      |        ~~~~~~^~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc: In member function 'XrdSysTrace& XrdSysTrace::operator<<(int)':
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:255:14: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  255 |    if (doHex < 0) doHex = 0;
      |        ~~~~~~^~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc: In member function 'XrdSysTrace& XrdSysTrace::operator<<(long long int)':
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:291:14: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  291 |    if (doHex < 0) doHex = 0;
      |        ~~~~~~^~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc: In member function 'XrdSysTrace& XrdSysTrace::operator<<(short unsigned int)':
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:314:14: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  314 |    if (doHex < 0) doHex = 0;
      |        ~~~~~~^~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc: In member function 'XrdSysTrace& XrdSysTrace::operator<<(unsigned int)':
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:337:14: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  337 |    if (doHex < 0) doHex = 0;
      |        ~~~~~~^~~
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc: In member function 'XrdSysTrace& XrdSysTrace::operator<<(long long unsigned int)':
/builddir/build/BUILD/xrootd-5.3.2/src/XrdSys/XrdSysTrace.cc:373:14: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  373 |    if (doHex < 0) doHex = 0;
      |        ~~~~~~^~~
~~~

This PR is against stable-5.3.x since the code has changed in master.