### PR TITLE
[XrdThrottle] do not initialise a string with a null pointer (5.3.x)

### DIFF
--- a/src/XrdThrottle/XrdThrottleFile.cc
+++ b/src/XrdThrottle/XrdThrottleFile.cc
@@ -32,7 +32,7 @@ File::File(const char                     *user,
      m_sfs(sfs),
 #endif
      m_uid(0),
-     m_user(user),
+     m_user(user ? user : ""),
      m_throttle(throttle),
      m_eroute(eroute)
 {}


### PR DESCRIPTION
Fix for https://github.com/xrootd/xrootd/issues/1544

(for stable-5.3.x)