### PR TITLE
Fix typos

### DIFF
--- a/docs/man/xrdcp.1
+++ b/docs/man/xrdcp.1
@@ -159,7 +159,7 @@ local.
 .RE
 \fB-X\fR | \fB--xrate-threshold\fR \fIrate\fR
 .RS 5
-If the transfer rate drops bellow given threshold force the client to use
+If the transfer rate drops below given threshold force the client to use
 different source or if no more sources are available fail the transfer.
 
 .RE

--- a/src/Xrd/XrdLink.cc
+++ b/src/Xrd/XrdLink.cc
@@ -373,7 +373,7 @@ void XrdLink::Serialize()
 {
 
 // This is meant to make sure that no protocol objects are refering to this
-// link so that we can safely run in psuedo single thread mode for critical
+// link so that we can safely run in pseudo single thread mode for critical
 // functions.
 //
    linkXQ.LinkInfo.opMutex.Lock();

--- a/src/XrdApps/XrdClProxyPlugin/README.md
+++ b/src/XrdApps/XrdClProxyPlugin/README.md
@@ -1,6 +1,6 @@
 # XrdClProxyPrefix Plugin
 
-This XRootD Client Plugin can be used to tunnel traffic through an XRootD Proxy machine. The proxy endpoint is specifed as an environment variable. To enable this plugin the **XRD_PLUGIN** environment variable needs to point to the **libXrdClProxyPlugin.so** library.
+This XRootD Client Plugin can be used to tunnel traffic through an XRootD Proxy machine. The proxy endpoint is specified as an environment variable. To enable this plugin the **XRD_PLUGIN** environment variable needs to point to the **libXrdClProxyPlugin.so** library.
 
 For example:
 

--- a/src/XrdApps/XrdCpConfig.cc
+++ b/src/XrdApps/XrdCpConfig.cc
@@ -991,7 +991,7 @@ void XrdCpConfig::Usage(int rc)
    "-V | --version                prints the version number\n"
    "-X | --xrate <rate>           limits the transfer to the specified rate. You can\n"
    "                              suffix the value with 'k', 'm', or 'g'\n"
-   "     --xrate-threshold <rate> If the transfer rate drops bellow given threshold force\n"
+   "     --xrate-threshold <rate> If the transfer rate drops below given threshold force\n"
    "                              the client to use different source or if no more sources\n"
    "                              are available fail the transfer. You can suffix the value\n"
    "                              with 'k', 'm', or 'g'\n"

--- a/src/XrdCl/XrdClParallelOperation.hh
+++ b/src/XrdCl/XrdClParallelOperation.hh
@@ -272,7 +272,7 @@ namespace XrdCl
             return false;
           }
           size_t f = failed.fetch_add( 1, std::memory_order_relaxed );
-          // did we dropped bellow the threshold
+          // did we drop below the threshold
           if( f == size - threshold ) return true;
           // we still have a chance there will be enough of successful operations
           return false;
@@ -313,7 +313,7 @@ namespace XrdCl
           // although we might have the minimum to succeed we wait for the rest
           if( status.IsOK() ) return ( pending == 0 );
           size_t nb = failed_cnt.fetch_add( 1, std::memory_order_relaxed );
-          if( nb == failed_threshold ) res = status; // we dropped bellow the threshold
+          if( nb == failed_threshold ) res = status; // we dropped below the threshold
           // if we still have to wait for pending operations return false,
           // otherwise all is done, return true
           return ( pending == 0 );

--- a/src/XrdCl/XrdClPostMaster.cc
+++ b/src/XrdCl/XrdClPostMaster.cc
@@ -477,7 +477,7 @@ namespace XrdCl
     }
 
     Log *log = DefaultEnv::GetLog();
-    log->Info( PostMasterMsg, "Lable channel %s with alias %s.",
+    log->Info( PostMasterMsg, "Label channel %s with alias %s.",
                url.GetHostId().c_str(), alias.GetHostId().c_str() );
 
     Channel *active = new Channel( alias, pImpl->pPoller, trHandler,

--- a/src/XrdCms/XrdCmsClientConfig.cc
+++ b/src/XrdCms/XrdCmsClientConfig.cc
@@ -135,7 +135,7 @@ int XrdCmsClientConfig::Configure(const char *cfn, configWhat What,
    temp = XrdOucUtils::genPath(CMSPath, (const char *)0, ".olb");
    free(CMSPath); CMSPath = temp;
    XrdOucEnv::Export("XRDCMSPATH", temp);
-   XrdOucEnv::Export("XRDOLBPATH", temp); //Compatability
+   XrdOucEnv::Export("XRDOLBPATH", temp); //Compatibility
 
 // Determine what type of role we are playing
 //
@@ -246,7 +246,7 @@ int XrdCmsClientConfig::ConfigProc(const char *ConfigFN)
 //
    while((var = Config.GetMyFirstWord()))
         {if (!strncmp(var, "cms.", 4)
-         ||  !strncmp(var, "odc.", 4)      // Compatability
+         ||  !strncmp(var, "odc.", 4)      // Compatibility
          ||  !strcmp(var, "all.manager")
          ||  !strcmp(var, "all.adminpath")
          ||  !strcmp(var, "olb.adminpath"))

--- a/src/XrdNet/XrdNetPMarkCfg.cc
+++ b/src/XrdNet/XrdNetPMarkCfg.cc
@@ -214,7 +214,7 @@ XrdNetPMark::Handle *XrdNetPMarkCfg::Begin(XrdNetAddrInfo      &addrInfo,
           }
       }
 
-// If we are allowed to use the flow label set on the incomming connection
+// If we are allowed to use the flow label set on the incoming connection
 // then try to do so. This is only valid for IPv6 connections. Currently,
 // this is not implemented.
 //

--- a/src/XrdNet/XrdNetRegistry.cc
+++ b/src/XrdNet/XrdNetRegistry.cc
@@ -119,7 +119,7 @@ const char *XrdNetRegistry::GetAddrs(const std::string       &hSpec,
    XrdSysMutexHelper mHelp(regMutex);
    if (!(reP = regEntry::Find(hSpec.c_str())))
       {aVec.clear();
-       return "psuedo host not registered";
+       return "pseudo host not registered";
       }
 
 // Hold this entry as we don't want to hold the global lock doing DNS lookups.

--- a/src/XrdOfs/XrdOfs.hh
+++ b/src/XrdOfs/XrdOfs.hh
@@ -344,7 +344,7 @@ const   char          *getVersion();
                                 const char             *opaque = 0);
 // Management functions
 //
-virtual int            Configure(XrdSysError &); // Backward Compatability
+virtual int            Configure(XrdSysError &); // Backward Compatibility
 
 virtual int            Configure(XrdSysError &, XrdOucEnv *);
 

--- a/src/XrdOss/XrdOssStat.cc
+++ b/src/XrdOss/XrdOssStat.cc
@@ -232,7 +232,7 @@ int XrdOssSys::StatLS(XrdOucEnv &env, const char *path, char *buff, int &blen)
    char *cgrp, cgbuff[XrdOssSpace::minSNbsz];
    int retc;
 
-// We provide psuedo support whould be not have a cache
+// We provide pseudo support whould be not have a cache
 //
    if (!XrdOssCache_Group::fsgroups)
       {unsigned long long Opt;
@@ -244,7 +244,7 @@ int XrdOssSys::StatLS(XrdOucEnv &env, const char *path, char *buff, int &blen)
        return XrdOssOK;
       }
 
-// Find the cache group. We provide psuedo support should we not have a cache
+// Find the cache group. We provide pseudo support should we not have a cache
 //
    if (!(cgrp = env.Get(OSS_CGROUP)))
       {if ((retc = getCname(path, &sbuff, cgbuff))) return retc;

--- a/src/XrdOssCsi/XrdOssCsiPages.cc
+++ b/src/XrdOssCsi/XrdOssCsiPages.cc
@@ -250,7 +250,7 @@ int XrdOssCsiPages::VerifyRange(XrdOssDF *const fd, const void *buff, const off_
 
    if (offset+blen > static_cast<size_t>(trackinglen))
    {
-      TRACE(Warn, "Verify request for " << (offset+blen-trackinglen) << " bytes from " << fn_ << " beyond tracked lengh");
+      TRACE(Warn, "Verify request for " << (offset+blen-trackinglen) << " bytes from " << fn_ << " beyond tracked length");
       return -EDOM;
    }
 
@@ -663,7 +663,7 @@ int XrdOssCsiPages::FetchRange(
 
    if (offset+blen > static_cast<size_t>(trackinglen))
    {
-      TRACE(Warn, "Fetch request for " << (offset+blen-trackinglen) << " bytes from " << fn_ << " beyond tracked lengh");
+      TRACE(Warn, "Fetch request for " << (offset+blen-trackinglen) << " bytes from " << fn_ << " beyond tracked length");
       return -EDOM;
    }
 

--- a/src/XrdOuc/XrdOucGatherConf.cc
+++ b/src/XrdOuc/XrdOucGatherConf.cc
@@ -170,7 +170,7 @@ int XrdOucGatherConf::Gather(const char *cfname, Level lvl, const char *parms)
             }
         }
 
-// Now check if any errors occured during file i/o
+// Now check if any errors occurred during file i/o
 //
    if ((rc = Config.LastError()))
       {if (eDest) eDest->Emsg("Gcf", rc, "read config file", cfname);

--- a/src/XrdOuc/XrdOucSHA3.hh
+++ b/src/XrdOuc/XrdOucSHA3.hh
@@ -131,7 +131,7 @@ static void SHAKE_Update(sha3_ctx_t *c, const void *data, size_t len)
 //-----------------------------------------------------------------------------
 //! Return final message digest of desired length. This function may be called
 //! iteratively to get as many bits as needed. Bits beyound MDLen form a
-//! psuedo-random sequence (i.e. are repeatable with the same input).
+//! pseudo-random sequence (i.e. are repeatable with the same input).
 //!
 //! @param  c       Pointer to context.
 //! @param  out     Pointer to buffer of size len to receive result.

--- a/src/XrdPosix/XrdPosixObject.cc
+++ b/src/XrdPosix/XrdPosixObject.cc
@@ -310,7 +310,7 @@ void XrdPosixObject::Shutdown()
    XrdPosixObject *oP;
    int i;
 
-// Destory all files and static data
+// Destroy all files and static data
 //
    fdMutex.Lock();
    if (myFiles)

--- a/src/XrdXrootd/XrdXrootdConfigMon.cc
+++ b/src/XrdXrootd/XrdXrootdConfigMon.cc
@@ -284,7 +284,7 @@ int XrdXrootdProtocol::xmon(XrdOucStream &Config)
                   {char bName[16], bType = *val;
                    snprintf(bName,sizeof(bName),"monitor %s",val);
                    if (!(val = Config.GetWord()))
-                      {eDest.Emsg("Config", "value not specifed"); return 1;}
+                      {eDest.Emsg("Config", "value not specified"); return 1;}
                    if (XrdOuca2x::a2sz(eDest,bName,val,&tempval,1024,65535))
                       return 1;
                    int bVal = static_cast<int>(tempval);

--- a/src/XrdXrootd/XrdXrootdXeqChkPnt.cc
+++ b/src/XrdXrootd/XrdXrootdXeqChkPnt.cc
@@ -139,7 +139,7 @@ int XrdXrootdProtocol::do_ChkPntXeq()
    if (Request.header.requestid == kXR_chkpoint)
       {ClientRequestHdr *Subject = (ClientRequestHdr *)(argp->buff);
        if (memcmp(Request.header.streamid, Subject->streamid, sidSZ))
-          {Response.Send(kXR_ArgInvalid, "Request streamid missmatch");
+          {Response.Send(kXR_ArgInvalid, "Request streamid mismatch");
            return -1;
           }
        if (Request.header.dlen != sizeof(Request.header))


### PR DESCRIPTION
bellow → below
compatability → compatibility
destory → destroy
incomming → incoming
lable → label
lengh → length
missmatch → mismatch
occured → occurred
psuedo → pseudo
specifed → specified