### PR TITLE
Rebased version of PR#1493

### DIFF
--- a/src/XrdCrypto/XrdCryptoFactory.hh
+++ b/src/XrdCrypto/XrdCryptoFactory.hh
@@ -79,7 +79,7 @@ typedef int (*XrdCryptoX509ChainToFile_t)(XrdCryptoX509Chain *, const char *);
 
 // certificates from file parsing
 typedef int (*XrdCryptoX509ParseFile_t)(const char *fname,
-                                        XrdCryptoX509Chain *);
+                                        XrdCryptoX509Chain *, const char *);
 
 // certificates from STACK_OF(X509*)
 typedef int (*XrdCryptoX509ParseStack_t)(XrdTlsPeerCerts* pc,

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -514,18 +514,20 @@ int XrdCryptosslX509ParseFile(FILE *fcer,
    // If we found something, and we are asked to extract a key,
    // rewind and look for it
    if (nci) {
+      FILE *fcersave = 0;
       if (!fkey) {
          // Look in the same file, after rewinding
          rewind(fcer);
       } else {
          // We can close the file now
-         fclose(fcer);
+         fcersave = fcer;
 	 // Open key file
          fcer = fopen(fkey, "r");
          if (!fcer) {
            DEBUG("unable to open key file (errno: "<<errno<<")");
+           fcer = fcersave;
            return nci;
-         }	 
+         }
       }
       RSA  *rsap = 0;
       if (!PEM_read_RSAPrivateKey(fcer, &rsap, 0, 0)) {
@@ -579,6 +581,11 @@ int XrdCryptosslX509ParseFile(FILE *fcer,
          }
          // Cleanup
          BIO_free(bkey);
+      }
+      if (fkey) {
+         // Re-establish original fcer pointer
+         fclose(fcer);
+         fcer = fcersave;
       }
    }
 

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -452,7 +452,7 @@ int XrdCryptosslX509ParseStack(XrdTlsPeerCerts* pc, XrdCryptoX509Chain *chain)
 
 //____________________________________________________________________________
 int XrdCryptosslX509ParseFile(const char *fname,
-                              XrdCryptoX509Chain *chain)
+                              XrdCryptoX509Chain *chain, const char *fkey)
 {
    EPNAME("X509ParseFile");
 
@@ -465,7 +465,7 @@ int XrdCryptosslX509ParseFile(const char *fname,
       return 0;
    }
 
-   auto retval = XrdCryptosslX509ParseFile(fcer, chain, fname);
+   auto retval = XrdCryptosslX509ParseFile(fcer, chain, fname, fkey);
    fclose(fcer);
    return retval;
 }
@@ -473,7 +473,7 @@ int XrdCryptosslX509ParseFile(const char *fname,
 //____________________________________________________________________________
 int XrdCryptosslX509ParseFile(FILE *fcer,
                               XrdCryptoX509Chain *chain,
-                              const char *fname)
+                              const char *fname, const char *fkey)
 {
    // Parse content of file 'fname' and add X509 certificates to
    // chain (which must be initialized by the caller).
@@ -514,7 +514,19 @@ int XrdCryptosslX509ParseFile(FILE *fcer,
    // If we found something, and we are asked to extract a key,
    // rewind and look for it
    if (nci) {
-      rewind(fcer);
+      if (!fkey) {
+         // Look in the same file, after rewinding
+         rewind(fcer);
+      } else {
+         // We can close the file now
+         fclose(fcer);
+	 // Open key file
+         fcer = fopen(fkey, "r");
+         if (!fcer) {
+           DEBUG("unable to open key file (errno: "<<errno<<")");
+           return nci;
+         }	 
+      }
       RSA  *rsap = 0;
       if (!PEM_read_RSAPrivateKey(fcer, &rsap, 0, 0)) {
          DEBUG("no RSA private key found in file " << fname);

--- a/src/XrdCrypto/XrdCryptosslAux.hh
+++ b/src/XrdCrypto/XrdCryptosslAux.hh
@@ -62,9 +62,9 @@ int XrdCryptosslX509ChainToFile(XrdCryptoX509Chain *c, const char *fn);
 // export single certificate to file; fname is solely for debug message purposes
 extern "C" int XrdCryptosslX509ToFile(XrdCryptoX509 *x509, FILE *file, const char *fname);
 // certificates from file parsing
-int XrdCryptosslX509ParseFile(const char *fname, XrdCryptoX509Chain *c);
+int XrdCryptosslX509ParseFile(const char *fname, XrdCryptoX509Chain *c, const char *fkey = 0);
 // certificates from FILE object; fname is solely for debug message purposes
-extern "C" int XrdCryptosslX509ParseFile(FILE *file, XrdCryptoX509Chain *c, const char *fname);
+extern "C" int XrdCryptosslX509ParseFile(FILE *file, XrdCryptoX509Chain *c, const char *fname, const char *fkey = 0);
 // certificates from bucket parsing
 int XrdCryptosslX509ParseBucket(XrdSutBucket *b, XrdCryptoX509Chain *c);
 // certificates from STACK_OF(X509*)

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3043,6 +3043,11 @@ int XrdSecProtocolgsi::ClientDoInit(XrdSutBuffer *br, XrdSutBuffer **bm,
    //
    // Extract no proxy option, if any
    bool createpxy = (PxyReqOpts & kOptsCreatePxy) ? 1 : 0;
+   if (hs->RemVers < XrdSecgsiVersCertKey && !createpxy) {
+      // Server does not accept pure cert files
+      createpxy = 1;
+      DEBUG("Server does not accept pure cert/key authentication: version < "<< (int)XrdSecgsiVersCertKey);
+   }
 
    //
    // Resolve place-holders in cert, key and proxy file paths, if any

--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -1016,8 +1016,8 @@ char *XrdSecProtocolgsi::Init(gsiOptions opt, XrdOucErrInfo *erp)
       }
       //
       // No proxy options
-      if (opt.nopxy) {
-         PxyReqOpts |= kOptsNoPxy;
+      if (opt.createpxy) {
+         PxyReqOpts |= kOptsCreatePxy;
       }
       //
       // Define valid CNs for the server certificates; default is null, which means that
@@ -1033,8 +1033,8 @@ char *XrdSecProtocolgsi::Init(gsiOptions opt, XrdOucErrInfo *erp)
       TRACE(Authen, "proxy: depth of signature path: "<<DepLength);
       TRACE(Authen, "proxy: bits in key:             "<<DefBits);
       TRACE(Authen, "server cert: allowed names:     "<<SrvAllowedNames);
-      if (PxyReqOpts & kOptsNoPxy) {
-         TRACE(Authen, "forcing 'no proxy' cert/key authentication ");
+      if (!(PxyReqOpts & kOptsCreatePxy)) {
+         TRACE(Authen, "allowing for pure cert/key authentication (no proxy) ");
       }
 
       // We are done
@@ -2299,7 +2299,7 @@ void gsiOptions::Print(XrdOucTrace *t)
       POPTS(t, " Proxy bits: " << bits);
       POPTS(t, " Proxy sign option: "<< sigpxy);
       POPTS(t, " Proxy delegation option: "<< dlgpxy);
-      if (nopxy) POPTS(t, " Cert/Key authentication enforced");
+      if (createpxy) POPTS(t, " Pure Cert/Key authentication allowed");
       POPTS(t, " Allowed server names: "<< (srvnames ? srvnames : "[*/]<target host name>[/*]"));
    } else {
       POPTS(t, " Certificate: " << (cert ? cert : XrdSecProtocolgsi::SrvCert));
@@ -2413,8 +2413,9 @@ char *XrdSecProtocolgsiInit(const char mode,
       //                                     0 deny; 1 sign request created
       //                                     by server; 2 forward local proxy
       //                                     (include private key) [1]
-      //             "XrdSecGSINOPROXY"      Controls use of proxy:
-      //                                     0 use proxy; 1 use certificate+key [0]
+      //             "XrdSecGSICREATEPROXY"  Controls use of proxy [1]:
+      //                                       1 auto-generate proxy from the cert/key pair if no one is not found
+      //                                       0 a proxy is used if present; else, the cert/key pair is used if present.
       //             "XrdSecGSISRVNAMES"     Server names allowed: if the server CN
       //                                     does not match any of these, or it is
       //                                     explicitely denied by these, or it is
@@ -2505,9 +2506,9 @@ char *XrdSecProtocolgsiInit(const char mode,
          opts.dlgpxy = atoi(cenv);
 
       // No proxy
-      cenv = getenv("XrdSecGSINOPROXY");
+      cenv = getenv("XrdSecGSICREATEPROXY");
       if (cenv)
-         opts.nopxy = atoi(cenv);
+         opts.createpxy = atoi(cenv);
 
       // Allowed server name formats
       cenv = getenv("XrdSecGSISRVNAMES");
@@ -3041,7 +3042,7 @@ int XrdSecProtocolgsi::ClientDoInit(XrdSutBuffer *br, XrdSutBuffer **bm,
 
    //
    // Extract no proxy option, if any
-   bool nopxy = (PxyReqOpts & kOptsNoPxy) ? 1 : 0;
+   bool createpxy = (PxyReqOpts & kOptsCreatePxy) ? 1 : 0;
 
    //
    // Resolve place-holders in cert, key and proxy file paths, if any
@@ -3055,18 +3056,16 @@ int XrdSecProtocolgsi::ClientDoInit(XrdSutBuffer *br, XrdSutBuffer **bm,
    }
    //
    // In the standard case we need to resolve also the proxy file path
-   if (!nopxy) {
-      // Get the proxy path
-      if (XrdSutResolve(UsrProxy, Entity.host, Entity.vorg, Entity.grps, Entity.name) != 0) {
-         PRINT("Problems resolving templates in "<<UsrProxy);
-         return -1;
-      }
+   // Get the proxy path
+   if (XrdSutResolve(UsrProxy, Entity.host, Entity.vorg, Entity.grps, Entity.name) != 0) {
+      PRINT("Problems resolving templates in "<<UsrProxy);
+      return -1;
    }
    //
    // Load / Attach-to user proxies
    ProxyIn_t pi = {UsrCert.c_str(), UsrKey.c_str(), CAdir.c_str(),
                    UsrProxy.c_str(), PxyValid.c_str(),
-                   DepLength, DefBits, nopxy};
+                   DepLength, DefBits, createpxy};
    ProxyOut_t po = {hs->PxyChain, sessionKsig, hs->Cbck };
    if (QueryProxy(1, &cachePxy, UsrProxy.c_str(),
                   sessionCF, hs->TimeStamp, &pi, &po) != 0) {
@@ -3808,14 +3807,14 @@ int XrdSecProtocolgsi::ServerDoCert(XrdSutBuffer *br,  XrdSutBuffer **bm,
       return -1;
    }
    // Parse bucket
-   int ncimin = (hs->Options & kOptsNoPxy) ? 1 : 2;
+   int ncimin = (hs->Options & kOptsCreatePxy) ? 2 : 1;
    int nci = (*ParseBucket)(bck, hs->Chain);
    if (nci < ncimin) {
-      cmsg = "wrong number of certificates in received bucket (";
+      cmsg = "wrong number of certificates in received bucket (received: ";
       cmsg += nci;
-      cmsg += " > ";
+      cmsg += ", expected: >= ";
       cmsg += ncimin;
-      cmsg += " expected)";
+      cmsg += ")";
       return -1;
    }
    //
@@ -5056,7 +5055,7 @@ int XrdSecProtocolgsi::QueryProxy(bool checkcache, XrdSutCache *cache,
    while (!hasproxy && ntry > 0) {
 
       // Try init as last option if not in pure cert/key mode
-      if (ntry == 1 && !pi->nopxy) {
+      if (ntry == 1 && pi->createpxy) {
 
          // Cleanup the chain
          po->chain->Cleanup();
@@ -5111,23 +5110,25 @@ int XrdSecProtocolgsi::QueryProxy(bool checkcache, XrdSutCache *cache,
                   continue;
                }
             }
-            if (pi->nopxy) {
-               // Parse the cert file
-               int nci = (*ParseFile)(pi->cert, po->chain, pi->key);
-               if (nci < 1) {
-                  DEBUG("proxy files must have at least 1 certificates"
-                        " (found: "<<nci<<")");
-                  continue;
-               }
-            } else {
-               // Parse the proxy file
-               int nci = (*ParseFile)(pi->out, po->chain, 0);
-               if (nci < 2) {
-                  DEBUG("proxy files must have at least 2 certificates"
-                        " (found: "<<nci<<")");
+
+            // Parse the proxy file
+            int nci = (*ParseFile)(pi->out, po->chain, 0);
+            if (nci < 2) {
+               DEBUG("proxy files must have at least 2 certificates"
+                     " (found: "<<nci<<")");
+               if (!pi->createpxy) {
+                  // Parse the cert file if requested
+                  int nci = (*ParseFile)(pi->cert, po->chain, pi->key);
+                  if (nci < 1) {
+                     DEBUG("cert files must have at least 1 certificates"
+                           " (found: "<<nci<<")");
+                     continue;
+                  }
+               } else {
                   continue;
                }
             }
+
             // Check if any CA was in the file
             bool checkselfsigned = (CACheck > caVerifyss) ? true : false;
             po->chain->CheckCA(checkselfsigned);

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -63,7 +63,7 @@ typedef XrdCryptogsiX509Chain X509Chain;
   
 #define XrdSecPROTOIDENT    "gsi"
 #define XrdSecPROTOIDLEN    sizeof(XrdSecPROTOIDENT)
-#define XrdSecgsiVERSION    10500
+#define XrdSecgsiVERSION    10600
 #define XrdSecNOIPCHK       0x0001
 #define XrdSecDEBUG         0x1000
 #define XrdCryptoMax        10
@@ -73,6 +73,8 @@ typedef XrdCryptogsiX509Chain X509Chain;
 
 #define XrdSecgsiVersDHsigned  10400  // Version at which started signing
                                       // of server DH parameters 
+#define XrdSecgsiVersCertKey   10600  // Version at which started supporting
+                                      // authentication with cert/key only
 
 //
 // Message codes either returned by server or included in buffers

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -109,7 +109,7 @@ enum kgsiHandshakeOpts {
    kOptsPxFile     = 16,     // 0x0010: Save delegated proxies in file
    kOptsDelChn     = 32,     // 0x0020: Delete chain
    kOptsPxCred     = 64,     // 0x0040: Save delegated proxies as credentials
-   kOptsNoPxy      = 128     // 0x0080: Do not request a proxy (no client signature)
+   kOptsCreatePxy  = 128     // 0x0080: Request a client proxy
 };
 
 // Error codes
@@ -197,7 +197,7 @@ public:
    int    dlgpxy; // [c] explicitely ask the creation of a delegated proxy; default 0
                   // [s] ask client for proxies; default: do not accept delegated proxies
    int    sigpxy; // [c] accept delegated proxy requests
-   int    nopxy; // [c] force pure cert/key client authentications
+   int    createpxy; // [c] force client proxy authentications
    char  *srvnames;// [c] '|' separated list of allowed server names
    char  *exppxy; // [s] template for the exported file with proxies
    int    authzpxy; // [s] if 1 make proxy available in exported form in the 'endorsement'
@@ -220,7 +220,7 @@ public:
                   ogmap = 1; dlgpxy = 0; sigpxy = 1; srvnames = 0;
                   exppxy = 0; authzpxy = 0;
                   vomsat = 1; vomsfun = 0; vomsfunparms = 0; moninfo = 0;
-                  hashcomp = 1; trustdns = true; nopxy = 0;}
+                  hashcomp = 1; trustdns = true; createpxy = 1;}
    virtual ~gsiOptions() { } // Cleanup inside XrdSecProtocolgsiInit
    void Print(XrdOucTrace *t); // Print summary of gsi option status
 };
@@ -244,7 +244,7 @@ typedef struct {
    const char *valid;
    int         deplen;
    int         bits;
-   bool        nopxy;
+   bool        createpxy;
 } ProxyIn_t;
 
 template<class T>

--- a/src/XrdSecgsi/XrdSecProtocolgsi.hh
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.hh
@@ -63,7 +63,7 @@ typedef XrdCryptogsiX509Chain X509Chain;
   
 #define XrdSecPROTOIDENT    "gsi"
 #define XrdSecPROTOIDLEN    sizeof(XrdSecPROTOIDENT)
-#define XrdSecgsiVERSION    10400
+#define XrdSecgsiVERSION    10500
 #define XrdSecNOIPCHK       0x0001
 #define XrdSecDEBUG         0x1000
 #define XrdCryptoMax        10
@@ -108,7 +108,8 @@ enum kgsiHandshakeOpts {
    kOptsSrvReq     = 8,      // 0x0008: Server request for delegated proxy
    kOptsPxFile     = 16,     // 0x0010: Save delegated proxies in file
    kOptsDelChn     = 32,     // 0x0020: Delete chain
-   kOptsPxCred     = 64      // 0x0040: Save delegated proxies as credentials
+   kOptsPxCred     = 64,     // 0x0040: Save delegated proxies as credentials
+   kOptsNoPxy      = 128     // 0x0080: Do not request a proxy (no client signature)
 };
 
 // Error codes
@@ -196,6 +197,7 @@ public:
    int    dlgpxy; // [c] explicitely ask the creation of a delegated proxy; default 0
                   // [s] ask client for proxies; default: do not accept delegated proxies
    int    sigpxy; // [c] accept delegated proxy requests
+   int    nopxy; // [c] force pure cert/key client authentications
    char  *srvnames;// [c] '|' separated list of allowed server names
    char  *exppxy; // [s] template for the exported file with proxies
    int    authzpxy; // [s] if 1 make proxy available in exported form in the 'endorsement'
@@ -218,7 +220,7 @@ public:
                   ogmap = 1; dlgpxy = 0; sigpxy = 1; srvnames = 0;
                   exppxy = 0; authzpxy = 0;
                   vomsat = 1; vomsfun = 0; vomsfunparms = 0; moninfo = 0;
-                  hashcomp = 1; trustdns = true;}
+                  hashcomp = 1; trustdns = true; nopxy = 0;}
    virtual ~gsiOptions() { } // Cleanup inside XrdSecProtocolgsiInit
    void Print(XrdOucTrace *t); // Print summary of gsi option status
 };
@@ -242,6 +244,7 @@ typedef struct {
    const char *valid;
    int         deplen;
    int         bits;
+   bool        nopxy;
 } ProxyIn_t;
 
 template<class T>

--- a/src/XrdSecgsi/XrdSecgsiProxy.cc
+++ b/src/XrdSecgsi/XrdSecgsiProxy.cc
@@ -224,7 +224,7 @@ int main( int argc, char **argv )
       // Display info about existing proxies
       // Parse the proxy file
       cPXp = new XrdCryptogsiX509Chain();
-      nci = (*ParseFile)(PXcert.c_str(), cPXp);
+      nci = (*ParseFile)(PXcert.c_str(), cPXp, 0);
       if (nci < 2) {
          if (Exists) {
             exitrc = 1;

--- a/src/XrdSecgsi/XrdSecgsitest.cc
+++ b/src/XrdSecgsi/XrdSecgsitest.cc
@@ -294,7 +294,7 @@ int main( int argc, char **argv )
    XrdCryptoRSA *key = 0;
    XrdCryptoX509Chain *chain = new XrdCryptoX509Chain();
    if (ParseFile) {
-      int nci = (*ParseFile)(PXcert.c_str(), chain);
+      int nci = (*ParseFile)(PXcert.c_str(), chain, 0);
       if (!(key = chain->Begin()->PKI())) {
          pdots("getting PKI", 0);
       }


### PR DESCRIPTION
Adding support for pure cert/key authentication.
Client controls this mode via XrdSecGSICREATEPROXY:
  1. If XrdSecGSICREATEPROXY=1 (default), a proxy is auto-generated from the cert/key pair if one is not found.
  2. If XrdSecGSICREATEPROXY=0, a proxy is used if present. Otherwise, the cert/key pair is used if present (no proxy).
This is mostly meant, on the server side, for pass-less authentication, possible when the key file is pass-less.
NB1: if the key-file is pass-less and XrdSecGSICREATEPROXY = 1 (default) authentication still works with the usual protocol, i.e. creating a proxy and using that for the handshake. Setting XrdSecGSICREATEPROXY = 0 avoids those additional steps.
NB2: Forward / backward compatibility is obtained by enabling the cert/pair mechanism only for versions supporting it