### PR TITLE
[XrdSciTokens] Avoid double slashes in the final path rule that can r…

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <unordered_map>
 #include <tuple>
+#include <regex>
 
 #include "INIReader.h"
 #include "picojson.h"
@@ -647,6 +648,8 @@ private:
             for (auto path : config.m_base_paths) {
                 auto path_rule = rule;
                 path_rule.m_path_prefix = path + rule.m_path_prefix;
+                path_rule.m_path_prefix = std::regex_replace(path_rule.m_path_prefix,
+                                                             std::regex("//"), "/");
                 map_rules.emplace_back(path_rule);
             }
         }


### PR DESCRIPTION
…esult from

concatenating the base path with a path from a name_mapfile rule.

Exmaple:
/etc/xrootd/scitokens.cfg
-------------------------
...
base_path=/
name_mapfile=/etc/xrootd/mapfile.json
...

/etc/xrootd/mapfile.json
-------------------------
[{"sub": "abbaabba", "path":/some/path", "response": "someuser"}]

The resulting rule against which the maching will be attempeted will use the path
"//some/path" which will will never match a legitimate path.