### PR TITLE
Fix compilation when char is unsigned (armv7hl, aarch64, ppc64le, s390x)

### DIFF
--- a/src/XrdNet/XrdNetPMarkCfg.cc
+++ b/src/XrdNet/XrdNetPMarkCfg.cc
@@ -132,7 +132,7 @@ bool          tryVO   = false;
 bool          useDefs = false;
 
 bool          useFLbl = false;
-char          useFFly = -1;
+signed char   useFFly = -1;
 bool          addFLFF = false;
 bool          useSTag = true;
 


### PR DESCRIPTION
../xrootd-5.4.0/src/XrdNet/XrdNetPMarkCfg.cc: In static member function 'static XrdNetPMark* XrdNetPMarkCfg::Config(XrdSysError*, XrdScheduler*, XrdSysTrace*, bool&)':
../xrootd-5.4.0/src/XrdNet/XrdNetPMarkCfg.cc:271:16: error: comparison is always false due to limited range of data type [-Werror=type-limits]
  271 |    if (useFFly < 0)
      |        ~~~~~~~~^~~
../xrootd-5.4.0/src/XrdNet/XrdNetPMarkCfg.cc: In static member function 'static int XrdNetPMarkCfg::Parse(XrdSysError*, XrdOucStream&)':
../xrootd-5.4.0/src/XrdNet/XrdNetPMarkCfg.cc:1037:20: error: comparison is always false due to limited range of data type [-Werror=type-limits]
 1037 |        if (useFFly < 0) useFFly = 1;
      |            ~~~~~~~~^~~