### PR TITLE
Help older compiler find the right template.

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -1,5 +1,4 @@
 
-#include <regex>
 #include <cstring>
 #include <string>
 #include <iostream>

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -15,7 +15,6 @@
 #include <fstream>
 #include <unordered_map>
 #include <tuple>
-#include <regex>
 
 #include "INIReader.h"
 #include "picojson.h"
@@ -648,8 +647,10 @@ private:
             for (auto path : config.m_base_paths) {
                 auto path_rule = rule;
                 path_rule.m_path_prefix = path + rule.m_path_prefix;
-                path_rule.m_path_prefix = std::regex_replace(path_rule.m_path_prefix,
-                                                             std::regex("//"), "/");
+                auto pos = path_rule.m_path_prefix.find("//");
+                if (pos != std::string::npos) {
+                    path_rule.m_path_prefix.erase(pos + 1, 1);
+                }
                 map_rules.emplace_back(path_rule);
             }
         }


### PR DESCRIPTION
../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc: In member function 'bool XrdAccSciTokens::GenerateAcls(const string&, uint64_t&, {anonymous}::AccessRulesRaw&, std::string&, std::string&, std::string&, std::vector<{anonymous}::MapRule>&, std::vector<std::basic_string<char> >&)':
../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc:652:83: error: no matching function for call to 'regex_replace(std::string&, std::regex, const char [2])'
                                                              std::regex("//"), "/");
                                                                                   ^
../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc:652:83: note: candidates are:
In file included from /usr/include/c++/4.8.2/regex:62:0,
                 from ../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc:18:
/usr/include/c++/4.8.2/bits/regex.h:2162:5: note: template<class _Out_iter, class _Bi_iter, class _Rx_traits, class _Ch_type> _Out_iter std::regex_replace(_Out_iter, _Bi_iter, _Bi_iter, const std::basic_regex<_Ch_type, _Rx_traits>&, const std::basic_string<_Ch_type>&, std::regex_constants::match_flag_type)
     regex_replace(_Out_iter __out, _Bi_iter __first, _Bi_iter __last,
     ^
/usr/include/c++/4.8.2/bits/regex.h:2162:5: note:   template argument deduction/substitution failed:
../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc:652:83: note:   deduced conflicting types for parameter '_Bi_iter' ('std::basic_regex<char>' and 'const char*')
                                                              std::regex("//"), "/");
                                                                                   ^
In file included from /usr/include/c++/4.8.2/regex:62:0,
                 from ../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc:18:
/usr/include/c++/4.8.2/bits/regex.h:2182:5: note: template<class _Rx_traits, class _Ch_type> std::basic_string<_Ch_type> std::regex_replace(const std::basic_string<_Ch_type>&, const std::basic_regex<_Ch_type, _Rx_traits>&, const std::basic_string<_Ch_type>&, std::regex_constants::match_flag_type)
     regex_replace(const basic_string<_Ch_type>& __s,
     ^
/usr/include/c++/4.8.2/bits/regex.h:2182:5: note:   template argument deduction/substitution failed:
../xrootd-5.4.0/src/XrdSciTokens/XrdSciTokensAccess.cc:652:83: note:   mismatched types 'const std::basic_string<_Ch_type>' and 'const char [2]'
                                                              std::regex("//"), "/");
                                                                                   ^