### PR TITLE
Add missing include

### DIFF
--- a/src/XrdApps/XrdPrep.cc
+++ b/src/XrdApps/XrdPrep.cc
@@ -42,6 +42,7 @@
 
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdSys/XrdSysE2T.hh"
+#include "XrdSys/XrdSysPlatform.hh"
 #include "XrdCl/XrdClFileSystem.hh"
 
 using namespace XrdCl;


### PR DESCRIPTION
Fixes GNU/Hurd build

/<<PKGBUILDDIR>>/src/XrdApps/XrdPrep.cc: In function ‘int main(int, char**)’:
/<<PKGBUILDDIR>>/src/XrdApps/XrdPrep.cc:109:34: error: ‘MAXPATHLEN’ was not declared in this scope
  109 |    static const int MaxPathLen = MAXPATHLEN+1;
      |                                  ^~~~~~~~~~
/<<PKGBUILDDIR>>/src/XrdApps/XrdPrep.cc:213:24: error: size of array ‘fBuff’ is not an integral constant-expression
  213 |        char *sP, fBuff[MaxPathLen];
      |                        ^~~~~~~~~~
src/CMakeFiles/xrdprep.dir/build.make:78: recipe for target 'src/CMakeFiles/xrdprep.dir/XrdApps/XrdPrep.cc.o' failed