### PR TITLE
[XrdSciTokens] Modifying std::map invalidates iterator

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -959,9 +959,11 @@ private:
         if (now <= m_next_clean) {return;}
         std::lock_guard<std::mutex> guard(m_mutex);
 
-        for (auto iter = m_map.begin(); iter != m_map.end(); iter++) {
+        for (auto iter = m_map.begin(); iter != m_map.end(); ) {
             if (iter->second->expired()) {
-                m_map.erase(iter);
+                iter = m_map.erase(iter);
+            } else {
+                ++iter;
             }
         }
         Reconfig();


### PR DESCRIPTION
@clundst found a segfault in xrootd scitokens, apparently related to iterator use. 

<details>
<summary>backtrace from 5.3.0-1.1.osg35up.el7 with jemalloc junk:true</summary>

```
#5  0x00007f53c4e800c8 in signalHandler (sig=11, info=0x7f53cc7decf0, uc=0x7f53cc7debc0) at /usr/src/debug/java-1.8.0-openjdk-1.8.0.292.b10-1.el7_9.x86_64/openjdk/hotspot/src/os/linux/vm/os_linux.cpp:4588
#6  <signal handler called>
#7  local_Rb_tree_increment (__x=0x5a5a5a5a5a5a5a5a, __x@entry=0x7f53bd80a440) at ../../../../../libstdc++-v3/src/c++98/tree.cc:65
#8  std::_Rb_tree_increment (__x=__x@entry=0x7f53bd80a440) at ../../../../../libstdc++-v3/src/c++98/tree.cc:85
#9  0x00007f53c2e3fe85 in operator++ (this=<synthetic pointer>) at /opt/rh/devtoolset-7/root/usr/include/c++/7/bits/stl_tree.h:295
#10 Check (now=12020703, this=0x7f53cd7c6800) at /usr/src/debug/xrootd/xrootd/src/XrdSciTokens/XrdSciTokensAccess.cc:959
#11 XrdAccSciTokens::Access (this=0x7f53cd7c6800, Entity=0x7f53bd80d038, path=0x7f53bd94d800 "/store/user/clundst/test12.root", oper=AOP_Stat, env=0x7f53cc7df6c0) at /usr/src/debug/xrootd/xrootd/src/XrdSciTokens/XrdSciTokensAccess.cc:317
#12 0x00007f53c038932d in Macaroons::Authz::Access (this=0x7f53cc38fe90, Entity=0x7f53bd80d038, path=0x7f53bd94d800 "/store/user/clundst/test12.root", oper=<optimized out>, env=0x7f53cc7df6c0) at /usr/src/debug/xrootd/xrootd/src/XrdMacaroons/XrdMacaroonsAuthz.cc:167
#13 0x00007f53d2359a6e in XrdOfs::stat (this=0x7f53d25d8360 <XrdSfsGetDefaultFileSystem(XrdSfsFileSystem*, XrdSysLogger*, char const*, XrdOucEnv*)::XrdDefaultOfsFS>, path=0x7f53bd94d800 "/store/user/clundst/test12.root", buf=0x7f53cc7df770, einfo=..., client=0x7f53bd80d038, info=<optimized out>)
    at /usr/src/debug/xrootd/xrootd/src/XrdOfs/XrdOfs.cc:2296
#14 0x00007f53d234eece in XrdXrootdProtocol::do_Stat (this=this@entry=0x7f53bd926008) at /usr/src/debug/xrootd/xrootd/src/XrdXrootd/XrdXrootdXeq.cc:2808
```
</details>

When m_map is modified, iter is invalidated, and when iter is incremented it may cause a segfault. (Note that this PR assumes C++11.)