### PR TITLE
Define ENODATA if not defined

### DIFF
--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -53,7 +53,11 @@
 #include "XrdSys/XrdSysError.hh"
 #include "XrdSys/XrdSysPlatform.hh"
 #include "XrdSys/XrdSysPthread.hh"
-  
+
+#ifndef ENODATA
+#define ENODATA ENOATTR
+#endif
+
 /******************************************************************************/
 /*                         L o c a l   M e t h o d s                          */
 /******************************************************************************/
@@ -469,7 +473,7 @@ char *XrdOucUtils::getFile(const char *path, int &rc, int maxsz, bool notempty)
 //
    if (Stat.st_size > maxsz) {rc = EFBIG; return 0;}
 
-// Make sure the file is not empty is empty files are disallowed
+// Make sure the file is not empty if empty files are disallowed
 //
    if (Stat.st_size == 0 && notempty) {rc = ENODATA; return 0;}
 


### PR DESCRIPTION
Fixes compilation errors on Debian kfreebsd:
~~~
../src/XrdOuc/XrdOucUtils.cc: In static member function ‘static char* XrdOucUtils::getFile(const char*, int&, int, bool)’:
../src/XrdOuc/XrdOucUtils.cc:474:45: error: ‘ENODATA’ was not declared in this scope
  474 |    if (Stat.st_size == 0 && notempty) {rc = ENODATA; return 0;}
      |                                             ^~~~~~~
~~~
