### PR TITLE
Save token subject in the XrdSecEntity extended attribute API

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -212,11 +212,11 @@ struct IssuerConfig
 class XrdAccRules
 {
 public:
-    XrdAccRules(uint64_t expiry_time, const std::string &username, const std::string &token_username,
+    XrdAccRules(uint64_t expiry_time, const std::string &username, const std::string &token_subject,
         const std::string &issuer, const std::vector<MapRule> &rules, const std::vector<std::string> &groups) :
         m_expiry_time(expiry_time),
         m_username(username),
-        m_token_username(token_username),
+        m_token_subject(token_subject),
         m_issuer(issuer),
         m_map_rules(rules),
         m_groups(groups)
@@ -245,7 +245,7 @@ public:
     std::string get_username(const std::string &req_path)
     {
         for (const auto &rule : m_map_rules) {
-            std::string name = rule.match(m_token_username, req_path, m_groups);
+            std::string name = rule.match(m_token_subject, req_path, m_groups);
             if (!name.empty()) {
                 return name;
             }
@@ -253,6 +253,10 @@ public:
         return "";
     }
 
+        // Return the token's subject, an opaque unique string within the issuer's
+        // namespace.  It may or may not be related to the username one should
+        // use within the authorization framework.
+    const std::string & get_token_subject() const {return m_token_subject;}
     const std::string & get_default_username() const {return m_username;}
     const std::string & get_issuer() const {return m_issuer;}
 
@@ -263,7 +267,7 @@ private:
     AccessRulesRaw m_rules;
     uint64_t m_expiry_time{0};
     const std::string m_username;
-    const std::string m_token_username;
+    const std::string m_token_subject;
     const std::string m_issuer;
     const std::vector<MapRule> m_map_rules;
     const std::vector<std::string> m_groups;
@@ -328,12 +332,12 @@ public:
 		uint64_t cache_expiry;
 		AccessRulesRaw rules;
                 std::string username;
-                std::string token_username;
+                std::string token_subject;
                 std::string issuer;
                 std::vector<MapRule> map_rules;
                 std::vector<std::string> groups;
-                if (GenerateAcls(authz, cache_expiry, rules, username, token_username, issuer, map_rules, groups)) {
-                    access_rules.reset(new XrdAccRules(now + cache_expiry, username, token_username, issuer, map_rules, groups));
+                if (GenerateAcls(authz, cache_expiry, rules, username, token_subject, issuer, map_rules, groups)) {
+                    access_rules.reset(new XrdAccRules(now + cache_expiry, username, token_subject, issuer, map_rules, groups));
                     access_rules->parse(rules);
                 } else {
                     return OnMissing(Entity, path, oper, env);
@@ -403,6 +407,16 @@ public:
         if (mapping_success) {
             // Set scitokens.name in the extra attribute
             Entity->eaAPI->Add("request.name", username, true);
+        }
+
+            // Make the token subject available.  Even though it's a reasonably bad idea
+            // to use for *authorization* for file access, there may be other use cases.
+            // For example, the combination of (vorg, token.subject) is a reasonable
+            // approximation of a unique 'entity' (either person or a robot) and is
+            // more reasonable to use for resource fairshare in XrdThrottle.
+        const auto &token_subject = access_rules->get_token_subject();
+        if (!token_subject.empty()) {
+            Entity->eaAPI->Add("token.subject", token_subject, true);
         }
 
         // When the scope authorized this access, allow immediately.  Otherwise, chain
@@ -518,7 +532,7 @@ private:
         return XrdAccPriv_None;
     }
 
-    bool GenerateAcls(const std::string &authz, uint64_t &cache_expiry, AccessRulesRaw &rules, std::string &username, std::string &token_username, std::string &issuer, std::vector<MapRule> &map_rules, std::vector<std::string> &groups) {
+    bool GenerateAcls(const std::string &authz, uint64_t &cache_expiry, AccessRulesRaw &rules, std::string &username, std::string &token_subject, std::string &issuer, std::vector<MapRule> &map_rules, std::vector<std::string> &groups) {
         if (strncmp(authz.c_str(), "Bearer%20", 9)) {
             return false;
         }
@@ -635,11 +649,11 @@ private:
             scitoken_destroy(token);
             return false;
         }
-        token_username = std::string(value);
+        token_subject = std::string(value);
         free(value);
 
         if (config.m_map_subject) {
-            username = token_username;
+            username = token_subject;
         } else {
             username = config.m_default_user;
         }


### PR DESCRIPTION
Hi @esindril !

Your question the other day about the token subject got me thinking and I was able to identify a use case where the subject was useful independent of the (authorization system): we can utilize it for the throttling plugin.

Mind you, I still think it's a bad idea to feed this to EOS... but with this it's at least available in the `token.subject` xattr for the incoming request.

Brian