### PR TITLE
Track maximum concurrency limits in throttle plugin

### DIFF
--- a/src/XrdThrottle/XrdThrottle.hh
+++ b/src/XrdThrottle/XrdThrottle.hh
@@ -125,6 +125,7 @@ private:
    unique_sfs_ptr m_sfs;
    int m_uid; // A unique identifier for this user; has no meaning except for the fairshare.
    std::string m_loadshed;
+   std::string m_connection_id; // Identity for the connection; may or may authenticated
    std::string m_user;
    XrdThrottleManager &m_throttle;
    XrdSysError &m_eroute;
@@ -280,6 +281,9 @@ private:
 
    int
    xtrace(XrdOucStream &Config);
+
+   int
+   xmaxopen(XrdOucStream &Config);
 
    static FileSystem  *m_instance;
    XrdSysError         m_eroute;

--- a/src/XrdThrottle/XrdThrottle.hh
+++ b/src/XrdThrottle/XrdThrottle.hh
@@ -122,6 +122,7 @@ private:
    virtual
    ~File();
 
+   bool m_is_open{false};
    unique_sfs_ptr m_sfs;
    int m_uid; // A unique identifier for this user; has no meaning except for the fairshare.
    std::string m_loadshed;
@@ -284,6 +285,9 @@ private:
 
    int
    xmaxopen(XrdOucStream &Config);
+
+   int
+   xmaxconn(XrdOucStream &Config);
 
    static FileSystem  *m_instance;
    XrdSysError         m_eroute;

--- a/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
@@ -147,6 +147,7 @@ FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs)
          if (!val || !val[0]) {log.Emsg("Config", "fslib not specified."); continue;}
          fslib = val;
       }
+      TS_Xeq("throttle.max_open_files", xmaxopen);
       TS_Xeq("throttle.throttle", xthrottle);
       TS_Xeq("throttle.loadshed", xloadshed);
       TS_Xeq("throttle.trace", xtrace);
@@ -165,6 +166,32 @@ FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs)
 
    return 0;
 }
+
+/******************************************************************************/
+/*                            x m a x o p e n                                 */
+/******************************************************************************/
+
+/* Function: xmaxopen
+
+   Purpose:  Parse the directive: throttle.max_open_files <limit>
+
+             <limit>   maximum number of open file handles for a unique entity.
+
+  Output: 0 upon success or !0 upon failure.
+*/
+int
+FileSystem::xmaxopen(XrdOucStream &Config)
+{
+    auto val = Config.GetWord();
+    if (!val || val[0] == '\0')
+       {m_eroute.Emsg("Config", "Max open files not specified!  Example usage: throttle.max_open_files 16000");}
+    long long max_open = -1;
+    if (XrdOuca2x::a2sz(m_eroute, "max open files value", val, &max_open, 1)) return 1;
+
+    m_throttle.SetMaxOpen(max_open);
+    return 0;
+}
+
 
 /******************************************************************************/
 /*                            x t h r o t t l e                               */
@@ -306,6 +333,7 @@ int FileSystem::xtrace(XrdOucStream &Config)
       {"iops",      TRACE_IOPS},
       {"bandwidth", TRACE_BANDWIDTH},
       {"ioload",    TRACE_IOLOAD},
+      {"files",     TRACE_FILES},
    };
    int i, neg, trval = 0, numopts = sizeof(tropts)/sizeof(struct traceopts);
 

--- a/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
@@ -148,6 +148,7 @@ FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs)
          fslib = val;
       }
       TS_Xeq("throttle.max_open_files", xmaxopen);
+      TS_Xeq("throttle.max_active_connections", xmaxconn);
       TS_Xeq("throttle.throttle", xthrottle);
       TS_Xeq("throttle.loadshed", xloadshed);
       TS_Xeq("throttle.trace", xtrace);
@@ -189,6 +190,32 @@ FileSystem::xmaxopen(XrdOucStream &Config)
     if (XrdOuca2x::a2sz(m_eroute, "max open files value", val, &max_open, 1)) return 1;
 
     m_throttle.SetMaxOpen(max_open);
+    return 0;
+}
+
+
+/******************************************************************************/
+/*                            x m a x c o n n                                 */
+/******************************************************************************/
+
+/* Function: xmaxconn
+
+   Purpose:  Parse the directive: throttle.max_active_connections <limit>
+
+             <limit>   maximum number of connections with at least one open file for a given entity
+
+  Output: 0 upon success or !0 upon failure.
+*/
+int
+FileSystem::xmaxconn(XrdOucStream &Config)
+{
+    auto val = Config.GetWord();
+    if (!val || val[0] == '\0')
+       {m_eroute.Emsg("Config", "Max active cconnections not specified!  Example usage: throttle.max_active_connections 4000");}
+    long long max_conn = -1;
+    if (XrdOuca2x::a2sz(m_eroute, "max active connections value", val, &max_conn, 1)) return 1;
+
+    m_throttle.SetMaxConns(max_conn);
     return 0;
 }
 
@@ -334,6 +361,7 @@ int FileSystem::xtrace(XrdOucStream &Config)
       {"bandwidth", TRACE_BANDWIDTH},
       {"ioload",    TRACE_IOLOAD},
       {"files",     TRACE_FILES},
+      {"connections",TRACE_CONNS},
    };
    int i, neg, trval = 0, numopts = sizeof(tropts)/sizeof(struct traceopts);
 

--- a/src/XrdThrottle/XrdThrottleManager.hh
+++ b/src/XrdThrottle/XrdThrottleManager.hh
@@ -31,6 +31,8 @@
 #include <string>
 #include <vector>
 #include <ctime>
+#include <mutex>
+#include <unordered_map>
 
 #include "XrdSys/XrdSysPthread.hh"
 
@@ -47,6 +49,9 @@ public:
 
 void        Init();
 
+bool        OpenFile(const std::string &entity);
+bool        CloseFile(const std::string &entity);
+
 void        Apply(int reqsize, int reqops, int uid);
 
 bool        IsThrottling() {return (m_ops_per_second > 0) || (m_bytes_per_second > 0);}
@@ -57,6 +62,8 @@ void        SetThrottles(float reqbyterate, float reqoprate, int concurrency, fl
 
 void        SetLoadShed(std::string &hostname, unsigned port, unsigned frequency)
             {m_loadshed_host = hostname; m_loadshed_port = port; m_loadshed_frequency = frequency;}
+
+void        SetMaxOpen(unsigned long max_open) {m_max_open = max_open;}
 
 //int         Stats(char *buff, int blen, int do_sync=0) {return m_pool.Stats(buff, blen, do_sync);}
 
@@ -126,6 +133,11 @@ std::string m_loadshed_host;
 unsigned m_loadshed_port;
 unsigned m_loadshed_frequency;
 int m_loadshed_limit_hit;
+
+// Maximum number of open files
+unsigned long m_max_open{0};
+std::unordered_map<std::string, unsigned long> m_file_counters;
+std::mutex m_file_mutex;
 
 static const char *TraceID;
 

--- a/src/XrdThrottle/XrdThrottleManager.hh
+++ b/src/XrdThrottle/XrdThrottleManager.hh
@@ -33,6 +33,7 @@
 #include <ctime>
 #include <mutex>
 #include <unordered_map>
+#include <memory>
 
 #include "XrdSys/XrdSysPthread.hh"
 
@@ -49,7 +50,7 @@ public:
 
 void        Init();
 
-bool        OpenFile(const std::string &entity);
+bool        OpenFile(const std::string &entity, std::string &open_error_message);
 bool        CloseFile(const std::string &entity);
 
 void        Apply(int reqsize, int reqops, int uid);
@@ -64,6 +65,8 @@ void        SetLoadShed(std::string &hostname, unsigned port, unsigned frequency
             {m_loadshed_host = hostname; m_loadshed_port = port; m_loadshed_frequency = frequency;}
 
 void        SetMaxOpen(unsigned long max_open) {m_max_open = max_open;}
+
+void        SetMaxConns(unsigned long max_conns) {m_max_conns = max_conns;}
 
 //int         Stats(char *buff, int blen, int do_sync=0) {return m_pool.Stats(buff, blen, do_sync);}
 
@@ -136,7 +139,10 @@ int m_loadshed_limit_hit;
 
 // Maximum number of open files
 unsigned long m_max_open{0};
+unsigned long m_max_conns{0};
 std::unordered_map<std::string, unsigned long> m_file_counters;
+std::unordered_map<std::string, unsigned long> m_conn_counters;
+std::unordered_map<std::string, std::unique_ptr<std::unordered_map<pid_t, unsigned long>>> m_active_conns;
 std::mutex m_file_mutex;
 
 static const char *TraceID;

--- a/src/XrdThrottle/XrdThrottleTrace.hh
+++ b/src/XrdThrottle/XrdThrottleTrace.hh
@@ -10,6 +10,7 @@
 #define TRACE_IOPS      0x0002
 #define TRACE_IOLOAD    0x0004
 #define TRACE_DEBUG     0x0008
+#define TRACE_FILES     0x0010
 
 #ifndef NODEBUG
 

--- a/src/XrdThrottle/XrdThrottleTrace.hh
+++ b/src/XrdThrottle/XrdThrottleTrace.hh
@@ -11,6 +11,7 @@
 #define TRACE_IOLOAD    0x0004
 #define TRACE_DEBUG     0x0008
 #define TRACE_FILES     0x0010
+#define TRACE_CONNS     0x0020
 
 #ifndef NODEBUG
 


### PR DESCRIPTION
This adds two new concurrency limits in the throttle plugin:
1.  Maximum number of open files per unique entity (which might be a unique identifier from a token).
2. Maximum number of "active connections" per entity.

The intent is to provide some per-"user" limits on resource consumption.  (1) should be self-evident; open file handles are expensive for some filesystems and this prevents exhaustion by a single user.

(2) is less obvious.  I define an "active connection" to be a thread with at least one open file handle.  It's meant to approximate "open connections" as each connection currently costs an OS thread and these are definitely finite resources.  I see the throttle plugin as a reasonable place to do this because (a) it's self-contained (no changes outside the plugin) and (b) for connections not associated with a particular entity (e.g., tokens), an open file might be the only reasonable place where the "owner" is defined.  This will *not* be useful for limiting idle connections (but the reaper can help with these) or connections where files aren't being opened (e.g., a client only doing stat's).  This *would* cover the instances that @juztas has described where a user with many concurrent jobs overloads his server; I just wanted to point out it's not a general-purpose solution (and, after a few tries, I've concluded that a solution without any tradeoffs is not obviously in reach...).

This introduces two new configuration parameters and two new debug levels.  Here's what I was using in testing:

```
xrootd.fslib ++ throttle
throttle.max_open_files 3
throttle.max_active_connections 2
throttle.trace debug files connections
```