### PR TITLE
[Question] Missing return when dns error in delegation

### DIFF
--- a/src/XrdSecgsi/XrdSecProtocolgsi.cc
+++ b/src/XrdSecgsi/XrdSecProtocolgsi.cc
@@ -3241,6 +3241,7 @@ int XrdSecProtocolgsi::ClientDoCert(XrdSutBuffer *br, XrdSutBuffer **bm,
           {hs->Options &= ~(kOptsFwdPxy | kOptsSigReq);
            std::cerr <<"secgsi: proxy delegation forbidden when trusting DNS "
                        "to resolve '" <<wantHost <<"'!\n" <<std::flush;
+           return -1;
           }
       }
 


### PR DESCRIPTION
Hi,

we have seen this error happening but the operation still succeeded. I happened to notice that there is no `return` statement. No idea if it is by design or not.