### PR TITLE
fix: Use `shutil.which` over `distutils.spawn.find_executable` when possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,6 +226,13 @@ jobs:
         python3 -c 'import pyxrootd; print(pyxrootd)'
         python3 -c 'from XRootD import client; print(client.FileSystem("root://someserver:1094"))'
 
+    - name: Build sdist using publishing workflow
+      run: |
+        . /opt/rh/devtoolset-7/enable
+        cp packaging/wheel/* .
+        ./publish.sh
+        ls -lhtra dist/
+
   sdist-centos7:
 
     runs-on: ubuntu-latest

--- a/bindings/python/setup_pypi.py
+++ b/bindings/python/setup_pypi.py
@@ -3,7 +3,6 @@ from distutils.core import Extension
 from distutils import sysconfig
 from os import getenv, walk, path, path, getcwd, chdir
 from platform import system
-import subprocess
 
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.
 cfg_vars = sysconfig.get_config_vars()

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -107,13 +107,17 @@ BuildRequires: json-c-devel
 
 %if %{python2only}
 BuildRequires: python2-devel
+BuildRequires: python2-setuptools
 %endif
 %if %{python2and3}
 BuildRequires: python2-devel
+BuildRequires: python2-setuptools
 BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-setuptools
 %endif
 %if %{python3only}
 BuildRequires: python%{python3_pkgversion}-devel
+BuildRequires: python%{python3_pkgversion}-setuptools
 %endif
 
 BuildRequires: openssl-devel

--- a/packaging/wheel/install.sh
+++ b/packaging/wheel/install.sh
@@ -58,6 +58,8 @@ fi
 cd $startdir
 rm -r xrootdbuild
 
+# TODO: Remove all of the below and build a wheel using PyPA tools
+
 # convert the egg-info into a proper dist-info
 egginfo_path=$(ls $1/xrootd-*.egg-info)
 core="${egginfo_path%.*}"

--- a/packaging/wheel/install.sh
+++ b/packaging/wheel/install.sh
@@ -38,8 +38,19 @@ if [ "$res" -ne "0" ]; then
 fi
 
 cd ../bindings/python
-$6 setup.py install $3 # $6 holds the python sys.executable
-res=$?
+
+# Determine if shutil.which is available for a modern Python package install
+${6} -c 'import shutil.which' &> /dev/null  # $6 holds the python sys.executable
+shutil_which_available=$?
+if [ "${shutil_which_available}" -ne "0" ]; then
+    ${6} setup.py install ${3}
+    res=$?
+else
+    ${6} -m pip install ${3} .
+    res=$?
+fi
+unset shutil_which_available
+
 if [ "$res" -ne "0" ]; then
     exit 1
 fi

--- a/packaging/wheel/publish.sh
+++ b/packaging/wheel/publish.sh
@@ -5,4 +5,35 @@ version=$(./genversion.sh --print-only)
 version=${version#v}
 echo $version > bindings/python/VERSION
 rm -r dist
-python3 setup.py sdist
+
+# Determine if wheel.bdist_wheel is available for wheel.bdist_wheel in setup.py
+python3 -c 'import wheel' &> /dev/null
+wheel_available=$?
+if [ "${wheel_available}" -ne "0" ]; then
+    python3 -m pip install wheel
+    wheel_available=$?
+
+    if [ "${wheel_available}" -ne "0" ]; then
+        echo "ERROR: Unable to find wheel and unable to install wheel with '$(command -v python3) -m pip install wheel'."
+        echo "       Please ensure wheel is available to $(command -v python3) and try again."
+        exit 1
+    fi
+fi
+unset wheel_available
+
+# Determine if build is available
+python3 -c 'import build' &> /dev/null
+build_available=$?
+if [ "${build_available}" -ne "0" ]; then
+    python3 -m pip install build
+    build_available=$?
+fi
+
+if [ "${build_available}" -ne "0" ]; then
+    echo "WARNING: Unable to find build and unable to install build from PyPI with '$(command -v python3) -m pip install build'."
+    echo "         Falling back to building sdist with '$(command -v python3) setup.py sdist'."
+    python3 setup.py sdist
+else
+    python3 -m build --sdist .
+fi
+unset build_available

--- a/packaging/wheel/setup.py
+++ b/packaging/wheel/setup.py
@@ -3,6 +3,13 @@ from setuptools.command.install import install
 from setuptools.command.sdist import sdist
 from wheel.bdist_wheel import bdist_wheel
 
+# shutil.which was added in Python 3.3
+# c.f. https://docs.python.org/3/library/shutil.html#shutil.which
+try:
+    from shutil import which
+except ImportError:
+    from distutils.spawn import find_executable as which
+
 import subprocess
 import sys
 import getpass
@@ -27,11 +34,9 @@ def get_version_from_file():
 
 def binary_exists(name):
     """Check whether `name` is on PATH."""
-    from distutils.spawn import find_executable
-    return find_executable(name) is not None
+    return which(name) is not None
 
 def check_cmake3(path):
-    from distutils.spawn import find_executable
     args = (path, "--version")
     popen = subprocess.Popen(args, stdout=subprocess.PIPE)
     popen.wait()
@@ -42,12 +47,11 @@ def check_cmake3(path):
 
 def cmake_exists():
     """Check whether CMAKE is on PATH."""
-    from distutils.spawn import find_executable
-    path = find_executable('cmake')
+    path = which('cmake')
     if path is not None:
         if check_cmake3(path): return True, path
-    path = find_executable('cmake3')
-    return path is not None, path 
+    path = which('cmake3')
+    return path is not None, path
 
 def is_rhel7():
     """check if we are running on rhel7 platform"""
@@ -78,9 +82,8 @@ def has_cxx14():
 
 # def python_dependency_name( py_version_short, py_version_nodot ):
 #     """ find the name of python dependency """
-#     from distutils.spawn import find_executable
 #     # this is the path to default python
-#     path = find_executable( 'python' )
+#     path = which( 'python' )
 #     from os.path import realpath
 #     # this is the real default python after resolving symlinks
 #     real = realpath(path)

--- a/packaging/wheel/setup.py
+++ b/packaging/wheel/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, Extension
+from setuptools import setup
 from setuptools.command.install import install
 from setuptools.command.sdist import sdist
 from wheel.bdist_wheel import bdist_wheel
@@ -12,7 +12,6 @@ except ImportError:
 
 import subprocess
 import sys
-import getpass
 
 def get_version():
     version = subprocess.check_output(['./genversion.sh', '--print-only'])


### PR DESCRIPTION
This is part one of two PRs that will address Issue #1579.

As `distutils` and Easy Install are deprecated

c.f.:
* https://setuptools.pypa.io/en/stable/deprecated/distutils-legacy.html
* https://setuptools.pypa.io/en/stable/deprecated/easy_install.html

it is preferable convert use  of `distutils` to either use existing CPython libraries or use `setuptool`'s versions of them, as advocated by the PyPA.

* [`distutils.sysconfig` -> CPython's `sysconfig`](https://discuss.python.org/t/understanding-site-packages-directories/12959/4)
* `distutils.setup` -> `setuptools.setup`
* `distutils.core.Extension` -> `setuptools.Extension`
* `distutils.spawn.find_executable` -> [`shutil.which`](https://docs.python.org/3/library/shutil.html#shutil.which) 


However, this PR only applies

* `distutils.spawn.find_executable` -> `shutil.which`

for the packaging scripts. (@henryiii pointed out that `shutil.which` (added in Python 3.3) is preferable to `setuptools._distutils.spawn.find_executable`.)

This PR was meant to also change:

* `distutils.setup` -> `setuptools.setup`
* `distutils.sysconfig` -> CPython's `sysconfig`

but it seems that these are still required given the current state of the build and will need to be revised in a later PR.


The change

`distutils.core.Extension` -> `setuptools.Extension`

could be applied in:

* `bindings/python/setup_pypi.py`
* `bindings/python/setup_standalone.py`

but isn't as these files are obsolete and should be removed (c.f. Issue #1594).

To ensure the RPM build continues to succeed `python2-setuptools` and `python3-setuptools` are added as `BuildRequires`.

To make the packaging scripts as easy to work with as possible for future releases of `pip` and `setuptools` (c.f. Issue #1579), have the `packaging/wheel/install.sh` script use `pip` to perform a local install if `shutil.which` is available (falling back to the deprecated `python setup.py install` if not) and have `packaging/wheel/publish.sh` attempt to use `build` to build the `sdist` (falling back to the deprecated `python setup.py sdist` if it can't access PyPI).

---

~~The XRootD docs are not clear on how to run the test suite (or at least don't make it easy to find at all) as setting `ENABLE_TESTS=ON` isn't sufficient, so while I'd really appreciate it if someone could tell me _how_ to do that at there doesn't seem to be any CI hooked up on GitHub here's an example Dockerfile that demonstrates on my fork that things still build fine~~

```dockerfile
# docker/Dockerfile
ARG BASE_IMAGE=neubauergroup/centos-build-base:3.8.11
FROM ${BASE_IMAGE} as base

SHELL [ "/bin/bash", "-c" ]

RUN yum update -y && \
    yum install -y \
        cmake \
        krb5-devel \
        libuuid-devel \
        libxml2-devel \
        openssl-devel \
        systemd-devel \
        zlib-devel \
        python3-devel \
        devtoolset-7-gcc-c++ \
        curl \
        cppunit \
        cpptest \
        git && \
    yum clean all && \
    python -m pip install --no-cache-dir --upgrade pip setuptools wheel

COPY . /code/xrootd

WORKDIR /code
RUN source scl_source enable devtoolset-8 && \
    . /usr/local/venv/bin/activate && \
    cmake \
        -DCMAKE_INSTALL_PREFIX=/usr/local/venv \
        -DPYTHON_EXECUTABLE=$(command -v python3) \
        -DENABLE_TESTS=ON \
        -S xrootd \
        -B build && \
    cmake build -LH && \
    cmake \
        --build build \
        --clean-first \
        --parallel $(($(nproc) - 1)) && \
    cmake --build build --target install && \
    cd / && \
    rm -rf /code && \
    python -m pip list

WORKDIR /

# Load libraries
ENV LD_LIBRARY_PATH=/usr/local/venv/lib:$LD_LIBRARY_PATH

ENTRYPOINT ["/bin/bash", "-l", "-c"]
CMD ["/bin/bash"]
```

~~that when built from the top level of my fork with~~

```
docker build --file docker/Dockerfile --tag xrootd/xrootd:debug-pr-1585 .
```

~~still builds okay~~

```console
$ docker run --rm -ti xrootd/xrootd:debug-pr-1585
[root@58ad262bf249 /]# cat /etc/os-release 
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

[root@58ad262bf249 /]# python -c "import pyxrootd; print(pyxrootd)"
<module 'pyxrootd' from '/usr/local/venv/lib/python3.8/site-packages/xrootd-v20220110_1d50f8d-py3.8-linux-x86_64.egg/pyxrootd/__init__.py'>
[root@58ad262bf249 /]# python -c "import XRootD; print(XRootD)"
<module 'XRootD' from '/usr/local/venv/lib/python3.8/site-packages/xrootd-v20220110_1d50f8d-py3.8-linux-x86_64.egg/XRootD/__init__.py'>
[root@58ad262bf249 /]# command -v xrootd
/usr/local/venv/bin/xrootd
[root@58ad262bf249 /]# command -v xrdcp
/usr/local/venv/bin/xrdcp
[root@58ad262bf249 /]# python
Python 3.8.11 (default, Aug  2 2021, 20:01:57) 
[GCC 8.3.1 20190311 (Red Hat 8.3.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from XRootD import client
>>> from XRootD.client.flags import DirListFlags, OpenFlags, MkDirFlags, QueryCode
>>> myclient = client.FileSystem('root://someserver:1094')
>>> 
KeyboardInterrupt
>>> 
[root@58ad262bf249 /]# exit
exit
```