### PR TITLE
fix: Install Python bindings with `pip` if available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/local/ \
             -DPYTHON_EXECUTABLE=$(command -v python3) \
             -DENABLE_TESTS=ON \
+            -DPIP_VERBOSE=ON \
             -S xrootd \
             -B build
         cmake3 build -LH
@@ -135,6 +136,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/local/ \
             -DPYTHON_EXECUTABLE=$(command -v python3) \
             -DENABLE_TESTS=ON \
+            -DPIP_VERBOSE=ON \
             -S xrootd \
             -B build
         cmake3 build -LH
@@ -202,6 +204,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX=/usr/ \
             -DPYTHON_EXECUTABLE=$(command -v python2) \
             -DENABLE_TESTS=ON \
+            -DPIP_VERBOSE=ON \
             -S xrootd \
             -B build
         cmake3 build -LH

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -32,6 +32,12 @@ endif()
 
 configure_file(${SETUP_PY_IN} ${SETUP_PY})
 
+if( PIP_VERBOSE )
+  set(PIP_INSTALL_VERBOSE_FLAG "--verbose")
+else()
+  set(PIP_INSTALL_VERBOSE_FLAG "")
+endif()
+
 # Check it the Python interpreter has a valid version of pip
 execute_process(
         COMMAND ${PYTHON_EXECUTABLE} -m pip --version
@@ -53,7 +59,7 @@ if ( NOT ${VALID_PIP_EXIT_CODE} EQUAL 0 )
 
   # https://docs.python.org/3/install/#splitting-the-job-up
   add_custom_command(OUTPUT ${OUTPUT}
-                     COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} build
+                     COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} ${PIP_INSTALL_VERBOSE_FLAG} build
                      DEPENDS ${DEPS})
 
   add_custom_target(python_target ALL DEPENDS ${OUTPUT} XrdCl)
@@ -73,6 +79,7 @@ if ( NOT ${VALID_PIP_EXIT_CODE} EQUAL 0 )
     CODE
     "EXECUTE_PROCESS(
       COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install \
+                ${PIP_INSTALL_VERBOSE_FLAG} \
                 --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} \
                 ${DEB_INSTALL_ARGS} \
                 --record PYTHON_INSTALLED
@@ -85,6 +92,7 @@ else()
     CODE
     "EXECUTE_PROCESS(
       COMMAND ${PYTHON_EXECUTABLE} -m pip install \
+                ${PIP_INSTALL_VERBOSE_FLAG} \
                 --force-reinstall \
                 --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} \
                 ${CMAKE_CURRENT_BINARY_DIR}

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -32,25 +32,62 @@ endif()
 
 configure_file(${SETUP_PY_IN} ${SETUP_PY})
 
-add_custom_command(OUTPUT ${OUTPUT}
-                   COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} build
-                   DEPENDS ${DEPS})
+# Check it the Python interpreter has a valid version of pip
+execute_process(
+        COMMAND ${PYTHON_EXECUTABLE} -m pip --version
+        RESULT_VARIABLE VALID_PIP_EXIT_CODE
+        OUTPUT_QUIET
+)
 
-add_custom_target(python_target ALL DEPENDS ${OUTPUT} XrdCl)
+if ( NOT ${VALID_PIP_EXIT_CODE} EQUAL 0 )
+  # Attempt to still install with deprecated invocation of setup.py
+  message(WARNING
+         " ${PYTHON_EXECUTABLE} does not have a valid pip associated with it."
+         " It is recommended that you install a version of pip to install Python"
+         " packages and bindings. If you are unable to install a version of pip"
+         " through a package manager or with your Python build try using the PyPA's"
+         " get-pip.py bootstrapping script ( https://github.com/pypa/get-pip ).\n"
+         " The installation of the Python bindings will attempt to continue using"
+         " the deprecated method of `${PYTHON_EXECUTABLE} setup.py install`."
+         )
 
-# Get the distribution name on Debian families
-execute_process( COMMAND grep -i ^NAME=\" /etc/os-release
-                 OUTPUT_VARIABLE DEB_DISTRO )
-STRING(REGEX REPLACE "^NAME=\"" "" DEB_DISTRO "${DEB_DISTRO}")
-STRING(REGEX REPLACE "\".*"     "" DEB_DISTRO "${DEB_DISTRO}")
+  # https://docs.python.org/3/install/#splitting-the-job-up
+  add_custom_command(OUTPUT ${OUTPUT}
+                     COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} build
+                     DEPENDS ${DEPS})
 
-if( DEB_DISTRO STREQUAL "Debian" OR DEB_DISTRO STREQUAL "Ubuntu" )
-  set(PYTHON_LAYOUT  "unix" CACHE STRING "Python installation layout (deb or unix)")
-  set(DEB_INSTALL_ARGS "--install-layout ${PYTHON_LAYOUT}")
+  add_custom_target(python_target ALL DEPENDS ${OUTPUT} XrdCl)
+
+  # Get the distribution name on Debian families
+  execute_process( COMMAND grep -i ^NAME= /etc/os-release
+                   OUTPUT_VARIABLE DEB_DISTRO )
+  STRING(REGEX REPLACE "^NAME=\"" "" DEB_DISTRO "${DEB_DISTRO}")
+  STRING(REGEX REPLACE "\".*"     "" DEB_DISTRO "${DEB_DISTRO}")
+
+  if( DEB_DISTRO STREQUAL "Debian" OR DEB_DISTRO STREQUAL "Ubuntu" )
+    set(PYTHON_LAYOUT  "unix" CACHE STRING "Python installation layout (deb or unix)")
+    set(DEB_INSTALL_ARGS "--install-layout ${PYTHON_LAYOUT}")
+  endif()
+
+  install(
+    CODE
+    "EXECUTE_PROCESS(
+      COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install \
+                --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} \
+                ${DEB_INSTALL_ARGS} \
+                --record PYTHON_INSTALLED
+    )"
+  )
+
+else()
+  # Use --force-reinstall to ensure a clean install if a rebuild needs to happen
+  install(
+    CODE
+    "EXECUTE_PROCESS(
+      COMMAND ${PYTHON_EXECUTABLE} -m pip install \
+                --force-reinstall \
+                --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} \
+                ${CMAKE_CURRENT_BINARY_DIR}
+      )"
+  )
 endif()
-
-install(
-  CODE
-  "EXECUTE_PROCESS(
-    COMMAND ${PYTHON_EXECUTABLE} ${SETUP_PY} install --prefix \$ENV{DESTDIR}/${CMAKE_INSTALL_PREFIX} ${DEB_INSTALL_ARGS} --record PYTHON_INSTALLED)" )
-

--- a/cmake/XRootDDefaults.cmake
+++ b/cmake/XRootDDefaults.cmake
@@ -18,6 +18,7 @@ option( ENABLE_XRDCL     "Enable XRootD client."                                
 option( ENABLE_TESTS     "Enable unit tests."                                             FALSE )
 option( ENABLE_HTTP      "Enable HTTP component."                                         TRUE )
 option( ENABLE_PYTHON    "Enable python bindings."                                        TRUE )
+option( PIP_VERBOSE      "Turn on --verbose flag for pip during Python bindings install." FALSE )
 option( XRDCL_ONLY       "Build only the client and necessary dependencies"               FALSE )
 option( XRDCL_LIB_ONLY   "Build only the client libraries and necessary dependencies"     FALSE )
 option( PYPI_BUILD       "The project is being built for PyPI release"                    FALSE )

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -106,6 +106,7 @@ BuildRequires: libmacaroons-devel
 BuildRequires: json-c-devel
 
 %if %{python2only}
+BuildRequires: python2-pip
 BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 %endif


### PR DESCRIPTION
* This is part two of two PRs that will address Issue #1579.
* Requires PR #1585 to go in first for atomicity, and then will rebase on top of it.
* Resolves #1579
   - There might be a few more things to _really_ resolve this, but I think this is good enough for now.

---

As directly invoking `python setup.py` is considered deprecated behavior by the PyPA, use `python -m pip install` to install the Python bindings if the Python interpreter has a valid version of pip associated with it.

If there is a valid pip, build and install the Python bindings with `python -m pip install`.

If there is no valid pip, warn the user and give them instructions on how to get pip on their machine. Attempt to still install the Python bindings by falling back on the deprecated `python setup.py build` and `python setup.py install` which will also invoke Easy Install if `setuptools` `v0.60.0+` is used.


Both branches have been tested in CI (well, both have been tested on a branch on my fork where I force there to be no `pip` available on one. In the CI that ran for this PR all situations have `pip` available.)

<details>
<summary>(and in Docker image builds):</summary>

## Building with `python -m pip install`

```console
$ docker run --rm -ti xrootd/xrootd:build-pip-pass 
[root@f6701ee26ac7 /]# python -c "import pyxrootd; print(pyxrootd)"
<module 'pyxrootd' from '/usr/local/venv/lib/python3.8/site-packages/pyxrootd/__init__.py'>
[root@f6701ee26ac7 /]# python -c "import XRootD; print(XRootD)"
<module 'XRootD' from '/usr/local/venv/lib/python3.8/site-packages/XRootD/__init__.py'>
[root@f6701ee26ac7 /]# command -v xrootd
/usr/local/venv/bin/xrootd
[root@f6701ee26ac7 /]# command -v xrdcp
/usr/local/venv/bin/xrdcp
[root@f6701ee26ac7 /]# python
Python 3.8.11 (default, Aug  2 2021, 20:01:57) 
[GCC 8.3.1 20190311 (Red Hat 8.3.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from XRootD import client
>>> from XRootD.client.flags import DirListFlags, OpenFlags, MkDirFlags, QueryCode
>>> myclient = client.FileSystem('root://someserver:1094')
>>> myclient
<XRootD.client.filesystem.FileSystem object at 0x7fb564b22fa0>
>>> 
[root@f6701ee26ac7 /]#
```

## Falling back to `python setup.py install`

```console
$ docker run --rm -ti xrootd/xrootd:build-setup-py-pass 
[root@62f223b14e6e /]# python -c "import pyxrootd; print(pyxrootd)"
<module 'pyxrootd' from '/usr/local/venv/lib/python3.8/site-packages/xrootd-v20220111_a98ec84-py3.8-linux-x86_64.egg/pyxrootd/__init__.py'>
[root@62f223b14e6e /]# python -c "import XRootD; print(XRootD)"
<module 'XRootD' from '/usr/local/venv/lib/python3.8/site-packages/xrootd-v20220111_a98ec84-py3.8-linux-x86_64.egg/XRootD/__init__.py'>
[root@62f223b14e6e /]# command -v xrootd
/usr/local/venv/bin/xrootd
[root@62f223b14e6e /]# command -v xrdcp
/usr/local/venv/bin/xrdcp
[root@62f223b14e6e /]# python
Python 3.8.11 (default, Aug  2 2021, 20:01:57) 
[GCC 8.3.1 20190311 (Red Hat 8.3.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from XRootD import client
>>> from XRootD.client.flags import DirListFlags, OpenFlags, MkDirFlags, QueryCode
>>> myclient = client.FileSystem('root://someserver:1094')
>>> myclient
<XRootD.client.filesystem.FileSystem object at 0x7f6541b55fa0>
>>> 
[root@62f223b14e6e /]# 
```

</details>

