### PR TITLE
Update to XrdCl and XrdEC

### DIFF
--- a/src/XrdCl/XrdClEcHandler.hh
+++ b/src/XrdCl/XrdClEcHandler.hh
@@ -355,7 +355,7 @@ namespace XrdCl
         std::vector<uint64_t> verNums;
         std::vector<std::string>  xattrkeys;
         std::vector<XrdCl::XAttr> xattrvals;
-        xattrkeys.push_back("xrdec.chunkver");
+        xattrkeys.push_back("xrdec.strpver");
         for( size_t i = 0; i < info->GetSize(); ++i )
         {
           FileSystem *fs_i = new FileSystem(info->At( i ).GetAddress());

--- a/src/XrdCl/XrdClPlugInManager.cc
+++ b/src/XrdCl/XrdClPlugInManager.cc
@@ -354,6 +354,7 @@ namespace XrdCl
 #ifdef WITH_XRDEC
     if( lib == "XrdEcDefault" )
     {
+      setenv("XRDCL_EC", "True", 1);
       auto itr = config.find( "nbdta" );
       if( itr == config.end() )
         return std::make_pair<XrdOucPinLoader*, PlugInFactory*>( nullptr, nullptr );

--- a/src/XrdCl/XrdClZipArchive.hh
+++ b/src/XrdCl/XrdClZipArchive.hh
@@ -247,7 +247,10 @@ namespace XrdCl
           return XRootDStatus( stError, errNotFound );
         // create the result
         info = make_stat( fn );
-        return XRootDStatus();
+        if (info) 
+          return XRootDStatus();
+        else // have difficult to access the openned archive.
+          return XRootDStatus( stError, errNotFound );
       }
 
       //-----------------------------------------------------------------------
@@ -464,6 +467,7 @@ namespace XrdCl
       {
         StatInfo *infoptr = 0;
         XRootDStatus st = archive.Stat( false, infoptr );
+        if (!st.IsOK()) return nullptr;
         std::unique_ptr<StatInfo> stinfo( infoptr );
         auto itr = cdmap.find( fn );
         if( itr == cdmap.end() ) return nullptr;

--- a/src/XrdEc/XrdEcObjCfg.hh
+++ b/src/XrdEc/XrdEcObjCfg.hh
@@ -29,6 +29,7 @@ namespace XrdEc
     return crc32_gzip_refl( crc, buffer, len );
   }
 
+  static const std::string ObjStr = "obj";
   struct ObjCfg
   {
       ObjCfg() = delete;
@@ -77,7 +78,7 @@ namespace XrdEc
 
       inline std::string GetFileName( size_t blknb, size_t strpnb ) const
       {
-        return obj + '.' + std::to_string( blknb ) + '.' + std::to_string( strpnb );
+        return ObjStr + '.' + std::to_string( blknb ) + '.' + std::to_string( strpnb );
       }
 
       const std::string obj;
@@ -88,7 +89,6 @@ namespace XrdEc
       const uint64_t    chunksize;  // size of single chunk (nbchunks * chunksize = blksize)
       const uint64_t    paritysize; // size of the parity in the block
       const uint64_t    blksize;    // the whole block size (data + parity) in MB
-
       std::vector<std::string> plgr;
       std::vector<std::string> dtacgi;
       std::vector<std::string> mdtacgi;

--- a/src/XrdEc/XrdEcStrmWriter.cc
+++ b/src/XrdEc/XrdEcStrmWriter.cc
@@ -297,12 +297,8 @@ namespace XrdEc
     closes.reserve( size );
     std::string closeTime = std::to_string( time(NULL) );
 
-    XrdCl::xattr_t xa1("xrdec.filesize", std::to_string(GetSize()));
-    XrdCl::xattr_t xa2("xrdec.strpver", closeTime.c_str());
-
-    std::vector<XrdCl::xattr_t> xav;
-    xav.push_back( std::move(xa1) );
-    xav.push_back( std::move(xa2) );
+    std::vector<XrdCl::xattr_t> xav{ {"xrdec.filesize", std::to_string(GetSize())},
+                                     {"xrdec.strpver", closeTime.c_str()} };
 
     for( size_t i = 0; i < size; ++i )
     {

--- a/src/XrdEc/XrdEcStrmWriter.cc
+++ b/src/XrdEc/XrdEcStrmWriter.cc
@@ -234,7 +234,8 @@ namespace XrdEc
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
     for( size_t i = 0; i < cdcnt; ++i )
     {
-      std::string fn = std::to_string( i );                          // file name (URL of the data archive)
+      //std::string fn = std::to_string( i );                          // file name (URL of the data archive)
+      std::string fn = XrdEc::ObjStr;
       buffer_t buff( dataarchs[i]->GetCD() );                        // raw data buffer (central directory of the data archive)
       uint32_t cksum = objcfg.digest( 0, buff.data(), buff.size() ); // digest (crc) of the buffer
       lfhs.emplace_back( fn, cksum, buff.size(), time( 0 ) );        // LFH record for the buffer
@@ -294,6 +295,7 @@ namespace XrdEc
     std::vector<XrdCl::Pipeline> closes;
     std::vector<XrdCl::Pipeline> save_metadata;
     closes.reserve( size );
+    std::string closeTime = std::to_string( time(NULL) );
     for( size_t i = 0; i < size; ++i )
     {
       //-----------------------------------------------------------------------
@@ -303,6 +305,7 @@ namespace XrdEc
       {
         std::string size( std::to_string( GetSize() ) );
         XrdCl::Pipeline p = XrdCl::SetXAttr( dataarchs[i]->GetFile(), "xrdec.filesize", size )
+                          | XrdCl::SetXAttr( dataarchs[i]->GetFile(), "xrdec.chunkver", closeTime.c_str() )
                           | XrdCl::CloseArchive( *dataarchs[i] );
         closes.emplace_back( std::move( p ) );
       }

--- a/src/XrdEc/XrdEcStrmWriter.cc
+++ b/src/XrdEc/XrdEcStrmWriter.cc
@@ -234,8 +234,7 @@ namespace XrdEc
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
     for( size_t i = 0; i < cdcnt; ++i )
     {
-      //std::string fn = std::to_string( i );                          // file name (URL of the data archive)
-      std::string fn = XrdEc::ObjStr;
+      std::string fn = std::to_string( i );                          // file name (URL of the data archive)
       buffer_t buff( dataarchs[i]->GetCD() );                        // raw data buffer (central directory of the data archive)
       uint32_t cksum = objcfg.digest( 0, buff.data(), buff.size() ); // digest (crc) of the buffer
       lfhs.emplace_back( fn, cksum, buff.size(), time( 0 ) );        // LFH record for the buffer

--- a/src/XrdEc/XrdEcStrmWriter.cc
+++ b/src/XrdEc/XrdEcStrmWriter.cc
@@ -298,7 +298,7 @@ namespace XrdEc
     std::string closeTime = std::to_string( time(NULL) );
 
     XrdCl::xattr_t xa1("xrdec.filesize", std::to_string(GetSize()));
-    XrdCl::xattr_t xa2("xrdec.chunkver", closeTime.c_str());
+    XrdCl::xattr_t xa2("xrdec.strpver", closeTime.c_str());
 
     std::vector<XrdCl::xattr_t> xav;
     xav.push_back( std::move(xa1) );

--- a/src/XrdEc/XrdEcStrmWriter.cc
+++ b/src/XrdEc/XrdEcStrmWriter.cc
@@ -296,6 +296,14 @@ namespace XrdEc
     std::vector<XrdCl::Pipeline> save_metadata;
     closes.reserve( size );
     std::string closeTime = std::to_string( time(NULL) );
+
+    XrdCl::xattr_t xa1("xrdec.filesize", std::to_string(GetSize()));
+    XrdCl::xattr_t xa2("xrdec.chunkver", closeTime.c_str());
+
+    std::vector<XrdCl::xattr_t> xav;
+    xav.push_back( std::move(xa1) );
+    xav.push_back( std::move(xa2) );
+
     for( size_t i = 0; i < size; ++i )
     {
       //-----------------------------------------------------------------------
@@ -303,9 +311,7 @@ namespace XrdEc
       //-----------------------------------------------------------------------
       if( dataarchs[i]->IsOpen() )
       {
-        std::string size( std::to_string( GetSize() ) );
-        XrdCl::Pipeline p = XrdCl::SetXAttr( dataarchs[i]->GetFile(), "xrdec.filesize", size )
-                          | XrdCl::SetXAttr( dataarchs[i]->GetFile(), "xrdec.chunkver", closeTime.c_str() )
+        XrdCl::Pipeline p = XrdCl::SetXAttr( dataarchs[i]->GetFile(), xav )
                           | XrdCl::CloseArchive( *dataarchs[i] );
         closes.emplace_back( std::move( p ) );
       }


### PR DESCRIPTION
1. add pgread/pgwrite
2. avoid 'qdl' delay during read
3. avoid servers in ServerPending state during write
4. store a version number to an Xattr in order to identify (and ignore) old zip archived left by previous deletion
5. set chunk names inside a zip archive to "obj.1.0", etc (not tied to the file name) so that we can rename
6. Set env XRDCL_EC so that other code can act accordingly
7. bug fix