### PR TITLE
[XrdCrypto] Generate DH parameters on first call to XrdCryptosslCipher

### DIFF
--- a/src/XrdCrypto/XrdCryptosslCipher.cc
+++ b/src/XrdCrypto/XrdCryptosslCipher.cc
@@ -32,6 +32,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 #include <cstring>
+#include <assert.h>
 
 #include "XrdSut/XrdSutRndm.hh"
 #include "XrdCrypto/XrdCryptosslTrace.hh"
@@ -459,7 +460,7 @@ XrdCryptosslCipher::XrdCryptosslCipher(bool padded, int bits, char *pub,
    // Constructor for key agreement.
    // If pub is not defined, generates a DH full key,
    // the public part and parameters can be retrieved using Public().
-   // The number of random bits to be used in 'bits'.
+   // 'bits' is ignored (DH key is generated once)
    // If pub is defined with the public part and parameters of the
    // counterpart fully initialize a cipher with that information.
    // Sets also the name to 't', if different from the default one.
@@ -474,15 +475,21 @@ XrdCryptosslCipher::XrdCryptosslCipher(bool padded, int bits, char *pub,
    cipher = 0;
    deflength = 1;
 
+   static DH *dhparms = [] {
+        DH *dh = DH_new();
+        DEBUG("generate DH parameters");
+        DH_generate_parameters_ex(dh, kDHMINBITS, DH_GENERATOR_5, NULL);
+        DEBUG("generate DH parameters done");
+        return dh;
+   }();
+
+   assert(DH_get0_p(dhparms));
+
    if (!pub) {
-      DEBUG("generate DH full key");
-      //
-      // at least 128 bits
-      bits = (bits < kDHMINBITS) ? kDHMINBITS : bits;
-      //
-      // Generate params for DH object
-      fDH = DH_new();
-      if (fDH && DH_generate_parameters_ex(fDH, bits, DH_GENERATOR_5, NULL)) {
+      DEBUG("configure DH parameters");
+      // Set params for DH object
+      fDH = DHparams_dup(dhparms);
+      if (fDH) {
          int prc = 0;
          DH_check(fDH,&prc);
          if (prc == 0) {

--- a/src/XrdCrypto/XrdCryptosslCipher.cc
+++ b/src/XrdCrypto/XrdCryptosslCipher.cc
@@ -32,7 +32,7 @@
 /*                                                                            */
 /* ************************************************************************** */
 #include <cstring>
-#include <assert.h>
+#include <cassert>
 
 #include "XrdSut/XrdSutRndm.hh"
 #include "XrdCrypto/XrdCryptosslTrace.hh"
@@ -475,32 +475,27 @@ XrdCryptosslCipher::XrdCryptosslCipher(bool padded, int bits, char *pub,
    cipher = 0;
    deflength = 1;
 
-   static DH *dhparms = [] {
-        DH *dh = DH_new();
-        DEBUG("generate DH parameters");
-        DH_generate_parameters_ex(dh, kDHMINBITS, DH_GENERATOR_5, NULL);
-        DEBUG("generate DH parameters done");
-        return dh;
-   }();
-
-   assert(DH_get0_p(dhparms));
-
    if (!pub) {
+      static DH *dhparms = [] {
+         DH *dh = DH_new();
+         DEBUG("generate DH parameters");
+         DH_generate_parameters_ex(dh, kDHMINBITS, DH_GENERATOR_5, NULL);
+         DEBUG("generate DH parameters done");
+         return dh;
+      }();
+
       DEBUG("configure DH parameters");
       // Set params for DH object
+      assert(DH_get0_p(dhparms));
       fDH = DHparams_dup(dhparms);
       if (fDH) {
-         int prc = 0;
-         DH_check(fDH,&prc);
-         if (prc == 0) {
-            //
-            // Generate DH key
-            if (DH_generate_key(fDH)) {
-               // Init context
-               ctx = EVP_CIPHER_CTX_new();
-               if (ctx)
-                  valid = 1;
-            }
+         //
+         // Generate DH key
+         if (DH_generate_key(fDH)) {
+            // Init context
+            ctx = EVP_CIPHER_CTX_new();
+            if (ctx)
+               valid = 1;
          }
       }
 


### PR DESCRIPTION
This should address the increased load issue discussed in #1556. I've _very lightly_ tested this change in production, and it seems OK. I'm planning more thorough tests tomorrow.

We'll also need to update `openssl3/XrdCryptosslCipher.cc` to match, but it should be fairly straightforward.