### PR TITLE
Fix compiler warnings about pointers used after free:

### DIFF
--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -438,8 +438,8 @@ XrdCpFile *IndexRemote( XrdCl::FileSystem *fs,
     current = new XrdCpFile( path.c_str(), badUrl );
     if( badUrl )
     {
-      delete current;
       log->Error( AppMsg, "Bad URL: %s", current->Path );
+      delete current;
       return 0;
     }
 

--- a/src/XrdCms/XrdCmsUtils.cc
+++ b/src/XrdCms/XrdCmsUtils.cc
@@ -223,15 +223,15 @@ bool XrdCmsUtils::ParseMan(XrdSysError *eDest, XrdOucTList **oldMans,
                   }
                oldP = oldP->next;
               }
-         if (!plus || strcmp(hSpec, newP->text)) isBad = false;
-            else {eDest->Say("Config warning: "
-                             "Cyclic DNS registration for ",newP->text,"\n"
-                             "Config warning: This cluster will exhibit "
-                             "undefined behaviour!!!");
-             isBad = true;
-            }
-         if (!oldP) 
-            {appList = SInsert(appList, newP);
+         if (!oldP)
+            {if (!plus || strcmp(hSpec, newP->text)) isBad = false;
+                else {eDest->Say("Config warning: "
+                                 "Cyclic DNS registration for ",newP->text,"\n"
+                                 "Config warning: This cluster will exhibit "
+                                 "undefined behaviour!!!");
+                      isBad = true;
+                     }
+             appList = SInsert(appList, newP);
              if (plus && !hush) Display(eDest, hSpec, newP->text, isBad);
             }
         }


### PR DESCRIPTION
~~~
.../src/XrdCms/XrdCmsUtils.cc: In function 'XrdCmsUtils::ParseMan(XrdSysError*, XrdOucTList**, char*, char*, int*, bool)':
.../src/XrdCms/XrdCmsUtils.cc:226:43: error: pointer 'newMans_175' may be used after 'operator delete(void*, unsigned long)' [-Werror=use-after-free]
  226 |          if (!plus || strcmp(hSpec, newP->text)) isBad = false;
      |                                     ~~~~~~^~~~
.../src/XrdCms/XrdCmsUtils.cc:221:27: note: call to 'operator delete(void*, unsigned long)' here
  221 |                    delete newP;
      |                           ^~~~

.../src/XrdCl/XrdClCopy.cc: In function 'IndexRemote(XrdCl::FileSystem*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, unsigned short)':
.../src/XrdCl/XrdClCopy.cc:442:17: error: pointer used after 'operator delete(void*, unsigned long)' [-Werror=use-after-free]
  442 |       log->Error( AppMsg, "Bad URL: %s", current->Path );
      |       ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../src/XrdCl/XrdClCopy.cc:441:14: note: call to 'operator delete(void*, unsigned long)' here
  441 |       delete current;
      |              ^~~~~~~
~~~
