### PR TITLE
Fix warnings about allocations exceeding maximum object size

### DIFF
--- a/src/Xrd/XrdBuffXL.cc
+++ b/src/Xrd/XrdBuffXL.cc
@@ -63,7 +63,8 @@ XrdBuffXL::XrdBuffXL() : bucket(0), totalo(0), pagsz(getpagesize()), slots(0),
 
 void XrdBuffXL::Init(int maxMSZ)
 {
-   int lg2, chunksz;
+   unsigned int lg2;
+   int chunksz;
 
 // If this is a duplicate call, delete the previous setup
 //

--- a/src/XrdNet/XrdNetUtils.cc
+++ b/src/XrdNet/XrdNetUtils.cc
@@ -259,7 +259,7 @@ const char  *XrdNetUtils::GetAddrs(const char            *hSpec,
 //
    if (aInfo.aNum4 || aInfo.aNum6)
       {aVsz = aInfo.aNum4 + aInfo.aNum6;
-       *aVec = new XrdNetAddr[aVsz];
+       *aVec = new XrdNetAddr[(unsigned int)aVsz];
        FillAddr(aInfo, *aVec);
       }
 

--- a/src/XrdOuc/XrdOucBuffer.cc
+++ b/src/XrdOuc/XrdOucBuffer.cc
@@ -76,7 +76,7 @@ XrdOucBuffPool::XrdOucBuffPool(int minsz, int maxsz,
 
 // Allocate a slot vector for this
 //
-   bSlot = new BuffSlot[slots];
+   bSlot = new BuffSlot[(unsigned int)slots];
 
 // Complete initializing the slot vector
 //

--- a/src/XrdOuc/XrdOucTable.hh
+++ b/src/XrdOuc/XrdOucTable.hh
@@ -40,7 +40,7 @@ public:
 
          XrdOucTable(int maxe)
                     {int i;
-                     Table = new OucTable[maxe];
+                     Table = new OucTable[(unsigned int)maxe];
                      maxnum = maxe; curnum = 0; avlnum = 0;
                      for (i = 1; i < maxe; i++) Table[i-1].Fnum = i;
                      Table[maxe-1].Fnum = -1;

--- a/src/XrdPosix/XrdPosixAdmin.cc
+++ b/src/XrdPosix/XrdPosixAdmin.cc
@@ -49,7 +49,7 @@ XrdCl::URL *XrdPosixAdmin::FanOut(int &num)
    XrdCl::URL                    *uVec;
    XrdNetAddr netLoc;
    const char *hName;
-   int i;
+   unsigned int i;
 
 // Make sure admin is ok
 //


### PR DESCRIPTION
~~~
In member function 'Init',
    inlined from 'Init' at .../src/Xrd/XrdBuffXL.cc:64:6:
.../src/Xrd/XrdBuffXL.cc:90:30: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   90 |    bucket = new BuckVec[lg2+1];
      |                              ^
/usr/include/c++/12/new: In member function 'Init':
/usr/include/c++/12/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^

.../src/XrdOuc/XrdOucBuffer.cc: In member function '__ct_base ':
.../src/XrdOuc/XrdOucBuffer.cc:79:30: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   79 |    bSlot = new BuffSlot[slots];
      |                              ^
/usr/include/c++/12/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^

.../src/XrdNet/XrdNetUtils.cc: In function 'GetAddrs':
.../src/XrdNet/XrdNetUtils.cc:262:35: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
  262 |        *aVec = new XrdNetAddr[aVsz];
      |                                   ^
/usr/include/c++/12/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^

In member function '__ct ',
    inlined from '__ct_base ' at .../src/XrdXrootd/XrdXrootdJob.cc:459:29:
.../src/./XrdOuc/XrdOucTable.hh:43:30: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   43 |                      Table = new OucTable[maxe];
      |                              ^
/usr/include/c++/12/new: In member function '__ct_base ':
/usr/include/c++/12/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^

.../src/XrdPosix/XrdPosixAdmin.cc: In member function 'FanOut':
.../src/XrdPosix/XrdPosixAdmin.cc:69:27: warning: argument 1 value '18446744073709551615' exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   69 |    uVec = new XrdCl::URL[i];
      |                           ^
/usr/include/c++/12/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
~~~
