### PR TITLE
fix: Sanitize Python version to be PEP 440 compliant

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,7 +336,8 @@ jobs:
         . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
-        python3 -m pip --verbose install dist/xrootd-*.tar.gz
+        cd ..  # Move xrootd.egg-info off PYTHONPATH
+        python3 -m pip --verbose install xrootd/dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Verify Python bindings
@@ -383,7 +384,8 @@ jobs:
         . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
-        python3 -m pip --verbose install dist/xrootd-*.tar.gz
+        cd ..  # Move xrootd.egg-info off PYTHONPATH
+        python3 -m pip --verbose install xrootd/dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Verify Python bindings

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -50,10 +50,9 @@ if version.startswith('unknown'):
     import os
     version_file_path = os.path.join('${CMAKE_CURRENT_SOURCE_DIR}', 'VERSION')
     print('Version file path: {}'.format(version_file_path))
-    f = open(version_file_path, 'r')
-    version = f.read().split('/n')[0] 
-    print('Version from file: {}'.format(version))
-    f.close()
+    with open(version_file_path, 'r') as f:
+      version = f.read().split('/n')[0]
+      print('Version from file: {}'.format(version))
   except Exception as e:
     print('{} \nCannot open VERSION_INFO file. {} will be used'.format(e, version))
 

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -57,6 +57,30 @@ if version.startswith('unknown'):
   except Exception as e:
     print('{} \nCannot open VERSION_INFO file. {} will be used'.format(e, version))
 
+# Sanitize in keeping with PEP 440
+# c.f. https://www.python.org/dev/peps/pep-0440/
+# c.f. https://github.com/pypa/pip/issues/8368
+# version needs to pass pip._vendor.packaging.version.Version()
+version = version.replace("-", ".")
+
+if version.startswith("v"):
+    version = version[1:]
+
+version_parts = version.split(".")
+if len(version_parts[0]) == 8:
+    # CalVer
+    date = version_parts[0]
+    year = date[:4]
+    incremental = date[4:]
+    if incremental.startswith("0"):
+      incremental = incremental[1:]
+
+    version = year + "." + incremental
+
+    if len(version_parts) > 1:
+      # https://github.com/pypa/pip/issues/9188#issuecomment-736025963
+      hash = version_parts[1]
+      version = version + "+" + hash
 
 print('XRootD library dir:    ', xrdlibdir)
 print('XRootD src include dir:', xrdsrcincdir)

--- a/packaging/wheel/setup.py
+++ b/packaging/wheel/setup.py
@@ -14,11 +14,30 @@ import subprocess
 import sys
 
 def get_version():
-    version = subprocess.check_output(['./genversion.sh', '--print-only'])
-    version = version.decode()
-    if version.startswith('v'):
+    version = subprocess.check_output(['./genversion.sh', '--print-only']).decode()
+
+    # Sanitize in keeping with PEP 440
+    # c.f. https://www.python.org/dev/peps/pep-0440/
+    # c.f. https://github.com/pypa/pip/issues/8368
+    # version needs to pass pip._vendor.packaging.version.Version()
+    version = version.replace("-", ".")
+
+    if version.startswith("v"):
         version = version[1:]
-    version = version.split('-')[0]
+
+    version_parts = version.split(".")
+
+    # Assume SemVer as default case
+    if len(version_parts[0]) == 8:
+        # CalVer
+        date = version_parts[0]
+        year = date[:4]
+        incremental = date[4:]
+        if incremental.startswith("0"):
+          incremental = incremental[1:]
+
+        version = year + "." + incremental
+
     return version
 
 def get_version_from_file():

--- a/packaging/wheel/setup.py
+++ b/packaging/wheel/setup.py
@@ -42,9 +42,8 @@ def get_version():
 
 def get_version_from_file():
     try:
-        f = open('./bindings/python/VERSION')
-        version = f.read().split('/n')[0]
-        f.close()
+        with open('./bindings/python/VERSION') as f:
+            version = f.read().split('/n')[0]
         return version
     except:
         print('Failed to get version from file. Using unknown')


### PR DESCRIPTION
To avoid errors in modern versions of `pip`, ensure that the version name created for the Python bindings is sanitized to be compliant with [PEP 440](https://www.python.org/dev/peps/pep-0440/)

c.f.:
* https://www.python.org/dev/peps/pep-0440/
* https://github.com/pypa/pip/issues/8368

This essentially means that the version number needs to pass `pip._vendor.packaging.version.Version()`

Example:

```python
from pip._vendor.packaging.version import Version

Version("v20220128-34c8a39")  # pip._vendor.packaging.version.InvalidVersion: Invalid version: 'v20220128-34c8a39'
Version("2022.128")  # <Version('2022.128')>
Version("2022.128+a28a91c")  # <Version('2022.128+a28a91c')>
Version("6.0.0")  # <Version('6.0.0')>