### PR TITLE
Ignore -Warray-bounds warnings from stricter check in gcc 12.

### DIFF
--- a/src/XrdFrm/XrdFrmMonitor.cc
+++ b/src/XrdFrm/XrdFrmMonitor.cc
@@ -149,6 +149,12 @@ int XrdFrmMonitor::Init(const char *iHost, const char *iProg, const char *iName)
 //
    if (!isEnabled) return 1;
 
+// Ignore array bounds warning from gcc 12 triggered because the allocated
+// memory for the XrdXrootdMonMap is smaller than sizeof(XrdXrootdMonMap)
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 // Create identification record
 //
    idLen = strlen(iBuff) + sizeof(XrdXrootdMonHeader) + sizeof(kXR_int32);
@@ -158,6 +164,9 @@ int XrdFrmMonitor::Init(const char *iHost, const char *iProg, const char *iName)
    mP->hdr.pseq = 0;
    mP->dictid   = 0;
    strcpy(mP->info, iBuff);
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif
 
 // Setup the primary destination
 //

--- a/src/XrdXrootd/XrdXrootdMonitor.cc
+++ b/src/XrdXrootd/XrdXrootdMonitor.cc
@@ -625,6 +625,12 @@ void XrdXrootdMonitor::Init(XrdScheduler *sp,    XrdSysError *errp,
    kySIDSZ = strlen(kySID);
    monHost = strdup(iHost);
 
+// Ignore array bounds warning from gcc 12 triggered because the allocated
+// memory for the XrdXrootdMonMap is smaller than sizeof(XrdXrootdMonMap)
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 // Create identification record
 //
    idLen = strlen(iBuff) + sizeof(XrdXrootdMonHeader) + sizeof(kXR_int32);
@@ -634,6 +640,9 @@ void XrdXrootdMonitor::Init(XrdScheduler *sp,    XrdSysError *errp,
    mP->hdr.pseq = 0;
    mP->dictid   = 0;
    strcpy(mP->info, iBuff);
+#if defined(__GNUC__) && __GNUC__ >= 12
+#pragma GCC diagnostic pop
+#endif
 
 // Generate a CGI version of all the variations
 //


### PR DESCRIPTION
```
.../src/XrdFrm/XrdFrmMonitor.cc: In function 'XrdFrmMonitor::Init(char const*, char const*, char const*)':
.../src/XrdFrm/XrdFrmMonitor.cc:158:12: warning: array subscript 'struct XrdXrootdMonMap[0]' is partly outside array bounds of 'unsigned char[1036]' [-Warray-bounds]
  158 |    mP->hdr.pseq = 0;
      |    ~~~~~~~~^~~~
.../src/XrdFrm/XrdFrmMonitor.cc:155:26: note: object of size [13, 1036] allocated by 'malloc'
  155 |    idRec = (char *)malloc(idLen+1);
      |                    ~~~~~~^~~~~~~~~
.../src/XrdFrm/XrdFrmMonitor.cc:159:8: warning: array subscript 'struct XrdXrootdMonMap[0]' is partly outside array bounds of 'unsigned char[1036]' [-Warray-bounds]
  159 |    mP->dictid   = 0;
      |    ~~~~^~~~~~
.../src/XrdFrm/XrdFrmMonitor.cc:155:26: note: object of size [13, 1036] allocated by 'malloc'
  155 |    idRec = (char *)malloc(idLen+1);
      |                    ~~~~~~^~~~~~~~~

.../src/XrdXrootd/XrdXrootdMonitor.cc: In function 'XrdXrootdMonitor::Init(XrdScheduler*, XrdSysError*, char const*, char const*, char const*, int)':
.../src/XrdXrootd/XrdXrootdMonitor.cc:634:12: warning: array subscript 'struct XrdXrootdMonMap[0]' is partly outside array bounds of 'unsigned char[1036]' [-Warray-bounds]
  634 |    mP->hdr.pseq = 0;
      |    ~~~~~~~~^~~~
.../src/XrdXrootd/XrdXrootdMonitor.cc:631:26: note: object of size [13, 1036] allocated by 'malloc'
  631 |    idRec = (char *)malloc(idLen+1);
      |                    ~~~~~~^~~~~~~~~
.../src/XrdXrootd/XrdXrootdMonitor.cc:635:8: warning: array subscript 'struct XrdXrootdMonMap[0]' is partly outside array bounds of 'unsigned char[1036]' [-Warray-bounds]
  635 |    mP->dictid   = 0;
      |    ~~~~^~~~~~
.../src/XrdXrootd/XrdXrootdMonitor.cc:631:26: note: object of size [13, 1036] allocated by 'malloc'
  631 |    idRec = (char *)malloc(idLen+1);
      |                    ~~~~~~^~~~~~~~~
```
