### PR TITLE
[pip] Sanitize release candidate versions to PEP 440

### DIFF
--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -66,6 +66,12 @@ if version.startswith("v"):
     version = version[1:]
 
 version_parts = version.split(".")
+
+# Ensure release candidates sanitized to <major>.<minor>.<patch>rc<candidate>
+if version_parts[-1].startswith("rc"):
+    version = ".".join(version_parts[:-1]) + version_parts[-1]
+    version_parts = version.split(".")
+
 if len(version_parts[0]) == 8:
     # CalVer
     date = version_parts[0]

--- a/packaging/wheel/setup.py
+++ b/packaging/wheel/setup.py
@@ -27,6 +27,11 @@ def get_version():
 
     version_parts = version.split(".")
 
+    # Ensure release candidates sanitized to <major>.<minor>.<patch>rc<candidate>
+    if version_parts[-1].startswith("rc"):
+        version = ".".join(version_parts[:-1]) + version_parts[-1]
+        version_parts = version.split(".")
+
     # Assume SemVer as default case
     if len(version_parts[0]) == 8:
         # CalVer


### PR DESCRIPTION
Resolves #1621

Ensure release candidates are all sanitized to the PEP 440 form of `<major>.<minor>.<patch>rc<candidate>`.

Example:

```python
from pip._vendor.packaging.version import Version
Version("v5.4.1-rc2")  # <Version('5.4.1rc2')>
Version("v5.4.1.rc2")  # <Version('5.4.1rc2')>
Version("v5.4.1rc2")  # <Version('5.4.1rc2')>
```