### PR TITLE
Do not trigger DeepLocate with pss.origin is http(s)

### DIFF
--- a/docs/PreReleaseNotes.txt
+++ b/docs/PreReleaseNotes.txt
@@ -37,6 +37,8 @@ Prerelease Notes
   **Commits: 48b1bf4a
   **[Proxy]** Allow for URLs with username.
   **Commits: 05a8c0ed
+  **[XrdPss]** Do not trigger DeepLocate when pss.origin is http(s)
+  **Commits: 753fd54
 
 + **Miscellaneous**
   **[GSI]** Comment out no longer needed trace record

--- a/src/XrdPss/XrdPssConfig.cc
+++ b/src/XrdPss/XrdPssConfig.cc
@@ -799,7 +799,8 @@ int XrdPssSys::xorig(XrdSysError *errp, XrdOucStream &Config)
 // of domain. Composite listings are normally disabled for out of domain nodes.
 //
    if (!index(mval, '.')
-   || !strcmp(XrdPssUtils::getDomain(mval), XrdPssUtils::getDomain(myHost)))
+   || (!strcmp(XrdPssUtils::getDomain(mval), XrdPssUtils::getDomain(myHost))
+       && !strcmp(protName, "http://") && !strcmp(protName, "https://")))
       XrdPosixConfig::SetEnv("DirlistDflt", 1);
 
 // All done


### PR DESCRIPTION
Correspond to issue # 1622