### PR TITLE
Modify vector's size instead of capacity to avoid bounds-checking failures

### DIFF
--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -568,8 +568,7 @@ Handler::GenerateMacaroonResponse(XrdHttpExtReq &req, const std::string &resourc
 
     size_t size_hint = macaroon_serialize_size_hint(mac_with_date);
 
-    std::vector<char> macaroon_resp; macaroon_resp.reserve(size_hint);
-    macaroon_resp.push_back((char)0);
+    std::vector<char> macaroon_resp; macaroon_resp.resize(size_hint);
     if (macaroon_serialize(mac_with_date, &macaroon_resp[0], size_hint, &mac_err))
     {
         printf("Returned macaroon_serialize code: %lu\n", (unsigned long)size_hint);

--- a/src/XrdThrottle/XrdThrottleManager.cc
+++ b/src/XrdThrottle/XrdThrottleManager.cc
@@ -48,10 +48,10 @@ XrdThrottleManager::Init()
 {
    TRACE(DEBUG, "Initializing the throttle manager.");
    // Initialize all our shares to zero.
-   m_primary_bytes_shares.reserve(m_max_users);
-   m_secondary_bytes_shares.reserve(m_max_users);
-   m_primary_ops_shares.reserve(m_max_users);
-   m_secondary_ops_shares.reserve(m_max_users);
+   m_primary_bytes_shares.resize(m_max_users);
+   m_secondary_bytes_shares.resize(m_max_users);
+   m_primary_ops_shares.resize(m_max_users);
+   m_secondary_ops_shares.resize(m_max_users);
    // Allocate each user 100KB and 10 ops to bootstrap;
    for (int i=0; i<m_max_users; i++)
    {

--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -113,9 +113,9 @@ private:
             }
 
             // Inflate the underlying buffer if needed.
-            ssize_t new_bytes_needed = (m_size + size) - m_buffer.capacity();
+            ssize_t new_bytes_needed = (m_size + size) - m_buffer.size();
             if (new_bytes_needed > 0) {
-                m_buffer.reserve(m_capacity);
+                m_buffer.resize(m_capacity);
             }
 
             // Finally, do the copy.


### PR DESCRIPTION
There are three commits, each to a distinct file.  All involve using `vector::resize` instead of `reserve`, and `vector::size` instead of `capacity`, and the unmodified code produces a bounds-checking assertion failure in `vector::operator[]` when compiled with `-D_GLIBCXX_ASSERTIONS`.  A [smoke test](https://github.com/paulmillar/http-tpc-utils/blob/master/bin/smoke-test.sh) was applied to the first two commits to verify that they eliminate a problem.
The first (in `XrdMacaroonsHandler.cc`) specifically fixes xrootd/xrootd#1614.  Although already closed, I think this change would be more readable.
The second (in `XrdTpcStream.hh`) is in code that was not engaged/discovered during the smoke test until the first was fixed.
The third (in `XrdThrottleManager.cc`) was found just by a scan of the code, and is not engaged by our configuration.  However, adding `xrootd.fslib throttle default` does engage it, and causes the assertion failure as soon as the process starts up without the fix.
