### PR TITLE
Add support support for musl libc on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,6 +297,77 @@ jobs:
         python3 -c 'import pyxrootd; print(pyxrootd)'
         python3 -c 'from XRootD import client; print(client.FileSystem("root://someserver:1094"))'
 
+  cmake-voidlinux:
+
+    runs-on: ubuntu-latest
+    container: 'ghcr.io/void-linux/xbps-src-masterdir:20220527RC01-x86_64-musl'
+
+    steps:
+    - name: Install external dependencies with xbps
+      run: |
+        # Sync and upgrade once, assume error comes from xbps update
+        xbps-install -Syu || xbps-install -yu xbps
+        # Upgrade again (in case there was a xbps update)
+        xbps-install -Syu
+        # Install script dependencies
+        xbps-install -y \
+          gcc \
+          git \
+          cmake \
+          make \
+          pkg-config \
+          libuuid-devel \
+          openssl-devel \
+          readline-devel \
+          libexecinfo-devel \
+          zlib-devel \
+          python3 \
+          python3-pip \
+          python3-wheel \
+          python3-devel
+
+    - name: Clone repository
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+
+    - name: Build with cmake
+      run: |
+        git config --global --add safe.directory "$PWD"
+        cd ..
+        cmake \
+            -DCMAKE_INSTALL_PREFIX=/usr/local/ \
+            -DPYTHON_EXECUTABLE=$(command -v python3) \
+            -DENABLE_TESTS=ON \
+            -DCMAKE_CXX_STANDARD_LIBRARIES=-lexecinfo \
+            -DPIP_OPTIONS="--verbose" \
+            -S xrootd \
+            -B build
+        cmake build -LH
+        cmake \
+            --build build \
+            --clean-first \
+            --parallel $(($(nproc) - 1))
+        cmake --build build --target install
+        python3 -m pip list
+
+    - name: Verify install
+      run: |
+        command -v xrootd
+        command -v xrdcp
+
+    - name: Verify Python bindings
+      run: |
+        export LD_LIBRARY_PATH="/usr/local/lib64:${LD_LIBRARY_PATH}"
+        export PYTHON_VERSION_MINOR=$(python3 -c 'import sys; print(f"{sys.version_info.minor}")')
+        export PYTHONPATH="/usr/local/lib/python3.${PYTHON_VERSION_MINOR}/site-packages:${PYTHONPATH}"
+        python3 --version --version
+        python3 -m pip list
+        python3 -m pip show xrootd
+        python3 -c 'import XRootD; print(XRootD)'
+        python3 -c 'import pyxrootd; print(pyxrootd)'
+        python3 -c 'from XRootD import client; print(client.FileSystem("root://someserver:1094"))'
+
   cmake-macos:
 
     runs-on: macos-latest

--- a/cmake/XRootDOSDefs.cmake
+++ b/cmake/XRootDOSDefs.cmake
@@ -3,6 +3,10 @@
 #-------------------------------------------------------------------------------
 
 include( CheckCXXSourceRuns )
+include( CheckFunctionExists )
+include( CheckSymbolExists ) 
+include( CheckIncludeFile )
+
 
 set( LINUX    FALSE )
 set( KFREEBSD FALSE )
@@ -70,6 +74,20 @@ if( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
   set( LINUX TRUE )
   include( GNUInstallDirs )
   set( EXTRA_LIBS rt )
+
+  check_symbol_exists( __GLIBC__ features.h HAVE_GLIBC )
+  if ( LINUX AND NOT HAVE_GLIBC )
+    check_function_exists( __fseterr HAVE_fseterr )
+    check_include_file( bits/alltypes.h HAVE_BITS_ALLTYPES )
+    check_include_file( stdio_ext.h HAVE_STDIO_EXT )
+    if ( HAVE_fseterr AND HAVE_BITS_ALLTYPES AND HAVE_STDIO_EXT )
+      add_definitions( -DHAVE_MUSL_LIBC )
+      check_include_file( execinfo.h HAVE_EXECINFO )
+      if ( NOT HAVE_EXECINFO )
+        message(FATAL_ERROR "Cannot find execinfo.h!")
+      endif()
+    endif()
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/src/Xrd/XrdConfig.hh
+++ b/src/Xrd/XrdConfig.hh
@@ -34,6 +34,11 @@
 #include "Xrd/XrdProtLoad.hh"
 #include "Xrd/XrdProtocol.hh"
 
+#if defined(__linux__) && defined(HAVE_MUSL_LIBC)
+#define __NEED_mode_t
+#include <bits/alltypes.h>
+#endif
+
 class XrdSysError;
 class XrdTcpMonInfo;
 class XrdNetSecurity;

--- a/src/Xrd/XrdPoll.hh
+++ b/src/Xrd/XrdPoll.hh
@@ -29,7 +29,7 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
-#include <sys/poll.h>
+#include <poll.h>
 #include "XrdSys/XrdSysPthread.hh"
 
 #define XRD_NUMPOLLERS 3

--- a/src/XrdAcc/XrdAccGroups.cc
+++ b/src/XrdAcc/XrdAccGroups.cc
@@ -46,6 +46,14 @@
 #include "XrdAcc/XrdAccGroups.hh"
 #include "XrdAcc/XrdAccPrivs.hh"
 
+#if defined(__linux__) && defined(HAVE_MUSL_LIBC)
+int innetgr(const char *netgroup, const char *host, const char *user,
+             const char *domain)
+{
+   return 0;
+}
+#endif
+
 // Additionally, this routine does not support a user in more than
 // NGROUPS_MAX groups. This is a standard unix limit defined in limits.h.
   

--- a/src/XrdCl/XrdClFileStateHandler.hh
+++ b/src/XrdCl/XrdClFileStateHandler.hh
@@ -42,6 +42,12 @@
 #include <sys/uio.h>
 #include <cstdint>
 
+#if defined(__linux__) && defined(HAVE_MUSL_LIBC)
+#define __NEED_suseconds_t
+#define __NEED_struct_timeval
+#include <bits/alltypes.h>
+#endif
+
 namespace
 {
   class PgReadHandler;

--- a/src/XrdCl/XrdClMonitor.hh
+++ b/src/XrdCl/XrdClMonitor.hh
@@ -43,6 +43,12 @@
 
 #include "XrdCl/XrdClFileSystem.hh"
 
+#if defined(__linux__) && defined(HAVE_MUSL_LIBC)
+#define __NEED_suseconds_t
+#define __NEED_struct_timeval
+#include <bits/alltypes.h>
+#endif
+
 namespace XrdCl
 {
   class URL;

--- a/src/XrdNet/XrdNetMsg.cc
+++ b/src/XrdNet/XrdNetMsg.cc
@@ -29,7 +29,7 @@
 /******************************************************************************/
 
 #include <cerrno>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include "XrdNet/XrdNet.hh"
 #include "XrdNet/XrdNetMsg.hh"

--- a/src/XrdNet/XrdNetSecurity.cc
+++ b/src/XrdNet/XrdNetSecurity.cc
@@ -40,12 +40,14 @@
 #include <sys/types.h>
 #include <Winsock2.h>
 #include <io.h>
+#include "XrdSys/XrdWin32.hh"
+#endif
+#if WIN32 || defined(__linux__) && defined(HAVE_MUSL_LIBC)
 int innetgr(const char *netgroup, const char *host, const char *user,
              const char *domain)
 {
    return 0;
 }
-#include "XrdSys/XrdWin32.hh"
 #endif
 
 #include "XrdNet/XrdNetAddr.hh"

--- a/src/XrdOfs/XrdOfsHandle.cc
+++ b/src/XrdOfs/XrdOfsHandle.cc
@@ -30,7 +30,7 @@
 
 #include <cstdio>
 #include <ctime>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/types.h>
 
 #include "XrdOfs/XrdOfsHandle.hh"

--- a/src/XrdOssCsi/XrdOssCsiTagstoreFile.hh
+++ b/src/XrdOssCsi/XrdOssCsiTagstoreFile.hh
@@ -38,7 +38,7 @@
 #include <memory>
 #include <mutex>
 
-#if defined(__GLIBC__) || defined(__BIONIC__) || defined(__CYGWIN__)
+#if defined(__GLIBC__) || defined(HAVE_MUSL_LIBC) || defined(__BIONIC__) || defined(__CYGWIN__)
 #include <byteswap.h>
 #elif defined(__APPLE__)
 // Make sure that byte swap functions are not already defined.

--- a/src/XrdPosix/XrdPosixLinkage.hh
+++ b/src/XrdPosix/XrdPosixLinkage.hh
@@ -40,6 +40,7 @@
 #include <unistd.h>
 
 #include "XrdPosix/XrdPosixOsDep.hh"
+#include "XrdPosix/XrdPosixXrootd.hh"
 #include "XrdSys/XrdSysPlatform.hh"
 
 /******************************************************************************/

--- a/src/XrdPosix/XrdPosixMap.hh
+++ b/src/XrdPosix/XrdPosixMap.hh
@@ -36,6 +36,11 @@
 #include "XrdCl/XrdClFileSystem.hh"
 #include "XrdCl/XrdClXRootDResponses.hh"
 
+#if defined(__linux__) && defined(HAVE_MUSL_LIBC)
+#define __NEED_dev_t
+#include <bits/alltypes.h>
+#endif
+
 class XrdPosixMap
 {
 public:

--- a/src/XrdPosix/XrdPosixPreload.cc
+++ b/src/XrdPosix/XrdPosixPreload.cc
@@ -42,6 +42,22 @@
 
 #include "XrdPosix/XrdPosixExtern.hh"
  
+#ifdef creat64
+#undef creat64
+#undef fseeko64
+#undef ftello64
+#undef ftruncate64
+#undef lseek64
+#undef open64
+#undef pread64
+#undef pwrite64
+#undef readdir64
+#undef readdir64_r
+#undef statfs64
+#undef statvfs64
+#undef truncate64
+#endif
+
 /******************************************************************************/
 /*                   G l o b a l   D e c l a r a t i o n s                    */
 /******************************************************************************/

--- a/src/XrdSys/XrdSysPlatform.hh
+++ b/src/XrdSys/XrdSysPlatform.hh
@@ -241,16 +241,8 @@ extern "C"
 #if defined(_AIX) || \
    (defined(XR__SUNGCC3) && !defined(__arch64__))
 #   define SOCKLEN_t size_t
-#elif defined(XR__GLIBC) || \
-   defined(__FreeBSD__) || \
-   (defined(__FreeBSD_kernel__) && defined(__GLIBC__)) || \
-   (defined(XR__SUNGCC3) && defined(__arch64__)) || defined(__APPLE__) || \
-   (defined(__sun) && defined(_SOCKLEN_T))
-#   ifndef SOCKLEN_t
-#      define SOCKLEN_t socklen_t
-#   endif
 #elif !defined(SOCKLEN_t)
-#   define SOCKLEN_t int
+#   define SOCKLEN_t socklen_t
 #endif
 
 #ifdef _LP64

--- a/src/XrdSys/XrdSysPthread.hh
+++ b/src/XrdSys/XrdSysPthread.hh
@@ -351,7 +351,7 @@ enum PrefType {prefWR=1};
 
         XrdSysRWLock(PrefType ptype)
                     {
-#ifdef __linux__
+#ifdef __GLIBC__
                      pthread_rwlockattr_t attr;
                      pthread_rwlockattr_setkind_np(&attr,
                              PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);
@@ -367,7 +367,7 @@ enum PrefType {prefWR=1};
 inline void ReInitialize(PrefType ptype)
 {
   pthread_rwlock_destroy(&lock);
-#ifdef __linux__
+#ifdef __GLIBC__
   pthread_rwlockattr_t attr;
   pthread_rwlockattr_setkind_np(&attr,
                      PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP);

--- a/src/XrdTls/XrdTlsTempCA.cc
+++ b/src/XrdTls/XrdTlsTempCA.cc
@@ -30,7 +30,7 @@
 #include <cstdlib>
 #include <fcntl.h>
 #include <dirent.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <unordered_set>
 #include <memory>

--- a/src/XrdVoms/XrdVomsMapfile.cc
+++ b/src/XrdVoms/XrdVomsMapfile.cc
@@ -40,7 +40,7 @@
 #include <vector>
 #include <string>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 
 bool XrdVomsMapfile::tried_configure = false;
 std::unique_ptr<XrdVomsMapfile> XrdVomsMapfile::mapper;


### PR DESCRIPTION
These changes are to make it possible to compile xrootd on musl libc, which is a standards conforming C standard library for linux. I put this together while packaging xrootd for void linux, which supports both glibc and musl ( void-linux/void-packages#34647 ).