### PR TITLE
Make the `acc` subsystem aware of request-based name mapping.

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -406,6 +406,7 @@ public:
         if (mapping_success) {
             // Set scitokens.name in the extra attribute
             Entity->eaAPI->Add("request.name", username, true);
+            new_secentity.eaAPI->Add("request.name", username, true);
         }
 
             // Make the token subject available.  Even though it's a reasonably bad idea


### PR DESCRIPTION
When a per-request mapping is made (such as with SciTokens), the mapped name is not put in the typical `Entity.name` but rather an extended attribute.  Only authorization plugins that have been explicitly updated to look for this attribute can be usefully chained after per-request mapping.

These changes allow the `acc` subsystem to be chained in a useful manner after a token plugin (such as SciTokens).