### PR TITLE
Vector cleared after use so it can be shrunk.

### DIFF
--- a/src/XrdTpc/XrdTpcStream.hh
+++ b/src/XrdTpc/XrdTpcStream.hh
@@ -98,6 +98,7 @@ private:
             }
             m_offset = -1;
             m_size = 0;
+            m_buffer.clear();
             return retval;
         }
 


### PR DESCRIPTION
Sorry, I missed something in 5ea200480df332215235e13bb02035d460cd5a46.  The `vector::shrink_to_fit` call at [`XrdTpcStream.hh` line 133](https://github.com/xrootd/xrootd/blob/master/src/XrdTpc/XrdTpcStream.hh#L133) relies upon the vector size (which used to be always 0) being less than its capacity.  (It seems it's only invoked when ['low buffer occupancy'](https://github.com/xrootd/xrootd/blob/master/src/XrdTpc/XrdTpcStream.cc#L153-L160) is detected.)  Now the (size, capacity) will only ever be either (0, 0) or (`m_capacity`, `>=m_capacity`), instead of (0, 0) or (0, `m_capacity`), so `shrink_to_fit` won't be able to fully de-allocate.  I don't think it's a functional failure, but it could mean the allocation is retained for longer than expected.
By clearing the vector just after its contents are transmitted (and when `m_size` and `m_offset` are reset, marking the buffer as empty and available), `shrink_to_fit` should become effective again.