### PR TITLE
Have the XrdHttp extraction logic match GSI.

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -90,6 +90,7 @@ char *XrdHttpProtocol::secretkey = 0;
 
 char *XrdHttpProtocol::gridmap = 0;
 bool XrdHttpProtocol::isRequiredGridmap = false;
+bool XrdHttpProtocol::compatNameGeneration = false;
 int XrdHttpProtocol::sslverifydepth = 9;
 BIO *XrdHttpProtocol::sslbio_err = 0;
 XrdHttpSecXtractor *XrdHttpProtocol::secxtractor = 0;
@@ -1958,7 +1959,7 @@ int XrdHttpProtocol::xsslkey(XrdOucStream & Config) {
 
 /* Function: xgmap
 
-   Purpose:  To parse the directive: gridmap [required] <path>
+   Purpose:  To parse the directive: gridmap [required] [compatNameGeneration] <path>
 
      required   optional parameter which if present treats any grimap errors
                 as fatal.
@@ -1992,6 +1993,19 @@ int XrdHttpProtocol::xgmap(XrdOucStream & Config) {
       return 1;
     }
   }
+
+  // Handle optional parameter "compatNameGeneration"
+  //
+  if (!strcmp(val, "compatNameGeneration")) {
+    compatNameGeneration = true;
+    val = Config.GetWord();
+    if (!val || !val[0]) {
+      eDest.Emsg("Config", "HTTP X509 gridmap file missing after "
+                 "[compatNameGeneration] parameter");
+      return 1;
+    }
+  }
+
 
   // Record the path
   //

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -161,9 +161,11 @@ private:
   int GetVOMSData(XrdLink *lp);
 
   // Handle gridmap file mapping if present
+  // Second argument is the OpenSSL hash of the EEC, if present; this allows
+  // a consistent fallback if the user is not in the mapfile.
   //
   // @return 0 if successful, otherwise !0
-  int HandleGridMap(XrdLink* lp);
+  int HandleGridMap(XrdLink* lp, const char * eechash);
 
   /// Get up to blen bytes from the connection. Put them into mybuff.
   /// This primitive, for the way it is used, is not supposed to block
@@ -366,7 +368,8 @@ protected:
   /// Gridmap file location. The same used by XrdSecGsi
   static char *gridmap;// [s] gridmap file [/etc/grid-security/gridmap]
   static bool isRequiredGridmap; // If true treat gridmap errors as fatal
-   
+  static bool compatNameGeneration; // If true, utilize the old algorithm for username generation for unknown users.
+
   /// The key used to calculate the url hashes
   static char *secretkey;
 


### PR DESCRIPTION
The GSI security protocol defaults to the "trymap" logic which, according to documentation, is "try to map the DN but if unsuccessful use the hash of the client’s DN as the user identifier (username)". With this change, the XrdHttpSecurity interface will follow the same logic.

Since some sites may have special setups which rely on the old mechanism, one can get the old behavior by setting the optional new `compatNameGeneration` configuration in the `http.gridmap` setting.  For example:

```
http.gridmap compatNameGeneration /etc/xrootd/grid-mapfile
```

Would restore the old behavior.

With this change, a user can effectively match the `nomap`, `trymap`, and `usemap` settings between the XRootD and HTTP protocols and the two protocols have the same default.  Without the change, only the `usemap` setting could be matched with HTTP.  Having the defaults the same greatly decreases the "surprise" factor of using both protocols; the prior HTTP default of guessing a name from the DN is undocumented.

VOMS-based mappings (and mapfile) behavior is unaffected.

@olifre - you have one of the more complex security configs that I could think of.  Would you be unaffected by this change?