### PR TITLE
Also grant Readdir when token grants read permission.

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -701,6 +701,7 @@ private:
                 MakeCanonical(base_path + acl_path, path);
                 if (!strcmp(acl_authz, "read")) {
                     xrd_rules.emplace_back(AOP_Read, path);
+                    xrd_rules.emplace_back(AOP_Readdir, path);
                     xrd_rules.emplace_back(AOP_Stat, path);
                 } else if (!strcmp(acl_authz, "write")) {
                     xrd_rules.emplace_back(AOP_Update, path);


### PR DESCRIPTION
Before this change, directory listing is impossible with a read claim,
leading to the confusing situation that trying to access files in a directory
may return 404 but listing the directory returns permission denied.