### PR TITLE
chore: Use `command -v` over `which` for portability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
             systemd-devel \
             zlib-devel \
             devtoolset-7-gcc-c++ \
-            which \
             python3-devel \
             python3-setuptools \
             git \
@@ -116,7 +115,6 @@ jobs:
             systemd-devel \
             zlib-devel \
             devtoolset-7-gcc-c++ \
-            which \
             python3-devel \
             python3-setuptools \
             git \
@@ -183,7 +181,6 @@ jobs:
             systemd-devel \
             zlib-devel \
             devtoolset-7-gcc-c++ \
-            which \
             python2-pip \
             python2-setuptools \
             python2-devel \
@@ -310,7 +307,6 @@ jobs:
         yum install --nogpg -y \
             gcc-c++ \
             rpm-build \
-            which \
             git \
             python-srpm-macros \
             centos-release-scl
@@ -380,7 +376,6 @@ jobs:
         dnf install --nogpg -y \
             gcc-c++ \
             rpm-build \
-            which \
             tar \
             dnf-plugins-core \
             git
@@ -509,7 +504,6 @@ jobs:
             systemd-devel \
             zlib-devel \
             devtoolset-7-gcc-c++ \
-            which \
             python3-devel \
             python3-setuptools \
             git \
@@ -557,7 +551,6 @@ jobs:
             systemd-devel \
             zlib-devel \
             devtoolset-7-gcc-c++ \
-            which \
             python3-devel \
             python3-setuptools \
             git \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,7 @@ build:cs9:
   image: gitlab-registry.cern.ch/linuxsupport/cs9-base
   script:
     - dnf install -y epel-release
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git
     - dnf install -y cppunit-devel
     - cd packaging/
     - ./makesrpm.sh --define "_with_python3 1" --define "_with_tests 1" --define "_without_xrootd_user 1" --define "_with_xrdclhttp 1" --define "_with_scitokens 1" -D "dist .el9"
@@ -70,7 +70,7 @@ build:cs8:
   image: gitlab-registry.cern.ch/linuxsupport/cs8-base
   script:
     - dnf install -y epel-release
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git
     - dnf config-manager --set-enabled powertools
     - cd packaging
     - ./makesrpm.sh --define "_with_python3 1" --define "_with_tests 1" --define "_with_xrdclhttp 1" --define "_with_scitokens 1"
@@ -101,7 +101,7 @@ build:cc7:
   image: gitlab-registry.cern.ch/linuxsupport/cc7-base
   script:
     - head -n -6 /etc/yum.repos.d/epel.repo > /tmp/epel.repo ; mv -f /tmp/epel.repo /etc/yum.repos.d/epel.repo
-    - yum install --nogpg -y gcc-c++ rpm-build which git python-srpm-macros centos-release-scl
+    - yum install --nogpg -y gcc-c++ rpm-build git python-srpm-macros centos-release-scl
     - cd packaging/
     - ./makesrpm.sh --define "_with_python3 1" --define "_with_tests 1" --define "_with_xrdclhttp 1" --define "_with_scitokens 1" --define "_with_isal 1"
     - yum-builddep --nogpgcheck -y *.src.rpm
@@ -129,7 +129,7 @@ build:cc7:
 #  stage: build:rpm
 #  image: fedora:36
 #  script:
-#    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git
+#    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git
 #    - cd packaging/
 #    - ./makesrpm.sh --define "_with_python3 1" --define "_with_xrdclhttp 1" --define "_with_ceph11 1"
 #    - dnf builddep --nogpgcheck -y *.src.rpm
@@ -157,7 +157,7 @@ build:fedorai-35:
   stage: build:rpm
   image: fedora:35
   script:
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git
     - cd packaging/
     - ./makesrpm.sh --define "_with_python3 1" --define "_with_ceph11 1"
     - dnf builddep --nogpgcheck -y *.src.rpm
@@ -185,7 +185,7 @@ build:fedora-34:
   stage: build:rpm
   image: fedora:34
   script:
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git
     - cd packaging/
     - ./makesrpm.sh --define "_with_python3 1" --define "_with_xrdclhttp 1" --define "_with_ceph11 1"
     - dnf builddep --nogpgcheck -y *.src.rpm
@@ -213,7 +213,7 @@ build:fedora-33:
   stage: build:rpm
   image: fedora:33
   script:
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git
     - cd packaging/
     - ./makesrpm.sh --define "_with_python3 1" --define "_with_xrdclhttp 1" --define "_with_ceph11 1"
     - dnf builddep --nogpgcheck -y *.src.rpm
@@ -299,7 +299,7 @@ release:cs8-x86_64:
   image: gitlab-registry.cern.ch/linuxsupport/cs8-base
   script:
     - dnf install -y epel-release
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git python-macros
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git python-macros
     - dnf config-manager --set-enabled powertools
     - dnf install -y cppunit-devel
     - dnf -y update libarchive
@@ -331,7 +331,7 @@ release:rocky8-x86_64:
   image: rockylinux:8
   script:
     - dnf install -y epel-release
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git python-macros
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git python-macros
     - dnf config-manager --set-enabled powertools
     - dnf install -y cppunit-devel
     - dnf -y update libarchive
@@ -363,13 +363,13 @@ release:cc7-x86_64:
   image: gitlab-registry.cern.ch/linuxsupport/cc7-base
   script:
     - head -n -6 /etc/yum.repos.d/epel.repo > /tmp/epel.repo ; mv -f /tmp/epel.repo /etc/yum.repos.d/epel.repo
-    - yum install --nogpg -y gcc-c++ rpm-build which git python-srpm-macros centos-release-scl
+    - yum install --nogpg -y gcc-c++ rpm-build git python-srpm-macros centos-release-scl
     - mkdir cc-7-x86_64
     - ./gen-tarball.sh $CI_COMMIT_TAG
     - mv xrootd-${CI_COMMIT_TAG#"v"}.tar.gz cc-7-x86_64
     - cd packaging/
     - git checkout tags/${CI_COMMIT_TAG}
-    - ./makesrpm.sh --define "_with_python3 1" --define "_with_tests 1" --define "_without_xrootd_user 1" --define "_with_xrdclhttp 1" --define "_with_scitokens 1" --define "_with_isal 1" -D "dist .el7" 
+    - ./makesrpm.sh --define "_with_python3 1" --define "_with_tests 1" --define "_without_xrootd_user 1" --define "_with_xrdclhttp 1" --define "_with_scitokens 1" --define "_with_isal 1" -D "dist .el7"
     - yum-builddep --nogpgcheck -y *.src.rpm
     - mkdir RPMS
     - rpmbuild --rebuild --define "_rpmdir RPMS/" --define "_with_python3 1" --define "_with_tests 1" --define "_without_xrootd_user 1" --define "_with_xrdclhttp 1" --define "_with_scitokens 1" --define "_with_isal 1" --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" -D "dist .el7" *.src.rpm
@@ -412,7 +412,7 @@ release:pypi:
   stage: build:rpm
   image: gitlab-registry.cern.ch/linuxsupport/cc7-base
   script:
-    - yum install --nogpg -y git python3-pip which
+    - yum install --nogpg -y git python3-pip
     - cp packaging/wheel/* .
     - ./publish.sh
   artifacts:
@@ -448,7 +448,7 @@ weekly:cs8:
   image: gitlab-registry.cern.ch/linuxsupport/cs8-base
   script:
     - dnf install -y epel-release
-    - dnf install --nogpg -y gcc-c++ rpm-build which tar dnf-plugins-core git python-macros
+    - dnf install --nogpg -y gcc-c++ rpm-build tar dnf-plugins-core git python-macros
     - dnf config-manager --set-enabled powertools
     - dnf install -y cppunit-devel
     - dnf -y update libarchive
@@ -483,7 +483,7 @@ weekly:cc7:
   image: gitlab-registry.cern.ch/linuxsupport/cc7-base
   script:
     - head -n -6 /etc/yum.repos.d/epel.repo > /tmp/epel.repo ; mv -f /tmp/epel.repo /etc/yum.repos.d/epel.repo
-    - yum install --nogpg -y gcc-c++ rpm-build which git cppunit-devel python-srpm-macros centos-release-scl
+    - yum install --nogpg -y gcc-c++ rpm-build git cppunit-devel python-srpm-macros centos-release-scl
     - xrootd_version=$(git for-each-ref --sort=taggerdate --format '%(refname)' refs/tags | grep '^refs/tags/v' | grep -v 'rc.*$' | grep -v 'osghotfix' | grep -v 'CERN$' | sed -e '$!d')
     - xrootd_version=${xrootd_version:11}
     - echo $xrootd_version

--- a/genversion.sh
+++ b/genversion.sh
@@ -61,7 +61,7 @@ function getVersionFromRefs()
 function getVersionFromLog()
 {
   AWK=gawk
-  EX="`which gawk`"
+  EX="$(command -v gawk)"
   if test x"${EX}" == x -o ! -x "${EX}"; then
     AWK=awk
   fi
@@ -167,7 +167,7 @@ elif test x$USER_VERSION != x; then
 #-------------------------------------------------------------------------------
 else
   echo "[I] Determining version from git" 1>&2
-  EX="`which git`"
+  EX="$(command -v git)"
   if test x"${EX}" == x -o ! -x "${EX}"; then
     echo "[!] Unable to find git in the path: setting the version tag to unknown" 1>&2
   else

--- a/packaging/makesrpm.sh
+++ b/packaging/makesrpm.sh
@@ -13,7 +13,7 @@ CERNEXP='^[0-9]+\.[0-9]+\.[0-9]+\-[0-9]+\.CERN.*$'
 function findProg()
 {
   for prog in $@; do
-    if test -x "`which $prog 2>/dev/null`"; then
+    if test -x "$(command -v $prog 2>/dev/null)"; then
       echo $prog
       break
     fi


### PR DESCRIPTION
`command -v` is a POSIX safe way to find an executable program. While `which` is very common, it still requires installation on many Linux operating systems, and so `command -v` can offer a more portable alternative with a very low amount of additional cognitive overhead on the maintainers.

Additionally, use a subshell, `$()`, over backticks for command substitution as `$()` is recommended for multiple reasons including readability.

c.f.:
* https://stackoverflow.com/a/4708569/8931942
* [Why is $(...) preferred over `...` (backticks)?](http://mywiki.wooledge.org/BashFAQ/082)
* [POSIX spec for Command Substitution](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xcu_chap02.html#tag_23_02_06_03)

I made the decision to leave `which` in 

https://github.com/xrootd/xrootd/blob/62d11709ca6247cec3c40596be7b9948f885f9e3/docker/builds/DockerfileCentos7#L6

and 

https://github.com/xrootd/xrootd/blob/62d11709ca6247cec3c40596be7b9948f885f9e3/docker/builds/DockerfileCentos8#L6

while no longer required, as I figured that these serve as debugging environments where having `which` handy might be nice for alternative reasons, just as how `vim` is installed in them as well.