### PR TITLE
[XrdHttp] Use 405 for mkcol/mkdir EEXIST

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2692,8 +2692,12 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
     {
 
       if (xrdresp != kXR_ok) {
-        prot->SendSimpleResp(httpStatusCode, NULL, NULL,
-                             httpStatusText.c_str(), httpStatusText.length(), false);
+        if (xrderrcode == kXR_ItExists) {
+          prot->SendSimpleResp(405, NULL, NULL, (char *) "Method is not allowed; resource already exists.", 0, false);
+        } else {
+          prot->SendSimpleResp(httpStatusCode, NULL, NULL,
+                               httpStatusText.c_str(), httpStatusText.length(), false);
+        }
         return -1;
       }
 


### PR DESCRIPTION
Hi,

This is the patch to use return code 405 for mkcol if the directory already exists as discussed in #1663.

Resolves #1663

Regards,
Simon
