### PR TITLE
Fix Python 3.10+ issues from PY_SSIZE_T_CLEAN not being set

### DIFF
--- a/bindings/python/src/PyXRootD.hh
+++ b/bindings/python/src/PyXRootD.hh
@@ -25,6 +25,7 @@
 #ifndef PYXROOTD_HH_
 #define PYXROOTD_HH_
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <string>
 #include "structmember.h"

--- a/bindings/python/src/PyXRootDFile.cc
+++ b/bindings/python/src/PyXRootDFile.cc
@@ -424,7 +424,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "buffer", "offset", "size", "timeout",
                                      "callback", NULL };
     const  char *buffer;
-    int          buffsize;
+    Py_ssize_t   buffsize;
     uint64_t     offset   = 0;
     uint32_t     size     = 0;
     uint16_t     timeout  = 0;
@@ -641,7 +641,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "arg", "timeout", "callback", NULL };
     const char         *buffer   = 0;
-    int                 buffSize = 0;
+    Py_ssize_t          buffSize = 0;
     uint16_t            timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL, *pyresponse = NULL;
     XrdCl::XRootDStatus status;


### PR DESCRIPTION
Writing files with XRootD and Python 3.10 currently fails with:

```python
In [4]: with XRootD.client.File() as file:
   ...:     status, _ = file.open(f"{eos.url}{dest}", OpenFlags.NEW)
   ...:     assert status.ok, status
   ...:     status, _ = file.write(new_data)
   ...:     assert status.ok, status
   ...:
---------------------------------------------------------------------------
SystemError                               Traceback (most recent call last)
Input In [4], in <cell line: 1>()
      2 status, _ = file.open(f"{eos.url}{dest}", OpenFlags.NEW)
      3 assert status.ok, status
----> 4 status, _ = file.write(new_data)
      5 assert status.ok, status

File ~/mambaforge/envs/logse-sqlite/lib/python3.10/site-packages/XRootD/client/file.py:190, in File.write(self, buffer, offset, size, timeout, callback)
    187   callback = CallbackWrapper(callback, None)
    188   return XRootDStatus(self.__file.write(buffer, offset, size, timeout, callback))
--> 190 status, response = self.__file.write(buffer, offset, size, timeout)
    191 return XRootDStatus(status), None

SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
```

This PR fixes the issue by defining `PY_SSIZE_T_CLEAN` as suggested. Though I'm leaving it as a draft at the moment as I still need to change `int` to `Py_ssize_t` in the various places to be fully correct.

There is no issue with backwards compatibilty as support for [`PY_SSIZE_T_CLEAN` was added in Python 2.5](https://docs.python.org/release/2.5/whatsnew/pep-353.html)

See [the release notes](https://docs.python.org/3/whatsnew/3.10.html#id2) and [PEP-353](https://peps.python.org/pep-0353/) for details.