### PR TITLE
[FIX] Fix import syntax to enable shutil.which check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -641,3 +641,57 @@ jobs:
         python3 -c 'import XRootD; print(XRootD)'
         python3 -c 'import pyxrootd; print(pyxrootd)'
         python3 -c 'from XRootD import client; print(client.FileSystem("root://someserver:1094"))'
+
+  sdist-ubuntu:
+
+    # Use of sudo as https://github.com/actions/virtual-environments requires it
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install external dependencies with apt-get
+      run: |
+        sudo apt-get update -y
+        DEBIAN_FRONTEND=noninteractive sudo apt-get install -y \
+          g++ \
+          git \
+          cmake \
+          uuid-dev \
+          dpkg-dev \
+          libssl-dev \
+          libx11-dev \
+          python3 \
+          python3-pip \
+          python3-venv \
+          python3-dev \
+          pkg-config \
+          tree
+        sudo apt-get autoclean -y
+        python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel
+        python3 -m pip list
+
+    - name: Clone repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Build sdist using publishing workflow
+      run: |
+        cp packaging/wheel/* .
+        ./publish.sh
+        python3 -m pip --verbose install ./dist/xrootd-*.tar.gz
+        python3 -m pip list
+
+    - name: Show site-pacakges layout for XRootD modules
+      run: |
+        find $(python3 -c 'import XRootD; import pathlib; print(str(pathlib.Path(XRootD.__path__[0]).parent))') \
+          -type d \
+          -iname "*xrootd*" | xargs tree
+
+    - name: Verify Python bindings
+      run: |
+        python3 --version --version
+        python3 -m pip list
+        python3 -m pip show xrootd
+        python3 -c 'import XRootD; print(XRootD)'
+        python3 -c 'import pyxrootd; print(pyxrootd)'
+        python3 -c 'from XRootD import client; print(client.FileSystem("root://someserver:1094"))'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -282,8 +282,8 @@ jobs:
     - name: Verify Python bindings
       run: |
         export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
-        export PYTHON_VERSION_MINOR=$(_tmp=$(find /usr/local/lib/ -type d -iname "python*") && echo ${_tmp: -3}; unset _tmp)
-        export PYTHONPATH="/usr/local/lib/python${PYTHON_VERSION_MINOR}/site-packages:${PYTHONPATH}"
+        export PYTHON_VERSION_MINOR=$(python3 -c 'import sys; print(f"{sys.version_info.minor}")')
+        export PYTHONPATH="/usr/local/lib/python3.${PYTHON_VERSION_MINOR}/site-packages:${PYTHONPATH}"
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -305,7 +305,6 @@ jobs:
           krb5 \
           ossp-uuid \
           libxml2 \
-          git \
           openssl@3
 
     - name: Install necessary Python libraries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -252,7 +252,7 @@ jobs:
         python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel
 
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -313,7 +313,7 @@ jobs:
         python3 -m pip list
 
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -445,7 +445,7 @@ jobs:
         dnf clean all
 
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -504,7 +504,7 @@ jobs:
         sudo apt-get autoclean -y
 
     - name: Clone repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/packaging/wheel/install.sh
+++ b/packaging/wheel/install.sh
@@ -40,7 +40,7 @@ fi
 cd ../bindings/python
 
 # Determine if shutil.which is available for a modern Python package install
-${6} -c 'import shutil.which' &> /dev/null  # $6 holds the python sys.executable
+${6} -c 'from shutil import which' &> /dev/null  # $6 holds the python sys.executable
 shutil_which_available=$?
 if [ "${shutil_which_available}" -ne "0" ]; then
     ${6} setup.py install ${3}

--- a/packaging/wheel/install.sh
+++ b/packaging/wheel/install.sh
@@ -40,6 +40,8 @@ fi
 cd ../bindings/python
 
 # Determine if shutil.which is available for a modern Python package install
+# (shutil.which was added in Python 3.3, so any version of Python 3 now will have it)
+# TODO: Drop support for Python 3.3 and simplify to pip approach
 ${6} -c 'from shutil import which' &> /dev/null  # $6 holds the python sys.executable
 shutil_which_available=$?
 if [ "${shutil_which_available}" -ne "0" ]; then
@@ -57,28 +59,3 @@ fi
 
 cd $startdir
 rm -r xrootdbuild
-
-# TODO: Remove all of the below and build a wheel using PyPA tools
-
-# convert the egg-info into a proper dist-info
-egginfo_path=$(ls $1/xrootd-*.egg-info)
-core="${egginfo_path%.*}"
-core="${egginfo_path#$1/}"
-sufix="${core#xrootd-*.*.*_-}"
-core="${core%_-*}"
-if [[ "$core" == "$sufix" ]]
-then
-    distinfo_path="${egginfo_path%.*}.dist-info"
-else
-    distinfo_path="$1/$core-$sufix"
-fi
-echo $distinfo_path >> /tmp/out.txt
-mkdir $distinfo_path
-mv $egginfo_path $distinfo_path/METADATA
-echo -e "Wheel-Version: 1.0\nGenerator: bdist_wheel (0.35.1)\nRoot-Is-Purelib: true\nTag: py2-none-any\nTag: py3-none-any" > $distinfo_path/WHEEL
-touch $distinfo_path/RECORD
-distinfo_name=${distinfo_path#"$1"}
-find $1/pyxrootd/      -type f -exec sha256sum {} \; | awk '{printf$2 ",sha256=" $1 "," ; system("stat --printf=\"%s\" "$2) ; print '\n'; }' >> $distinfo_path/RECORD
-find $1/$distinfo_name -type f -exec sha256sum {} \; | awk '{printf$2 ",sha256=" $1 "," ; system("stat --printf=\"%s\" "$2) ; print '\n'; }' >> $distinfo_path/RECORD
-find $1/XRootD/        -type f -exec sha256sum {} \; | awk '{printf$2 ",sha256=" $1 "," ; system("stat --printf=\"%s\" "$2) ; print '\n'; }' >> $distinfo_path/RECORD
-find $1/pyxrootd/ -type l | awk '{print$1 ",,"}' >> $distinfo_path/RECORD


### PR DESCRIPTION
Resolves #1668

In PR #1585 a syntax error was introduced  as `shutil.which` is a method of the Python 'shutil' module and not a module, so the proper import is `from shutil import which` as regardless of the CPython version `import shutil.which` will result in a

```pytb
ModuleNotFoundError: No module named 'shutil.which'; 'shutil' is not a package
```

This error was causing all runs of `packaging/wheel/install.sh` to use the legacy behavior of `python setup.py install` regardless if `shutil.which` was available or not.

As all CPython versions that have `shutil.which` (Python 3.3+) are able to run `packaging/wheel/setup.py` then they will be able to take advantage of having pip be able to create a valid wheel during install time. In the event that a very old version of pip is used, an egg distribution will be installed but it will still work fine so there is no real reason to rename it in a manner that mocks the dist-info of a wheel.

Also a GHA job to build on Ubuntu to add as an additional check.


This PR also avoids finding multiple directories that have 'python' in the name under `/usr/local/lib/` on the GitHub Actions runners, use the `maxdepth` option for `find` to limit the search to directories of the pattern `/usr/local/lib/python3.*`.