### PR TITLE
Don't abort if it looks like we're about to fork

### DIFF
--- a/src/XrdSys/XrdSysIOEventsPollKQ.icc
+++ b/src/XrdSys/XrdSysIOEventsPollKQ.icc
@@ -224,7 +224,15 @@ void XrdSys::IOEvents::PollKQ::Begin(XrdSysSemaphore *syncsem,
        else if (numpolled <  0)
                {int rc = errno;
                 cerr <<"KQ: " <<XrdSysE2T(rc) <<" polling for events" <<endl;
-                abort();
+                //--------------------------------------------------------------
+                // If we are in a child process and the poll file descriptor
+                // has been closed, there is an immense chance the fork will be
+                // followed by an exec, in which case we don't want to abort
+                //--------------------------------------------------------------
+                if( rc == EBADF && parentPID != getpid() )
+                  return;
+                else
+                  abort();
                }
        else for (int i = 0; i < numpolled; i++)
                 {if ((cP = (Channel *)pollTab[i].udata)) Dispatch(cP, i);

--- a/src/XrdSys/XrdSysIOEventsPollPoll.icc
+++ b/src/XrdSys/XrdSysIOEventsPollPoll.icc
@@ -199,7 +199,15 @@ void XrdSys::IOEvents::PollPoll::Begin(XrdSysSemaphore *syncsem,
        else if (numpolled <  0)
                {int rc = errno;
                 cerr <<"EPoll: " <<XrdSysE2T(rc) <<" polling for events" <<endl;
-                abort();
+                //--------------------------------------------------------------
+                // If we are in a child process and the poll file descriptor
+                // has been closed, there is an immense chance the fork will be
+                // followed by an exec, in which case we don't want to abort
+                //--------------------------------------------------------------
+                if( rc == EBADF && parentPID != getpid() )
+                  return;
+                else
+                  abort();
                }
        else{if (pollTab[0].revents) numpolled--;
             for (i = 1; i < num2poll && numpolled; i++)

--- a/src/XrdSys/XrdSysIOEventsPollPort.icc
+++ b/src/XrdSys/XrdSysIOEventsPollPort.icc
@@ -197,7 +197,15 @@ void XrdSys::IOEvents::PollPort::Begin(XrdSysSemaphore *syncsem,
                {if (errno == ETIME || !errno) CbkTMO();
                    else {int rc = errno;
                          cerr <<"PollP: " <<XrdSysE2T(rc) <<" polling for events" <<endl;
-                         abort();
+                         //--------------------------------------------------------------
+                         // If we are in a child process and the poll file descriptor
+                         // has been closed, there is an immense chance the fork will be
+                         // followed by an exec, in which case we don't want to abort
+                         //--------------------------------------------------------------
+                         if( rc == EBADF && parentPID != getpid() )
+                            return;
+                         else
+                            abort();
                         }
                }
        for (int i = 0; i < (int)numpolled; i++)


### PR DESCRIPTION
Uses the same solution that was applied to the epoll implementation in https://github.com/xrootd/xrootd/commit/5ece48c16de3c6c1508fc84eea65d10333020854.

I've only tested on macOS but hopefully the same applies to `XrdSysIOEventsPollPoll` and `XrdSysIOEventsPollPort`.

Fixes #1673. See that issue for more details.

