### PR TITLE
Check if we need libatomic to use atomic operations in the C++ code

### DIFF
--- a/src/XrdDaemons.cmake
+++ b/src/XrdDaemons.cmake
@@ -58,6 +58,7 @@ target_link_libraries(
   XrdServer
   XrdUtils
   ${CMAKE_THREAD_LIBS_INIT}
+  ${ATOMIC_LIBRARY}
   ${EXTRA_LIBS}
   ${SOCKET_LIBRARY} )
 


### PR DESCRIPTION
This is required for using 64 bit atomics on some 32 bit architectures.