### PR TITLE
[CI] Simplify sdist install jobs and logging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,7 +422,6 @@ jobs:
 
     - name: Build sdist using publishing workflow
       run: |
-        . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
         ls -lhtra dist/
@@ -559,6 +558,7 @@ jobs:
         yum update -y
         yum install --nogpg -y \
             cmake3 \
+            gcc-c++ \
             make \
             krb5-devel \
             libuuid-devel \
@@ -580,7 +580,6 @@ jobs:
 
     - name: Build sdist using publishing workflow
       run: |
-        . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
         cd ..  # Move xrootd.egg-info off PYTHONPATH
@@ -606,6 +605,7 @@ jobs:
         yum update -y
         yum install --nogpg -y \
             cmake3 \
+            gcc-c++ \
             make \
             krb5-devel \
             libuuid-devel \
@@ -627,7 +627,6 @@ jobs:
 
     - name: Build sdist using publishing workflow
       run: |
-        . /opt/rh/devtoolset-7/enable
         cp packaging/wheel/* .
         ./publish.sh
         cd ..  # Move xrootd.egg-info off PYTHONPATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -582,8 +582,7 @@ jobs:
       run: |
         cp packaging/wheel/* .
         ./publish.sh
-        cd ..  # Move xrootd.egg-info off PYTHONPATH
-        python3 -m pip --verbose install xrootd/dist/xrootd-*.tar.gz
+        python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Verify Python bindings
@@ -629,8 +628,7 @@ jobs:
       run: |
         cp packaging/wheel/* .
         ./publish.sh
-        cd ..  # Move xrootd.egg-info off PYTHONPATH
-        python3 -m pip --verbose install xrootd/dist/xrootd-*.tar.gz
+        python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Verify Python bindings
@@ -677,7 +675,7 @@ jobs:
       run: |
         cp packaging/wheel/* .
         ./publish.sh
-        python3 -m pip --verbose install ./dist/xrootd-*.tar.gz
+        python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
     - name: Show site-pacakges layout for XRootD modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -154,6 +155,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -221,6 +223,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python2 --version
         python2 -m pip list
         python2 -m pip show xrootd
         python2 -c 'import XRootD; print(XRootD)'
@@ -284,6 +287,7 @@ jobs:
         export LD_LIBRARY_PATH="/usr/local/lib:${LD_LIBRARY_PATH}"
         export PYTHON_VERSION_MINOR=$(python3 -c 'import sys; print(f"{sys.version_info.minor}")')
         export PYTHONPATH="/usr/local/lib/python3.${PYTHON_VERSION_MINOR}/site-packages:${PYTHONPATH}"
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -347,6 +351,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -414,6 +419,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -477,6 +483,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -541,6 +548,7 @@ jobs:
 
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -570,6 +578,7 @@ jobs:
             python3-devel \
             python3-setuptools \
             git \
+            tree \
             cppunit-devel
         yum clean all
         python3 -m pip --no-cache-dir install wheel
@@ -585,8 +594,15 @@ jobs:
         python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
+    - name: Show site-pacakges layout for XRootD modules
+      run: |
+        find $(python3 -c 'import XRootD; import pathlib; print(str(pathlib.Path(XRootD.__path__[0]).parent))') \
+          -type d \
+          -iname "*xrootd*" | xargs tree
+
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'
@@ -616,6 +632,7 @@ jobs:
             python3-devel \
             python3-setuptools \
             git \
+            tree \
             cppunit-devel
         yum clean all
         python3 -m pip --no-cache-dir install --upgrade pip setuptools wheel
@@ -631,8 +648,15 @@ jobs:
         python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
         python3 -m pip list
 
+    - name: Show site-pacakges layout for XRootD modules
+      run: |
+        find $(python3 -c 'import XRootD; import pathlib; print(str(pathlib.Path(XRootD.__path__[0]).parent))') \
+          -type d \
+          -iname "*xrootd*" | xargs tree
+
     - name: Verify Python bindings
       run: |
+        python3 --version --version
         python3 -m pip list
         python3 -m pip show xrootd
         python3 -c 'import XRootD; print(XRootD)'


### PR DESCRIPTION
Following up @simonmichal's https://github.com/xrootd/xrootd/pull/1672#issuecomment-1109472205 this removes unnecessary sourcing of `devtoolset-7` in the sdist build jobs. With `devtoolset-7` no longer providing a compiler to the environment at detection time in `setup.py` also add `gcc-c++` to the list of packages to install with `yum`.

Also simplify installs (c.f. https://github.com/xrootd/xrootd/pull/1672#issuecomment-1108914342) by installing with

```
python3 -m pip --verbose install --upgrade ./dist/xrootd-*.tar.gz
```

(Note the use of `--upgrade` is only necessary on tags where there is properly formatted SemVer version info in the `xrootd.egg-info`. A dev version like '20220426.post7797547' doesn't need the --upgrade, but it is easier to just always use it.)

For better logging and debugging info in CI:
* Show python version used in CI with `python --version --version`.
* Post installation for sdist install builds, show the site-packages layout for the installed XRootD modules. This introduces a dependency on `tree` so also ensure that is installed.
