### PR TITLE
Separate out authorization to overwrite data

### DIFF
--- a/src/XrdAcc/XrdAccAccess.cc
+++ b/src/XrdAcc/XrdAccAccess.cc
@@ -125,7 +125,7 @@ XrdAccPrivs XrdAccAccess::Access(const XrdSecEntity    *Entity,
 //
    std::string username;
    auto got_token = Entity->eaAPI->Get("request.name", username);
-   if (got_token)
+   if (got_token && !username.empty())
       {eInfo.name = username.c_str();
        isuser = true;
       }
@@ -307,7 +307,7 @@ int XrdAccAccess::Audit(const int              accok,
    std::string username;
    const char *id = "*";
    auto got_token = Entity->eaAPI->Get("request.name", username);
-   if (got_token) {
+   if (got_token && !username.empty()) {
        id = username.c_str();
    } else if (Entity->name) id = Entity->name;
    const char *host = (Entity->host ? (const char *)Entity->host : "?");

--- a/src/XrdAcc/XrdAccAuthorize.hh
+++ b/src/XrdAcc/XrdAccAuthorize.hh
@@ -38,20 +38,22 @@
   
 //! The following are supported operations
 
-enum Access_Operation  {AOP_Any      = 0,  //!< Special for getting privs
-                        AOP_Chmod    = 1,  //!< chmod()
-                        AOP_Chown    = 2,  //!< chown()
-                        AOP_Create   = 3,  //!< open() with create
-                        AOP_Delete   = 4,  //!< rm() or rmdir()
-                        AOP_Insert   = 5,  //!< mv() for target
-                        AOP_Lock     = 6,  //!< n/a
-                        AOP_Mkdir    = 7,  //!< mkdir()
-                        AOP_Read     = 8,  //!< open() r/o, prepare()
-                        AOP_Readdir  = 9,  //!< opendir()
-                        AOP_Rename   = 10, //!< mv() for source
-                        AOP_Stat     = 11, //!< exists(), stat()
-                        AOP_Update   = 12, //!< open() r/w or append
-                        AOP_LastOp   = 12  //   For limits testing
+enum Access_Operation  {AOP_Any         = 0,  //!< Special for getting privs
+                        AOP_Chmod       = 1,  //!< chmod()
+                        AOP_Chown       = 2,  //!< chown()
+                        AOP_Create      = 3,  //!< open() with create
+                        AOP_Delete      = 4,  //!< rm() or rmdir()
+                        AOP_Insert      = 5,  //!< mv() for target
+                        AOP_Lock        = 6,  //!< n/a
+                        AOP_Mkdir       = 7,  //!< mkdir()
+                        AOP_Read        = 8,  //!< open() r/o, prepare()
+                        AOP_Readdir     = 9,  //!< opendir()
+                        AOP_Rename      = 10, //!< mv() for source
+                        AOP_Stat        = 11, //!< exists(), stat()
+                        AOP_Update      = 12, //!< open() r/w or append
+                        AOP_Excl_Create = 13, //!< open() with O_EXCL|O_CREAT
+                        AOP_Excl_Insert = 14, //!< mv() where destination doesn't exist.
+                        AOP_LastOp      = 14  //   For limits testing
                        };
 
 /******************************************************************************/

--- a/src/XrdApps/XrdAccTest.cc
+++ b/src/XrdApps/XrdAccTest.cc
@@ -84,10 +84,12 @@ optab_t optab[] =
               {"cm",     AOP_Chmod},
               {"co",     AOP_Chown},
               {"cr",     AOP_Create},
+              {"ec",     AOP_Excl_Create},
               {"rm",     AOP_Delete},
               {"lk",     AOP_Lock},
               {"mk",     AOP_Mkdir},
               {"mv",     AOP_Rename},
+              {"ei",     AOP_Excl_Insert},
               {"rd",     AOP_Read},
               {"ls",     AOP_Readdir},
               {"st",     AOP_Stat},
@@ -108,6 +110,7 @@ void Usage(const char *msg)
    cerr <<"<act>: <opc> <path> [<path> [...]]\n";
    cerr <<"<opc>: cr - create    mv - rename    st - status    lk - lock\n";
    cerr <<"       rd - read      wr - write     ls - readdir   rm - remove\n";
+   cerr <<"       ec - excl create              ei - excl rename\n";
    cerr <<"       *  - zap args  ?  - display privs\n";
    cerr <<flush;
    exit(msg ? 1 : 0);

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1034,6 +1034,13 @@ int XrdHttpReq::ProcessHTTPReq() {
     resourceplusopaque.append(q);
     TRACEI(DEBUG, "Appended header fields to opaque info: '" 
                  << hdr2cgistr.c_str() << "'");
+
+    // We assume that anything appended to the CGI str should also
+    // apply to the destination in case of a MOVE.
+    if (strchr(destination.c_str(), '?')) destination.append("&");
+    else destination.append("?");
+    destination.append(q);
+
     free(q);
     m_appended_hdr2cgistr = true;
     }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2752,7 +2752,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
     {
 
       if (xrdresp != kXR_ok) {
-        prot->SendSimpleResp(409, NULL, NULL, (char *) etext.c_str(), 0, false);
+        prot->SendSimpleResp(httpStatusCode, NULL, NULL, (char *) etext.c_str(), 0, false);
         return -1;
       }
 

--- a/src/XrdOfs/XrdOfs.cc
+++ b/src/XrdOfs/XrdOfs.cc
@@ -2284,8 +2284,11 @@ int XrdOfs::rename(const char             *old_name,  // In
        evsObject->Notify(XrdOfsEvs::Mv, evInfo);
       }
 
-// If we cannot overwrite, we must open-exclusive first.  This will test whether
+// If we cannot overwrite, we must test for existence first.  This will test whether
 // we will destroy data in the rename (without actually destroying data).
+// Note there's an obvious race condition here; it was seen as the lesser-of-evils
+// compared to creating an exclusive file and potentially leaking it in the event
+// of a crash.
 //
    if (cannot_overwrite)
       {XrdSfsFileExistence exists_flag;

--- a/src/XrdOfs/XrdOfs.cc
+++ b/src/XrdOfs/XrdOfs.cc
@@ -37,6 +37,7 @@
 #include <ctime>
 #include <netdb.h>
 #include <cstdlib>
+#include <memory>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -83,6 +84,7 @@
 #include "XrdOuc/XrdOucTList.hh"
 #include "XrdOuc/XrdOucTPC.hh"
 #include "XrdSec/XrdSecEntity.hh"
+#include "XrdSec/XrdSecEntityAttr.hh"
 #include "XrdSfs/XrdSfsAio.hh"
 #include "XrdSfs/XrdSfsFlags.hh"
 #include "XrdSfs/XrdSfsInterface.hh"
@@ -582,7 +584,22 @@ int XrdOfsFile::open(const char          *path,      // In
    if (open_flag & O_CREAT)
       {// Apply security, as needed
        //
-       AUTHORIZE(client,&Open_Env,AOP_Create,"create",path,error);
+       // If we aren't requesting O_EXCL, one needs AOP_Create
+       if (!(open_flag & O_EXCL))
+          {if (client && XrdOfsFS->Authorization &&
+               !XrdOfsFS->Authorization->Access(client, path, AOP_Create, &Open_Env))
+              { // We don't have the ability to create a file without O_EXCL.  If we have AOP_Excl_Create,
+                // then manipulate the open flags and see if we're successful with it.
+                AUTHORIZE(client,&Open_Env,AOP_Excl_Create,"create",path,error);
+                open_flag |= O_EXCL;
+                open_flag &= ~O_TRUNC;
+              }
+          }
+       // If we are in O_EXCL mode, then we accept either AOP_Excl_Create or AOP_Create
+       else if (client && XrdOfsFS->Authorization &&
+            !XrdOfsFS->Authorization->Access(client, path, AOP_Excl_Create, &Open_Env))
+          {AUTHORIZE(client,&Open_Env,AOP_Create,"create",path,error);}
+
        OOIDENTENV(client, Open_Env);
 
        // For ephemeral file, we must enter the file into the queue
@@ -2229,9 +2246,18 @@ int XrdOfs::rename(const char             *old_name,  // In
 
 // Apply security, as needed
 //
-   AUTHORIZE2(client, einfo,
-              AOP_Rename, "renaming",    old_name, &old_Env,
-              AOP_Insert, "renaming to", new_name, &new_Env );
+   // Make a copy of the XrdSecEntity object xattrs as the authorization below may change it.
+   AUTHORIZE(client, &old_Env, AOP_Rename, "renaming", old_name, einfo);
+   if (client) client->eaAPI->Add("request.name", "", true);
+
+// If we do not have full-blown insert authorization, we'll need to test for
+// destination existence
+   bool cannot_overwrite = false;
+   if (client && XrdOfsFS->Authorization &&
+      !XrdOfsFS->Authorization->Access(client, new_name, AOP_Insert, &new_Env))
+      {cannot_overwrite = true;
+       AUTHORIZE(client, &new_Env, AOP_Excl_Insert, "renaming to (no overwrite)", new_name, einfo);
+      }
 
 // Find out where we should rename this file
 //
@@ -2252,10 +2278,29 @@ int XrdOfs::rename(const char             *old_name,  // In
        evsObject->Notify(XrdOfsEvs::Mv, evInfo);
       }
 
+// If we cannot overwrite, we must open-exclusive first.  This will test whether
+// we will destroy data in the rename (without actually destroying data).
+//
+   std::unique_ptr<XrdSfsFile> tmp_fp = nullptr;
+   if (cannot_overwrite)
+      {tmp_fp.reset(newFile(einfo));
+       if (!tmp_fp)
+          {return fsError(einfo, ENOMEM);}
+       if (SFS_OK != tmp_fp->open(new_name, SFS_O_CREAT, 0700, client, infoN))
+          {return fsError(einfo, -tmp_fp->error.getErrInfo());}
+      }
+
 // Perform actual rename operation
 //
    if ((retc = XrdOfsOss->Rename(old_name, new_name, &old_Env, &new_Env)))
-      return XrdOfsFS->Emsg(epname, einfo, retc, "rename", old_name);
+      {if (tmp_fp)
+          {tmp_fp.reset();
+           // Try cleaning up the destination file we temporarily created.
+           if (SFS_OK != remove('f', new_name, einfo, client, infoN))
+              {OfsEroute.Emsg("Overwrite_Test", "Failed to cleanup overwrite testfile; potential file leak at", new_name);}
+          }
+       return XrdOfsFS->Emsg(epname, einfo, retc, "rename", old_name);
+      }
    XrdOfsHandle::Hide(old_name);
    if (Balancer) {Balancer->Removed(old_name);
                   Balancer->Added(new_name);

--- a/src/XrdOfs/XrdOfs.cc
+++ b/src/XrdOfs/XrdOfs.cc
@@ -2246,8 +2246,14 @@ int XrdOfs::rename(const char             *old_name,  // In
 
 // Apply security, as needed
 //
-   // Make a copy of the XrdSecEntity object xattrs as the authorization below may change it.
    AUTHORIZE(client, &old_Env, AOP_Rename, "renaming", old_name, einfo);
+
+// The above authorization may mutate the XrdSecEntity by putting a mapped name
+// into the extended attributes.  This mapped name will affect the subsequent
+// authorization check below, giving the client access that may not be permitted.
+// Hence, we delete this attribute to reset the object back to "pristine" state.
+// If there was a way to make a copy of the XrdSecEntity, we could avoid this
+// hack-y reach inside the extended attributes.
    if (client) client->eaAPI->Add("request.name", "", true);
 
 // If we do not have full-blown insert authorization, we'll need to test for

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -821,9 +821,10 @@ private:
                     xrd_rules.emplace_back(AOP_Stat, path);
                 } else if (!strcmp(acl_authz, "create")) {
                     paths_create_or_modify_seen.insert(path);
-                    xrd_rules.emplace_back(AOP_Create, path);
+                    xrd_rules.emplace_back(AOP_Excl_Create, path);
                     xrd_rules.emplace_back(AOP_Mkdir, path);
                     xrd_rules.emplace_back(AOP_Rename, path);
+                    xrd_rules.emplace_back(AOP_Excl_Insert, path);
                 } else if (!strcmp(acl_authz, "modify")) {
                     paths_create_or_modify_seen.insert(path);
                     xrd_rules.emplace_back(AOP_Create, path);

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -88,12 +88,14 @@ XrdAccPrivs AddPriv(Access_Operation op, XrdAccPrivs privs)
         case AOP_Chown:
             new_privs |= static_cast<int>(XrdAccPriv_Chown);
             break;
+        case AOP_Excl_Create: // fallthrough
         case AOP_Create:
             new_privs |= static_cast<int>(XrdAccPriv_Create);
             break;
         case AOP_Delete:
             new_privs |= static_cast<int>(XrdAccPriv_Delete);
             break;
+        case AOP_Excl_Insert: // fallthrough
         case AOP_Insert:
             new_privs |= static_cast<int>(XrdAccPriv_Insert);
             break;
@@ -128,7 +130,9 @@ const std::string OpToName(Access_Operation op) {
         case AOP_Chmod: return "chmod";
         case AOP_Chown: return "chown";
         case AOP_Create: return "create";
+        case AOP_Excl_Create: return "excl_create";
         case AOP_Delete: return "del";
+        case AOP_Excl_Insert: return "excl_insert";
         case AOP_Insert: return "insert";
         case AOP_Lock: return "lock";
         case AOP_Mkdir: return "mkdir";

--- a/src/XrdThrottle/XrdThrottleFile.cc
+++ b/src/XrdThrottle/XrdThrottleFile.cc
@@ -57,7 +57,8 @@ File::open(const char                *fileName,
    if (client->eaAPI && client->eaAPI->Get("token.subject", m_user)) {
        if (client->vorg) m_user = std::string(client->vorg) + ":" + m_user;
    } else if (client->eaAPI) {
-       client->eaAPI->Get("request.name", m_user);
+       std::string user;
+       if (client->eaAPI->Get("request.name", user) && !user.empty()) m_user = user;
    }
    if (m_user.empty()) {m_user = client->name ? client->name : "nobody";}
    m_uid = XrdThrottleManager::GetUid(m_user.c_str());

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -459,7 +459,7 @@ int XrdXrootdProtocol::do_CKsum(int canit)
        args[1] = algT;
        args[2] = argp->buff;
        args[3] = const_cast<char *>(Client->tident);
-       if (Client->eaAPI->Get(std::string("request.name"), keyval))
+       if (Client->eaAPI->Get(std::string("request.name"), keyval) && !keyval.empty())
           args[4] = const_cast<char *>(keyval.c_str());
           else if (Client->name) args[4] = Client->name;
                   else args[4] = 0;


### PR DESCRIPTION
This PR introduces a lower-privileged versions of `AOP_Insert` and `AOP_Create` which do not permit overwriting / destroying existing data during `rename` and `open` operations, respectively.  Through the use of the `O_EXCL` flag in the filesystem, xrootd now refuses to overwrite data if a session has the lower-privileged version instead of the full-fledged authorization.

With this, the `UPLOAD` Macaroon authorization and `storage.create` SciToken authorization are correctly implemented.

Note one other fixup had to be included: for HTTP MOVE operations, we now append the token correctly to the destination as well as the source.

Finally, because https://github.com/xrootd/xrootd/pull/1644 iterates through the list of operations, I decided to apply this branch on top of #1644; please do not merge this PR until #1644 is across the finish line.

Fixes #1655 