### PR TITLE
[Python] Deprecate distutils for setuptools for Python 3.7+

### DIFF
--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -1,7 +1,23 @@
 from __future__ import print_function
 
-from distutils.core import setup, Extension
-from distutils import sysconfig
+# setuptools._distutils added in setuptools v48.0.0
+# c.f. https://setuptools.pypa.io/en/latest/history.html#v48-0-0
+try:
+    from setuptools._distutils.core import setup, Extension
+    # sysconfig v48.0.0+ is incompatible for Python 3.6 only, so fall back to distutils.
+    # Instead of checking setuptools.__version__ explicitly, use the knowledge that
+    # to get here in the 'try' block requires setuptools v48.0.0+.
+    # FIXME: When support for Python 3.6 is dropped simplify this
+    import sys
+
+    if sys.version_info < (3, 7):
+        from distutils import sysconfig
+    else:
+        import sysconfig
+except ImportError:
+    from distutils.core import setup, Extension
+    from distutils import sysconfig
+
 from os import getenv, walk, path
 import subprocess
 

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -112,6 +112,7 @@ BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 %endif
 %if %{python2and3}
+BuildRequires: python2-pip
 BuildRequires: python2-devel
 BuildRequires: python2-setuptools
 BuildRequires: python%{python3_pkgversion}-devel


### PR DESCRIPTION
Resolves #1698

In CPython 3.10 `distutils` was formally marked as deprecated and it will be removed from CPython in 3.12. To avoid complications, deprecate use of `distutils` moving forward in favor of using `setuptools` as recommended.

For Python 3.7+ (which should by default have `pip` `v22.0.0+` and `setuptools` `v57.5.0+`) use:
* `setuptools._distutils.core` over `distutils.core`
* CPython's `sysconfig` library over `distutils.sysconfig`

If `setuptools._distutils` (added in `setuptools` `v48.0.0`) is not available in the Python 3 environment, fall back to using `distutils.core` and `distutils.sysconfig`.

For Python < 3.7 (so Python 3.6 only for all intents and purposes) fall back to `distutils.sysconfig` in the event that `setuptools` is `v48.0.0+`.

Additional supporting advice given in:
* https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html
* https://peps.python.org/pep-0632/#migration-advice

PR #1691 maybe should go in first, though it doesn't affect this PR, just for clarity.