### PR TITLE
[CI] Avoid unsafe repository error from GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,6 +456,8 @@ jobs:
 
     - name: Build
       run: |
+        # c.f. https://github.com/actions/checkout/issues/760
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
         cd packaging/
         ./makesrpm.sh \
           --define "_with_python3 1" \

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -153,7 +153,7 @@ build:cc7:
 #    - schedules
 #    - web
 
-build:fedorai-35:
+build:fedora-35:
   stage: build:rpm
   image: fedora:35
   script:


### PR DESCRIPTION
To avoid the Fedora build failure that is happening only in GitHub Actions jobs, add 

```
git config --global --add safe.directory "$GITHUB_WORKSPACE"
```

to the GitHub Actions workflow job to avoid the issues of https://github.com/actions/checkout/issues/760.