### PR TITLE
Add a "python3-xrootd" provides to the Python 3 bindings in EL7 builds too

### DIFF
--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -378,6 +378,7 @@ Python 2 bindings for XRootD
 %package -n python%{python3_pkgversion}-%{name}
 Summary:       Python 3 bindings for XRootD
 Group:         Development/Libraries
+%{?python_provide:%python_provide python%{python3_pkgversion}-%{name}}
 Requires:      %{name}-client-libs%{?_isa} = %{epoch}:%{version}-%{release}
 
 %description -n python%{python3_pkgversion}-%{name}


### PR DESCRIPTION
This is already being done in EL8 (%python3only case) but not in EL7 builds.