### PR TITLE
Fix davix/auth path

### DIFF
--- a/src/XrdClHttp/XrdClHttpPosix.cc
+++ b/src/XrdClHttp/XrdClHttpPosix.cc
@@ -13,8 +13,8 @@
 #include "XrdCl/XrdClXRootDResponses.hh"
 #include "XrdCl/XrdClURL.hh"
 
-#include "davix/auth/davixx509cred.hpp"
-#include "davix/auth/davixauth.hpp"
+#include "auth/davixx509cred.hpp"
+#include "auth/davixauth.hpp"
 
 #include <string>
 


### PR DESCRIPTION
https://github.com/xrootd/xrootd/blob/master/src/XrdClHttp/CMakeLists.txt#L1 adds `${Davix_INCLUDE_DIRS}/davix` due to which xrootd failed to find `davix/auth/davixauth.hpp`. 