### PR TITLE
[CI] Set XRD_PYTHON_REQ_VERSION for Python 2.7 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,6 +206,7 @@ jobs:
             -DPYTHON_EXECUTABLE=$(command -v python2) \
             -DENABLE_TESTS=ON \
             -DPIP_OPTIONS="--verbose" \
+            -DXRD_PYTHON_REQ_VERSION="2.7" \
             -S xrootd \
             -B build
         cmake3 build -LH


### PR DESCRIPTION
Explicitly set `XRD_PYTHON_REQ_VERSION="2.7"` at CMake configure to allow for Python 2.7 builds until Python 2 support is dropped in XRootD `v5.5.0`.

c.f. Issue #1711