### PR TITLE
Fix compilation errors at FreeBSD.

### DIFF
--- a/genversion.sh
+++ b/genversion.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #-------------------------------------------------------------------------------
 # Process the git decoration expansion and try to derive version number

--- a/src/XrdOuc/XrdOucStream.cc
+++ b/src/XrdOuc/XrdOucStream.cc
@@ -36,7 +36,7 @@
 #include <poll.h>
 #include <unistd.h>
 #include <strings.h>
-#if !defined(__linux__) && !defined(__CYGWIN__) && !defined(__GNU__)
+#if !defined(__linux__) && !defined(__CYGWIN__) && !defined(__GNU__) && !defined(__FreeBSD__)
 #include <sys/conf.h>
 #endif
 #include <sys/stat.h>

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -1240,7 +1240,7 @@ void File::ProcessBlockResponse(BlockResponseHandler* brh, int res)
          TRACEF(Error, tpfx << "block " << b << ", idx=" << b->m_offset/BufferSize() << ", off=" << b->m_offset << " error=" << res);
       } else {
          TRACEF(Error, tpfx << "block " << b << ", idx=" << b->m_offset/BufferSize() << ", off=" << b->m_offset << " incomplete, got " << res << " expected " << b->get_size());
-#if defined(__APPLE__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
+#if defined(__APPLE__) || defined(__GNU__) || defined(__FreeBSD__)
          res = -EIO;
 #else
          res = -EREMOTEIO;

--- a/src/XrdPosix/XrdPosixDir.hh
+++ b/src/XrdPosix/XrdPosixDir.hh
@@ -33,7 +33,7 @@
 
 #include <dirent.h>
 
-#if  defined(__APPLE__)
+#if  defined(__APPLE__) || defined(__FreeBSD__)
 #if !defined(dirent64)
 #define dirent64 dirent
 #endif

--- a/src/XrdSecsss/XrdSecProtocolsss.cc
+++ b/src/XrdSecsss/XrdSecProtocolsss.cc
@@ -28,7 +28,9 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
+#if !defined(__FreeBSD__)
 #include <alloca.h>
+#endif
 #include <cctype>
 #include <iostream>
 #include <cstdlib>

--- a/src/XrdSys/XrdSysFAttrBsd.icc
+++ b/src/XrdSys/XrdSysFAttrBsd.icc
@@ -160,7 +160,7 @@ int XrdSysFAttr::Set(const char *Aname, const void *Aval, int Avsz,
 //
   if (isNew)
      {ec = (fd < 0 ? extattr_get_file(Path,EXTATTR_NAMESPACE_USER,Aname,0,0)
-                   : extattr_get_fd(  fd,  EXTATTR_NAMESPACE_USER,Aname,0 0));
+                   : extattr_get_fd(  fd,  EXTATTR_NAMESPACE_USER,Aname,0,0));
       if (ec >= 0) return -EEXIST;
      }
 


### PR DESCRIPTION
This change fixes compilation errors at FreeBSD 13.1 (with `-DENABLE_KRB5=OFF`).