### PR TITLE
Return removed Debian GNU/kFreeBSD definition.

### DIFF
--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -1240,7 +1240,7 @@ void File::ProcessBlockResponse(BlockResponseHandler* brh, int res)
          TRACEF(Error, tpfx << "block " << b << ", idx=" << b->m_offset/BufferSize() << ", off=" << b->m_offset << " error=" << res);
       } else {
          TRACEF(Error, tpfx << "block " << b << ", idx=" << b->m_offset/BufferSize() << ", off=" << b->m_offset << " incomplete, got " << res << " expected " << b->get_size());
-#if defined(__APPLE__) || defined(__GNU__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__)) || defined(__FreeBSD__)
          res = -EIO;
 #else
          res = -EREMOTEIO;


### PR DESCRIPTION
This request provides a correction for #1714. In the affected line, the condition `(defined(__FreeBSD_kernel__) && defined(__GLIBC__))` was removed, but it is actually [from Debian GNU/kFreeBSD](https://wiki.debian.org/Debian_GNU/kFreeBSD_FAQ#Q._How_do_I_detect_kfreebsd_with_preprocessor_directives_in_a_C_program.3F). It is returned back again, although please note that it is [no longer an officially supported architecture](https://www.debian.org/ports/kfreebsd-gnu/index.en.html).