### PR TITLE
Fix deprecated-header warning.

### DIFF
--- a/src/XrdSys/XrdSysLogger.cc
+++ b/src/XrdSys/XrdSysLogger.cc
@@ -40,7 +40,7 @@
 #include <unistd.h>
 #include <strings.h>
 #include <sys/param.h>
-#include <sys/termios.h>
+#include <termios.h>
 #include <sys/uio.h>
 #endif // WIN32
 


### PR DESCRIPTION
The corresponding specification is [here](https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/basedefs/termios.h.html).