### PR TITLE
[XrdCl] Avoid race condition in AsyncSocketHander on use of reader/writer objects after link is re-enabled

### DIFF
--- a/src/XrdCl/XrdClAsyncSocketHandler.cc
+++ b/src/XrdCl/XrdClAsyncSocketHandler.cc
@@ -370,8 +370,6 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     if( !pPoller->EnableReadNotification( pSocket, true, pTimeoutResolution ) )
     {
-      hswriter.reset();
-      hsreader.reset();
       pStream->OnConnectError( pSubStreamNum,
                                XRootDStatus( stFatal, errPollerError ) );
       return;
@@ -661,9 +659,6 @@ namespace XrdCl
     log->Error( AsyncSockMsg, "[%s] Socket error encountered: %s",
                 pStreamName.c_str(), st.ToString().c_str() );
 
-    rspreader.reset();
-    reqwriter.reset();
-
     pStream->OnError( pSubStreamNum, st );
   }
 
@@ -675,8 +670,6 @@ namespace XrdCl
     Log *log = DefaultEnv::GetLog();
     log->Error( AsyncSockMsg, "[%s] Socket error while handshaking: %s",
                 pStreamName.c_str(), st.ToString().c_str() );
-    hsreader.reset();
-    hswriter.reset();
 
     pStream->OnConnectError( pSubStreamNum, st );
   }
@@ -694,14 +687,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   void AsyncSocketHandler::OnReadTimeout()
   {
-    bool isBroken = false;
-    pStream->OnReadTimeout( pSubStreamNum, isBroken );
-
-    if( isBroken )
-    {
-      rspreader.reset();
-      reqwriter.reset();
-    }
+    pStream->OnReadTimeout( pSubStreamNum );
   }
 
   //----------------------------------------------------------------------------
@@ -724,9 +710,6 @@ namespace XrdCl
     // a stream t/o and all requests are retried
     //--------------------------------------------------------------------------
     pStream->ForceError( XRootDStatus( stError, errSocketError ) );
-
-    rspreader.reset();
-    reqwriter.reset();
   }
 
   //----------------------------------------------------------------------------

--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -1003,10 +1003,8 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Call back when a message has been reconstructed
   //----------------------------------------------------------------------------
-  void Stream::OnReadTimeout( uint16_t substream, bool &isBroken )
+  void Stream::OnReadTimeout( uint16_t substream )
   {
-    isBroken = false;
-
     //--------------------------------------------------------------------------
     // We only take the main stream into account
     //--------------------------------------------------------------------------
@@ -1062,7 +1060,6 @@ namespace XrdCl
                                             *pChannelData );
     if( !st.IsOK() )
     {
-      isBroken =  true;
       scopedLock.UnLock();
       OnError( substream, st );
     }

--- a/src/XrdCl/XrdClStream.hh
+++ b/src/XrdCl/XrdClStream.hh
@@ -218,7 +218,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! On read timeout
       //------------------------------------------------------------------------
-      void OnReadTimeout( uint16_t subStream, bool &isBroken );
+      void OnReadTimeout( uint16_t subStream );
 
       //------------------------------------------------------------------------
       //! On write timeout


### PR DESCRIPTION
Hi,

This patch is intended to fix a crash seen on EOS MGMs. The crash is consistent with the race between reset() and use of the unique_ptr rspreader and reqwriter. A trace obtained indicated a reset was happening in AsyncSocketHandler::OnReadTimeout() while the unique_ptr was being sued concurrently in AsyncMsgWriter::Write().

The race is understood to be started in AsyncSocketHandler::OnReadTimeout(), triggered by the pStream->OnReadTimeout call (XrdClAsyncSocketHandler.cc:698). On this timeout condition the XrdClStream may first Close() the AsyncSocketHandler. Close() calls pPoller->RemoveSocket(), which eventually calls XrdSys::IOEvents::Channel::Delete(), which will remove the socket from the IOEvents poller with XrdSys::IOEvents::Poller::Detach().

The above calls are done under the OnReadTimeout(), inside a callback from within the poller's event loop. The Detach correctly handles the situation where it is called from the poller's event loop, without blocking.

A later call by XrdClStream (in the same thread) reenables the link with EnableLink() in Stream::OnError(), which will call AsyncSocketHandler::Connect(). This will then re-add the socket to a poller by calling PollerBuiltIn::AddSocket(). AddSocket will assign the socket's XrdSys::IOEvents::Channel to a XrdSys::IOEvents::Poller from its poller pool. SInce EOS uses XRD_PARALLELEVTLOOP=4 the new poller may not be the same as the original (assuming the closed stream was the only one registered for the channelId). The AddSocket() is still being called from within the original poller's event loop, but if it is re-added to a different poller the AsyncSocketHandler event callbacks can now be called concurrently with the ongoing execution of the original 