### PR TITLE
[XrdCl] Set the error status if the re-connection fails early during recovery

### DIFF
--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -3027,6 +3027,7 @@ namespace XrdCl
     if( !st.IsOK() )
     {
       pFileState = Error;
+      pStatus    = st;
       FailQueuedMessages( st );
     }
 


### PR DESCRIPTION
This is thought to solve a XrdCl hang: an XrdCl synchronous call waiting for the callback apparently indefinitely. (This issue has entry EOS-4323 the EOS tracker). The problem was seen to be associated with a network glitch on the service machines hanging a messaging thread which uses XrdCl.

The flow is believed to be that ReOpenFileAtServer() returns an error, e.g. due to DNS name lookup failure. RunRecover() then sets the FileStateHandler's pFileState = Error, but sets no error in pStatus. The Error state causes subsequent calls like FileStateHandler::Close() or Stat() etc. to fail by returning the status contained in pStatus. In this cases pStatus still contains an OK status. Thus the client waits forever for a response that never comes, as it was never submitted nor failed at submission time.

The above has been reproduced in a test program with forced network problems; but not from with EOS code.