### PR TITLE
Length check in the LFH constructor

### DIFF
--- a/src/XrdZip/XrdZipLFH.hh
+++ b/src/XrdZip/XrdZipLFH.hh
@@ -68,8 +68,10 @@ namespace XrdZip
     //-------------------------------------------------------------------------
     //! Constructor from buffer
     //-------------------------------------------------------------------------
-    LFH( const char *buffer )
+    LFH( const char *buffer, const uint64_t bufferSize = 0 )
     {
+    	if(bufferSize > 0 && bufferSize < (uint64_t)lfhBaseSize)
+    		throw bad_data();
       // check if the buffer contains a LFH record
       uint32_t signature = 0;
       from_buffer( signature, buffer );
@@ -84,6 +86,9 @@ namespace XrdZip
       from_buffer( uncompressedSize, buffer );
       from_buffer( filenameLength, buffer );
       from_buffer( extraLength, buffer );
+
+      if(bufferSize > 0 && (uint64_t)(lfhBaseSize + filenameLength + extraLength) > bufferSize)
+    	  throw bad_data();
       // parse the filename
       filename.assign( buffer, filenameLength );
       buffer += filenameLength;


### PR DESCRIPTION
 A maximum length is given to the constructor to detect corruption and prevent reading over the borders of the LFH.
In case the lengths read from the buffer are larger than the buffer itself, bad_data is thrown.