### PR TITLE
MaxSize of the EOCD constructor and check against file size

### DIFF
--- a/src/XrdCl/XrdClZipArchive.cc
+++ b/src/XrdCl/XrdClZipArchive.cc
@@ -321,10 +321,18 @@ namespace XrdCl
                                                             "End-of-central-directory signature not found." );
                                         Pipeline::Stop( error );
                                       }
-                                      eocd.reset( new EOCD( eocdBlock ) );
+                                      try{
+                                      eocd.reset( new EOCD( eocdBlock, chunk.length - uint32_t(eocdBlock - buff) ) );
                                       log->Dump( ZipMsg, "[0x%x] EOCD record parsed: %s", this,
                                                          eocd->ToString().c_str() );
-
+                                      if(eocd->cdOffset > archsize || eocd->cdOffset + eocd->cdSize > archsize)
+                                    	  throw bad_data();
+                                      }
+                                      catch(const bad_data &ex){
+                                    	  XRootDStatus error( stError, errDataError, 0,
+                                    	               "End-of-central-directory signature corrupted." );
+                                    	  Pipeline::Stop( error );
+                                      }
                                       // Do we have the whole archive?
                                       if( chunk.length == archsize )
                                       {

--- a/src/XrdZip/XrdZipEOCD.hh
+++ b/src/XrdZip/XrdZipEOCD.hh
@@ -51,7 +51,7 @@ namespace XrdZip
     //-------------------------------------------------------------------------
     //! Constructor from buffer
     //-------------------------------------------------------------------------
-    EOCD( const char *buffer )
+    EOCD( const char *buffer, uint32_t maxSize = 0 )
     {
       nbDisk        = *reinterpret_cast<const uint16_t*>( buffer + 4 );
       nbDiskCd      = *reinterpret_cast<const uint16_t*>( buffer + 6 );
@@ -60,6 +60,8 @@ namespace XrdZip
       cdSize        = *reinterpret_cast<const uint32_t*>( buffer + 12 );
       cdOffset      = *reinterpret_cast<const uint32_t*>( buffer + 16 );
       commentLength = *reinterpret_cast<const uint16_t*>( buffer + 20 );
+      if(maxSize > 0 && (uint32_t)(eocdBaseSize + commentLength) > maxSize)
+    	  throw bad_data();
       comment       = std::string( buffer + 22, commentLength );
 
       eocdSize = eocdBaseSize + commentLength;


### PR DESCRIPTION
Check the EOCD length against the actual buffer size to detect corruption in the EOCD and to avoid reading over the end of the file. Default argument is still zero to allow for compatibility. 
In the XrdClZipArchive's OpenArchive method, the call to the EOCD constructor catches the bad_data error.
Additionally added a check of the "cdOffset" and "cdSize" attributes of the EOCD object against the archive size.
In case of failure, the OpenArchive operation is stopped and returns an error status.