### PR TITLE
[XrdXroot] Reset the buffer pointer after a non-aligned pgRead reques…

### DIFF
--- a/src/XrdXrootd/XrdXrootdXeqPgrw.cc
+++ b/src/XrdXrootd/XrdXrootdXeqPgrw.cc
@@ -323,6 +323,7 @@ int XrdXrootdProtocol::do_PgRIO()
        if (pgOff)
           {iov[2].iov_base = argp->buff;
            iov[2].iov_len  = pgPageSize;
+           buff = argp->buff;
            pgOff = 0;
           }
 


### PR DESCRIPTION
…t to avoid head-buffer-overflow corruptions Fixes #1743