### PR TITLE
reduce maxCSSZ to avoid readv EINVAL error

### DIFF
--- a/src/XrdXrootd/XrdXrootdXeqPgrw.cc
+++ b/src/XrdXrootd/XrdXrootdXeqPgrw.cc
@@ -205,7 +205,7 @@ int XrdXrootdProtocol::do_PgRIO()
 // We restrict the maximum transfer size to generate no more than 1023 iovec
 // elements where the first is used for the header.
 //
-   static const int maxCSSZ = 1022;
+   static const int maxCSSZ = 511;
 // static const int maxCSSZ = 32;
    static const int maxPGRD = maxCSSZ*pgPageSize; // 2,093,056 usually
    static const int maxIOVZ = maxCSSZ*2+1;


### PR DESCRIPTION
if the reported value goes above 2093056, clients crash due to readv having iovcnt > 1024.
The original value of 1022 * page size of 4096 generated dlen of 4186112. These were then resolved client side in XrdCl/XrdClAsyncPageReader.hh to ::readv calls of iovcnt 2044, triggering the einval error. 

fix for #1740 