### PR TITLE
ret type error on compilation

### DIFF
--- a/src/XrdCl/XrdClAsyncPageReader.hh
+++ b/src/XrdCl/XrdClAsyncPageReader.hh
@@ -191,7 +191,7 @@ class AsyncPageReader
     //--------------------------------------------------------------------------
     inline static uint32_t CalcIOVSize( uint32_t dleft )
     {
-      uint32_t ret = ( dleft / PageWithDigest + 2 ) * 2;
+      int ret = ( dleft / PageWithDigest + 2 ) * 2;
       return ( ret > max_iovcnt() ? max_iovcnt() : ret );
     }
 


### PR DESCRIPTION
type comparison - max_iovcnt() is of type int