### PR TITLE
[XrdCl] Avoid that pgread responses could be timedout while being processed

### DIFF
--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -278,6 +278,7 @@ namespace XrdCl
         // kXR_status response, we can handle the raw data (if any) only after
         // we have the whole kXR_status body
         //----------------------------------------------------------------------
+        pTimeoutFence.store( true, std::memory_order_relaxed );
         return None;
       }
 
@@ -364,10 +365,7 @@ namespace XrdCl
       action |= Raw;
 
       if( rspst->status.bdy.resptype == XrdProto::kXR_PartialResult )
-      {
         action |= NoProcess;
-        pTimeoutFence.store( true, std::memory_order_relaxed );
-      }
       else
         action |= RemoveHandler;
     }


### PR DESCRIPTION
Hello,

This is part of a set of 3 PRs for a set of changes to avoid various problems seen while investigating some EOS crashes or issues. There may well be discussion over these PRs.

This PR changes the location where the XRootDMsgHandler "timeout fence" is set in the case of pgread responses.

The motivation for the change is avoiding a crash seen during some tests - I'll attach a description of a test and a trace below.

The change moves setting the fence for non-pgwrite kxr_status messages (i.e. pgread) from InspectStatusRsp() to Examine(). This avoid a race where the MessageHandger could be removed + deleted in the time between these two methods called, via AsyncMsgReader.  A consequence is that the fence is set even in the case the pgread response consists of only a single kXR_FinalResult, rather than a response containing 1 or more kXR_PartialResult. (A patch was considered to allow the fence to be taken down between readout of results - including the partial results, but this is a rather larger change).