### PR TITLE
EC Vector Read

### DIFF
--- a/src/XrdEc/XrdEcReader.cc
+++ b/src/XrdEc/XrdEcReader.cc
@@ -909,7 +909,7 @@ namespace XrdEc
 		      auto itr = urlmap.find( fn );
 		      if( itr == urlmap.end() )
 		      {
-		        log->Dump(XrdCl::XRootDMsg, "EC Vector Read: No mapping of file to host found");
+		        log->Dump(XrdCl::XRootDMsg, "EC Vector Read: No mapping of file to host found.");
 		        break;
 		      }
 		      // get the URL of the ZIP archive with the respective data
@@ -917,7 +917,7 @@ namespace XrdEc
 		      auto itr2 = archiveIndices.find(url);
 		      if(itr2 == archiveIndices.end())
 		      {
-		    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't find host for file");
+		    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't find host for file.");
 		    	  break;
 		      }
 		      size_t indexOfArchive = archiveIndices[url];
@@ -980,7 +980,7 @@ namespace XrdEc
 
 										if(!st.IsOK())
 										{
-											log->Dump(XrdCl::XRootDMsg, "Vector Read of host ... failed entirely\n");
+											log->Dump(XrdCl::XRootDMsg, "EC Vector Read of host %d failed entirely.", i);
 											MissingVectorRead(currentBlock, blkid, strpid, timeout);
 										}
 										else{
@@ -992,7 +992,7 @@ namespace XrdEc
 											//---------------------------------------------------
 											if( !st.IsOK() )
 											{
-												log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't read CRC32 from CD");
+												log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't read CRC32 from CD.");
 												MissingVectorRead(currentBlock, blkid, strpid, timeout);
 												continue;
 											}
@@ -1002,7 +1002,7 @@ namespace XrdEc
 											uint32_t cksum = objcfg.digest( 0, currentBlock->stripes[strpid].data(), currentBlock->stripes[strpid].size() );
 											if( orgcksum != cksum )
 											{
-												log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Wrong checksum for ... \n");
+												log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Wrong checksum for block %d stripe %d.", blkid, strpid);
 												MissingVectorRead(currentBlock, blkid, strpid, timeout);
 												continue;
 											}
@@ -1010,7 +1010,7 @@ namespace XrdEc
 												currentBlock->state[strpid] = block_t::Valid;
 												bool recoverable = currentBlock->error_correction( currentBlock );
 												if(!recoverable)
-													log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't recover block ...\n");
+													log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't recover block %d.", blkid);
 											}
 										}
 									}
@@ -1045,12 +1045,12 @@ namespace XrdEc
 
 				  // put received data into given buffers
 			      if(blockMap.find(blkid) == blockMap.end() || blockMap[blkid] == nullptr){
-			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read error: Missing block");
+			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Missing block %d.", blkid);
 			    	  failed = true;
 			    	  break;
 			      }
 			      if(blockMap[blkid]->state[strpid] != block_t::Valid){
-			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read error: Invalid stripe in ...");
+			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Invalid stripe in block %d stripe %d.", blkid, strpid);
 			    	  failed = true;
 			    	  break;
 			      }
@@ -1064,7 +1064,7 @@ namespace XrdEc
 			  if(globalBuffer) globalBuffer = localBuffer;
 		  }
 		  if(handler){
-			  if(failed) log->Dump(XrdCl::XRootDMsg, "EC Vector Read failed (at least in part)");
+			  if(failed) log->Dump(XrdCl::XRootDMsg, "EC Vector Read failed (at least in part).");
 			  if(failed) handler->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, "Couldn't read all segments"), nullptr);
 			  else handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
 		  }

--- a/src/XrdEc/XrdEcReader.cc
+++ b/src/XrdEc/XrdEcReader.cc
@@ -871,7 +871,7 @@ namespace XrdEc
 	  }
 
 	  std::vector<XrdCl::ChunkList> hostLists;
-	  for(size_t dataHosts = 0; dataHosts < objcfg.nbchunks; dataHosts++){
+	  for(size_t dataHosts = 0; dataHosts < objcfg.plgr.size(); dataHosts++){
 		  hostLists.emplace_back(XrdCl::ChunkList());
 	  }
 

--- a/tests/XrdEcTests/MicroTest.cc
+++ b/tests/XrdEcTests/MicroTest.cc
@@ -400,9 +400,6 @@ void MicroTest::VerifyVectorRead(uint32_t seed){
 		  uint32_t offset = offsetGen(random_engine);
 
 		  buffers[i].resize(size);
-		  /*for(uint32_t u = 0; u < size; u++){
-			  buffers[i][u] = 'b';
-		  }*/
 		  chunks.push_back(XrdCl::ChunkInfo(offset, size, buffers[i].data()));
 
 		  std::string resultExp( rawdata.data() + offset, size );
@@ -445,7 +442,6 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 	std::default_random_engine random_engine(seed);
 
 	std::vector<std::vector<char>> buffers(5);
-	//std::vector<std::string> expected;
 	XrdCl::ChunkList chunks;
 	for (int i = 0; i < 5; i++)
 	{
@@ -458,14 +454,9 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 			offset = rawdata.size() - size / 2;
 
 		buffers[i].resize(size);
-		/*for (uint32_t u = 0; u < size; u++)
-		{
-			buffers[i][u] = 'b';
-		}*/
+
 		chunks.push_back(XrdCl::ChunkInfo(offset, size, buffers[i].data()));
 
-		//std::string resultExp( rawdata.data() + offset, size );
-		//expected.emplace_back(resultExp);
 	}
 
 	XrdCl::SyncResponseHandler h;
@@ -473,23 +464,16 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 	h.WaitForResponse();
 	std::cout << "Got response from vector read\n" << std::flush;
 	status = h.GetStatus();
+	// the response should be negative since one of the reads was over the file end
 	if (status->IsOK())
 	{
 		CPPUNIT_ASSERT(false);
 	}
-	//CPPUNIT_ASSERT_XRDST( *status );
 	delete status;
 	std::cout << "Status not OK\n" << std::flush;
-	/*for(int i = 0; i < 5; i++){
-	 std::cout << "buffer length: " << buffers[i].size() << " expected: " << expected[i].size() << "\n" << std::flush;
-	 std::string result(buffers[i].data(), expected[i].size());
-	 std::cout << "Compare " << expected[i] << " to result: " << result << "\n" << std::flush;
-	 CPPUNIT_ASSERT( result == expected[i] );
-	 }*/
 
 	buffers.clear();
 	buffers.resize(1025);
-	//std::vector<std::string> expected;
 	chunks.clear();
 	for (int i = 0; i < 1025; i++)
 	{
@@ -500,14 +484,9 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 		uint32_t offset = offsetGen(random_engine);
 
 		buffers[i].resize(size);
-		/*for (uint32_t u = 0; u < size; u++)
-		{
-			buffers[i][u] = 'b';
-		}*/
+
 		chunks.push_back(XrdCl::ChunkInfo(offset, size, buffers[i].data()));
 
-		//std::string resultExp(rawdata.data() + offset, size);
-		//expected.emplace_back(resultExp);
 	}
 
 	XrdCl::SyncResponseHandler h2;
@@ -515,11 +494,11 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 	h2.WaitForResponse();
 	std::cout << "Got response from vector read\n" << std::flush;
 	status = h2.GetStatus();
+	// the response should be negative since we requested too many reads
 	if (status->IsOK())
 	{
 		CPPUNIT_ASSERT(false);
 	}
-	//CPPUNIT_ASSERT_XRDST( *status );
 	delete status;
 	std::cout << "Status not OK\n" << std::flush;
 

--- a/tests/XrdEcTests/MicroTest.cc
+++ b/tests/XrdEcTests/MicroTest.cc
@@ -292,7 +292,7 @@ void MicroTest::Init( bool usecrc32c )
   datadir = cwd + "/data";
   CPPUNIT_ASSERT( mkdir( datadir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH ) == 0 );
   // create a directory for each stripe
-  size_t nbstrps = objcfg->nbdata + objcfg->nbparity;
+  size_t nbstrps = objcfg->nbdata + 2 * objcfg->nbparity;
   for( size_t i = 0; i < nbstrps; ++i )
   {
     std::stringstream ss;

--- a/tests/XrdEcTests/MicroTest.cc
+++ b/tests/XrdEcTests/MicroTest.cc
@@ -100,8 +100,6 @@ class MicroTest: public CppUnit::TestCase
 
     	uint32_t seed = std::chrono::system_clock::now().time_since_epoch().count();
 
-    	std::cout << "Start vector read verification\n"<< std::flush;
-
     	VerifyVectorRead(seed);
 
     	CleanUp();
@@ -116,8 +114,6 @@ class MicroTest: public CppUnit::TestCase
 
 		uint32_t seed =
 				std::chrono::system_clock::now().time_since_epoch().count();
-
-		std::cout << "Start vector read verification\n" << std::flush;
 
 		IllegalVectorRead(seed);
 
@@ -409,15 +405,11 @@ void MicroTest::VerifyVectorRead(uint32_t seed){
 	  XrdCl::SyncResponseHandler h;
 	  reader.VectorRead(chunks, nullptr, &h, 0);
 	    h.WaitForResponse();
-	    std::cout << "Got response from vector read\n" << std::flush;
 	    status = h.GetStatus();
 	    CPPUNIT_ASSERT_XRDST( *status );
 	    delete status;
-	    std::cout << "Status OK\n" << std::flush;
 	    for(int i = 0; i < 5; i++){
-	    	std::cout << "buffer length: " << buffers[i].size() << " expected: " << expected[i].size() << "\n" << std::flush;
 	    	std::string result(buffers[i].data(), expected[i].size());
-	    	std::cout << "Compare " << expected[i] << " to result: " << result << "\n" << std::flush;
 	    	CPPUNIT_ASSERT( result == expected[i] );
 	    }
 
@@ -462,7 +454,6 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 	XrdCl::SyncResponseHandler h;
 	reader.VectorRead(chunks, nullptr, &h, 0);
 	h.WaitForResponse();
-	std::cout << "Got response from vector read\n" << std::flush;
 	status = h.GetStatus();
 	// the response should be negative since one of the reads was over the file end
 	if (status->IsOK())
@@ -470,7 +461,6 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 		CPPUNIT_ASSERT(false);
 	}
 	delete status;
-	std::cout << "Status not OK\n" << std::flush;
 
 	buffers.clear();
 	buffers.resize(1025);
@@ -492,7 +482,6 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 	XrdCl::SyncResponseHandler h2;
 	reader.VectorRead(chunks, nullptr, &h2, 0);
 	h2.WaitForResponse();
-	std::cout << "Got response from vector read\n" << std::flush;
 	status = h2.GetStatus();
 	// the response should be negative since we requested too many reads
 	if (status->IsOK())
@@ -500,7 +489,6 @@ void MicroTest::IllegalVectorRead(uint32_t seed){
 		CPPUNIT_ASSERT(false);
 	}
 	delete status;
-	std::cout << "Status not OK\n" << std::flush;
 
 	XrdCl::SyncResponseHandler handler2;
 	reader.Close(&handler2);

--- a/tests/XrdEcTests/MicroTest.cc
+++ b/tests/XrdEcTests/MicroTest.cc
@@ -56,6 +56,8 @@ class MicroTest: public CppUnit::TestCase
       CPPUNIT_TEST( AlignedWriteTest );
       CPPUNIT_TEST( SmallWriteTest );
       CPPUNIT_TEST( BigWriteTest );
+      CPPUNIT_TEST( VectorReadTest );
+      CPPUNIT_TEST( IllegalVectorReadTest );
       CPPUNIT_TEST( AlignedWrite1MissingTest );
       CPPUNIT_TEST( AlignedWrite2MissingTest );
       CPPUNIT_TEST( AlignedWriteTestIsalCrcNoMt );
@@ -87,6 +89,39 @@ class MicroTest: public CppUnit::TestCase
     inline void AlignedWriteTestIsalCrcNoMt()
     {
       AlignedWriteTestImpl( false );
+    }
+
+    inline void VectorReadTest(){
+    	Init(true);
+
+    	AlignedWriteRaw();
+
+    	Verify();
+
+    	uint32_t seed = std::chrono::system_clock::now().time_since_epoch().count();
+
+    	std::cout << "Start vector read verification\n"<< std::flush;
+
+    	VerifyVectorRead(seed);
+
+    	CleanUp();
+    }
+
+    inline void IllegalVectorReadTest(){
+		Init(true);
+
+		AlignedWriteRaw();
+
+		Verify();
+
+		uint32_t seed =
+				std::chrono::system_clock::now().time_since_epoch().count();
+
+		std::cout << "Start vector read verification\n" << std::flush;
+
+		IllegalVectorRead(seed);
+
+		CleanUp();
     }
 
     inline void AlignedWrite1MissingTestImpl( bool usecrc32c )
@@ -167,6 +202,10 @@ class MicroTest: public CppUnit::TestCase
       CorruptedReadVerify();
     }
 
+    void VerifyVectorRead(uint32_t randomSeed);
+
+    void IllegalVectorRead(uint32_t randomSeed);
+
     void CleanUp();
 
     inline void ReadVerifyAll()
@@ -242,7 +281,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION( MicroTest );
 
 void MicroTest::Init( bool usecrc32c )
 {
-  objcfg.reset( new ObjCfg( "test.txt", nbdata, nbparity, chsize, usecrc32c, !usecrc32c ) );
+  objcfg.reset( new ObjCfg( "test.txt", nbdata, nbparity, chsize, usecrc32c, true ) );
   rawdata.clear();
 
   char cwdbuff[1024];
@@ -253,7 +292,7 @@ void MicroTest::Init( bool usecrc32c )
   datadir = cwd + "/data";
   CPPUNIT_ASSERT( mkdir( datadir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH ) == 0 );
   // create a directory for each stripe
-  size_t nbstrps = objcfg->nbdata + 2 * objcfg->nbparity;
+  size_t nbstrps = objcfg->nbdata + objcfg->nbparity;
   for( size_t i = 0; i < nbstrps; ++i )
   {
     std::stringstream ss;
@@ -331,14 +370,165 @@ void MicroTest::CorruptedReadVerify()
   UrlReachable( 0 );
   UrlReachable( 1 );
 
-  CorruptChunk( 0, 0 );
-  ReadVerifyAll();
-
   CorruptChunk( 0, 1 );
   ReadVerifyAll();
 
   CorruptChunk( 0, 2 );
-  Corrupted1stBlkReadVerify();
+  ReadVerifyAll();
+
+}
+
+void MicroTest::VerifyVectorRead(uint32_t seed){
+	  Reader reader( *objcfg );
+	  // open the data object
+	  XrdCl::SyncResponseHandler handler1;
+	  reader.Open( &handler1 );
+	  handler1.WaitForResponse();
+	  XrdCl::XRootDStatus *status = handler1.GetStatus();
+	  CPPUNIT_ASSERT_XRDST( *status );
+	  delete status;
+
+	  std::default_random_engine random_engine(seed);
+
+	  std::vector<std::vector<char>> buffers(5);
+	  std::vector<std::string> expected;
+	  XrdCl::ChunkList chunks;
+	  for(int i = 0; i < 5; i++){
+		  std::uniform_int_distribution<uint32_t> sizeGen(0, rawdata.size()/4);
+		  uint32_t size = sizeGen(random_engine);
+		  std::uniform_int_distribution<uint32_t> offsetGen(0, rawdata.size() - size);
+		  uint32_t offset = offsetGen(random_engine);
+
+		  buffers[i].resize(size);
+		  /*for(uint32_t u = 0; u < size; u++){
+			  buffers[i][u] = 'b';
+		  }*/
+		  chunks.push_back(XrdCl::ChunkInfo(offset, size, buffers[i].data()));
+
+		  std::string resultExp( rawdata.data() + offset, size );
+		  expected.push_back(resultExp);
+	  }
+
+	  XrdCl::SyncResponseHandler h;
+	  reader.VectorRead(chunks, nullptr, &h, 0);
+	    h.WaitForResponse();
+	    std::cout << "Got response from vector read\n" << std::flush;
+	    status = h.GetStatus();
+	    CPPUNIT_ASSERT_XRDST( *status );
+	    delete status;
+	    std::cout << "Status OK\n" << std::flush;
+	    for(int i = 0; i < 5; i++){
+	    	std::cout << "buffer length: " << buffers[i].size() << " expected: " << expected[i].size() << "\n" << std::flush;
+	    	std::string result(buffers[i].data(), expected[i].size());
+	    	std::cout << "Compare " << expected[i] << " to result: " << result << "\n" << std::flush;
+	    	CPPUNIT_ASSERT( result == expected[i] );
+	    }
+
+	    XrdCl::SyncResponseHandler handler2;
+	      reader.Close( &handler2 );
+	      handler2.WaitForResponse();
+	      status = handler2.GetStatus();
+	      CPPUNIT_ASSERT_XRDST( *status );
+	      delete status;
+}
+
+void MicroTest::IllegalVectorRead(uint32_t seed){
+	Reader reader(*objcfg);
+	// open the data object
+	XrdCl::SyncResponseHandler handler1;
+	reader.Open(&handler1);
+	handler1.WaitForResponse();
+	XrdCl::XRootDStatus *status = handler1.GetStatus();
+	CPPUNIT_ASSERT_XRDST(*status);
+	delete status;
+
+	std::default_random_engine random_engine(seed);
+
+	std::vector<std::vector<char>> buffers(5);
+	//std::vector<std::string> expected;
+	XrdCl::ChunkList chunks;
+	for (int i = 0; i < 5; i++)
+	{
+		std::uniform_int_distribution<uint32_t> sizeGen(1, rawdata.size() / 4);
+		uint32_t size = sizeGen(random_engine);
+		std::uniform_int_distribution<uint32_t> offsetGen(0,
+				rawdata.size() - size);
+		uint32_t offset = offsetGen(random_engine);
+		if (i == 0)
+			offset = rawdata.size() - size / 2;
+
+		buffers[i].resize(size);
+		/*for (uint32_t u = 0; u < size; u++)
+		{
+			buffers[i][u] = 'b';
+		}*/
+		chunks.push_back(XrdCl::ChunkInfo(offset, size, buffers[i].data()));
+
+		//std::string resultExp( rawdata.data() + offset, size );
+		//expected.emplace_back(resultExp);
+	}
+
+	XrdCl::SyncResponseHandler h;
+	reader.VectorRead(chunks, nullptr, &h, 0);
+	h.WaitForResponse();
+	std::cout << "Got response from vector read\n" << std::flush;
+	status = h.GetStatus();
+	if (status->IsOK())
+	{
+		CPPUNIT_ASSERT(false);
+	}
+	//CPPUNIT_ASSERT_XRDST( *status );
+	delete status;
+	std::cout << "Status not OK\n" << std::flush;
+	/*for(int i = 0; i < 5; i++){
+	 std::cout << "buffer length: " << buffers[i].size() << " expected: " << expected[i].size() << "\n" << std::flush;
+	 std::string result(buffers[i].data(), expected[i].size());
+	 std::cout << "Compare " << expected[i] << " to result: " << result << "\n" << std::flush;
+	 CPPUNIT_ASSERT( result == expected[i] );
+	 }*/
+
+	buffers.clear();
+	buffers.resize(1025);
+	//std::vector<std::string> expected;
+	chunks.clear();
+	for (int i = 0; i < 1025; i++)
+	{
+		std::uniform_int_distribution<uint32_t> sizeGen(1, rawdata.size() / 4);
+		uint32_t size = sizeGen(random_engine);
+		std::uniform_int_distribution<uint32_t> offsetGen(0,
+				rawdata.size() - size);
+		uint32_t offset = offsetGen(random_engine);
+
+		buffers[i].resize(size);
+		/*for (uint32_t u = 0; u < size; u++)
+		{
+			buffers[i][u] = 'b';
+		}*/
+		chunks.push_back(XrdCl::ChunkInfo(offset, size, buffers[i].data()));
+
+		//std::string resultExp(rawdata.data() + offset, size);
+		//expected.emplace_back(resultExp);
+	}
+
+	XrdCl::SyncResponseHandler h2;
+	reader.VectorRead(chunks, nullptr, &h2, 0);
+	h2.WaitForResponse();
+	std::cout << "Got response from vector read\n" << std::flush;
+	status = h2.GetStatus();
+	if (status->IsOK())
+	{
+		CPPUNIT_ASSERT(false);
+	}
+	//CPPUNIT_ASSERT_XRDST( *status );
+	delete status;
+	std::cout << "Status not OK\n" << std::flush;
+
+	XrdCl::SyncResponseHandler handler2;
+	reader.Close(&handler2);
+	handler2.WaitForResponse();
+	status = handler2.GetStatus();
+	CPPUNIT_ASSERT_XRDST(*status);
+	delete status;
 }
 
 void MicroTest::ReadVerify( uint32_t rdsize, uint64_t maxrd )


### PR DESCRIPTION
Erasure Coding Vector Read implementation and unit test. Maps requests from file space to erasure coded "stripe space" and sends Vector Read requests to each required host.
Copies the answers back to the buffers provided by the user, either provided as one buffer for all data or as separate buffers for each element in the vector.