### PR TITLE
Return permission denied when overwrites are not allowed

### DIFF
--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -5,6 +5,83 @@ XRootD
 Release Notes
 =============
 
+-------------
+Version 5.5.0
+-------------
+
++ **New Features**
+  **[XrdApps]** Provide command line too to manipulate checksum xattr.
+  **[XrdApps]** xrdreplay: support quoted columns
+  **[XrdApps]** xrdrecorder: allow to set the output path using XRD_RECORDERPATH
+                envar.
+  **[Protocol]** Add reflink capability to protocol via kXR_open options.
+  **[Server] Separate out authorization to overwrite data.
+  **[Server] Allow set variable values to come from a file.
+  **[Server]** Implement gStream to monitor all http and xroot TPC events.
+  **[Server]** Bring packet marking up to current specification.
+  **[Server]** Provide g-stream monitoring for Third Party Copy (TPC).
+  **[SciTokens]** Allow the SciToken plugin to consume based on ZTN tokens.
+  **[Server]** Report experiment and activity codes when present for monitoring.
+  **[HTTP]** Have the XrdHttp extraction logic match GSI/
+  **[XrdAcc]** Make the acc subsystem aware of request-based name mapping.
+  **[XrdFfs]** update xrootdfs to work with XrdEC faster
+  **[Posix]** Make xrootd proxy, xrootdfs and xrdadler32 work with XrdCl+EC
+  **[SciTokens]** Save token subject as an XrdSecEntity xattr
+  **[Throttle]** Track maximum concurrency limits in throttle plugin
+  **[XrdCl]** xrdfs: support multiple rm paths
+  **[XrdCl]** record / replay plug-in
+  **[XrdCl]** In EC, add adjustable preference to servers based on free space
+  **[XrdCl]** Add recorder plug-in and xrdreply tool.
+  **[XrdCl]** xrdcp --server: report IP stack to stderr.
+  **[XrdCl]** Introduce Stream queries (IpAddr, IpStack, HostName).
+  **[XrdFfs]** same above
+  **[XrdVomsMapfile]** Add support for VOMS mapfile
+  **[XrdCl/XrdEc]** Make the remote ec cfg more flexible.
+  **[Pfc]** Implement async read and readV from the perspective of XrdOucCacheIO.
+
++ **Major bug fixes**
+  **[Server]** Modify vector's size instead of capacity to avoid undef behaviour
+  **[XrdEc]** Make sure returned read size is correct.
+  **[XrdEc]** Reader: make sure the completion handler is called if the read is of
+              zero size.
+  **[XrdCl]** Avoid race condition in AsyncSocketHander on use of reader/writer
+              objects after link is re-enabled
+  **[XrdCl]** Set the error status if the re-connection fails early during recovery
+  **[XrdCl]** xrdcp: don't use a common static status obj across all copy jobs.
+  **[XrdCl]** ZIP: respect file sizes > 4GB.
+  **[XrdCl]** Correctly calculate #pages in pgread rsp (for small rsp).
+  **[XrdCl]** PgRead: don't exceed max iovcnt.
+  **[Server]** Reset the buffer pointer after a non-aligned pgRead request.
+  **[XrdPfc]** Count number of active reads on an PfcIO object so that POSIX AIO
+               bailout detach can be handled correctly.
+  **[XrdPfc]** Do early exit when prefetching of a block fails with no other
+               subscribers.
+  **[XrdHttp]** Map kXR_ItExists to HTTP 409.
+
++ **Minor bug fixes**
+  **[Frm]** Fix incorrect logic in frm_admin audit space.
+  **[Server]** Avoid SEGV during client recovery due to close waitresp.
+  **[Server]** Allow disablement of the tardy async I/O timeout path.
+  **[Proxy]** Allow for URLs with username.
+  **[XrdPss]** Do not trigger DeepLocate when pss.origin is http(s)
+  **[XrdPosix]** bug fix, report correct st_blocks in EC
+
++ **Miscellaneous**
+  **[SciTokens]** Add addition messages and debugging.
+  **[SciTokens]** Also grant Readdir when token grants read permission.
+  **[Server]** Ignore -Warray-bounds warnings from stricter check in gcc 12.
+  **[CMake]** XRootDOSDefs: Use define_default on default values
+  **[CMake]** Add XrdOuc/XrdOucPgrwUtils.hh to private headers.
+  **[CMake]** Change Py required version to 3.
+  **[CI]** Add Ubunty Jammy builds.
+  **[XrdClHttp]** Move to xrootd core.
+  **[XrdCl]** Refactor kXR_read raw data socket readout.
+  **[XrdCl]** Support HostList in lambda completion handlers.
+  **[XrdCl]** Make sure FileStateHandler is preserved until all outstanding
+              requests are resolved.
+  **[XrdCl]** Make sure FS data are preserved until all outstanding requests
+              are resolved.
+  **[Crypto]** bf32: Load "legacy" provider for blowfish in openssl v3.
 
 --------------
 Version 5.4.3

--- a/src/XrdAcc/XrdAccAccess.cc
+++ b/src/XrdAcc/XrdAccAccess.cc
@@ -300,8 +300,10 @@ int XrdAccAccess::Audit(const int              accok,
                                     "read",            // 8
                                     "readdir",         // 9
                                     "rename",          // 10
-                                    "stat",            // 10
-                                    "update"           // 12
+                                    "stat",            // 11
+                                    "update",          // 12
+                                    "excl_create",     // 13
+                                    "excl_insert"      // 14
                              };
    const char *opname = (oper > AOP_LastOp ? "???" : Opername[oper]);
    std::string username;
@@ -427,8 +429,12 @@ int XrdAccAccess::Test(const XrdAccPrivs priv,const Access_Operation oper)
                                 XrdAccPriv_Readdir,              // 9
                                 XrdAccPriv_Rename,               // 10
                                 XrdAccPriv_Lookup,               // 11
-                                XrdAccPriv_Update                // 12
+                                XrdAccPriv_Update,               // 12
+                                (XrdAccPrivs)0xffff,             // 13
+                                (XrdAccPrivs)0xffff              // 14
                                };
+   // Note AOP_Excl* does not have a corresponding XrdAccPrivs; this is on
+   // purpose as the Excl* privilege is not modelled within the AuditDB framework.
    if (oper < 0 || oper > AOP_LastOp) return 0;
    return (int)(need[oper] & priv) == need[oper];
 }


### PR DESCRIPTION
For the new "exclusive create" permission (meaning "never overwrite existing data"), if the file cannot be created due to the destination existing, we should return a "permission denied".

This also fixes a relatively serious issue in the built-in AuthDB module where it may incorrectly authorize the creation of files due to an uninitialized memory read.

Fixes: #1752 