### PR TITLE
xrootd: fix missing byteswap.h error on MacOS build with gcc

### DIFF
--- a/src/XrdOssCsi/XrdOssCsiTagstoreFile.hh
+++ b/src/XrdOssCsi/XrdOssCsiTagstoreFile.hh
@@ -37,7 +37,19 @@
 
 #include <memory>
 #include <mutex>
+
+#if defined(__GLIBC__) || defined(__BIONIC__) || defined(__CYGWIN__)
 #include <byteswap.h>
+#elif defined(__APPLE__)
+// Make sure that byte swap functions are not already defined.
+#if !defined(bswap_16)
+// Mac OS X / Darwin features
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+#endif
+#endif
 
 class XrdOssCsiTagstoreFile : public XrdOssCsiTagstore
 {


### PR DESCRIPTION
This PR fixes a missing header error on MacOS when building with GCC.
Confirmed to fix the build on 10.6.8 with `gcc12`.

Clang builds on latest MacOS versions are all good too: https://github.com/macports/macports-ports/pull/15807 (checks pass).

Code borrowed from: https://gerrit.pixelexperience.org/plugins/gitiles/external_libtextclassifier/+/b23e2125be90bbf6124e9cd5684fc93026c5ec4d/util/base/endian.h