### PR TITLE
Fix self-move.

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -776,10 +776,11 @@ private:
         token_subject = std::string(value);
         free(value);
 
+        std::string tmp_username;
         if (config.m_map_subject) {
-            username = token_subject;
+            tmp_username = token_subject;
         } else {
-            username = config.m_default_user;
+            tmp_username = config.m_default_user;
         }
 
         for (auto rule : config.m_map_rules) {
@@ -856,7 +857,7 @@ private:
 
         cache_expiry = expiry;
         rules = std::move(xrd_rules);
-        username = std::move(username);
+        username = std::move(tmp_username);
         issuer = std::move(token_issuer);
         groups = std::move(groups_parsed);
 


### PR DESCRIPTION
In what appears to be a refactor gone wrong, the `username` variable is moved to itself.  On RHEL7's compiler, this appears to be a no-op.  In RHEL8 (probably correctly) it clears out the string, un-setting the username completely.

@simonmichal - please also backport to the 5.5.x branch.