### PR TITLE
Fix staged installation of Python bindings with pip

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -95,7 +95,7 @@ else()
     CODE
     "EXECUTE_PROCESS(
       COMMAND /usr/bin/env ${XROOTD_PYBUILD_ENV} ${PYTHON_EXECUTABLE} -m pip install \
-                ${PIP_OPTIONS} \
+                --ignore-installed ${PIP_OPTIONS} \
                 ${CMAKE_CURRENT_BINARY_DIR}
       )"
   )


### PR DESCRIPTION
When performing a staged installation with pip, it will attempt to uninstall a previous installation of XRootD if it exists, so if XRootD is already installed into `/usr`, it may try to remove files installed by the system package manager.

Fixes: 31e3d717ad191e966ddbd4802f85982bfb5618bd
Closes: #1768

See also: https://bugs.gentoo.org/861452