### PR TITLE
[XrdTls] The start of the CRLRefresh thread is now triggered in the constructor of the XrdTlsContext class

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1685,13 +1685,13 @@ bool XrdHttpProtocol::InitTLS() {
 
    std::string eMsg;
    uint64_t opts = XrdTlsContext::servr | XrdTlsContext::logVF |
-                   XrdTlsContext::artON;
+                   XrdTlsContext::artON | XrdTlsContext::scRefr;
 
 // Create a new TLS context
 //
    if (sslverifydepth > 255) sslverifydepth = 255;
    opts = TLS_SET_VDEPTH(opts, sslverifydepth);
-   xrdctx = new XrdTlsContext(sslcert,sslkey,sslcadir,sslcafile,opts,&eMsg,true);
+   xrdctx = new XrdTlsContext(sslcert,sslkey,sslcadir,sslcafile,opts,&eMsg);
 
 // Make sure the context was created
 //

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1133,11 +1133,6 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
    eDest.Say("------ HTTPS initialization ", how);
    if (NoGo) return NoGo;
 
-// Turn on the refreshing
-//
-   if (!NoGo && xrdctx->x509Verify() && !(xrdctx->SetCrlRefresh()))
-      eDest.Say("Config warning: CRL refreshing could not be enabled!");
-
 // We can now load all the external handlers
 //
    if (LoadExtHandler(extHIVec, ConfigFN, *myEnv)) return 1;
@@ -1696,7 +1691,7 @@ bool XrdHttpProtocol::InitTLS() {
 //
    if (sslverifydepth > 255) sslverifydepth = 255;
    opts = TLS_SET_VDEPTH(opts, sslverifydepth);
-   xrdctx = new XrdTlsContext(sslcert,sslkey,sslcadir,sslcafile,opts,&eMsg);
+   xrdctx = new XrdTlsContext(sslcert,sslkey,sslcadir,sslcafile,opts,&eMsg,true);
 
 // Make sure the context was created
 //

--- a/src/XrdTls/XrdTlsContext.cc
+++ b/src/XrdTls/XrdTlsContext.cc
@@ -540,7 +540,7 @@ int VerCB(int aOK, X509_STORE_CTX *x509P)
   
 XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
                              const char *caDir, const char *caFile,
-                             uint64_t opts, std::string *eMsg,const bool startCRLRefreshThread)
+                             uint64_t opts, std::string *eMsg)
                             : pImpl( new XrdTlsContextImpl(this) )
 {
    class ctx_helper
@@ -726,7 +726,7 @@ XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
 
 // All went well, start the CRL refresh thread and keep the context.
 //
-   if(startCRLRefreshThread) {
+   if(opts & scRefr) {
        SetCrlRefresh();
    }
    ctx_tracker.Keep();
@@ -766,7 +766,13 @@ XrdTlsContext *XrdTlsContext::Clone(bool full,bool startCRLRefresh)
 
 // Cloning simply means getting a object with the old parameters.
 //
-   XrdTlsContext *xtc = new XrdTlsContext(cert, pkey, caD, caF, my.opts,nullptr,startCRLRefresh);
+   uint64_t myOpts = my.opts;
+   if(startCRLRefresh){
+       myOpts |= XrdTlsContext::scRefr;
+   } else {
+       myOpts &= ~XrdTlsContext::scRefr;
+   }
+   XrdTlsContext *xtc = new XrdTlsContext(cert, pkey, caD, caF, myOpts,nullptr);
 
 // Verify that the context was built
 //

--- a/src/XrdTls/XrdTlsContext.hh
+++ b/src/XrdTls/XrdTlsContext.hh
@@ -52,7 +52,7 @@ public:
 //!       the session cache is set to off with no identifier.
 //------------------------------------------------------------------------
 
-XrdTlsContext *Clone(bool full=true);
+XrdTlsContext *Clone(bool full=true, bool startCRLRefresh = false);
 
 //------------------------------------------------------------------------
 //! Get the underlying context (should not be used).
@@ -238,7 +238,7 @@ static const uint64_t artON = 0x0000002000000000; //!< Auto retry Handshake
 
        XrdTlsContext(const char *cert=0,  const char *key=0,
                      const char *cadir=0, const char *cafile=0,
-                     uint64_t opts=0, std::string *eMsg=0);
+                     uint64_t opts=0, std::string *eMsg=0,const bool startCRLRefreshThread = false);
 
 //------------------------------------------------------------------------
 //! Destructor

--- a/src/XrdTls/XrdTlsContext.hh
+++ b/src/XrdTls/XrdTlsContext.hh
@@ -130,6 +130,7 @@ static const int scNone = 0x00000000; //!< Do not change any option settings
 static const int scOff  = 0x00010000; //!< Turn off cache
 static const int scSrvr = 0x00020000; //!< Turn on  cache server mode (default)
 static const int scClnt = 0x00040000; //!< Turn on  cache client mode
+static const int scRefr = 0x20000000; //!< Turn on the CRL refresh thread
 static const int scKeep = 0x40000000; //!< Info: TLS-controlled flush disabled
 static const int scIdErr= 0x80000000; //!< Info: Id not set, is too long
 static const int scFMax = 0x00007fff; //!< Maximum flush interval in seconds
@@ -238,7 +239,7 @@ static const uint64_t artON = 0x0000002000000000; //!< Auto retry Handshake
 
        XrdTlsContext(const char *cert=0,  const char *key=0,
                      const char *cadir=0, const char *cafile=0,
-                     uint64_t opts=0, std::string *eMsg=0,const bool startCRLRefreshThread = false);
+                     uint64_t opts=0, std::string *eMsg=0);
 
 //------------------------------------------------------------------------
 //! Destructor

--- a/src/XrdXrootd/XrdXrootdConfig.cc
+++ b/src/XrdXrootd/XrdXrootdConfig.cc
@@ -576,7 +576,7 @@ int XrdXrootdProtocol::Config(const char *ConfigFN)
 // context must be of the non-verified kind as we don't accept certs.
 //
    if (!NoGo && tlsCtx)
-      {tlsCtx = tlsCtx->Clone(false);
+      {tlsCtx = tlsCtx->Clone(false,true);
        if (!tlsCtx)
           {eDest.Say("Config failure: unable to setup TLS for protocol!");
            NoGo = 1;


### PR DESCRIPTION
A boolean flag has been added to the constructor and the Clone() method of the XrdTlsContext class. If set to true, the TLS context created or cloned will run the CRLRefresh thread after having been succesfully initialized.