### PR TITLE
[XrdTls] The tlsca 'refresh' directive in the configuration file is now taken into account for both XrootD and HTTP TLS context

### DIFF
--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -47,6 +47,8 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/un.h>
+#include <algorithm>
+#include <limits>
 
 #include "XrdVersion.hh"
 
@@ -2450,7 +2452,7 @@ int XrdConfig::xtlsca(XrdSysError *eDest, XrdOucStream &Config)
                }
        else if (!strcmp(kword, "refresh"))
                {if (XrdOuca2x::a2tm(*eDest, "tlsca refresh interval",
-                                    val, &rt)) return 1;
+                                    val, &rt,1,std::min(int((XrdTlsContext::crlRF >> XrdTlsContext::crlRS) * 60),std::numeric_limits<int>::max()))) return 1;
                 if (rt < 60) rt = 60;
                    else if (rt % 60) rt += 60;
                 rt = rt/60;

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -365,6 +365,9 @@ protected:
   /// OpenSSL stuff
   static char *sslcert, *sslkey, *sslcadir, *sslcafile, *sslcipherfilter;
 
+  /// CRL thread refresh interval
+  static int crlRefIntervalSec;
+
   /// Gridmap file location. The same used by XrdSecGsi
   static char *gridmap;// [s] gridmap file [/etc/grid-security/gridmap]
   static bool isRequiredGridmap; // If true treat gridmap errors as fatal

--- a/src/XrdTls/XrdTlsContext.cc
+++ b/src/XrdTls/XrdTlsContext.cc
@@ -627,8 +627,10 @@ XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
    if (caDir)  pImpl->Parm.cadir  = caDir;
    if (caFile) pImpl->Parm.cafile = caFile;
    pImpl->Parm.opts   = opts;
-   if (opts & crlRF)
-      pImpl->Parm.crlRT = static_cast<int>((opts & crlRF)>>crlRS);
+   if (opts & crlRF) {
+       // What we store in crlRF is the time in minutes, convert it back to seconds
+       pImpl->Parm.crlRT = static_cast<int>((opts & crlRF) >> crlRS) * 60;
+   }
 
 // Get the correct method to use for TLS and check if successful create a
 // server context that uses the method.
@@ -1025,7 +1027,7 @@ bool XrdTlsContext::SetCrlRefresh(int refsec)
       {pImpl->crlMutex.WriteLock();
        refsec = pImpl->Parm.crlRT;
        pImpl->crlMutex.UnLock();
-       if (!refsec) refsec = 8*60*60;
+       if (!refsec) refsec = XrdTlsContext::DEFAULT_CRL_REF_INT_SEC;
       }
 
 // Make sure this is at least 60 seconds between refreshes

--- a/src/XrdTls/XrdTlsContext.hh
+++ b/src/XrdTls/XrdTlsContext.hh
@@ -62,6 +62,9 @@ XrdTlsContext *Clone(bool full=true, bool startCRLRefresh = false);
 
 void          *Context();
 
+//! Default CRL refresh interval in seconds
+static const int DEFAULT_CRL_REF_INT_SEC = 8 * 60 * 60;
+
 //------------------------------------------------------------------------
 //! Get parameters used to create the context.
 //!
@@ -77,7 +80,7 @@ struct CTX_Params
        int         crlRT;  //!< crl refresh interval time in seconds
        int         rsvd;
 
-       CTX_Params() : opts(0), crlRT(8*60*60), rsvd(0) {}
+       CTX_Params() : opts(0), crlRT(DEFAULT_CRL_REF_INT_SEC), rsvd(0) {}
       ~CTX_Params() {}
       };
 
@@ -233,7 +236,7 @@ static const uint64_t nopxy = 0x0000000100000000; //!< Do not allow proxy certs
 static const uint64_t rfCRL = 0x0000004000000000; //!< Turn on the CRL refresh thread
 static const uint64_t crlON = 0x0000008000000000; //!< Enables crl checking
 static const uint64_t crlFC = 0x000000C000000000; //!< Full crl chain checking
-static const uint64_t crlRF = 0x000000003fff0000; //!< Init crl refresh in Min
+static const uint64_t crlRF = 0x00000000ffff0000; //!< Mask to isolate crl refresh in min
 static const int      crlRS = 16;                 //!< Bits to shift   vdept
 static const uint64_t artON = 0x0000002000000000; //!< Auto retry Handshake
 


### PR DESCRIPTION
This refresh parameter did not work at all even before my previous changes.
I made it work for the refresh thread of the XrdTlsContext of HTTP and XRootD.