### PR TITLE
[XrdHttp + XrdHttpExtHandler] Fixes a segmentation fault happening when a client sends a first line starting with a space

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -90,7 +90,8 @@ verb(req->requestverb), headers(req->allheaders) {
   int envlen = 0;
   
   headers["xrd-http-query"] = req->opaque?req->opaque->Env(envlen):"";
-  headers["xrd-http-fullresource"] = req->resourceplusopaque.c_str();
+  const char * resourcePlusOpaque = req->resourceplusopaque.c_str();
+  headers["xrd-http-fullresource"] = resourcePlusOpaque != nullptr ? resourcePlusOpaque:"";
   headers["xrd-http-prot"] = prot->isHTTPS()?"https":"http";
   
   // These fields usually identify the client that connected

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -409,11 +409,19 @@ int XrdHttpReq::parseFirstLine(char *line, int len) {
     return -1;
   }
 
-  // The first token cannot be too long
+
   pos = p - line;
+  // The first token cannot be too long
   if (pos > MAX_TK_LEN - 1) {
     request = rtMalformed;
     return -2;
+  }
+
+  // The first space-delimited char cannot be the first one
+  // this allows to deal with the case when a client sends a first line that starts with a space " GET / HTTP/1.1"
+  if(pos == 0) {
+      request = rtMalformed;
+      return -4;
   }
 
   // the first token must be non empty


### PR DESCRIPTION
Hi Andy,

During normal EOS operations, we noticed that one storage node crashed in the XrdHttpExtHandler.cc:93 line.
@smithdh (many thanks again!) could reproduce the issue by starting an EOS FST and submitting, via netcat: 

```
nc -Cv localhost 11000
Ncat: Version 7.50 ( https://nmap.org/ncat )
Ncat: Connected to ::1:11000.
 GET // HTTP/1.1
```

Notice the first line starting with a space. This space, at the beginning of the first line would prevent the `XrdHttpReq::parseFirstLine()` method to call the `XrdHttpReq::parseResource()` one.

Once the constructor of an `XrdHttpExtReq` is called, the line `headers["xrd-http-fullresource"] = req->resourceplusopaque.c_str();` will segfault as the resource was not parsed. Indeed, the `resourceplusopaque` XrdOucString has not been asigned and its the c_str() method of an will therefore return a NULL pointer.

Hence my two fixes.

Cheers,
Cedric