### PR TITLE
Implement XrdSciTokensHelper interface for macaroons.

### DIFF
--- a/src/XrdMacaroons/XrdMacaroons.cc
+++ b/src/XrdMacaroons/XrdMacaroons.cc
@@ -27,6 +27,7 @@ extern XrdAccAuthorize *XrdAccDefaultAuthorizeObject(XrdSysLogger   *lp,
                                                      const char     *parm,
                                                      XrdVersionInfo &myVer);
 
+XrdSciTokensHelper *SciTokensHelper = nullptr;
 
 extern "C" {
 
@@ -38,7 +39,9 @@ XrdAccAuthorize *XrdAccAuthorizeObjAdd(XrdSysLogger *log,
 {
     try
     {
-        return new Macaroons::Authz(log, config, chain_authz);
+        auto new_authz = new Macaroons::Authz(log, config, chain_authz);
+        SciTokensHelper = new_authz;
+        return new_authz;
     }
     catch (std::runtime_error &e)
     {
@@ -109,7 +112,9 @@ XrdAccAuthorize *XrdAccAuthorizeObject(XrdSysLogger *log,
     }
     try
     {
-        return new Macaroons::Authz(log, config, chain_authz);
+        auto new_authz = new Macaroons::Authz(log, config, chain_authz);
+        SciTokensHelper = new_authz;
+        return new_authz;
     }
     catch (const std::runtime_error &e)
     {

--- a/src/XrdMacaroons/XrdMacaroonsAuthz.hh
+++ b/src/XrdMacaroons/XrdMacaroonsAuthz.hh
@@ -1,5 +1,6 @@
 
 #include "XrdAcc/XrdAccAuthorize.hh"
+#include "XrdSciTokens/XrdSciTokensHelper.hh"
 #include "XrdSys/XrdSysError.hh"
 
 
@@ -8,7 +9,7 @@ class XrdSysError;
 namespace Macaroons
 {
 
-class Authz : public XrdAccAuthorize
+class Authz final : public XrdAccAuthorize, public XrdSciTokensHelper
 {
 public:
     Authz(XrdSysLogger *lp, const char *parms, XrdAccAuthorize *chain);
@@ -18,20 +19,31 @@ public:
     virtual XrdAccPrivs Access(const XrdSecEntity     *Entity,
                                const char             *path,
                                const Access_Operation  oper,
-                                     XrdOucEnv        *env);
+                                     XrdOucEnv        *env) override;
+
+    // Do a minimal validation that this is a non-expired token; used
+    // for session tokens.
+    virtual bool Validate(const char   *token,
+                          std::string  &emsg,
+                          long long    *expT,
+                          XrdSecEntity *entP) override;
 
     virtual int Audit(const int accok, const XrdSecEntity *Entity,
                       const char *path, const Access_Operation oper,
-                      XrdOucEnv *Env)
+                      XrdOucEnv *Env) override
     {
         return 0;
     }
 
     virtual int Test(const XrdAccPrivs priv,
-                     const Access_Operation oper)
+                     const Access_Operation oper) override
     {
         return 0;
     }
+
+    // Macaroons don't have a concept off an "issuers"; return an empty
+    // list.
+    virtual Issuers IssuerList() {return Issuers();}
 
 private:
     XrdAccPrivs OnMissing(const XrdSecEntity     *Entity,

--- a/src/XrdMacaroons/export-lib-symbols
+++ b/src/XrdMacaroons/export-lib-symbols
@@ -3,6 +3,7 @@ global:
   XrdAccAuthorizeObject*;
   XrdAccAuthorizeObjAdd*;
   XrdHttpGetExtHandler*;
+  SciTokensHelper;
 
 local:
   *;


### PR DESCRIPTION
In order to use ZTN with a token library, the library must provide a XrdSciTokensHelper object.  This implements the interface inside the Macaroons::Authz object, allowing ZTN authentication to be utilized with a macaroon-based token.

This can be enabled with the following configuration directive:
```
sec.protocol -tokenlib libXrdMacaroons-5.so
```