### PR TITLE
[Server] Make sure Mkdir returns a negative code for an EEXIST error

### DIFF
--- a/docs/PreReleaseNotes.txt
+++ b/docs/PreReleaseNotes.txt
@@ -10,5 +10,6 @@ Prerelease Notes
 + **Major bug fixes**
 
 + **Minor bug fixes**
+  **[Server]** Make sure Mkdir returns a negative code for an EEXIST error
 
 + **Miscellaneous**

--- a/src/XrdOss/XrdOssApi.cc
+++ b/src/XrdOss/XrdOssApi.cc
@@ -333,7 +333,7 @@ int XrdOssSys::Mkdir(const char *path, mode_t mode, int mkpath, XrdOucEnv *envP)
 
    if (!stat(local_path, &Stat) && S_ISDIR(Stat.st_mode)
    && mode == (Stat.st_mode & accBits)) return XrdOssOK;
-   return EEXIST;
+   return -EEXIST;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
This is a change so that XrdOssSys::Mkdir returns -EEXIST (rather than the positive value); the function should return a negative number in case there is an error.