### PR TITLE
Actually include XrdSecEntity moninfo field in trace.

### DIFF
--- a/src/XrdSec/XrdSecEntity.cc
+++ b/src/XrdSec/XrdSecEntity.cc
@@ -60,7 +60,7 @@ void XrdSecEntity::Display(XrdSysError &mDest)
    class AttrCB : public XrdSecEntityAttrCB
         {public:
          XrdSecEntityAttrCB::Action Attr(const char *key, const char *val)
-                           {mDest.Say(Tid, "Attr  ",key," = '", val, "'");
+                           {mDest.Say(Tid, " Attr ",key," = '", val, "'");
                             return XrdSecEntityAttrCB::Next;
                            }
          AttrCB(XrdSysError &erp, const char *tid) : mDest(erp), Tid(tid) {}
@@ -92,6 +92,7 @@ void XrdSecEntity::Display(XrdSysError &mDest)
    mDest.Say(tident, " Grps '", (grps ? grps : ""), "'");
    mDest.Say(tident, " Caps '", (caps ? caps : ""), "'");
    mDest.Say(tident, " Pidn '", (pident ? pident : ""), "'");
+   mDest.Say(tident, " Mon  '", (moninfo ? moninfo : ""), "'");
 
    mDest.Say(tident, " Crlen ", std::to_string((LLint)credslen).c_str());
    mDest.Say(tident, " ueid  ", std::to_string((ULint)ueid).c_str());


### PR DESCRIPTION
This logs the monitoring information associated with the Entity (as well as fixing an annoying text alignment issue in the extended attributes).  With this, the xrootd authentication trace looks as follows for GSI:

```
bbockelm.183358:36@hcc-briantest7 Protocol 'gsi'
bbockelm.183358:36@hcc-briantest7 Name 'bbockelm'
bbockelm.183358:36@hcc-briantest7 Host 'hcc-briantest7.unl.edu'
bbockelm.183358:36@hcc-briantest7 Vorg 'cms cms cms'
bbockelm.183358:36@hcc-briantest7 Role 'NULL NULL NULL'
bbockelm.183358:36@hcc-briantest7 Grps '/cms /cms/integration /cms/uscms'
bbockelm.183358:36@hcc-briantest7 Caps ''
bbockelm.183358:36@hcc-briantest7 Pidn 'bbockelm.183358:36@hcc-briantest7'
bbockelm.183358:36@hcc-briantest7 Mon  '/DC=ch/DC=cern/OU=Organic Units/OU=Users/CN=bbockelm/CN=659869/CN=Brian Paul Bockelman'
bbockelm.183358:36@hcc-briantest7 Crlen 0
bbockelm.183358:36@hcc-briantest7 ueid  1
bbockelm.183358:36@hcc-briantest7 uid   0
bbockelm.183358:36@hcc-briantest7 gid   0
bbockelm.183358:36@hcc-briantest7 Attr gridmap.name = '1'
bbockelm.183358:36@hcc-briantest7 Attr  = ''
```