### PR TITLE
[XrdCl] Ensure URL::GetChannelId returns an Id which can be parsed again as a url

### DIFF
--- a/src/XrdCl/XrdClURL.cc
+++ b/src/XrdCl/XrdClURL.cc
@@ -493,7 +493,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   std::string URL::GetChannelId() const
   {
-    std::string ret = pProtocol + "://" + pHostId;
+    std::string ret = pProtocol + "://" + pHostId + "/";
     bool hascgi = false;
 
     std::string keys[] = { "xrdcl.intent",


### PR DESCRIPTION
A Channel's ChannelInfo contains an instance of a SIDManager which is a reference counted instance keyed by a channel id. SIDMgrPool::GetSIDMgr() accepts a URL, from which it calculates the channel id and returns the appropriate instance. Currently GetSIDMgr is passed the channel id directly when setting up the ChannelInfo. There is a problem that some URLs produce a channel id which cannot be re-parsed to a URL and back to the channel id again.

e.g. the url

root://machine:1194//big5?xrd.k5ccname=/foo

has channel id:

root://machine:1194?xrd.k5ccname=/foo

but instantiating a URL with the above and requesting its channel id gives

://

(Some channel id can be parsed in this way, but e.g. those with special opaque key-values can not). This patch changes the value passed to GetSIDMgr to the url rather than the derived channel id. That is the same way that the SIDMgr instance held by XRootDMsgHandler handlers obtain it. Possibly this PR could be enhanced to change URL so that it is able to parse the channel id and give back the same channel id.

The effect of the current situation is that for affected URLs the SIDMgr may be destroyed while the channel is open but there are no outstanding requests (i.e. handlers). If there is a single request, which times-out and another request is then sent there is a chance that the stream id of the first request can be re-used. If the sid is reused and the server then responds to the first request, the result is interpreted as belonging to the second request. It is possible that this causes problems, or a failure, or maybe it is interepred as a valid result of the second call, giving bad data but an Ok status.