### PR TITLE
[Xrd] Fix a short writev recovery case

### DIFF
--- a/src/Xrd/XrdLinkXeq.cc
+++ b/src/Xrd/XrdLinkXeq.cc
@@ -887,7 +887,7 @@ int XrdLinkXeq::SendIOV(const struct iovec *iov, int iocnt, int bytes)
                       {if (errno == EINTR) continue;
                           else break;
                       }
-                   n -= retc; Buff += retc;
+                   n -= retc; Buff += retc; bytesleft -= retc;
                   }
          if (retc < 0 || iocnt < 1) break;
         }


### PR DESCRIPTION
While looking into another problem I noticed an apparently not-handled case in XrdLinkXeq::SendIOV when it resumes a write after an incomplete writev: For instance in the case of iocnt=2, if the writev returns a short number of bytes from the first iov, iov[0], then remainder of iov[0] is sent by write(), and then iov[1] is sent by writev() [all as intended]; but then an attempt would be made to write() the contents of iov[2]. This should either give an error like ("bad address") for the link, or possibly send some trailing nonsense data to the client.

In fact I don't think this was related to the problem I had been looking at, and I didn't find any indication this is happening. e.g. even if I look at a busy server I don't notice any "bad address" link errors. So maybe this is rather rare or even not possible for some reason I've not understood. (e.g. iov[0] is typically very short, e.g. 8 bytes, and iov[1] or iov[2] is much longer, so a short writev is more likely to happen in the last iov[]).