### PR TITLE
feat: Use setuptools over setuptools._distutils.core

### DIFF
--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -1,22 +1,14 @@
 from __future__ import print_function
 
-# setuptools._distutils added in setuptools v48.0.0
-# c.f. https://setuptools.pypa.io/en/latest/history.html#v48-0-0
-try:
-    from setuptools import setup, Extension
-    # sysconfig v48.0.0+ is incompatible for Python 3.6 only, so fall back to distutils.
-    # Instead of checking setuptools.__version__ explicitly, use the knowledge that
-    # to get here in the 'try' block requires setuptools v48.0.0+.
-    # FIXME: When support for Python 3.6 is dropped simplify this
-    import sys
+from setuptools import setup, Extension
+# sysconfig with setuptools v48.0.0+ is incompatible for Python 3.6 only, so fall back to distutils.
+# FIXME: When support for Python 3.6 is dropped simplify this
+import sys
 
-    if sys.version_info < (3, 7):
-        from distutils import sysconfig
-    else:
-        import sysconfig
-except ImportError:
-    from distutils.core import setup, Extension
+if sys.version_info < (3, 7):
     from distutils import sysconfig
+else:
+    import sysconfig
 
 from os import getenv, walk, path
 import subprocess

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -3,7 +3,7 @@ from __future__ import print_function
 # setuptools._distutils added in setuptools v48.0.0
 # c.f. https://setuptools.pypa.io/en/latest/history.html#v48-0-0
 try:
-    from setuptools._distutils.core import setup, Extension
+    from setuptools import setup, Extension
     # sysconfig v48.0.0+ is incompatible for Python 3.6 only, so fall back to distutils.
     # Instead of checking setuptools.__version__ explicitly, use the knowledge that
     # to get here in the 'try' block requires setuptools v48.0.0+.


### PR DESCRIPTION
Resolves #1830

Drop all usage of `setuptools._distutils` in favor of pure `setuptools`. This effectively solves the problems that were present in the attempt in PR #1585 and PR #1700. With this, it is now possible to go further and drop direct usage of `distutils` in favor of `setuptools`. This effectively happens with the removal of `setuptools._distutils` as

```python
try:
    from setuptools import setup, Extension
    ...
```

should always pass, and so this just makes this explicitly clear by removing the `try/except` block.