### PR TITLE
[XrdApps] Fix small memory leak

### DIFF
--- a/src/XrdApps/XrdCpConfig.cc
+++ b/src/XrdApps/XrdCpConfig.cc
@@ -176,6 +176,7 @@ XrdCpConfig::~XrdCpConfig()
    if (inFile)  free(inFile);
    if (pHost)   free(pHost);
    if (parmVal) free(parmVal);
+   if (CksObj)  delete CksObj;
    if (CksMan)  delete CksMan;
    if (zipFile) free(zipFile);
    if (dstFile) delete dstFile;


### PR DESCRIPTION
Before:
```
xrdcp -f --cksum adler32 "root://eosams02.cern.ch//eos/ams/Data/AMS02/2011A/RawData/1308783516?eos.ruid=0" /var/tmp/dump
[1.195GB/1.195GB][100%][==================================================][102MB/s]    
Run: [ERROR] CheckSum error

=================================================================
==30521==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f537cff336f in operator new(unsigned long) (/usr/lib64/libasan.so.5+0x10e36f)
    #1 0x7f537cac208d in XrdCksCalcadler32::New() /eos-xrootd-code/src/./XrdCks/XrdCksCalcadler32.hh:95

SUMMARY: AddressSanitizer: 24 byte(s) leaked in 1 allocation(s).
```

After the fix:
```
xrdcp -f --cksum adler32 "root://eosams02.cern.ch//eos/ams/Data/AMS02/2011A/RawData/1308783516?eos.ruid=0" /var/tmp/dump
[1.195GB/1.195GB][100%][==================================================][111.3MB/s]  
Run: [ERROR] CheckSum error
```
