### PR TITLE
[XrdHttpTPC] PULL: Initialize the boolean for the opaque separator to…

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -965,7 +965,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         }
     }
     rec.streams = streams;
-    bool hasSetOpaque;
+    bool hasSetOpaque = false;
     std::string full_url = prepareURL(req, hasSetOpaque);
     std::string authz = GetAuthz(req);
     curl_easy_setopt(curl, CURLOPT_URL, resource.c_str());


### PR DESCRIPTION
… be set properly

This issue was discovered when a HTTP TPC PULL from a non-xrootd server was happening. The oss.asize attribute was put after a '&' instead of a '?'