### PR TITLE
Provide a mechanism to override the detected hostname by environment …

### DIFF
--- a/src/Xrd/XrdConfig.hh
+++ b/src/Xrd/XrdConfig.hh
@@ -30,6 +30,7 @@
 /******************************************************************************/
 
 #include <vector>
+#include <string>
 
 #include "Xrd/XrdProtLoad.hh"
 #include "Xrd/XrdProtocol.hh"
@@ -94,7 +95,7 @@ static const char  *TraceID;
 XrdNetSecurity     *Police;
 XrdTcpMonInfo      *tmoInfo;
 const char         *myProg;
-const char         *myName;
+std::string         myName;
 const char         *myDomain;
 const char         *mySitName;
 const char         *myInsName;


### PR DESCRIPTION
…variable.

Note the `myName` variable needed to be changed to a string as it must own the memory; the memory pointed to by `getenv` my change after future `setenv` calls.

Fixes #1855