### PR TITLE
Fix build failure due to possible large memory allocation

### DIFF
--- a/src/XrdPosix/XrdPosixAdmin.cc
+++ b/src/XrdPosix/XrdPosixAdmin.cc
@@ -29,6 +29,7 @@
 /******************************************************************************/
 
 #include <cerrno>
+#include <limits>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -66,6 +67,8 @@ XrdCl::URL *XrdPosixAdmin::FanOut(int &num)
 // Allocate an array large enough to hold this information
 //
    if (!(i = info->GetSize())) {delete info; return 0;}
+   if (i > std::numeric_limits<ptrdiff_t>::max() / sizeof(XrdCl::URL))
+      {delete info; return 0;}
    uVec = new XrdCl::URL[i];
 
 // Now start filling out the array


### PR DESCRIPTION
~~~
/builddir/build/BUILD/xrootd-5.5.1/src/XrdPosix/XrdPosixAdmin.cc: In member function 'FanOut': /builddir/build/BUILD/xrootd-5.5.1/src/XrdPosix/XrdPosixAdmin.cc:69:27: error: argument 1 value '4294967295' exceeds maximum object size 2147483647 [-Werror=alloc-size-larger-than=]
   69 |    uVec = new XrdCl::URL[i];
      |                           ^
/usr/include/c++/13/new:128:26: note: in a call to allocation function 'operator new []' declared here
  128 | _GLIBCXX_NODISCARD void* operator new[](std::size_t) _GLIBCXX_THROW (std::bad_alloc)
      |                          ^
~~~
Failure happens with gcc 13 on 32 bit systems.