### PR TITLE
[CI] Move from Fedora 35 to Fedora 37

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -442,7 +442,7 @@ jobs:
   rpm-fedora:
 
     runs-on: ubuntu-latest
-    container: fedora:35
+    container: fedora:37
 
     steps:
     - name: Install external dependencies with dnf


### PR DESCRIPTION
Fedora 35 repos are returning an HTTP 404 code. Making a PR just so CI runs.