### PR TITLE
Update XrdPosixAdmin.cc

### DIFF
--- a/src/XrdPosix/XrdPosixAdmin.cc
+++ b/src/XrdPosix/XrdPosixAdmin.cc
@@ -30,6 +30,7 @@
 
 #include <cerrno>
 #include <limits>
+#include <cstddef>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Fixes compilation issue on older gcc

```
/usr/src/xrootd-5.5.2/src/XrdPosix/XrdPosixAdmin.cc: In member function ‘XrdCl::URL* XrdPosixAdmin::FanOut(int&)’:
/usr/src/xrootd-5.5.2/src/XrdPosix/XrdPosixAdmin.cc:70:32: error: ‘ptrdiff_t’ was not declared in this scope
    if (i > std::numeric_limits<ptrdiff_t>::max() / sizeof(XrdCl::URL))
                                ^
/usr/src/xrootd-5.5.2/src/XrdPosix/XrdPosixAdmin.cc:70:32: note: suggested alternatives:
In file included from /usr/include/c++/5/limits:42:0,
                 from /usr/src/xrootd-5.5.2/src/XrdPosix/XrdPosixAdmin.cc:32:
/usr/include/x86_64-linux-gnu/c++/5/bits/c++config.h:197:28: note:   ‘std::ptrdiff_t’
   typedef __PTRDIFF_TYPE__ ptrdiff_t;
                            ^
/usr/include/x86_64-linux-gnu/c++/5/bits/c++config.h:197:28: note:   ‘std::ptrdiff_t’
/usr/src/xrootd-5.5.2/src/XrdPosix/XrdPosixAdmin.cc:70:41: error: template argument 1 is invalid
    if (i > std::numeric_limits<ptrdiff_t>::max() / sizeof(XrdCl::URL))
                                         ^
src/CMakeFiles/XrdPosix.dir/build.make:62: recipe for target 'src/CMakeFiles/XrdPosix.dir/XrdPosix/XrdPosixAdmin.cc.o' failed
make[2]: *** [src/CMakeFiles/XrdPosix.dir/XrdPosix/XrdPosixAdmin.cc.o] Error 1
```