### PR TITLE
fix: Avoid 'may be used uninitialized' warning

### DIFF
--- a/src/XrdCms/XrdCmsRRQ.cc
+++ b/src/XrdCms/XrdCmsRRQ.cc
@@ -360,7 +360,7 @@ void XrdCmsRRQ::sendRedResp(XrdCmsRRQSlot *rP)
 // EPNAME("sendRedResp");
    static const int ovhd = sizeof(kXR_unt32);
    XrdCmsNode *nP;
-   int doredir, port, hlen = 0;
+   int doredir = 0, port = 0, hlen = 0;
 
 // Determine where the client should be redirected
 //


### PR DESCRIPTION
* Initialize all variables to avoid a potential 'may be used uninitialized' warning that will become an error with `-flto=auto` is used.

This is needed to for PR #1906.