### PR TITLE
Allow XRootD to return trailers indicating failure

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -52,7 +52,7 @@ int XrdHttpExtReq::StartChunkedResp(int code, const char *desc, const char *head
 {
   if (!prot) return -1;
 
-  return prot->StartChunkedResp(code, desc, header_to_add, true);
+  return prot->StartChunkedResp(code, desc, header_to_add, -1, true);
 }
 
 int XrdHttpExtReq::ChunkResp(const char *body, long long bodylen)

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -271,15 +271,22 @@ private:
 
   /// Starts a chunked response; body of request is sent over multiple parts using the SendChunkResp
   //  API.
-  int StartChunkedResp(int code, const char *desc, const char *header_to_add, bool keepalive);
+  int StartChunkedResp(int code, const char *desc, const char *header_to_add, long long bodylen, bool keepalive);
 
   /// Send a (potentially partial) body in a chunked response; invoking with NULL body
   //  indicates that this is the last chunk in the response.
   int ChunkResp(const char *body, long long bodylen);
-  
+
+  /// Send the beginning of a chunked response but not the body; useful when the size
+  //  of the chunk is known but the body is not immediately available.
+  int ChunkRespHeader(long long bodylen);
+
+  /// Send the footer of the chunk response
+  int ChunkRespFooter();
+
   /// Gets a string that represents the IP address of the client. Must be freed
   char *GetClientIPStr();
-  
+
   /// Tells that we are just logging in
   bool DoingLogin;
   

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -298,6 +298,10 @@ int XrdHttpReq::parseLine(char *line, int len) {
       sendcontinue = true;
     } else if (!strcasecmp(key, "Transfer-Encoding") && strstr(val, "chunked")) {
       m_transfer_encoding_chunked = true;
+    } else if (!strcasecmp(key, "TE") && strstr(val, "trailers")) {
+      m_trailer_headers = true;
+    } else if (!strcasecmp(key, "X-Transfer-Status") && strstr(val, "true")) {
+      m_status_trailer = true;
     } else {
       // Some headers need to be translated into "local" cgi info.
       std::map< std:: string, std:: string > ::iterator it = prot->hdr2cgimap.find(key);
@@ -1047,6 +1051,9 @@ void XrdHttpReq::mapXrdErrorToHttpStatus() {
                  << "] to status code [" << httpStatusCode << "]");
 
     httpStatusText += "\n";
+  } else {
+      httpStatusCode = 200;
+      httpStatusText = "OK";
   }
 }
 
@@ -1417,7 +1424,9 @@ int XrdHttpReq::ProcessHTTPReq() {
               xrdreq.read.rlen = htonl(l);
             }
 
-            if (prot->ishttps) {
+            // If we are using HTTPS or if the client requested trailers, disable sendfile
+            // (in the latter case, the chunked encoding prevents sendfile usage)
+            if (prot->ishttps || (m_transfer_encoding_chunked && m_trailer_headers)) {
               if (!prot->Bridge->setSF((kXR_char *) fhandle, false)) {
                 TRACE(REQ, " XrdBridge::SetSF(false) failed.");
 
@@ -2297,8 +2306,12 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               
               if (rwOps.size() == 0) {
                 // Full file.
-                
-                prot->SendSimpleResp(200, NULL, m_digest_header.empty() ? NULL : m_digest_header.c_str(), NULL, filesize, keepalive);
+
+                if (m_transfer_encoding_chunked && m_trailer_headers) {
+                  prot->StartChunkedResp(200, NULL, m_digest_header.empty() ? NULL : m_digest_header.c_str(), filesize, keepalive);
+                } else {
+                  prot->SendSimpleResp(200, NULL, m_digest_header.empty() ? NULL : m_digest_header.c_str(), NULL, filesize, keepalive);
+                }
                 return 0;
               } else
                 if (rwOps.size() == 1) {
@@ -2366,10 +2379,58 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
           {
 
             // Nothing to do if we are postprocessing a close
-            if (ntohs(xrdreq.header.requestid) == kXR_close) return keepalive ? 1 : -1;
-            
+            if (ntohs(xrdreq.header.requestid) == kXR_close) {
+
+              if (m_transfer_encoding_chunked && m_trailer_headers) {
+                if (prot->ChunkRespHeader(0))
+                  return -1;
+
+                const std::string crlf = "\r\n";
+                std::stringstream ss;
+                ss << "X-Transfer-Status: " << httpStatusCode << ": " << httpStatusText << crlf;
+
+                const auto header = ss.str();
+                if (prot->SendData(header.c_str(), header.size()))
+                  return -1;
+
+                if (prot->ChunkRespFooter())
+                  return -1;
+              }
+
+              return keepalive ? 1 : -1;
+            }
+
             // Close() if this was the third state of a readv, otherwise read the next chunk
             if ((reqstate == 3) && (ntohs(xrdreq.header.requestid) == kXR_readv)) return keepalive ? 1: -1;
+
+            // If we are here it's too late to send a proper error message...
+            if (xrdresp == kXR_error) {
+              if (m_transfer_encoding_chunked && m_trailer_headers && m_status_trailer) {
+                // A trailer header is appropriate in this case; this is signified by
+                // a chunk with size zero, then the trailer, then a crlf.
+                //
+                // We only send the status trailer when explicitly requested; otherwise a
+                // "normal" HTTP client might simply see a short response and think it's a
+                // success
+                if (prot->ChunkRespHeader(0))
+                  return -1;
+
+                const std::string crlf = "\r\n";
+                std::stringstream ss;
+                ss << "X-Transfer-Status: " << httpStatusCode << ": " << httpStatusText << crlf;
+
+		const auto header = ss.str();
+                if (prot->SendData(header.c_str(), header.size()))
+                  return -1;
+
+                if (prot->ChunkRespFooter())
+                  return -1;
+
+                return -1;
+              } else {
+                return -1;
+              }
+            }
 
             // Prevent scenario where data is expected but none is actually read
             // E.g. Accessing files which return the results of a script
@@ -2380,8 +2441,6 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               return -1;
             }
 
-            // If we are here it's too late to send a proper error message...
-            if (xrdresp == kXR_error) return -1;
 
             TRACEI(REQ, "Got data vectors to send:" << iovN);
             if (ntohs(xrdreq.header.requestid) == kXR_readv) {
@@ -2431,11 +2490,21 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                 if (prot->SendData((char *) s.c_str(), s.size())) return -1;
               }
 
-            } else
+            } else {
+              // Send chunked encoding header
+              if (m_transfer_encoding_chunked && m_trailer_headers) {
+                int sum = 0;
+                for (int i = 0; i < iovN; i++) sum += iovP[i].iov_len;
+                prot->ChunkRespHeader(sum);
+              }
               for (int i = 0; i < iovN; i++) {
                 if (prot->SendData((char *) iovP[i].iov_base, iovP[i].iov_len)) return -1;
                 writtenbytes += iovP[i].iov_len;
               }
+              if (m_transfer_encoding_chunked && m_trailer_headers) {
+                prot->ChunkRespFooter();
+              }
+            }
               
             // Let's make sure that we avoid sending the same data twice,
             // in the case where PostProcessHTTPReq is invoked again
@@ -2900,6 +2969,9 @@ void XrdHttpReq::reset() {
   m_transfer_encoding_chunked = false;
   m_current_chunk_size = -1;
   m_current_chunk_offset = 0;
+
+  m_trailer_headers = false;
+  m_status_trailer = false;
 
   /// State machine to talk to the bridge
   reqstate = 0;

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -85,6 +85,14 @@ private:
   long long m_current_chunk_offset;
   long long m_current_chunk_size;
 
+  // Whether trailer headers were enabled
+  bool m_trailer_headers{false};
+
+  // Whether the client understands our special status trailer.
+  // The status trailer allows us to report when an IO error occurred
+  // after a response body has started
+  bool m_status_trailer{false};
+
   int parseContentRange(char *);
   int parseHost(char *);
   int parseRWOp(char *);


### PR DESCRIPTION
HTTP provides a response to include a "trailer" in addition to the better-known "header".  If a user sets the following headers in the request:

```
X-Transfer-Status: true
TE: trailers
Transfer-Encoding: chunked
```

Then the response will used chunked encoding and indicate, on the last returned chunk, whether an error has occurred.

Clients aware of these headers can now receive an error message from XRootD if there's an IO error in the middle of the response.  This is expected to be useful in XCache use cases where failure mid-response is somewhat more common.