### PR TITLE
Override error message for EAUTH

### DIFF
--- a/src/XrdSys/XrdSysE2T.cc
+++ b/src/XrdSys/XrdSysE2T.cc
@@ -63,6 +63,12 @@ int initErrTable()
            lastGood = i;
           }
       }
+   // NOTE: On systems without EAUTH (authentication error; currently all Glibc systems but GNU Hurd),
+   // EAUTH is remapped to EBADE ('invalid exchange').  Given there's no current XRootD use of a
+   // syscall that can return EBADE, we assume EBADE really means authentication denied.
+#if defined(EBADE)
+   Errno2String[EBADE] = "authentication failed - possible invalid exchange";
+#endif
 
 // Supply generic message for missing ones
 //


### PR DESCRIPTION
On Linux platforms, the "authentication denied" error is mapped to the EBADE errno (as EAUTH doesn't exist).  That results in authentication errors in XrdPss to generate the "invalid exchange" error message (this is because XrdPss takes the errno from XrdPosix and XrdPosix returns EBADE/EAUTH).

Rather than start tinkering with alternate errno's for this case, simply map EBADE's error message to "authentication denied".

Before:

```
Server responded with an error: [3030] Unable to open /user/ligo/test_access/access_ligo; invalid exchange
```

After:

```
Server responded with an error: [3030] Unable to open /user/ligo/test_access/access_ligo; authentication denied
```

This misleading error message was found when working on #1915 