### PR TITLE
Fix direct read for PFC

### DIFF
--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -1171,8 +1171,10 @@ void File::ProcessDirectReadFinished(ReadRequest *rreq, int bytes_read, int erro
 
    if (error_cond)
       rreq->update_error_cond(error_cond);
-   else
+   else {
       rreq->m_stats.m_BytesBypassed += bytes_read;
+      rreq->m_bytes_read += bytes_read;
+   }
 
    rreq->m_direct_done = true;
 


### PR DESCRIPTION
When direct reads ("bypass mode") are in use, the code was failing to increment the number of bytes serviced in the read request.  When there were no errors, that means the overall read operation returned 0 instead of the bytes read.

This resulted in 100% failure rate for HTTP requests when direct read mode was activated.

This was tested by disabling prefetch and then always forcing direct reads via this simple patch:

```
--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -804,7 +804,7 @@ int File::ReadOpusCoalescere(IO *io, const XrdOucIOVec *readV, int readVnum,
                read_req = new ReadRequest(io, rh);
 
             // Is there room for one more RAM Block?
-            Block *b = PrepareBlockRequest(block_idx, io, read_req, false);
+            Block *b = nullptr; // = PrepareBlockRequest(block_idx, io, read_req, false);
             if (b)
             {
                TRACEF(Dump, tpfx << "inc_ref_count new " <<  (void*)iUserBuff << " idx = " << block_idx);
```

Before -- HTTP requests would hang 100% of the time.  After -- everything worked.