### PR TITLE
Report cache object age for caching proxy mode

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2288,18 +2288,16 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               
               // Always try to parse response.  In the case of a caching proxy, the open
               // will have created the file in cache
-              filectime = 0;
               if (iovP[1].iov_len > 1) {
                 TRACEI(REQ, "Stat for GET " << resource.c_str()
                          << " stat=" << (char *) iovP[1].iov_base);
 
                 long dummyl;
-                sscanf((const char *) iovP[1].iov_base, "%ld %lld %ld %ld %ld",
+                sscanf((const char *) iovP[1].iov_base, "%ld %lld %ld %ld",
                       &dummyl,
                       &filesize,
                       &fileflags,
-                      &filemodtime,
-                      &filectime);
+                      &filemodtime);
 
                 // As above: if the client specified a response size, we use that.
                 // Otherwise, utilize the filesize
@@ -2320,7 +2318,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                   if (!responseHeader.empty()) {
                     responseHeader += "\r\n";
                   }
-                  long object_age = time(NULL) - filectime;
+                  long object_age = time(NULL) - filemodtime;
                   responseHeader += std::string("Age: ") + std::to_string(object_age < 0 ? 0 : object_age);
               }
 

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -274,6 +274,7 @@ public:
   long long filesize;
   long fileflags;
   long filemodtime;
+  long filectime;
   char fhandle[4];
   bool fopened;
 

--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -274,6 +274,9 @@ bool Cache::Config(const char *config_filename, const char *parameters)
    const char *theINS = getenv("XRDINSTANCE");
    m_isClient = (theINS != 0 && strncmp("*client ", theINS, 8) == 0);
 
+   // Tell everyone else we are a caching proxy
+   XrdOucEnv::Export("XRDPFC", 1);
+
    XrdOucEnv myEnv;
    XrdOucStream Config(&m_log, theINS, &myEnv, "=====> ");
 

--- a/src/XrdPfc/XrdPfcIOFile.cc
+++ b/src/XrdPfc/XrdPfcIOFile.cc
@@ -54,12 +54,10 @@ IOFile::~IOFile()
 //______________________________________________________________________________
 int IOFile::Fstat(struct stat &sbuff)
 {
-   std::string name = GetFilename() + Info::s_infoExtension;
-
    int res = 0;
    if( ! m_localStat)
    {
-      res = initCachedStat(name.c_str());
+      res = initCachedStat();
       if (res) return res;
    }
 
@@ -74,7 +72,7 @@ long long IOFile::FSize()
 }
 
 //______________________________________________________________________________
-int IOFile::initCachedStat(const char* path)
+int IOFile::initCachedStat()
 {
    // Called indirectly from the constructor.
 
@@ -83,18 +81,24 @@ int IOFile::initCachedStat(const char* path)
    int res = -1;
    struct stat tmpStat;
 
-   if (m_cache.GetOss()->Stat(GetFilename().c_str(), &tmpStat) == XrdOssOK)
+   std::string fname = GetFilename();
+   std::string iname = fname + Info::s_infoExtension;
+   if (m_cache.GetOss()->Stat(fname.c_str(), &tmpStat) == XrdOssOK)
    {
       XrdOssDF* infoFile = m_cache.GetOss()->newFile(Cache::GetInstance().RefConfiguration().m_username.c_str());
       XrdOucEnv myEnv;
       int       res_open;
-      if ((res_open = infoFile->Open(path, O_RDONLY, 0600, myEnv)) == XrdOssOK)
+      if ((res_open = infoFile->Open(iname.c_str(), O_RDONLY, 0600, myEnv)) == XrdOssOK)
       {
          Info info(m_cache.GetTrace());
-         if (info.Read(infoFile, path))
+         if (info.Read(infoFile, iname.c_str()))
          {
+            // The filesize from the file itself may be misleading if its download is incomplete; take it from the cinfo.
             tmpStat.st_size = info.GetFileSize();
-            TRACEIO(Info, trace_pfx << "successfully read size from info file = " << tmpStat.st_size);
+            // We are arguably abusing the mtime to be the creation time of the file; then ctime becomes the
+            // last time additional data was cached.
+            tmpStat.st_mtime = info.GetCreationTime();
+            TRACEIO(Info, trace_pfx << "successfully read size " << tmpStat.st_size << " and creation time " << tmpStat.st_mtime << " from info file");
             res = 0;
          }
          else

--- a/src/XrdPfc/XrdPfcIOFile.hh
+++ b/src/XrdPfc/XrdPfcIOFile.hh
@@ -87,7 +87,7 @@ private:
    int ReadVEnd(int retval, ReadReqRH *rh);
 
    struct stat *m_localStat;
-   int initCachedStat(const char* path);
+   int initCachedStat();
 
 
 };


### PR DESCRIPTION
When in caching proxy mode, have the HTTP response populate the standardized `Age` field so the client knows the approximate age of the object in cache.

@osschar 