### PR TITLE
XrdHttp: Fix byte range requests

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2305,6 +2305,8 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
               } else
                 if (rwOps.size() == 1) {
                 // Only one read to perform
+                if (rwOps[0].byteend < 0) // The requested range was along the lines of "Range: 1234-", meaning we need to fill in the end
+                  rwOps[0].byteend = filesize - 1;
                 int cnt = (rwOps[0].byteend - rwOps[0].bytestart + 1);
                 char buf[64];
                 
@@ -2312,7 +2314,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                 sprintf(buf, "%lld-%lld/%lld", rwOps[0].bytestart, rwOps[0].byteend, filesize);
                 s += buf;
                 if (!m_digest_header.empty()) {
-                  s += "\n";
+                  s += "\r\n";
                   s += m_digest_header.c_str();
                 }
 

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1973,7 +1973,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
           if (m_req_digest.size()) {
             return 0;
           } else {
-            prot->SendSimpleResp(200, NULL, NULL, NULL, filesize, keepalive);
+            prot->SendSimpleResp(200, NULL, "Accept-Ranges: bytes", NULL, filesize, keepalive);
             return keepalive ? 1 : -1;
           }
         }
@@ -1983,12 +1983,14 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
         return keepalive ? 1 : -1;
       } else { // We requested a checksum and now have its response.
         if (iovN > 0) {
-          std::string digest_response;
-          int response = PostProcessChecksum(digest_response);
+          std::string response_headers;
+          int response = PostProcessChecksum(response_headers);
           if (-1 == response) {
                 return -1;
           }
-          prot->SendSimpleResp(200, NULL, digest_response.c_str(), NULL, filesize, keepalive);
+          if (!response_headers.empty()) {response_headers += "\r\n";}
+          response_headers += "Accept-Ranges: bytes";
+          prot->SendSimpleResp(200, NULL, response_headers.c_str(), NULL, filesize, keepalive);
           return keepalive ? 1 : -1;
         } else {
           prot->SendSimpleResp(500, NULL, NULL, "Underlying filesystem failed to calculate checksum.", 0, false);


### PR DESCRIPTION
This PR (a) advertises the server supports byte range requests and (b) fixes the byte range request when resuming a download.

This allows libraries which can resume interrupted partial downloads to function with the xrootd server.