### PR TITLE
Allow building against system installed version of isa-l

### DIFF
--- a/cmake/Findisal.cmake
+++ b/cmake/Findisal.cmake
@@ -1,0 +1,55 @@
+#.rst:
+# Findisal
+# ---------
+#
+# Find Intelligent Storage Acceleration Library.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables:
+#
+# ::
+#
+#   ISAL_FOUND          - True if isa-l is found.
+#   ISAL_INCLUDE_DIRS   - Where to find isa-l.h
+#   ISAL_LIBRARIES      - Where to find libisal.so
+#
+# ::
+#
+#   ISAL_VERSION        - The version of ISAL found (x.y.z)
+#   ISAL_VERSION_MAJOR  - The major version of isa-l
+#   ISAL_VERSION_MINOR  - The minor version of isa-l
+#   ISAL_VERSION_PATCH  - The patch version of isa-l
+
+foreach(var ISAL_FOUND ISAL_INCLUDE_DIR ISAL_ISAL_LIBRARY ISAL_LIBRARIES)
+  unset(${var} CACHE)
+endforeach()
+
+find_path(ISAL_INCLUDE_DIR NAME isa-l.h PATH_SUFFIXES include)
+
+if(NOT ISAL_LIBRARY)
+  find_library(ISAL_LIBRARY NAMES isal PATH_SUFFIXES lib)
+endif()
+
+mark_as_advanced(ISAL_INCLUDE_DIR)
+
+if(ISAL_INCLUDE_DIR AND EXISTS "${ISAL_INCLUDE_DIR}/isa-l.h")
+  file(STRINGS "${ISAL_INCLUDE_DIR}/isa-l.h" ISAL_H REGEX "^#define ISAL_[A-Z_]+[ ]+[0-9]+.*$")
+  string(REGEX REPLACE ".+ISAL_MAJOR_VERSION[ ]+([0-9]+).*$" "\\1" ISAL_VERSION_MAJOR "${ISAL_H}")
+  string(REGEX REPLACE ".+ISAL_MINOR_VERSION[ ]+([0-9]+).*$" "\\1" ISAL_VERSION_MINOR "${ISAL_H}")
+  string(REGEX REPLACE ".+ISAL_PATCH_VERSION[ ]+([0-9]+).*$" "\\1" ISAL_VERSION_PATCH "${ISAL_H}")
+  set(ISAL_VERSION "${ISAL_VERSION_MAJOR}.${ISAL_VERSION_MINOR}.${ISAL_VERSION_PATCH}")
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(isal
+  REQUIRED_VARS ISAL_LIBRARY ISAL_INCLUDE_DIR VERSION_VAR ISAL_VERSION)
+
+if(ISAL_FOUND)
+  set(ISAL_INCLUDE_DIRS "${ISAL_INCLUDE_DIR}")
+
+  if(NOT ISAL_LIBRARIES)
+    set(ISAL_LIBRARIES ${ISAL_LIBRARY})
+  endif()
+endif()

--- a/cmake/XRootDDefaults.cmake
+++ b/cmake/XRootDDefaults.cmake
@@ -33,4 +33,5 @@ option( ENABLE_XRDCLHTTP "Enable xrdcl-http plugin."                            
 cmake_dependent_option( ENABLE_SCITOKENS "Enable SciTokens plugin." TRUE "NOT XRDCL_ONLY" FALSE )
 cmake_dependent_option( ENABLE_MACAROONS "Enable Macaroons plugin." TRUE "NOT XRDCL_ONLY" FALSE )
 option( FORCE_ENABLED    "Fail build if enabled components cannot be built."              FALSE )
+cmake_dependent_option( USE_SYSTEM_ISAL  "Use isa-l installed in the system" FALSE "ENABLE_XRDEC" FALSE )
 define_default( XRD_PYTHON_REQ_VERSION 3 )

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -28,8 +28,6 @@ endif()
 # XrdEc sources
 #-------------------------------------------------------------------------------
 if( BUILD_XRDEC )
-  link_directories( ${ISAL_LIBDIR} )
-  include_directories( ${ISAL_INCDIR} )
   set( XrdEcSources
        ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcRedundancyProvider.cc
        ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcUtilities.cc
@@ -37,7 +35,6 @@ if( BUILD_XRDEC )
        ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcReader.cc
        XrdClEcHandler.cc
   )
-  set( ISAL_LIB isal )
   add_compile_definitions( WITH_XRDEC )
 endif()
 
@@ -119,19 +116,17 @@ target_link_libraries(
   ${ZLIB_LIBRARIES}
   ${EXTRA_LIBS}
   ${CMAKE_DL_LIBS}
-  ${OPENSSL_LIBRARIES}
-  ${ISAL_LIB})
+  ${OPENSSL_LIBRARIES})
 
 set_target_properties(
   XrdCl
   PROPERTIES
-  INTERFACE_LINK_LIBRARIES ""
-  LINK_INTERFACE_LIBRARIES ""
   VERSION   ${XRD_CL_VERSION}
   SOVERSION ${XRD_CL_SOVERSION} )
 
 if( BUILD_XRDEC )
-  add_dependencies( XrdCl isa-l )
+  target_include_directories(XrdCl PUBLIC ${ISAL_INCLUDE_DIRS})
+  target_link_libraries(XrdCl ${ISAL_LIBRARIES})
 endif()
 
 #-------------------------------------------------------------------------------

--- a/src/XrdEc/CMakeLists.txt
+++ b/src/XrdEc/CMakeLists.txt
@@ -1,9 +1,6 @@
 include( XRootDCommon )
 include( ExternalProject )
 
-link_directories( ${ISAL_LIBDIR} )
-include_directories( ${ISAL_INCDIR} )
-
 #-------------------------------------------------------------------------------
 # The XrdEc shared library
 #-------------------------------------------------------------------------------
@@ -27,19 +24,14 @@ add_library(
 target_link_libraries(
   XrdEc
   XrdCl
-  isal
 )
 
 set_target_properties(
   XrdEc
   PROPERTIES
-  INTERFACE_LINK_LIBRARIES ""
-  LINK_INTERFACE_LIBRARIES ""
   VERSION   ${XRD_EC_VERSION}
   SOVERSION ${XRD_EC_SOVERSION} )
   
-add_dependencies( XrdEc isa-l )
-
 #------------------------------------------------------------------------------
 # Install XrdEc library
 #------------------------------------------------------------------------------

--- a/src/XrdEc/XrdEcObjCfg.hh
+++ b/src/XrdEc/XrdEcObjCfg.hh
@@ -10,7 +10,7 @@
 
 #include "XrdOuc/XrdOucCRC32C.hh"
 
-#include "isa-l/crc.h"
+#include <isa-l/crc.h>
 
 #include <cstdlib>
 #include <string>

--- a/src/XrdEc/XrdEcRedundancyProvider.cc
+++ b/src/XrdEc/XrdEcRedundancyProvider.cc
@@ -15,7 +15,7 @@
 
 #include "XrdEc/XrdEcRedundancyProvider.hh"
 
-#include "isa-l/isa-l.h"
+#include <isa-l.h>
 #include <cstring>
 #include <sstream>
 #include <algorithm>

--- a/src/XrdIsal.cmake
+++ b/src/XrdIsal.cmake
@@ -1,57 +1,47 @@
-include( XRootDCommon )
-include( ExternalProject )
+if(USE_SYSTEM_ISAL)
+  find_package(isal REQUIRED)
+endif()
+
+if(ISAL_FOUND)
+  return()
+endif()
 
 #-------------------------------------------------------------------------------
 # Build isa-l
 #-------------------------------------------------------------------------------
 
-set(MAKEOPTIONS "")
-if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i386" OR "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
-    set(MAKEOPTIONS "arch=32")
-endif()
+include(ExternalProject)
+include(FindPackageHandleStandardArgs)
 
-#EXECUTE_PROCESS(
-#     COMMAND git ls-remote --tags https://github.com/01org/isa-l
-#     COMMAND awk "{print $2}"
-#     COMMAND grep -v {}
-#     COMMAND awk -F "/" "{print $3}"
-#     COMMAND tail -1 
-#     OUTPUT_VARIABLE ISAL_VERSION
-#)
+set(ISAL_VERSION v2.30.0)
+message(STATUS "Building ISAL: ${ISAL_VERSION}")
 
-set( ISAL_VERSION v2.30.0 )
-MESSAGE( STATUS "Building ISAL: ${ISAL_VERSION}" )
+set(ISAL_ROOT "${CMAKE_BINARY_DIR}/isa-l")
+set(ISAL_LIBRARY "${ISAL_ROOT}/.libs/libisal.a")
+set(ISAL_INCLUDE_DIRS "${ISAL_ROOT}")
 
-set( ISAL_BUILDDIR "${CMAKE_BINARY_DIR}/isal/build" CACHE INTERNAL "" )
-set( ISAL_INCDIR   "${CMAKE_BINARY_DIR}/isal/include" CACHE INTERNAL "" )
-set( ISAL_LIBDIR   "${CMAKE_BINARY_DIR}/isal/lib" CACHE INTERNAL "" )
-
-set( ISAL_HEADERS 
-	 ${ISAL_BUILDDIR}/include/crc64.h  
-	 ${ISAL_BUILDDIR}/include/crc.h  
-	 ${ISAL_BUILDDIR}/include/erasure_code.h  
-	 ${ISAL_BUILDDIR}/include/gf_vect_mul.h  
-	 ${ISAL_BUILDDIR}/include/igzip_lib.h  
-	 ${ISAL_BUILDDIR}/include/mem_routines.h  
-	 ${ISAL_BUILDDIR}/include/multibinary.asm  
-	 ${ISAL_BUILDDIR}/include/raid.h  
-	 ${ISAL_BUILDDIR}/include/reg_sizes.asm  
-	 ${ISAL_BUILDDIR}/include/test.h  
-	 ${ISAL_BUILDDIR}/include/types.h
+ExternalProject_add(isa-l
+  URL https://github.com/intel/isa-l/archive/refs/tags/${ISAL_VERSION}.tar.gz
+  URL_HASH SHA256=bcf592c04fdfa19e723d2adf53d3e0f4efd5b956bb618fed54a1108d76a6eb56
+  SOURCE_DIR        ${CMAKE_BINARY_DIR}/isa-l
+  BUILD_IN_SOURCE   1
+  CONFIGURE_COMMAND ./autogen.sh COMMAND ./configure --with-pic
+  BUILD_COMMAND     make -j ${CMAKE_BUILD_PARALLEL_LEVEL}
+  INSTALL_COMMAND   ${CMAKE_COMMAND} -E copy_directory ${ISAL_ROOT}/include ${ISAL_ROOT}/isa-l
+  BUILD_BYPRODUCTS  ${ISAL_LIBRARY} ${ISAL_INCLUDE_DIRS}
 )
 
-ExternalProject_add(
-        isa-l
-        SOURCE_DIR          ${ISAL_BUILDDIR}
-        BUILD_IN_SOURCE     1
-        GIT_REPOSITORY      https://github.com/01org/isa-l.git
-        GIT_TAG             ${ISAL_VERSION}
-        CONFIGURE_COMMAND   ./autogen.sh COMMAND ./configure --with-pic
-        BUILD_COMMAND       make ${MAKEOPTIONS}
-        INSTALL_COMMAND     mkdir -p  ${ISAL_INCDIR}/isa-l
-        COMMAND             mkdir -p  ${ISAL_LIBDIR}
-        COMMAND             cp ${ISAL_HEADERS}                  ${ISAL_INCDIR}/isa-l
-        COMMAND             cp ${ISAL_BUILDDIR}/isa-l.h         ${ISAL_INCDIR}/isa-l
-        COMMAND             cp ${ISAL_BUILDDIR}/.libs/libisal.a ${ISAL_LIBDIR}/
+add_library(isal STATIC IMPORTED)
+
+set(ISAL_LIBRARIES isal)
+add_dependencies(isal isa-l)
+
+set_target_properties(isal
+  PROPERTIES
+    IMPORTED_LOCATION "${ISAL_LIBRARY}"
+    INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${ISAL_INCLUDE_DIRS}>"
 )
 
+# Emulate what happens when find_package(isal) succeeds
+find_package_handle_standard_args(isal
+  REQUIRED_VARS ISAL_INCLUDE_DIRS ISAL_LIBRARIES VERSION_VAR ISAL_VERSION)


### PR DESCRIPTION
I noticed that `make install` was rebuilding isa-l and some other things, so I tried to update the external project for isa-l to fix that, but also to allow building XRootD against isa-l which is already installed in `/usr`. I also added an option to enable using the system version, which I left disabled by default so that it will keep the previous behavior of preferring the internal copy of isa-l.