### PR TITLE
Add workaround to avoid sporadic crashes of the test runner

### DIFF
--- a/tests/common/TextRunner.cc
+++ b/tests/common/TextRunner.cc
@@ -149,6 +149,6 @@ int main( int argc, char **argv)
     new CppUnit::CompilerOutputter( &runner.result(), std::cerr ) );
 
   bool wasSuccessful = runner.run();
-  dlclose( libHandle );
+  // dlclose( libHandle );
   return wasSuccessful ? 0 : 1;
 }


### PR DESCRIPTION
Sometimes, the call to dlclose() being commented out here gets called while test cases using the loaded library are still running (on another thread), which causes random crashes in the test runner. As a workaround, let the OS do the clean up of loaded libraries.