### PR TITLE
[XrdSecztn] Allow to point to a token file using CGI '?xrd.ztn=tokenfile

### DIFF
--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -51,6 +51,7 @@
 #include "XrdVersion.hh"
 
 #include "XrdNet/XrdNetAddrInfo.hh"
+#include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOuc/XrdOucErrInfo.hh"
 #include "XrdOuc/XrdOucPinLoader.hh"
 #include "XrdOuc/XrdOucString.hh"
@@ -347,6 +348,16 @@ XrdSecCredentials *XrdSecProtocolztn::findToken(XrdOucErrInfo *erp,
         if ((bTok = Strip(aTok, sz))) return retToken(erp, bTok, sz);
        }
 
+// We support passing the credential cache path via Url parameter
+//
+   char *ccn = (erp && erp->getEnv()) ? erp->getEnv()->Get("xrd.ztn") : 0;
+   if (ccn)
+     {
+       resp = readToken(erp, ccn, isbad);
+       if (resp || isbad) return resp;
+     }
+
+// Look through all of the possible envars   
 // Nothing found
 //
   isbad = false;


### PR DESCRIPTION
As available in kerberos,gsi and sss I need to have a way to define in a multithreaded application the location of a token using CGI since environment variables don't work here. I have added the same mechanism supported by XrdCl to specify a tokenfile location in the URL, in this case you can say something like 
```
xrdcp foo root://....?xrd.ztn=/tmp/mytokenfile
```
