### PR TITLE
Enable scitokens-cpp client plugin under `XRDCL_ONLY`

### DIFF
--- a/cmake/XRootDDefaults.cmake
+++ b/cmake/XRootDDefaults.cmake
@@ -30,7 +30,7 @@ option( ENABLE_XRDEC     "Enable erasure coding component."                     
 option( ENABLE_ASAN      "Enable adress sanitizer."                                       FALSE )
 option( ENABLE_TSAN      "Enable thread sanitizer."                                       FALSE )
 option( ENABLE_XRDCLHTTP "Enable xrdcl-http plugin."                                      TRUE )
-cmake_dependent_option( ENABLE_SCITOKENS "Enable SciTokens plugin." TRUE "NOT XRDCL_ONLY" FALSE )
+option( ENABLE_SCITOKENS "Enable SciTokens plugin."                                       TRUE )
 cmake_dependent_option( ENABLE_MACAROONS "Enable Macaroons plugin." TRUE "NOT XRDCL_ONLY" FALSE )
 option( FORCE_ENABLED    "Fail build if enabled components cannot be built."              FALSE )
 cmake_dependent_option( USE_SYSTEM_ISAL  "Use isa-l installed in the system" FALSE "ENABLE_XRDEC" FALSE )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,15 @@ if( BUILD_XRDEC )
   add_subdirectory( XrdEc )
 endif()
 
+if( BUILD_SCITOKENS )
+  find_package( SciTokensCpp REQUIRED )
+  include_directories(
+    ${SCITOKENS_CPP_INCLUDE_DIR}
+    XrdSciTokens/vendor/picojson
+    XrdSciTokens/vendor/inih )
+  include( XrdSecztn )
+endif()
+
 if( NOT XRDCL_ONLY )
   include( XrdServer )
   include( XrdDaemons )
@@ -82,7 +91,6 @@ if( NOT XRDCL_ONLY )
 
   if( BUILD_SCITOKENS )
     include( XrdSciTokens )
-    include( XrdSecztn )
   endif()
 
 endif()

--- a/src/XrdSciTokens.cmake
+++ b/src/XrdSciTokens.cmake
@@ -1,16 +1,9 @@
 include( XRootDCommon )
 
-find_package( SciTokensCpp REQUIRED )
-
 #-------------------------------------------------------------------------------
 # Modules
 #-------------------------------------------------------------------------------
 set( LIB_XRD_SCITOKENS  XrdAccSciTokens-${PLUGIN_VERSION} )
-
-include_directories(
-   ${SCITOKENS_CPP_INCLUDE_DIR}
-   XrdSciTokens/vendor/picojson
-   XrdSciTokens/vendor/inih )
 
 #-------------------------------------------------------------------------------
 # The XrdPfc library


### PR DESCRIPTION
Allows the creation of the scitokens-cpp client plugin when `XRDCL_ONLY` is set.