### PR TITLE
Remove "using namespace std;" from XRootD (necessary to support C++17)

### DIFF
--- a/src/XrdApps/XrdCpConfig.cc
+++ b/src/XrdApps/XrdCpConfig.cc
@@ -47,7 +47,6 @@
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysLogger.hh"
 
-using namespace std;
 
 /******************************************************************************/
 /*                         D e f i n e   M a c r o s                          */

--- a/src/XrdApps/XrdCrc32c.cc
+++ b/src/XrdApps/XrdCrc32c.cc
@@ -42,7 +42,6 @@
 #include "XrdOuc/XrdOucCRC.hh"
 #include "XrdSys/XrdSysE2T.hh"
 
-using namespace std;
 
 namespace
 {const char *pgm = "xrdcrc32c";

--- a/src/XrdApps/XrdMpxXml.cc
+++ b/src/XrdApps/XrdMpxXml.cc
@@ -40,7 +40,6 @@
 #include "XrdApps/XrdMpxXml.hh"
 #include "XrdOuc/XrdOucTokenizer.hh"
 
-using namespace std;
 
 /******************************************************************************/
 /*                      v n M a p   D e f i n i t i o n                       */

--- a/src/XrdApps/XrdQStats.cc
+++ b/src/XrdApps/XrdQStats.cc
@@ -40,7 +40,6 @@
 #include "XrdCl/XrdClURL.hh"
 #include "XrdCl/XrdClXRootDResponses.hh"
 
-using namespace std;
   
 /******************************************************************************/
 /*                                 F a t a l                                  */

--- a/src/XrdNet/XrdNetIF.cc
+++ b/src/XrdNet/XrdNetIF.cc
@@ -47,7 +47,6 @@
 #include "XrdSys/XrdSysError.hh"
 
 #include <iostream>
-using namespace std;
   
 /******************************************************************************/
 /*                         L o c a l   S t a t i c s                          */

--- a/src/XrdOuc/XrdOucNSWalk.cc
+++ b/src/XrdOuc/XrdOucNSWalk.cc
@@ -40,7 +40,6 @@
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysPlatform.hh"
 
-using namespace std;
 
 /******************************************************************************/
 /*                           C o n s t r u c t o r                            */

--- a/src/XrdOuc/XrdOucString.hh
+++ b/src/XrdOuc/XrdOucString.hh
@@ -247,8 +247,6 @@
 #include <cstdlib>
 #include <cstdarg>
 
-using namespace std;
-
 #define STR_NPOS -1
 
 class XrdOucString {

--- a/src/XrdSciTokens/vendor/picojson/examples/github-issues.cc
+++ b/src/XrdSciTokens/vendor/picojson/examples/github-issues.cc
@@ -67,7 +67,6 @@ char *memfstrdup(MEMFILE *mf) {
   return buf;
 }
 
-using namespace std;
 using namespace picojson;
 
 int main(int argc, char *argv[]) {

--- a/src/XrdSciTokens/vendor/picojson/test.cc
+++ b/src/XrdSciTokens/vendor/picojson/test.cc
@@ -32,7 +32,6 @@
     #pragma warning(disable : 4127) // conditional expression is constant
 #endif
 
-using namespace std;
 
 #define is(x, y, name) _ok((x) == (y), name)
 

--- a/src/XrdSsi/XrdSsiLogging.cc
+++ b/src/XrdSsi/XrdSsiLogging.cc
@@ -51,7 +51,6 @@ namespace XrdSsi
 extern XrdSsiLogger::MCB_t *msgCB;
 }
 
-using namespace std;
 using namespace XrdSsi;
 
 /******************************************************************************/

--- a/src/XrdSsi/XrdSsiShMam.cc
+++ b/src/XrdSsi/XrdSsiShMam.cc
@@ -44,7 +44,6 @@
 #include "XrdSsi/XrdSsiShMam.hh"
 #include "XrdSys/XrdSysE2T.hh"
 
-using namespace std;
 
 /* Gentoo removed OF from their copy of zconf.h but we need it here.
    See https://bugs.gentoo.org/show_bug.cgi?id=383179 for the sad history.

--- a/src/XrdSys/XrdSysHeaders.hh
+++ b/src/XrdSys/XrdSysHeaders.hh
@@ -38,7 +38,6 @@
 
 // gcc >= 4.3, cl require this
 #  include <iostream>
-using namespace std;
 
 #else
 

--- a/src/XrdSys/XrdSysIOEventsPollE.icc
+++ b/src/XrdSys/XrdSysIOEventsPollE.icc
@@ -39,7 +39,6 @@
 #define Atomic(x) x
 #endif
 
-using namespace std;
   
 /******************************************************************************/
 /*                           C l a s s   P o l l E                            */

--- a/src/XrdSys/XrdSysIOEventsPollKQ.icc
+++ b/src/XrdSys/XrdSysIOEventsPollKQ.icc
@@ -40,7 +40,6 @@
 #define Atomic(x) x
 #endif
 
-using namespace std;
   
 /******************************************************************************/
 /*                           C l a s s   P o l l E                            */

--- a/src/XrdSys/XrdSysIOEventsPollPoll.icc
+++ b/src/XrdSys/XrdSysIOEventsPollPoll.icc
@@ -37,7 +37,6 @@
 #include "Xrd/XrdScheduler.hh"
 
 
-using namespace std;
   
 /******************************************************************************/
 /*                        C l a s s   P o l l P o l l                         */

--- a/src/XrdSys/XrdSysIOEventsPollPort.icc
+++ b/src/XrdSys/XrdSysIOEventsPollPort.icc
@@ -35,7 +35,6 @@
 
 @include "XrdSys/XrdSysE2T.hh"
 
-using namespace std;
   
 /******************************************************************************/
 /*                        C l a s s   P o l l P o r t                         */

--- a/tests/XrdSsiTests/XrdShMap.cc
+++ b/tests/XrdSsiTests/XrdShMap.cc
@@ -41,7 +41,6 @@
 
 #include "XrdSsi/XrdSsiShMap.hh"
 
-using namespace std;
 
 /* Gentoo removed OF from their copy of zconf.h but we need it here.
    See https://bugs.gentoo.org/show_bug.cgi?id=383179 for the sad history.


### PR DESCRIPTION
This is necessary to avoid clashes of names from the global namespace with names from the std namespace. It was identified as a problem when trying to compile XRootD with C++17 standard and support for VOMS, which has a 'struct data' in the global namespace that clashes with std::data from C++17.

What I'm looking at for review is if using `std::` everywhere is fine or if there's a preference to add `using namespace std;` in the `.cc` files. I think adding `std::` explicitly is more reliable, but the patch is quite large. Once we merge this, #1929 should be fine to merge as well without problems.