### PR TITLE
Adjust build rules to not depend on scitokenscpp to build libXrdSecztn

### DIFF
--- a/cmake/XRootDDefaults.cmake
+++ b/cmake/XRootDDefaults.cmake
@@ -29,7 +29,7 @@ option( ENABLE_XRDEC     "Enable erasure coding component."                     
 option( ENABLE_ASAN      "Enable adress sanitizer."                                       FALSE )
 option( ENABLE_TSAN      "Enable thread sanitizer."                                       FALSE )
 option( ENABLE_XRDCLHTTP "Enable xrdcl-http plugin."                                      TRUE )
-option( ENABLE_SCITOKENS "Enable SciTokens plugin."                                       TRUE )
+cmake_dependent_option( ENABLE_SCITOKENS "Enable SciTokens plugin." TRUE "NOT XRDCL_ONLY" FALSE )
 cmake_dependent_option( ENABLE_MACAROONS "Enable Macaroons plugin." TRUE "NOT XRDCL_ONLY" FALSE )
 option( FORCE_ENABLED    "Fail build if enabled components cannot be built."              FALSE )
 cmake_dependent_option( USE_SYSTEM_ISAL  "Use isa-l installed in the system" FALSE "ENABLE_XRDEC" FALSE )

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -883,9 +883,7 @@ fi
 %{_libdir}/libXrdSecpwd-5.so
 %{_libdir}/libXrdSecsss-5.so
 %{_libdir}/libXrdSecunix-5.so
-%if %{?_with_scitokens:1}%{!?_with_scitokens:0}
 %{_libdir}/libXrdSecztn-5.so
-%endif
 %{_libdir}/libXrdUtils.so.3*
 %{_libdir}/libXrdXml.so.3*
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ include( XrdSec )
 include( XrdXml )
 include( XrdHeaders )
 include( XrdSecgsi )
+include( XrdSecztn )
 
 if( BUILD_KRB5 )
   include( XrdSeckrb5 )
@@ -46,15 +47,6 @@ if( BUILD_XRDEC )
   add_subdirectory( XrdEc )
 endif()
 
-if( BUILD_SCITOKENS )
-  find_package( SciTokensCpp REQUIRED )
-  include_directories(
-    ${SCITOKENS_CPP_INCLUDE_DIR}
-    XrdSciTokens/vendor/picojson
-    XrdSciTokens/vendor/inih )
-  include( XrdSecztn )
-endif()
-
 if( NOT XRDCL_ONLY )
   include( XrdServer )
   include( XrdDaemons )
@@ -62,7 +54,6 @@ if( NOT XRDCL_ONLY )
   include( XrdFfs )
   include( XrdPlugins )
   include( XrdSsi )
-
   include( XrdPfc )
 
   if( CMAKE_COMPILER_IS_GNUCXX )

--- a/src/XrdSciTokens.cmake
+++ b/src/XrdSciTokens.cmake
@@ -1,9 +1,16 @@
 include( XRootDCommon )
 
+find_package( SciTokensCpp REQUIRED )
+
 #-------------------------------------------------------------------------------
 # Modules
 #-------------------------------------------------------------------------------
 set( LIB_XRD_SCITOKENS  XrdAccSciTokens-${PLUGIN_VERSION} )
+
+include_directories(
+   ${SCITOKENS_CPP_INCLUDE_DIR}
+   XrdSciTokens/vendor/picojson
+   XrdSciTokens/vendor/inih )
 
 #-------------------------------------------------------------------------------
 # The XrdPfc library


### PR DESCRIPTION
This partially reverts commit 984efbc72bdad86b43923569f4dfa707b7a287a2. Actually, libXrdSecztn does not depend on scitokenscpp, we can build it on the client side even when `-DENABLE_SCITOKENS=FALSE`.

@abh, I believe this is what you meant initially that we should do, right?