### PR TITLE
[XrdApps] xrdreplay: fix SEGVs when verifying or printing replays

### DIFF
--- a/src/XrdApps/XrdClRecordPlugin/XrdClReplay.cc
+++ b/src/XrdApps/XrdClRecordPlugin/XrdClReplay.cc
@@ -626,8 +626,6 @@ class ActionExecutor
           });
       else
       {
-	for (auto& ch : chunks)
-	  delete[](char*) ch.buffer;
         ending.reset();
         closing.reset();
       }
@@ -658,8 +656,6 @@ class ActionExecutor
               });
       else
       {
-	for (auto& ch : chunks)
-	  delete[](char*) ch.buffer;
         ending.reset();
         closing.reset();
       }


### PR DESCRIPTION
introduced by introduction of buffer-pool for buffer allocation