### PR TITLE
[XrdCl] Do not reuse sessionId when a new Stream object is made

### DIFF
--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -45,6 +45,11 @@
 namespace XrdCl
 {
   //----------------------------------------------------------------------------
+  // Statics
+  //----------------------------------------------------------------------------
+  RAtomic_uint64_t        Stream::sSessCntGen{0};
+
+  //----------------------------------------------------------------------------
   // Incoming message helper
   //----------------------------------------------------------------------------
   struct InMessageHelper
@@ -615,7 +620,7 @@ namespace XrdCl
       pLastFatalError  = XRootDStatus();
       pConnectionCount = 0;
       uint16_t numSub = pTransport->SubStreamNumber( *pChannelData );
-      ++pSessionId;
+      pSessionId = ++sSessCntGen;
 
       //------------------------------------------------------------------------
       // Create the streams if they don't exist yet

--- a/src/XrdCl/XrdClStream.hh
+++ b/src/XrdCl/XrdClStream.hh
@@ -29,6 +29,7 @@
 #include "XrdCl/XrdClUtils.hh"
 
 #include "XrdSys/XrdSysPthread.hh"
+#include "XrdSys/XrdSysRAtomic.hh"
 #include "XrdNet/XrdNetAddr.hh"
 #include <list>
 #include <vector>
@@ -371,6 +372,11 @@ namespace XrdCl
       // Data stream on-connect handler
       //------------------------------------------------------------------------
       std::shared_ptr<Job>           pOnDataConnJob;
+
+      //------------------------------------------------------------------------
+      // Track last assigned Id across all Streams, to ensure unique sessionId
+      //------------------------------------------------------------------------
+      static RAtomic_uint64_t        sSessCntGen;
   };
 }
 


### PR DESCRIPTION
This is a possible fix for issue #1942 