### PR TITLE
[XrdCl] Avoid possibility of Channel unregistering the wrong task

### DIFF
--- a/src/XrdCl/XrdClChannel.cc
+++ b/src/XrdCl/XrdClChannel.cc
@@ -132,7 +132,6 @@ namespace XrdCl
   Channel::~Channel()
   {
     pTickGenerator->Invalidate();
-    pTaskManager->UnregisterTask( pTickGenerator );
     delete pStream;
     pTransport->FinalizeChannel( pChannelData );
   }


### PR DESCRIPTION
This is (hopefully) a fix for issue #1883