### PR TITLE
Add basic support for the Cache-Control directives

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1041,6 +1041,10 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
        return 1;
       }
 
+// Some headers must always be converted to CGI key=value pairs
+//
+   hdr2cgimap["Cache-Control"] = "cache-control";
+
 // Test if XrdEC is loaded
    if (getenv("XRDCL_EC")) usingEC = true;
 

--- a/src/XrdOuc/XrdOucCacheDirective.cc
+++ b/src/XrdOuc/XrdOucCacheDirective.cc
@@ -1,0 +1,85 @@
+/******************************************************************************/
+/*                                                                            */
+/*              X r d O u c C a c h e D i r e c t i v e . c c                 */
+/*                                                                            */
+/* (c) 2023 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdOuc/XrdOucCacheDirective.hh"
+#include "XrdOuc/XrdOucString.hh"
+
+#include <cstring>
+
+XrdOucCacheDirective::XrdOucCacheDirective(const std::string &header)
+{
+    XrdOucString header_ouc(header.c_str());
+    int from = 0;
+    XrdOucString directive;
+    while ((from = header_ouc.tokenize(directive, from, ',')) != -1) {
+
+        // Trim out whitespace, make lowercase
+        int begin = 0;
+        while (begin < directive.length() && !isgraph(directive[begin])) {begin++;}
+        if (begin) directive.erasefromstart(begin);
+        if (directive.length()) {
+            int endtrim = 0;
+            while (endtrim < directive.length() && !isgraph(directive[directive.length() - endtrim - 1])) {endtrim++;}
+            if (endtrim) directive.erasefromend(endtrim);
+        }
+        if (directive.length() == 0) {continue;}
+        directive.lower(0);
+
+        int pos = directive.find('=');
+        // No known cache directive command is larger than 19 characters;
+        // use this fact so we can have a statically sized buffer.
+        if (pos > 19 || directive.length() > 19) {
+            m_unknown.push_back(directive.c_str());
+            continue;
+        }
+        char command[20];
+        command[19] = '\0';
+        if (pos == STR_NPOS) {
+            strncpy(command, directive.c_str(), 19);
+        } else {
+            memcpy(command, directive.c_str(), pos);
+            command[pos] = '\0';
+        }
+        if (!strcmp(command, "no-cache")) {
+            m_no_cache = true;
+        } else if (!strcmp(command, "no-store")) {
+            m_no_store = true;
+        } else if (!strcmp(command, "only-if-cached")) {
+            m_only_if_cached = true;
+        } else if (!strcmp(command, "max-age")) {
+            std::string value(directive.c_str() + pos + 1);
+            try {
+                m_max_age = std::stoi(value);
+            } catch (...) {
+                m_unknown.push_back(directive.c_str());
+            }
+        } else {
+            m_unknown.push_back(directive.c_str());
+        }
+    }
+}

--- a/src/XrdOuc/XrdOucCacheDirective.hh
+++ b/src/XrdOuc/XrdOucCacheDirective.hh
@@ -1,0 +1,82 @@
+/******************************************************************************/
+/*                                                                            */
+/*              X r d O u c C a c h e D i r e c t i v e . h h                 */
+/*                                                                            */
+/* (c) 2023 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+/**
+ * Helper class for parsing the known cache headers.
+ *
+ * Purposely hews to the HTTP cache-control headers where possible.  See
+ *   <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control>
+ * for a detailed explanation of the different directives.
+ */
+class XrdOucCacheDirective {
+
+public:
+    /**
+     * Given a header value, parse out to a list of known cache directives
+     */
+    XrdOucCacheDirective(const std::string &header);
+
+    /**
+     * Returns a list of unknown directives provided.
+     */
+    const std::vector<std::string> UnknownDirectives() const;
+
+    /**
+     * Returns true if the `no-cache` directive is present.
+     */
+    bool NoCache() const {return m_no_cache;}
+
+    /**
+     * Returns true if the `no-store` directive is present.
+     */
+    bool NoStore() const {return m_no_store;}
+
+    /**
+     * Returns true if the `only-if-cached` directive is present.
+     */
+    bool OnlyIfCached() const {return m_only_if_cached;}
+
+    /**
+     * Returns the value of the `max-age` directive; if the directive
+     * is not present, returns -1.
+     */
+    int MaxAge() const {return m_max_age;}
+
+private:
+    bool m_no_cache{false};
+    bool m_no_store{false};
+    bool m_only_if_cached{false};
+    int m_max_age{-1};
+
+    std::vector<std::string> m_unknown;
+};

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -301,6 +301,8 @@ public:
    void initiate_emergency_shutdown();
    bool is_in_emergency_shutdown() { return m_in_shutdown; }
 
+   void SetStore(bool val) {m_store = val;}
+
 private:
    //! Constructor.
    File(const std::string &path, long long offset, long long fileSize);
@@ -309,6 +311,8 @@ private:
    bool Open();
 
    static const char *m_traceID;
+
+   bool           m_store{true};        //!< indicates the file should cached
 
    int            m_ref_cnt;            //!< number of references from IO or sync
    

--- a/src/XrdPfc/XrdPfcIOFile.hh
+++ b/src/XrdPfc/XrdPfcIOFile.hh
@@ -77,6 +77,8 @@ public:
 
    long long FSize() override;
 
+   void SetStore(bool val) {if (m_file) m_file->SetStore(val);}
+
 private:
    File        *m_file;
 

--- a/src/XrdUtils.cmake
+++ b/src/XrdUtils.cmake
@@ -102,6 +102,7 @@ set ( XrdOucSources
   XrdOuc/XrdOucBuffer.cc        XrdOuc/XrdOucBuffer.hh
   XrdOuc/XrdOucCache.cc         XrdOuc/XrdOucCache.hh
                                 XrdOuc/XrdOucCacheStats.hh
+  XrdOuc/XrdOucCacheDirective.cc XrdOuc/XrdOucCacheDirective.hh
   XrdOuc/XrdOucCallBack.cc      XrdOuc/XrdOucCallBack.hh
                                 XrdOuc/XrdOucChkPnt.hh
   XrdOuc/XrdOucCRC.cc           XrdOuc/XrdOucCRC.hh


### PR DESCRIPTION
HTTP provides a standard set of commands, in the `Cache-Control` header, for manipulating the behavior of a cache.

This adds a framework for using these commands and adds preliminary support for the `no-store` / `no-cache` directives as requested in #1886 by @jthiltges.

This purposely does _not_ address some of the difficult concurrency issues (how to behave when a client reads from an already-open file handle) or implement `max-age`; those are intended for follow-up work.

Fixes #1886.