### PR TITLE
Implement `only-if-cached` mode for HTTP

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1041,6 +1041,10 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
        return 1;
       }
 
+// Some headers must always be converted to CGI key=value pairs
+//
+   hdr2cgimap["Cache-Control"] = "cache-control";
+
 // Test if XrdEC is loaded
    if (getenv("XRDCL_EC")) usingEC = true;
 

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -242,6 +242,8 @@ public:
   XrdOucString m_resource_with_digest;
   /// The computed digest for the HTTP response header.
   std::string m_digest_header;
+  /// The contents of the cache-control header for the request
+  std::string m_cache_control;
 
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;

--- a/src/XrdOuc/XrdOucCacheDirective.cc
+++ b/src/XrdOuc/XrdOucCacheDirective.cc
@@ -1,0 +1,85 @@
+/******************************************************************************/
+/*                                                                            */
+/*              X r d O u c C a c h e D i r e c t i v e . c c                 */
+/*                                                                            */
+/* (c) 2023 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdOuc/XrdOucCacheDirective.hh"
+#include "XrdOuc/XrdOucString.hh"
+
+#include <cstring>
+
+XrdOucCacheDirective::XrdOucCacheDirective(const std::string &header)
+{
+    XrdOucString header_ouc(header.c_str());
+    int from = 0;
+    XrdOucString directive;
+    while ((from = header_ouc.tokenize(directive, from, ',')) != -1) {
+
+        // Trim out whitespace, make lowercase
+        int begin = 0;
+        while (begin < directive.length() && !isgraph(directive[begin])) {begin++;}
+        if (begin) directive.erasefromstart(begin);
+        if (directive.length()) {
+            int endtrim = 0;
+            while (endtrim < directive.length() && !isgraph(directive[directive.length() - endtrim - 1])) {endtrim++;}
+            if (endtrim) directive.erasefromend(endtrim);
+        }
+        if (directive.length() == 0) {continue;}
+        directive.lower(0);
+
+        int pos = directive.find('=');
+        // No known cache directive command is larger than 19 characters;
+        // use this fact so we can have a statically sized buffer.
+        if (pos > 19 || directive.length() > 19) {
+            m_unknown.push_back(directive.c_str());
+            continue;
+        }
+        char command[20];
+        command[19] = '\0';
+        if (pos == STR_NPOS) {
+            strncpy(command, directive.c_str(), 19);
+        } else {
+            memcpy(command, directive.c_str(), pos);
+            command[pos] = '\0';
+        }
+        if (!strcmp(command, "no-cache")) {
+            m_no_cache = true;
+        } else if (!strcmp(command, "no-store")) {
+            m_no_store = true;
+        } else if (!strcmp(command, "only-if-cached")) {
+            m_only_if_cached = true;
+        } else if (!strcmp(command, "max-age")) {
+            std::string value(directive.c_str() + pos + 1);
+            try {
+                m_max_age = std::stoi(value);
+            } catch (...) {
+                m_unknown.push_back(directive.c_str());
+            }
+        } else {
+            m_unknown.push_back(directive.c_str());
+        }
+    }
+}

--- a/src/XrdOuc/XrdOucCacheDirective.hh
+++ b/src/XrdOuc/XrdOucCacheDirective.hh
@@ -1,0 +1,82 @@
+/******************************************************************************/
+/*                                                                            */
+/*              X r d O u c C a c h e D i r e c t i v e . h h                 */
+/*                                                                            */
+/* (c) 2023 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+/**
+ * Helper class for parsing the known cache headers.
+ *
+ * Purposely hews to the HTTP cache-control headers where possible.  See
+ *   <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control>
+ * for a detailed explanation of the different directives.
+ */
+class XrdOucCacheDirective {
+
+public:
+    /**
+     * Given a header value, parse out to a list of known cache directives
+     */
+    XrdOucCacheDirective(const std::string &header);
+
+    /**
+     * Returns a list of unknown directives provided.
+     */
+    const std::vector<std::string> UnknownDirectives() const;
+
+    /**
+     * Returns true if the `no-cache` directive is present.
+     */
+    bool NoCache() const {return m_no_cache;}
+
+    /**
+     * Returns true if the `no-store` directive is present.
+     */
+    bool NoStore() const {return m_no_store;}
+
+    /**
+     * Returns true if the `only-if-cached` directive is present.
+     */
+    bool OnlyIfCached() const {return m_only_if_cached;}
+
+    /**
+     * Returns the value of the `max-age` directive; if the directive
+     * is not present, returns -1.
+     */
+    int MaxAge() const {return m_max_age;}
+
+private:
+    bool m_no_cache{false};
+    bool m_no_store{false};
+    bool m_only_if_cached{false};
+    int m_max_age{-1};
+
+    std::vector<std::string> m_unknown;
+};

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -313,8 +313,10 @@ void File::AddIO(IO *io)
 
       insert_remote_location(loc);
 
-      if (m_prefetch_state == kStopped)
+      // In the case of "only if cached" mode, do not fire off a prefetch.
+      if (!m_only_if_cached && m_prefetch_state == kStopped)
       {
+         TRACEF(Debug, "AddIO() io = " << (void*)io << " enabling prefetch");
          m_prefetch_state = kOn;
          cache()->RegisterPrefetchFile(this);
       }
@@ -942,6 +944,9 @@ void File::WriteBlockToDisk(Block* b)
    long long   offset = b->m_offset - m_offset;
    long long   size   = b->get_size();
    ssize_t     retval;
+
+   if (m_cfi.GetCreationTime() == 0)
+      m_cfi.SetCreationTime(time(NULL));
 
    if (m_cfi.IsCkSumCache())
       if (b->has_cksums())

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -302,6 +302,7 @@ public:
    bool is_in_emergency_shutdown() { return m_in_shutdown; }
 
    void SetStore(bool val) {m_store = val;}
+   void SetOnlyIfCached(bool val) {m_only_if_cached = val;}
 
 private:
    //! Constructor.
@@ -313,6 +314,7 @@ private:
    static const char *m_traceID;
 
    bool           m_store{true};        //!< indicates the file should cached
+   bool           m_only_if_cached{false}; //!< indicates the 'only if cached' directive is set; disables prefetch
 
    int            m_ref_cnt;            //!< number of references from IO or sync
    

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -301,6 +301,8 @@ public:
    void initiate_emergency_shutdown();
    bool is_in_emergency_shutdown() { return m_in_shutdown; }
 
+   void SetStore(bool val) {m_store = val;}
+
 private:
    //! Constructor.
    File(const std::string &path, long long offset, long long fileSize);
@@ -309,6 +311,8 @@ private:
    bool Open();
 
    static const char *m_traceID;
+
+   bool           m_store{true};        //!< indicates the file should cached
 
    int            m_ref_cnt;            //!< number of references from IO or sync
    

--- a/src/XrdPfc/XrdPfcIOFile.cc
+++ b/src/XrdPfc/XrdPfcIOFile.cc
@@ -98,6 +98,10 @@ int IOFile::initCachedStat()
             // We are arguably abusing the mtime to be the creation time of the file; then ctime becomes the
             // last time additional data was cached.
             tmpStat.st_mtime = info.GetCreationTime();
+            // If no blocks have been written, assume it's newly created
+            if (!tmpStat.st_mtime) {
+               tmpStat.st_mtime = time(NULL);
+            }
             TRACEIO(Info, trace_pfx << "successfully read size " << tmpStat.st_size << " and creation time " << tmpStat.st_mtime << " from info file");
             res = 0;
          }

--- a/src/XrdPfc/XrdPfcIOFile.hh
+++ b/src/XrdPfc/XrdPfcIOFile.hh
@@ -77,8 +77,6 @@ public:
 
    long long FSize() override;
 
-   void SetStore(bool val) {if (m_file) m_file->SetStore(val);}
-
 private:
    File        *m_file;
 

--- a/src/XrdPfc/XrdPfcIOFile.hh
+++ b/src/XrdPfc/XrdPfcIOFile.hh
@@ -77,6 +77,8 @@ public:
 
    long long FSize() override;
 
+   void SetStore(bool val) {if (m_file) m_file->SetStore(val);}
+
 private:
    File        *m_file;
 

--- a/src/XrdPfc/XrdPfcInfo.cc
+++ b/src/XrdPfc/XrdPfcInfo.cc
@@ -166,7 +166,8 @@ void Info::SetBufferSizeFileSizeAndCreationTime(long long bs, long long fs)
    m_store.m_buffer_size = bs;
    m_store.m_file_size = fs;
    ResizeBits();
-   m_store.m_creationTime = time(0);
+   // Defer setting the creation time until we've had a single block write
+   m_store.m_creationTime = 0;
 }
 
 //------------------------------------------------------------------------------

--- a/src/XrdPfc/XrdPfcInfo.hh
+++ b/src/XrdPfc/XrdPfcInfo.hh
@@ -276,9 +276,14 @@ public:
    const std::vector<AStat>& RefAStats()     const { return m_astats; }
 
    //---------------------------------------------------------------------
-   //! Get file size
+   //! Get file creation time
    //---------------------------------------------------------------------
    time_t GetCreationTime() const { return m_store.m_creationTime; }
+
+   //---------------------------------------------------------------------
+   //! Set the file creation time
+   //
+   void SetCreationTime(time_t new_time) { m_store.m_creationTime = new_time; }
 
    //---------------------------------------------------------------------
    //! Get cksum, MD5 is for backward compatibility with V2 and V3.

--- a/src/XrdUtils.cmake
+++ b/src/XrdUtils.cmake
@@ -102,6 +102,7 @@ set ( XrdOucSources
   XrdOuc/XrdOucBuffer.cc        XrdOuc/XrdOucBuffer.hh
   XrdOuc/XrdOucCache.cc         XrdOuc/XrdOucCache.hh
                                 XrdOuc/XrdOucCacheStats.hh
+  XrdOuc/XrdOucCacheDirective.cc XrdOuc/XrdOucCacheDirective.hh
   XrdOuc/XrdOucCallBack.cc      XrdOuc/XrdOucCallBack.hh
                                 XrdOuc/XrdOucChkPnt.hh
   XrdOuc/XrdOucCRC.cc           XrdOuc/XrdOucCRC.hh


### PR DESCRIPTION
This implements the HTTP `only-if-cached` mode, allowing the client to prevent triggering a download from the origin.

This is envisioned to be used in the case where pulling from the origin is expensive and the client may want to decide to go to another cache first.

This is based on top of #1953 - to be reviewed after that work is committed.