### PR TITLE
[XrdCrypto] Fix utility function XrdCryptosslASN1toUTC to return in UTC

### DIFF
--- a/src/XrdCrypto/XrdCryptoAux.cc
+++ b/src/XrdCrypto/XrdCryptoAux.cc
@@ -77,6 +77,7 @@ void XrdCryptoSetTrace(kXR_int32 trace)
 time_t XrdCryptoTZCorr()
 {
    // Time Zone correction (wrt UTC)
+   // Assumes no DST, the correction is not expected to change during the year
    
    if (!TZInitialized) {
       time_t now = time(0);

--- a/src/XrdCrypto/XrdCryptoX509.cc
+++ b/src/XrdCrypto/XrdCryptoX509.cc
@@ -104,12 +104,10 @@ int XrdCryptoX509::BitStrength()
 //_____________________________________________________________________________
 bool XrdCryptoX509::IsValid(int when)
 {
-   // Check validity at local time 'when'. Use when =0 (default) to check
+   // Check validity at UTC time 'when'. Use when =0 (default) to check
    // at present time.
 
    int now = (when > 0) ? when : (int)time(0);
-   // Correct for time zone (certificate times are UTC plus, eventually, DST
-   now -= XrdCryptoTZCorr();
    return (now >= (NotBefore()-kAllowedSkew) && now <= NotAfter());
 }
 
@@ -120,8 +118,6 @@ bool XrdCryptoX509::IsExpired(int when)
    // at present time.
 
    int now = (when > 0) ? when : (int)time(0);
-   // Correct for time zone (certificate times are UTC plus, eventually, DST
-   now -= XrdCryptoTZCorr();
    return (now > NotAfter());
 }
 

--- a/src/XrdCrypto/XrdCryptosslAux.cc
+++ b/src/XrdCrypto/XrdCryptosslAux.cc
@@ -735,7 +735,7 @@ time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1)
    // Init also the ones not used by mktime
    ltm.tm_wday  = 0;        // day of the week 
    ltm.tm_yday  = 0;        // day in the year
-   ltm.tm_isdst = -1;       // daylight saving time
+   ltm.tm_isdst = 0;        // we will correct with an offset without dst
    //
    // Renormalize some values: year should be modulo 1900
    if (ltm.tm_year < 90)
@@ -744,10 +744,10 @@ time_t XrdCryptosslASN1toUTC(const ASN1_TIME *tsn1)
    // month should in [0, 11]
    (ltm.tm_mon)--;
    //
-   // Calculate UTC
+   // Calculate as if the UTC stamp was a localtime with no dst
    etime = mktime(&ltm);
-   // Include DST shift; here, because we have the information
-   if (ltm.tm_isdst > 0) etime += XrdCryptoDSTShift;
+   // Correct to UTC
+   etime += XrdCryptoTZCorr();
    // Notify, if requested
 // DEBUG(" UTC: "<<etime<<"  isdst: "<<ltm.tm_isdst);
    //

--- a/src/XrdCrypto/XrdCryptosslgsiAux.cc
+++ b/src/XrdCrypto/XrdCryptosslgsiAux.cc
@@ -887,7 +887,7 @@ int XrdCryptosslX509SignProxyReq(XrdCryptoX509 *xcpi, XrdCryptoRSA *kcpi,
    }
 
    // Make sure the certificate is not expired
-   int timeleft = xcpi->NotAfter() - (int)time(0) + XrdCryptoTZCorr();
+   int timeleft = xcpi->NotAfter() - (int)time(0);
    if (timeleft < 0) {
       PRINT("EEC certificate has expired");
       return -kErrPX_ExpiredEEC;


### PR DESCRIPTION
To fix issue #1955 and #985, concerning authentication failures for certificates/proxies with notbefore/after dates during the changeover hour of daylight saving time.