### PR TITLE
limit max number of sockets in poller. Fix #1962

### DIFF
--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -1187,7 +1187,7 @@ int XrdConfig::setFDL()
 
 // Set the limit to the maximum allowed
 //
-   if (rlim.rlim_max == RLIM_INFINITY) rlim.rlim_cur = maxFD;
+   if (rlim.rlim_max == RLIM_INFINITY || rlim.rlim_max > maxFD) rlim.rlim_cur = maxFD;
       else rlim.rlim_cur = rlim.rlim_max;
 #if (defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_5))
    if (rlim.rlim_cur > OPEN_MAX) rlim.rlim_max = rlim.rlim_cur = OPEN_MAX;


### PR DESCRIPTION
The number of FD in the poller is automatically configured from the value of `ulimit -n`. On newer linux installations, this limit is much higher by default. This can result in unbound memory consumption.

There is already a mechanism in place to handle the case when `ulimit -n == unlimited`. Extend it to support any unreasonable big limit value.