### PR TITLE
[XrdHttp] Proper handling of SSL_Shutdown() return code

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1758,11 +1758,26 @@ void XrdHttpProtocol::Cleanup() {
   }
 
   if (ssl) {
-
-
-    if (SSL_shutdown(ssl) != 1) {
-      TRACE(ALL, " SSL_shutdown failed");
-      ERR_print_errors(sslbio_err);
+    // Shutdown the SSL/TLS connection
+    // https://www.openssl.org/docs/man1.0.2/man3/SSL_shutdown.html
+    // We don't need a bidirectional shutdown as
+    // when we are here, the connection will not be re-used.
+    // In the case SSL_shutdown returns 0,
+    // "the output of SSL_get_error(3) may be misleading, as an erroneous SSL_ERROR_SYSCALL may be flagged even though no error occurred."
+    // we will then just flush the thread's queue.
+    // In the case an error really happened, we print the error that happened
+    int ret = SSL_shutdown(ssl);
+    if (ret != 1) {
+        if(ret == 0) {
+            // Clean this thread's error queue for the old openssl versions
+            #if OPENSSL_VERSION_NUMBER < 0x10100000L
+                ERR_remove_thread_state(nullptr);
+            #endif
+        } else {
+            //ret < 0, an error really happened.
+            TRACE(ALL, " SSL_shutdown failed");
+            ERR_print_errors(sslbio_err);
+        }
     }
 
     if (secxtractor)


### PR DESCRIPTION
Hi @abh3 , 

This PR to address the issue https://github.com/xrootd/xrootd/issues/1967

It looks to me like the shutdown of the TLS /SSLconnection via `SSL_shutdown()` is not as well protected as the way it is done in the XrdTlsSocket code: https://github.com/xrootd/xrootd/blob/master/src/XrdTls/XrdTlsSocket.cc#L753

For example, according to the documentation:
> Note that SSL_shutdown() must not be called if a previous fatal error has occurred on a connection i.e. if SSL_get_error() has returned SSL_ERROR_SYSCALL or SSL_ERROR_SSL.

Is this a problem that needs to be addressed?

Thanks in advance for your review