### PR TITLE
[XrdApps] Let XrdClProxyPlugin work with PgRead

### DIFF
--- a/src/XrdApps/XrdClProxyPlugin/ProxyPrefixFile.hh
+++ b/src/XrdApps/XrdClProxyPlugin/ProxyPrefixFile.hh
@@ -26,6 +26,8 @@
 #include "XrdCl/XrdClDefaultEnv.hh"
 #include "XrdCl/XrdClPlugInInterface.hh"
 
+#include <utility>
+
 using namespace XrdCl;
 
 namespace xrdcl_proxy
@@ -45,7 +47,7 @@ public:
   //----------------------------------------------------------------------------
   //! Destructor
   //----------------------------------------------------------------------------
-  virtual ~ProxyPrefixFile();
+  virtual ~ProxyPrefixFile() override;
 
   //----------------------------------------------------------------------------
   //! Open
@@ -54,13 +56,13 @@ public:
                             OpenFlags::Flags flags,
                             Access::Mode mode,
                             ResponseHandler* handler,
-                            uint16_t timeout);
+                            uint16_t timeout) override;
 
   //----------------------------------------------------------------------------
   //! Close
   //----------------------------------------------------------------------------
   virtual XRootDStatus Close(ResponseHandler* handler,
-                             uint16_t         timeout)
+                             uint16_t         timeout) override
   {
     return pFile->Close(handler, timeout);
   }
@@ -70,7 +72,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Stat(bool             force,
                             ResponseHandler* handler,
-                            uint16_t         timeout)
+                            uint16_t         timeout) override
   {
     return pFile->Stat(force, handler, timeout);
   }
@@ -83,9 +85,21 @@ public:
                             uint32_t         size,
                             void*            buffer,
                             ResponseHandler* handler,
-                            uint16_t         timeout)
+                            uint16_t         timeout) override
   {
     return pFile->Read(offset, size, buffer, handler, timeout);
+  }
+
+  //------------------------------------------------------------------------
+  //! PgRead
+  //------------------------------------------------------------------------
+  virtual XRootDStatus PgRead( uint64_t         offset,
+                               uint32_t         size,
+                               void            *buffer,
+                               ResponseHandler *handler,
+                               uint16_t         timeout ) override
+  {
+    return pFile->PgRead(offset, size, buffer, handler, timeout);
   }
 
   //----------------------------------------------------------------------------
@@ -95,16 +109,53 @@ public:
                              uint32_t         size,
                              const void*      buffer,
                              ResponseHandler* handler,
-                             uint16_t         timeout)
+                             uint16_t         timeout) override
   {
     return pFile->Write(offset, size, buffer, handler, timeout);
+  }
+
+  //------------------------------------------------------------------------
+  //! Write
+  //------------------------------------------------------------------------
+  virtual XRootDStatus Write( uint64_t          offset,
+                              Buffer          &&buffer,
+                              ResponseHandler  *handler,
+                              uint16_t          timeout = 0 ) override
+  {
+    return pFile->Write(offset, std::move(buffer), handler, timeout);
+  }
+
+  //------------------------------------------------------------------------
+  //! Write
+  //------------------------------------------------------------------------
+  virtual XRootDStatus Write( uint64_t            offset,
+                              uint32_t            size,
+                              Optional<uint64_t>  fdoff,
+                              int                 fd,
+                              ResponseHandler    *handler,
+                              uint16_t            timeout = 0 ) override
+  {
+    return pFile->Write(offset, size, fdoff, fd, handler, timeout);
+  }
+
+  //------------------------------------------------------------------------
+  //! PgWrite
+  //------------------------------------------------------------------------
+  virtual XRootDStatus PgWrite( uint64_t               offset,
+                                uint32_t               nbpgs,
+                                const void            *buffer,
+                                std::vector<uint32_t> &cksums,
+                                ResponseHandler       *handler,
+                                uint16_t               timeout ) override
+  {
+    return pFile->PgWrite(offset, nbpgs, buffer, cksums, handler, timeout);
   }
 
   //----------------------------------------------------------------------------
   //! Sync
   //----------------------------------------------------------------------------
   virtual XRootDStatus Sync(ResponseHandler* handler,
-                            uint16_t         timeout)
+                            uint16_t         timeout) override
   {
     return pFile->Sync(handler, timeout);
   }
@@ -114,7 +165,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Truncate(uint64_t         size,
                                 ResponseHandler* handler,
-                                uint16_t         timeout)
+                                uint16_t         timeout) override
   {
     return pFile->Truncate(size, handler, timeout);
   }
@@ -125,9 +176,31 @@ public:
   virtual XRootDStatus VectorRead(const ChunkList& chunks,
                                   void*            buffer,
                                   ResponseHandler* handler,
-                                  uint16_t         timeout)
+                                  uint16_t         timeout) override
   {
     return pFile->VectorRead(chunks, buffer, handler, timeout);
+  }
+
+  //------------------------------------------------------------------------
+  //! VectorWrite
+  //------------------------------------------------------------------------
+  virtual XRootDStatus VectorWrite( const ChunkList &chunks,
+                                    ResponseHandler *handler,
+                                    uint16_t         timeout = 0 ) override
+  {
+    return pFile->VectorWrite(chunks, handler, timeout);
+  }
+
+  //------------------------------------------------------------------------
+  //! @see XrdCl::File::WriteV
+  //------------------------------------------------------------------------
+  virtual XRootDStatus WriteV( uint64_t            offset,
+                               const struct iovec *iov,
+                               int                 iovcnt,
+                               ResponseHandler    *handler,
+                               uint16_t            timeout = 0 ) override
+  {
+    return pFile->WriteV(offset, iov, iovcnt, handler, timeout);
   }
 
   //----------------------------------------------------------------------------
@@ -135,7 +208,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Fcntl(const Buffer&    arg,
                              ResponseHandler* handler,
-                             uint16_t         timeout)
+                             uint16_t         timeout) override
   {
     return pFile->Fcntl(arg, handler, timeout);
   }
@@ -144,7 +217,7 @@ public:
   //! Visa
   //----------------------------------------------------------------------------
   virtual XRootDStatus Visa(ResponseHandler* handler,
-                            uint16_t         timeout)
+                            uint16_t         timeout) override
   {
     return pFile->Visa(handler, timeout);
   }
@@ -152,7 +225,7 @@ public:
   //----------------------------------------------------------------------------
   //! IsOpen
   //----------------------------------------------------------------------------
-  virtual bool IsOpen() const
+  virtual bool IsOpen() const override
   {
     return pFile->IsOpen();
   }
@@ -161,7 +234,7 @@ public:
   //! SetProperty
   //----------------------------------------------------------------------------
   virtual bool SetProperty(const std::string& name,
-                           const std::string& value)
+                           const std::string& value) override
   {
     return pFile->SetProperty(name, value);
   }
@@ -170,7 +243,7 @@ public:
   //! GetProperty
   //----------------------------------------------------------------------------
   virtual bool GetProperty(const std::string& name,
-                           std::string& value) const
+                           std::string& value) const override
   {
     return pFile->GetProperty(name, value);
   }


### PR DESCRIPTION
Hello. To fix #1993, a missing specialisation for PgRead is added to ProxyPrefixFile (in the XrdClProxyPlugin).
This patch also adds a few other missing method overrides. i.e.

(i) Added missing override of PgRead, Write (1 already present, 2 other overloads added), PgWrite, VectorWrite, WriteV.
(ii) Did not add override for Read(6 argument version); present in the base (XrdCl::FilePlugIn) but not called from XrdClFile. Method appears unused, possibly could be removed in release 6. (The XrdClPlugInInterface.hh is public so can't change before then).
(iii) Likely we're missing ReadV, but this is not present in the base. The ReadV() interface was added after release of xrootd5, so maybe ReadV can be added to XrdClPlugInInterface for release 6.
(iv) Added override specifier on declarator of overridden methods in ProxyPrefixFile.hh. (c++11)