### PR TITLE
[Server] Allow XrdXrootdFile::Serialize() to used to wait more than once

### DIFF
--- a/src/XrdXrootd/XrdXrootdFile.cc
+++ b/src/XrdXrootd/XrdXrootdFile.cc
@@ -170,7 +170,10 @@ void XrdXrootdFile::Ref(int num)
    fileMutex.Lock();
    refCount += num;
    TRACEI(FSAIO,"File::Ref="<<refCount<<" after +"<<num<<' '<<FileKey);
-   if (num < 0 && syncWait && refCount <= 0) syncWait->Post();
+   if (num < 0 && syncWait && refCount <= 0)
+      {syncWait->Post();
+       syncWait = nullptr;
+      }
    fileMutex.UnLock();
 }
 


### PR DESCRIPTION
This is a fix for issue #1995. (Fixes #1995)