### PR TITLE
Correct the fh returned when reusing a handle from external table

### DIFF
--- a/src/XrdXrootd/XrdXrootdFile.cc
+++ b/src/XrdXrootd/XrdXrootdFile.cc
@@ -218,6 +218,7 @@ int XrdXrootdFileTable::Add(XrdXrootdFile *fp)
           else {i -= XRD_FTABSIZE;
                 if (XTab && i < XTnum) fP = &XTab[i];
                    else fP = 0;
+                i += XRD_FTABSIZE;
                }
        if (fP && *fP == heldSpotP)
           {*fP = fp;


### PR DESCRIPTION
This is a proposed fix for a problem seen with EOS; I suppose it's probably only possible with xrootd servers configured with plugins so that they use the delayed close feature (i.e. when the Ofs file close() can return SFS_STARTED).

I haven't opened an issue ticket for now (to describing what was seen, or attempts to reproduce the problem), but I could do so later if we want, but for now I won't. Essentially it seems the wrong file was closed or bytes were read from the wrong file.

This PR aims to correct the file handle number returned by XrdXrootdFileTable::Add() in case a heldSpot in the external table gets reused.