### PR TITLE
[HttpExtHandler] Avoid SEGV incase request has object for opaque data but no content

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -89,9 +89,12 @@ verb(req->requestverb), headers(req->allheaders) {
   resource = req->resource.c_str();
   int envlen = 0;
   
-  headers["xrd-http-query"] = req->opaque?req->opaque->Env(envlen):"";
-  const char * resourcePlusOpaque = req->resourceplusopaque.c_str();
-  headers["xrd-http-fullresource"] = resourcePlusOpaque != nullptr ? resourcePlusOpaque:"";
+  const char *p = nullptr;
+  if (req->opaque)
+    p = req->opaque->Env(envlen);
+  headers["xrd-http-query"] = p ? p:"";
+  p = req->resourceplusopaque.c_str();
+  headers["xrd-http-fullresource"] = p ? p:"";
   headers["xrd-http-prot"] = prot->isHTTPS()?"https":"http";
   
   // These fields usually identify the client that connected


### PR DESCRIPTION
A SEGV was seen with a server with an http.exthandler configured. Sample trace from eos build of xrootd, v5.5.5:

```
#0  0x00007f30bc76a8c1 in __strlen_sse2_pminub () from /lib64/libc.so.6
#1  0x00007f30b81e6824 in std::char_traits<char>::length (__s=0x0)
    at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/char_traits.h:322
#2  std::string::assign (__s=0x0, this=0x7f300bcb03f8)
    at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/basic_string.h:4333
#3  std::string::operator= (__s=0x0, this=0x7f300bcb03f8)
    at /opt/rh/devtoolset-8/root/usr/include/c++/8/bits/basic_string.h:3656
#4  XrdHttpExtReq::XrdHttpExtReq (this=<optimized out>, req=<optimized out>, pr=<optimized out>)
    at /usr/src/debug/xrootd-5.5.9/src/XrdHttp/XrdHttpExtHandler.cc:92
#5  0x00007f30b81e110e in XrdHttpReq::ProcessHTTPReq (this=this@entry=0x7f3019c4ab60)
    at /usr/src/debug/xrootd-5.5.9/src/XrdHttp/XrdHttpReq.cc:976
#6  0x00007f30b81d7034 in XrdHttpProtocol::Process (this=0x7f3019c4aa00, lp=<optimized out>)
    at /usr/src/debug/xrootd-5.5.9/src/XrdHttp/XrdHttpProtocol.cc:871
#7  0x00007f30bd8d8ead in XrdLinkXeq::DoIt (this=<optimized out>)
    at /usr/src/debug/xrootd-5.5.9/src/Xrd/XrdLinkXeq.cc:320
#8  XrdLinkXeq::DoIt (this=0x7f305fc2a338) at /usr/src/debug/xrootd-5.5.9/src/Xrd/XrdLinkXeq.cc:308
```