### PR TITLE
Update HTTP Header Handling for Chunked Encoding and Status Trailer

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -184,11 +184,10 @@ int XrdHttpReq::parseLine(char *line, int len) {
 
     } else if (!strcmp(key, "Expect") && strstr(val, "100-continue")) {
       sendcontinue = true;
-    } else if (!strcasecmp(key, "Transfer-Encoding") && strstr(val, "chunked")) {
-      m_transfer_encoding_chunked = true;
     } else if (!strcasecmp(key, "TE") && strstr(val, "trailers")) {
       m_trailer_headers = true;
     } else if (!strcasecmp(key, "X-Transfer-Status") && strstr(val, "true")) {
+      m_transfer_encoding_chunked = true;
       m_status_trailer = true;
     } else {
       // Some headers need to be translated into "local" cgi info.


### PR DESCRIPTION
This commit updates the handling of HTTP headers to conform to HTTP standards and improve support for chunked transfer encoding and status trailers.

Previously, the server incorrectly expected to receive the "Transfer-Encoding: chunked" header in HTTP requests. However, it has been realized that the "Transfer-Encoding" header is reserved for HTTP responses and should not be anticipated in an HTTP request.

We've now corrected this behavior by removing the check for the "Transfer-Encoding" header in the incoming request. Instead, we now set the internal variable `m_transfer_encoding_chunked` when the client includes the custom header "X-Transfer-Status: true". This change aligns with the original intention, indicating that the client is prepared to receive a response using chunked transfer encoding and a status trailer.

The `m_trailer_headers` variable is still set when the client includes the "TE: trailers" header, indicating its acceptance of trailer fields in the response.