### PR TITLE
Fix build failure with latest glibc

### DIFF
--- a/src/XrdTls/XrdTlsTempCA.cc
+++ b/src/XrdTls/XrdTlsTempCA.cc
@@ -50,8 +50,8 @@
 #include <atomic>
 
 namespace {
-    
-typedef std::unique_ptr<FILE, decltype(&fclose)> file_smart_ptr;
+
+typedef std::unique_ptr<FILE, int(*)(FILE*)> file_smart_ptr;
 
 
 static uint64_t monotonic_time_s() {


### PR DESCRIPTION
The latest updates to glibc headers adds __nonnull to the fclose()

Declaration in old version:

    extern int fclose (FILE *__stream);

Declaration in new version:

    extern int fclose (FILE *__stream) __nonnull ((1));

This change causes a compilation error in xrootd:
~~~
/builddir/build/BUILD/xrootd-5.5.5/src/XrdTls/XrdTlsTempCA.cc:54:48: error: ignoring attributes on template argument 'int (*)(FILE*)' [-Werror=ignored-attributes]
   54 | typedef std::unique_ptr<FILE, decltype(&fclose)> file_smart_ptr;
      |                                                ^
~~~
This commit rewrites the code so the error is not triggered.