### PR TITLE
Add path suffixes for the davix libraries

### DIFF
--- a/cmake/FindDavix.cmake
+++ b/cmake/FindDavix.cmake
@@ -8,6 +8,7 @@ find_library(
     Davix_LIBRARIES
     NAMES davix
     HINTS ${Davix_LIBRARY_DIRS}
+    PATH_SUFFIXES lib64 lib
 )
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Recently, a new option has been added to spack to build with davix (https://github.com/spack/spack/pull/37682) and when doing so it doesn't work on ubuntu. I've checked the location of the davix libraries was in `lib64` so adding a suffix seems to make it find it. There are some other ways of fixing this in spack only but I guess it doesn't hurt to check for both `lib64` and `lib`? 

Error when building:

```
1 error found in build log:
     56    -- Found LibXml2: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-ubunt
           u22.04-gcc11.3.0-opt/libxml2/2.10.3-zbfzvz/lib/libxml2.so (found version "2.10.3")
     57    -- Found CURL: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-ubuntu22
           .04-gcc11.3.0-opt/curl/7.88.1-s2g5xy/lib/libcurl.so (found version "7.88.1")
     58    -- Found OpenSSL: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-ubunt
           u22.04-gcc11.3.0-opt/openssl/1.1.1t-5yysbw/lib/libcrypto.so (found suitable version "1
           .1.1t", minimum required is "1.0.2")
     59    -- Found Kerberos5: /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-ubu
           ntu22.04-gcc11.3.0-opt/krb5/1.20.1-53l3os/lib/libkrb5.so;/cvmfs/sw-nightlies.hsf.org/k
           ey4hep/releases/2023-05-20/x86_64-ubuntu22.04-gcc11.3.0-opt/krb5/1.20.1-53l3os/lib/lib
           com_err.so
     60    -- Looking for curl_multi_wait
     61    -- Looking for curl_multi_wait - found
  >> 62    CMake Error at /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-ubuntu22
           .04-gcc11.3.0-opt/cmake/3.26.3-bvci3r/share/cmake-3.26/Modules/FindPackageHandleStanda
           rdArgs.cmake:230 (message):
     63      Could NOT find Davix (missing: Davix_LIBRARIES)
     64    Call Stack (most recent call first):
     65      /cvmfs/sw-nightlies.hsf.org/key4hep/releases/2023-05-20/x86_64-ubuntu22.04-gcc11.3.0
           -opt/cmake/3.26.3-bvci3r/share/cmake-3.26/Modules/FindPackageHandleStandardArgs.cmake:
           600 (_FPHSA_FAILURE_MESSAGE)
     66      cmake/FindDavix.cmake:14 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
     67      cmake/XRootDFindLibs.cmake:210 (find_package)
     68      CMakeLists.txt:26 (include)`` shell

```