### PR TITLE
XrdHttp: The deletion of a non-empty directory returns a 405 error code instead of 500

### DIFF
--- a/src/XProtocol/XProtocol.hh
+++ b/src/XProtocol/XProtocol.hh
@@ -1370,7 +1370,12 @@ static int mapError(int rc)
            case ENOTBLK:       return kXR_NotFile;
            case ENOTSUP:       return kXR_Unsupported;
            case EISDIR:        return kXR_isDirectory;
-           case EEXIST:        return kXR_ItExists;
+           case ENOTEMPTY: [[fallthrough]];
+           // In the case one tries to delete a non-empty directory
+           // we have decided that until the next major release
+           // the kXR_ItExists flag will be returned
+           case EEXIST:
+                return kXR_ItExists;
            case EBADRQC:       return kXR_InvalidRequest;
            case ETXTBSY:       return kXR_inProgress;
            case ENODEV:        return kXR_FSError;
@@ -1391,10 +1396,6 @@ static int mapError(int rc)
            case ETIMEDOUT:     return kXR_ReqTimedOut;
            case EBADF:         return kXR_FileNotOpen;
            case ECANCELED:     return kXR_Cancelled;
-           // In the case one tries to delete a non-empty directory
-           // we have decided that until the next major release
-           // the kXR_ItExists flag will be returned
-           case ENOTEMPTY:     return kXR_ItExists;
            default:            return kXR_FSError;
           }
       }

--- a/src/XProtocol/XProtocol.hh
+++ b/src/XProtocol/XProtocol.hh
@@ -1391,6 +1391,10 @@ static int mapError(int rc)
            case ETIMEDOUT:     return kXR_ReqTimedOut;
            case EBADF:         return kXR_FileNotOpen;
            case ECANCELED:     return kXR_Cancelled;
+           // In the case one tries to delete a non-empty directory
+           // we have decided that until the next major release
+           // the kXR_ItExists flag will be returned
+           case ENOTEMPTY:     return kXR_ItExists;
            default:            return kXR_FSError;
           }
       }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -926,7 +926,14 @@ void XrdHttpReq::mapXrdErrorToHttpStatus() {
         httpStatusCode = 409; httpStatusText = "Resource is a directory";
         break;
       case kXR_ItExists:
-        httpStatusCode = 409; httpStatusText = "File already exists";
+        if(request != ReqType::rtDELETE) {
+          httpStatusCode = 409; httpStatusText = "File already exists";
+        } else {
+          // In the case the XRootD layer returns a kXR_ItExists after a deletion
+          // was submitted, we return a 405 status code with the error message set by
+          // the XRootD layer
+          httpStatusCode = 405;
+        }
         break;
       case kXR_InvalidRequest:
         httpStatusCode = 405; httpStatusText = "Method is not allowed";


### PR DESCRIPTION
The mapping between errno error codes and XRoot protocol error code has also been changed. ENOTEMPTY is mapped to kXR_ItExists