### PR TITLE
XrdHttp: Corrected regression where no performance markers were sent to the client during a HTTP TPC transfer

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1579,10 +1579,11 @@ int XrdHttpProtocol::StartChunkedResp(int code, const char *desc, const char *he
 /******************************************************************************/
   
 int XrdHttpProtocol::ChunkResp(const char *body, long long bodylen) {
-  if (ChunkRespHeader((bodylen <= 0) ? (body ? strlen(body) : 0) : bodylen))
+  long long content_length = (bodylen <= 0) ? (body ? strlen(body) : 0) : bodylen;
+  if (ChunkRespHeader(content_length))
     return -1;
 
-  if (body && SendData(body, bodylen))
+  if (body && SendData(body, content_length))
     return -1;
 
   return ChunkRespFooter();


### PR DESCRIPTION
Before this fix, no performance markers were sent to the client after a HTTP TPC transfer was started, there were weird numbers instead:

```
> COPY /tmp/BIGFILE_10GB HTTP/1.1
> User-Agent: curl/7.29.0
> Host: machine.cern.ch:1096
> Accept: */*
> Destination: https://machine.cern.ch:2001/tmp/BIGFILE_10GB_COPY
>
< HTTP/1.1 201 Created
< Connection: Keep-Alive
< Server: XrootD/v5.2.0-99-osghotfix...687
< Content-Type: text/plain
< Transfer-Encoding: chunked
< 

9b

9c

9c

32

0
```

After the fix, the perf markers are back:

```
> COPY /tmp/BIGFILE_10GB HTTP/1.1
> User-Agent: curl/7.29.0
> Host: machine.cern.ch:1096
> Accept: */*
> Destination: https://machine.cern.ch:2001/tmp/BIGFILE_10GB_COPY
> 
< HTTP/1.1 201 Created
< Connection: Keep-Alive
< Server: XrootD/v5.2.0-99-osghotfix...687
< Content-Type: text/plain
< Transfer-Encoding: chunked
< 
Perf Marker
Timestamp: 1685106809
Stripe Index: 0
Stripe Bytes Transferred: 0
Total Stripe Count: 1
End
Perf Marker
Timestamp: 1685106814
Stripe Index: 0
Stripe Bytes Transferred: 1017184256
Total Stripe Count: 1
RemoteConnections: tcp:137.138.123.14:2001
End
Perf Marker
Timestamp: 1685106819
Stripe Index: 0
Stripe Bytes Transferred: 2326478848
Total Stripe Count: 1
RemoteConnections: tcp:137.138.123.14:2001
End

```

Fixes the regression introduced in 56b2bdee0af49cc33e359a1bb8a170d0ed84f40e