### PR TITLE
Add sandboxing settings to systemd service files.

### DIFF
--- a/packaging/common/cmsd@.service
+++ b/packaging/common/cmsd@.service
@@ -6,6 +6,14 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+#PrivateDevices=true
+#ProtectHostname=true
+#ProtectClock=true
+#ProtectKernelTunables=true
+#ProtectKernelModules=true
+#ProtectKernelLogs=true
+#ProtectControlGroups=true
+#RestrictRealtime=true
 ExecStart=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/cmsd-%i.pid -n %i
 User=xrootd
 Group=xrootd

--- a/packaging/common/frm_purged@.service
+++ b/packaging/common/frm_purged@.service
@@ -6,6 +6,14 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+#PrivateDevices=true
+#ProtectHostname=true
+#ProtectClock=true
+#ProtectKernelTunables=true
+#ProtectKernelModules=true
+#ProtectKernelLogs=true
+#ProtectControlGroups=true
+#RestrictRealtime=true
 ExecStart=/usr/bin/frm_purged -l /var/log/xrootd/frm_purged.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/frm_purged-%i.pid -n %i
 User=xrootd
 Group=xrootd

--- a/packaging/common/frm_xfrd@.service
+++ b/packaging/common/frm_xfrd@.service
@@ -6,6 +6,14 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+#PrivateDevices=true
+#ProtectHostname=true
+#ProtectClock=true
+#ProtectKernelTunables=true
+#ProtectKernelModules=true
+#ProtectKernelLogs=true
+#ProtectControlGroups=true
+#RestrictRealtime=true
 ExecStart=/usr/bin/frm_xfrd -l /var/log/xrootd/frm_xfrd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/frm_xfrd-%i.pid -n %i
 User=xrootd
 Group=xrootd

--- a/packaging/common/xrootd@.service
+++ b/packaging/common/xrootd@.service
@@ -6,6 +6,14 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
+#PrivateDevices=true
+#ProtectHostname=true
+#ProtectClock=true
+#ProtectKernelTunables=true
+#ProtectKernelModules=true
+#ProtectKernelLogs=true
+#ProtectControlGroups=true
+#RestrictRealtime=true
 ExecStart=/usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /run/xrootd/xrootd-%i.pid -n %i
 User=xrootd
 Group=xrootd


### PR DESCRIPTION
This is a first attempt to implement stronger security settings in systemd service files. The sandboxing settings added with this commit are commented out until they can receive more testing, as discussed in issue #2033.