### PR TITLE
Increase default number of parallel event loops to 10

### DIFF
--- a/docs/man/xrdcp.1
+++ b/docs/man/xrdcp.1
@@ -332,7 +332,7 @@ The default value is \fIOFF\fR.
 
 XRD_PARALLELEVTLOOP
 .RS 5
-The number of event loops.
+The number of event loops (i.e. the number of threads handling requests). Default number is 10.
 .RE
 
 XRD_READRECOVERY

--- a/src/XrdCl/XrdClConstants.hh
+++ b/src/XrdCl/XrdClConstants.hh
@@ -70,7 +70,7 @@ namespace XrdCl
   const int DefaultTCPKeepAliveInterval    = 75;
   const int DefaultTCPKeepAliveProbes      = 9;
   const int DefaultMultiProtocol           = 0;
-  const int DefaultParallelEvtLoop         = 1;
+  const int DefaultParallelEvtLoop         = 10;
   const int DefaultMetalinkProcessing      = 1;
   const int DefaultLocalMetalinkFile       = 0;
   const int DefaultXRateThreshold          = 0;

--- a/src/XrdOuc/XrdOucPsx.cc
+++ b/src/XrdOuc/XrdOucPsx.cc
@@ -715,7 +715,7 @@ bool XrdOucPsx::ParseSet(XrdSysError *Eroute, XrdOucStream &Config)
          {"DataServerTTL",         "DataServerTTL",1},       // Default  300
          {"LBServerConn_ttl",      "LoadBalancerTTL",1},     // Default 1200
          {"LoadBalancerTTL",       "LoadBalancerTTL",1},     // Default 1200
-         {"ParallelEvtLoop",       "ParallelEvtLoop",0},     // Default    3
+         {"ParallelEvtLoop",       "ParallelEvtLoop",0},     // Default   10
          {"ParStreamsPerPhyConn",  "SubStreamsPerChannel",0},// Default    1
          {"ReadAheadSize",         0,0},
          {"ReadAheadStrategy",     0,0},

--- a/src/XrdPss/XrdPssConfig.cc
+++ b/src/XrdPss/XrdPssConfig.cc
@@ -199,7 +199,7 @@ int XrdPssSys::Configure(const char *cfn, XrdOucEnv *envP)
 
 // Set default number of event loops
 //
-   XrdPosixConfig::SetEnv("ParallelEvtLoop", 3);
+   XrdPosixConfig::SetEnv("ParallelEvtLoop", 10);
 
 // Turn off the fork handler as we always exec after forking.
 //

--- a/src/XrdSsi/XrdSsiClient.cc
+++ b/src/XrdSsi/XrdSsiClient.cc
@@ -76,7 +76,7 @@ extern XrdSsiLogger::MCB_t *msgCBCl;
        Atomic(int)   contactN(1);
        short         maxTCB   = 300;
        short         maxCLW   =  30;
-       short         maxPEL   =   3;
+       short         maxPEL   =  10;
        Atomic(bool)  initDone(false);
        bool          dsTTLSet = false;
        bool          reqTOSet = false;


### PR DESCRIPTION
This value has been chosen as default based on benchmarks that demonstrated that this is the minimum required number of threads to be able to saturate a link of 100Gbps.

Note: I have a small concern about clients launched by the server starting up way too many threads if enough of them are launched together after this patch. We should ensure this change will not cause problems for EOS, or make sure to set the number of event loops back to the old value in the environment in EOS instances before upgrading.