### PR TITLE
[XrdCl] Avoid race in postmaster QueryTransport

### DIFF
--- a/src/XrdCl/XrdClPostMaster.cc
+++ b/src/XrdCl/XrdClPostMaster.cc
@@ -245,11 +245,15 @@ namespace XrdCl
                                      AnyObject &result )
   {
     XrdSysRWLockHelper scopedLock( pImpl->pDisconnectLock );
-    PostMasterImpl::ChannelMap::iterator it =
-        pImpl->pChannelMap.find( url.GetChannelId() );
-    if( it == pImpl->pChannelMap.end() )
-      return Status( stError, errInvalidOp );
-    Channel *channel = it->second;
+    Channel *channel = 0;
+    {
+      XrdSysMutexHelper scopedLock2( pImpl->pChannelMapMutex );
+      PostMasterImpl::ChannelMap::iterator it =
+          pImpl->pChannelMap.find( url.GetChannelId() );
+      if( it == pImpl->pChannelMap.end() )
+        return Status( stError, errInvalidOp );
+      channel = it->second;
+    }
 
     if( !channel )
       return Status( stError, errNotSupported );


### PR DESCRIPTION
This change is avoid the possibility of accessing pChannelMap (a std::map) during PostMaster::QueryTransport, while that map is modified by another thread, e.g. by one executing PostMaster::Send. A crash due to this was seen in a test, but is probably rare.