### PR TITLE
[XrdCrypto] Avoid race in GetCryptoFactory

### DIFF
--- a/src/XrdCrypto/XrdCryptoFactory.cc
+++ b/src/XrdCrypto/XrdCryptoFactory.cc
@@ -43,6 +43,7 @@
 #include "XrdOuc/XrdOucHash.hh"
 #include "XrdOuc/XrdOucPinLoader.hh"
 #include "XrdSys/XrdSysPlatform.hh"
+#include "XrdSys/XrdSysPthread.hh"
 
 #include "XrdVersion.hh"
   
@@ -418,6 +419,7 @@ XrdCryptoFactory *XrdCryptoFactory::GetCryptoFactory(const char *factoryid)
    // Static method to load/locate the crypto factory named factoryid
  
    static XrdVERSIONINFODEF(myVer,cryptoloader,XrdVNUMBER,XrdVERSION);
+   static XrdSysMutex    fMutex;
    static FactoryEntry  *factorylist = 0;
    static int            factorynum = 0;
    static XrdOucHash<XrdOucPinLoader> plugins;
@@ -425,6 +427,10 @@ XrdCryptoFactory *XrdCryptoFactory::GetCryptoFactory(const char *factoryid)
    XrdCryptoFactory *factory;
    char factobjname[80], libfn[80];
    EPNAME("Factory::GetCryptoFactory");
+
+   // Factory entries are tracked in a static list.
+   // Make sure only one thread may be using or modifying the list at a time.
+   XrdSysMutexHelper mHelp(fMutex);
 
    //
    // The id must be defined


### PR DESCRIPTION
This change is to avoid race in accessing some global structures during XrdCryptoFactory::GetCryptoFactory. This did cause some authentication failures during a heavily multithreaded test, which was starting many concurrent gsi connections, and with ParallelEvtLoop>1. It is probably a rare problem.