### PR TITLE
.md is not .rst

### DIFF
--- a/bindings/python/docs/source/conf.py
+++ b/bindings/python/docs/source/conf.py
@@ -29,6 +29,16 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx', 'sphinx.ext.todo',
               'sphinx.ext.coverage', 'sphinx.ext.viewcode']
 
+try:
+    import sphinx_mdinclude
+    extensions.extend(['sphinx_mdinclude'])
+except ImportError:
+    try:
+        import m2r
+        extensions.extend(['m2r'])
+    except ImportError:
+        pass
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']
 

--- a/bindings/python/docs/source/conf.py
+++ b/bindings/python/docs/source/conf.py
@@ -250,4 +250,4 @@ texinfo_documents = [
 #texinfo_show_urls = 'footnote'
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'http://docs.python.org/': None}
+intersphinx_mapping = { 'python': ('https://docs.python.org/3/', None) }

--- a/bindings/python/docs/source/install.rst
+++ b/bindings/python/docs/source/install.rst
@@ -2,5 +2,5 @@
 **Installing** ``pyxrootd``
 ===========================
 
-.. include:: ../../README.md
+.. mdinclude:: ../../README.md
    :start-line: 8


### PR DESCRIPTION
The include statement in rst includes the included file verbatim and therefore assumes that the included file is also in rst format. If it is a different format, like e.g. md, there are many syntax errors and warnings.

Use mdinclude when including the README.md file during the documentation build.