### PR TITLE
[XrdHttp] Add back parsing of Transfer-Encoding header

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -186,6 +186,8 @@ int XrdHttpReq::parseLine(char *line, int len) {
       sendcontinue = true;
     } else if (!strcasecmp(key, "TE") && strstr(val, "trailers")) {
       m_trailer_headers = true;
+    } else if (!strcasecmp(key, "Transfer-Encoding") && strstr(val, "chunked")) {
+      m_transfer_encoding_chunked = true; 
     } else if (!strcasecmp(key, "X-Transfer-Status") && strstr(val, "true")) {
       m_transfer_encoding_chunked = true;
       m_status_trailer = true;


### PR DESCRIPTION
This commit reintroduces a header parser for `Transfer-Encoding: chunked` to maintain compatibility with the EGI Nagios probe. This issue was first mentioned in #2058.

Fixes: [d96b2b70487e159b47c24925abcfa00f975ec3d6](https://github.com/xrootd/xrootd/pull/2009/commits/d96b2b70487e159b47c24925abcfa00f975ec3d6), [#2009](https://github.com/xrootd/xrootd/pull/2009)