### PR TITLE
Fix logic error in user mapping

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -239,7 +239,7 @@ struct MapRule
     {
         if (!m_sub.empty() && sub != m_sub) {return "";}
 
-        if (!m_username.empty() && username != username) {return "";}
+        if (!m_username.empty() && username != m_username) {return "";}
 
         if (!m_path_prefix.empty() &&
             strncmp(req_path.c_str(), m_path_prefix.c_str(), m_path_prefix.size()))


### PR DESCRIPTION
When setting up mapping rules, if the user feature was utilized, a logic error would cause the rule to be ignored.

Fixes #2056