### PR TITLE
[Xrd] Add initialiser in one of the XrdScheduler constructors

### DIFF
--- a/src/Xrd/XrdScheduler.cc
+++ b/src/Xrd/XrdScheduler.cc
@@ -122,7 +122,7 @@ XrdScheduler::XrdScheduler(XrdSysError *eP, XrdOucTrace *tP,
 //
 XrdScheduler::XrdScheduler(int minw, int maxw, int maxi)
               : XrdJob("underused thread monitor"),
-                WorkAvail(0, "sched work")
+                XrdTraceOld(0), WorkAvail(0, "sched work")
 {
    XrdSysLogger *Logger;
    int eFD;


### PR DESCRIPTION
During a test I was starting an xcache that happened to be configured to use OssCsi (e.g. with config option "pfc.cschk net tls cache"). Server crashed at startup with:

```
#0  0x00007ffff7876e99 in XrdScheduler::Start() () from /lib64/libXrdUtils.so.3
#1  0x00007fffee922336 in XrdOssCsi::Init(XrdSysLogger*, char const*, char const*, XrdOucEnv*) ()
   from /lib64/libXrdOssCsi-5.so
#2  0x00007fffee922491 in XrdOssAddStorageSystem2 () from /lib64/libXrdOssCsi-5.so
#3  0x00007ffff7b5d450 in XrdOfsConfigPI::AddLibOss(XrdOucEnv*) () from /lib64/libXrdServer.so.3
#4  0x00007ffff7b5f20c in XrdOfsConfigPI::Load(int, XrdOucEnv*) () from /lib64/libXrdServer.so.3
#5  0x00007fffef17ea42 in XrdPfc::Cache::Config(char const*, char const*) () from /lib64/libXrdPfc-5.so
#6  0x00007fffef175b39 in XrdOucGetCache () from /lib64/libXrdPfc-5.so
#7  0x00007ffff782ecdc in XrdOucPsx::ConfigCache(XrdSysError&) () from /lib64/libXrdUtils.so.3
#8  0x00007ffff78306d6 in XrdOucPsx::ConfigSetup(XrdSysError&, bool) () from /lib64/libXrdUtils.so.3
#9  0x00007fffef7eb1c9 in XrdPssSys::Configure(char const*, XrdOucEnv*) () from /lib64/libXrdPss-5.so
#10 0x00007fffef7e5dbf in XrdPssSys::Init(XrdSysLogger*, char const*, XrdOucEnv*) () from /lib64/libXrdPss-5.so
#11 0x00007fffef7e643d in XrdOssGetStorageSystem2 () from /lib64/libXrdPss-5.so
#12 0x00007ffff7b76656 in XrdOssGetSS(XrdSysLogger*, char const*, char const*, char const*, XrdOucEnv*, XrdVersionInfo&) () from /lib64/libXrdServer.so.3
#13 0x00007ffff7b5f1ef in XrdOfsConfigPI::Load(int, XrdOucEnv*) () from /lib64/libXrdServer.so.3
#14 0x00007ffff7b5b43a in XrdOfs::Configure(XrdSysError&, XrdOucEnv*) () from /lib64/libXrdServer.so.3
#15 0x00007ffff7b64286 in XrdSfsGetDefaultFileSystem(XrdSfsFileSystem*, XrdSysLogger*, char const*, XrdOucEnv*)
    () from /lib64/libXrdServer.so.3
#16 0x00007ffff7b1e179 in XrdXrootdProtocol::ConfigFS(XrdOucEnv&, char const*) () from /lib64/libXrdServer.so.3
#17 0x00007ffff7b22542 in XrdXrootdProtocol::Configure(char*, XrdProtocol_Config*) ()
   from /lib64/libXrdServer.so.3
#18 0x00007ffff7b31c9f in XrdgetProtocol () from /lib64/libXrdServer.so.3
#19 0x000000000040dd88 in XrdProtLoad::Load(char const*, char const*, char*, XrdProtocol_Config*, bool) ()
#20 0x0000000000409bbc in XrdConfig::Setup(char*, char*) ()
#21 0x000000000040bd6e in XrdConfig::Configure(int, char**) ()
#22 0x0000000000405a9f in main ()
```

Seems to be a missing initializer from an XrdScheduler constructor that OssCsi was using. As far as I can see neither the Scheduler nor OssCsi changed in this respect recently, so there's no clear reason why this was only seen now. I'm attaching a patch to initialise the member in the constructor. I tested that this does avoid this crash.