### PR TITLE
XrdHttp: Headers provided by the client are now parsed in a case-inse…

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -109,6 +109,7 @@ XrdSecService *XrdHttpProtocol::CIA = 0; // Authentication Server
 int XrdHttpProtocol::m_bio_type = 0; // BIO type identifier for our custom BIO.
 BIO_METHOD *XrdHttpProtocol::m_bio_method = NULL; // BIO method constructor.
 char *XrdHttpProtocol::xrd_cslist = nullptr;
+XrdNetPMark * XrdHttpProtocol::pmarkHandle = nullptr;
 XrdHttpChecksumHandler XrdHttpProtocol::cksumHandler = XrdHttpChecksumHandler();
 XrdHttpReadRangeHandler::Configuration XrdHttpProtocol::ReadRangeConfig;
 
@@ -955,6 +956,8 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
   var = nullptr;
   XrdOucEnv::Import("XRD_READV_LIMITS", var);
   XrdHttpReadRangeHandler::Configure(eDest, var, ReadRangeConfig);
+
+  pmarkHandle = (XrdNetPMark* ) myEnv->GetPtr("XrdNetPMark*");
 
   cksumHandler.configure(xrd_cslist);
   auto nonIanaChecksums = cksumHandler.getNonIANAConfiguredCksums();

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -48,6 +48,7 @@
 #include "XrdOuc/XrdOucHash.hh"
 #include "XrdHttpChecksumHandler.hh"
 #include "XrdHttpReadRangeHandler.hh"
+#include "XrdNet/XrdNetPMark.hh"
 
 #include <openssl/ssl.h>
 
@@ -433,5 +434,8 @@ protected:
 
   /// The list of checksums that were configured via the xrd.cksum parameter on the server config file
   static char * xrd_cslist;
+
+  /// Packet marking handler pointer (assigned from the environment during the Config() call)
+  static XrdNetPMark * pmarkHandle;
 };
 #endif

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -196,7 +196,9 @@ int XrdHttpReq::parseLine(char *line, int len) {
       m_status_trailer = true;
     } else {
       // Some headers need to be translated into "local" cgi info.
-      std::map< std::string, std::string > ::iterator it = prot->hdr2cgimap.find(key);
+      auto it = std::find_if(prot->hdr2cgimap.begin(), prot->hdr2cgimap.end(),[key](const auto & item) {
+        return !strcasecmp(key,item.first.c_str());
+      });
       if (it != prot->hdr2cgimap.end() && (opaque ? (0 == opaque->Get(it->second.c_str())) : true)) {
         std::string s;
         s.assign(val, line+len-val);

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -89,6 +89,8 @@ private:
 
   int parseHost(char *);
 
+  void parseScitag(const std::string & val);
+
   //xmlDocPtr xmlbody; /* the resulting document tree */
   XrdHttpProtocol *prot;
 
@@ -185,6 +187,8 @@ public:
   // Appends the opaque info that we have
   // NOTE: this function assumes that the strings are unquoted, and will quote them
   void appendOpaque(XrdOucString &s, XrdSecEntity *secent, char *hash, time_t tnow);
+
+  void addCgi(const std::string & key, const std::string & value);
 
   // ----------------
   // Description of the request. The header/body parsing

--- a/src/XrdNet/XrdNetPMark.hh
+++ b/src/XrdNet/XrdNetPMark.hh
@@ -71,6 +71,9 @@ virtual Handle *Begin(XrdNetAddrInfo &addr, Handle     &handle,
 static  bool    getEA(const char *cgi, int &ecode, int &acode);
 
                 XrdNetPMark() {}
+
+static const int maxTotID = 0x7fff;
+
 protected:
 
 // ID limits and specifications
@@ -80,7 +83,6 @@ static const int mskActID =  63;
 static const int maxActID =  63;
 
 static const int maxExpID = 511;
-static const int maxTotID = 0x7fff;
 
 virtual        ~XrdNetPMark() {} // This object cannot be deleted!
 };


### PR DESCRIPTION
@abh3 , I did not find the XRootD documentation in order to update it. One just needs to specify that the following configuration needs to be set up in order to have packet marking with HTTP: `http.header2cgi SciTag scitag.flow`.