### PR TITLE
[XrdHttp] Fix max to min when reading chunk length

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1334,7 +1334,7 @@ int XrdHttpReq::ProcessHTTPReq() {
             // This is to prevent a malicious client from sending a very large chunk size
             // or a malformed chunk request.
             // 1TB in base-16 is 0x40000000000, so only allow 11 characters, plus the CRLF
-            long long max_chunk_size_chars = std::max(static_cast<long long>(prot->BuffUsed()), static_cast<long long>(13));
+            long long max_chunk_size_chars = std::min(static_cast<long long>(prot->BuffUsed()), static_cast<long long>(13));
             for (; idx < max_chunk_size_chars; idx++) {
               if (prot->myBuffStart[idx] == '\n') {
                 found_newline = true;


### PR DESCRIPTION
Small change to using the minimum of either the used buffer size or the first 13 characters of a chunk to read the chunk length.