### PR TITLE
Implement only-if-cached cache control using XrdPfcFsctl

### DIFF
--- a/src/XProtocol/XProtocol.cc
+++ b/src/XProtocol/XProtocol.cc
@@ -102,7 +102,8 @@ const char *errNames[kXR_ERRFENCE-kXR_ArgInvalid] =
                     "Request is not possible",    // kXR_Impossible
                     "Conflicting request",        // kXR_Conflict
                     "Too many errors",            // kXR_TooManyErrs
-                    "Request timed out"           // kXR_ReqTimedOut
+                    "Request timed out",          // kXR_ReqTimedOut
+                    "Timer expired"               // kXR_TimerExipred
                    };
 
 const char *reqNames[kXR_REQFENCE-kXR_auth] =

--- a/src/XProtocol/XProtocol.hh
+++ b/src/XProtocol/XProtocol.hh
@@ -1020,6 +1020,7 @@ enum XErrorCode {
    kXR_Conflict,        // 3032
    kXR_TooManyErrs,     // 3033
    kXR_ReqTimedOut,     // 3034
+   kXR_TimerExpired,    // 3035
    kXR_ERRFENCE,        // Always last valid errcode + 1
    kXR_noErrorYet = 10000
 };
@@ -1396,6 +1397,7 @@ static int mapError(int rc)
            case ETIMEDOUT:     return kXR_ReqTimedOut;
            case EBADF:         return kXR_FileNotOpen;
            case ECANCELED:     return kXR_Cancelled;
+           case ETIME:         return kXR_TimerExpired;
            default:            return kXR_FSError;
           }
       }
@@ -1438,6 +1440,7 @@ static int toErrno( int xerr )
         case kXR_Conflict:      return ENOTTY;
         case kXR_TooManyErrs:   return ETOOMANYREFS;
         case kXR_ReqTimedOut:   return ETIMEDOUT;
+        case kXR_TimerExpired:  return ETIME;  // Used for 504 Gateway timeout in proxy
         default:                return ENOMSG;
        }
 }

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1065,6 +1065,10 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
        return 1;
       }
 
+// Some headers must always be converted to CGI key=value pairs
+//
+   hdr2cgimap["Cache-Control"] = "cache-control";
+
 // Test if XrdEC is loaded
    if (getenv("XRDCL_EC")) usingEC = true;
 
@@ -1541,6 +1545,7 @@ int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *hea
     else if (code == 405) ss << "Method Not Allowed";
     else if (code == 416) ss << "Range Not Satisfiable";
     else if (code == 500) ss << "Internal Server Error";
+    else if (code == 504) ss << "Gateway Timeout";
     else ss << "Unknown";
   }
   ss << crlf;

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -895,6 +895,9 @@ void XrdHttpReq::mapXrdErrorToHttpStatus() {
       case kXR_InvalidRequest:
         httpStatusCode = 405; httpStatusText = "Method is not allowed";
         break;
+      case kXR_TimerExpired:
+        httpStatusCode = 504; httpStatusText = "Gateway timeout";
+        break;
       default:
         break;
     }

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -968,13 +968,26 @@ int Cache::ConsiderCached(const char *curl)
                {
                   is_cached = true;
                }
+               else if (info.GetFileSize() == 0)
+               {
+                  is_cached = true;
+               }
                else
                {
                   long long fileSize = info.GetFileSize();
                   long long bytesRead = info.GetNDownloadedBytes();
-                  if (bytesRead > m_configuration.m_onlyIfCachedMinSize &&
-                      (float)bytesRead/fileSize > m_configuration.m_onlyIfCachedMinFrac)
+
+                  if (fileSize < m_configuration.m_onlyIfCachedMinSize)
+                  {
+                     if ((float)bytesRead / fileSize > m_configuration.m_onlyIfCachedMinFrac)
                         is_cached = true;
+                  }
+                  else
+                  {
+                     if (bytesRead > m_configuration.m_onlyIfCachedMinSize &&
+                         (float)bytesRead / fileSize > m_configuration.m_onlyIfCachedMinFrac)
+                        is_cached = true;
+                  }
                }
             }
             infoFile->Close();

--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -111,6 +111,9 @@ struct Configuration
    time_t    m_cs_UVKeep;               //!< unverified checksum cache keep
    int       m_cs_Chk;                  //!< Checksum check
    bool      m_cs_ChkTLS;               //!< Allow TLS
+
+   long long m_onlyIfCachedMinSize;     //!< minumum size of downloaded file, used by only-if-cached CGI option
+   double    m_onlyIfCachedMinFrac;     //!< minimum fraction of downloaded file, used by only-if-cached CGI option
 };
 
 //------------------------------------------------------------------------------
@@ -290,6 +293,12 @@ public:
 
    // virtual function of XrdOucCache.
    virtual int  Unlink(const char *url);
+
+   //---------------------------------------------------------------------
+   //  Used by PfcFstcl::Fsctl function.
+   //  Test if file is cached taking in onlyifcached configuration parameters.
+   //---------------------------------------------------------------------
+   virtual int ConsiderCached(const char *url);
 
    //--------------------------------------------------------------------
    //! \brief Makes decision if the original XrdOucCacheIO should be cached.

--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -46,7 +46,9 @@ Configuration::Configuration() :
    m_flushCnt(2000),
    m_cs_UVKeep(-1),
    m_cs_Chk(CSChk_Net),
-   m_cs_ChkTLS(false)
+   m_cs_ChkTLS(false),
+   m_onlyIfCachedMinSize(1024*1024),
+   m_onlyIfCachedMinFrac(1.0)
 {}
 
 
@@ -488,7 +490,9 @@ bool Cache::Config(const char *config_filename, const char *parameters)
                       "       pfc.spaces %s %s\n"
                       "       pfc.trace %d\n"
                       "       pfc.flush %lld\n"
-                      "       pfc.acchistorysize %d\n",
+                      "       pfc.acchistorysize %d\n"
+                      "       pfc.onlyIfCachedMinBytes %lld\n"
+                      "       pfc.onlyIfCachedMinFrac %.2f\n",
                       config_filename,
                       csc[int(m_configuration.m_cs_Chk)], uvk,
                       m_configuration.m_bufferSize,
@@ -503,7 +507,9 @@ bool Cache::Config(const char *config_filename, const char *parameters)
                       m_configuration.m_meta_space.c_str(),
                       m_trace->What,
                       m_configuration.m_flushCnt,
-                      m_configuration.m_accHistorySize);
+                      m_configuration.m_accHistorySize,
+                      m_configuration.m_onlyIfCachedMinSize,
+                      m_configuration.m_onlyIfCachedMinFrac);
 
       if (m_configuration.is_dir_stat_reporting_on())
       {
@@ -823,6 +829,49 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
       {
          m_log.Emsg("Config", "Error: pfc.flush requires a parameter.");
          return false;
+      }
+   }
+   else if ( part == "onlyifcached" )
+   {
+      const char *p = 0;
+      while ((p = cwg.GetWord()) && cwg.HasLast())
+      {
+         if (strcmp(p, "minsize") == 0)
+         {
+            std::string minBytes = cwg.GetWord();
+            long long minBytesTop = 1024 * 1024 * 1024;
+            if (::isalpha(*(minBytes.rbegin())))
+            {
+               if (XrdOuca2x::a2sz(m_log, "Error in parsing minsize value for onlyifcached parameter", minBytes.c_str(), &m_configuration.m_onlyIfCachedMinSize, 0, minBytesTop))
+               {
+                  return false;
+               }
+            }
+            else
+            {
+               if (XrdOuca2x::a2ll(m_log, "Error in parsing numeric minsize value for onlyifcached parameter", minBytes.c_str(),&m_configuration.m_onlyIfCachedMinSize, 0, minBytesTop))
+               {
+                  return false;
+               }
+            }
+         }
+         if (strcmp(p, "minfrac") == 0)
+         {
+            std::string minFrac = cwg.GetWord();
+            char *eP;
+            errno = 0;
+            double frac = strtod(minFrac.c_str(), &eP);
+            if (errno || eP == minFrac.c_str())
+            {
+               m_log.Emsg("Config", "Error setting fraction for only-if-cached directive");
+               return false;
+            }
+            m_configuration.m_onlyIfCachedMinFrac = frac;
+         }
+         else
+         {
+            m_log.Emsg("Config", "Error: onlyifcached stanza contains unknown directive", p);
+         }
       }
    }
    else

--- a/src/XrdPfc/XrdPfcFSctl.cc
+++ b/src/XrdPfc/XrdPfcFSctl.cc
@@ -135,7 +135,7 @@ int XrdPfcFSctl::FSctl(const int               cmd,
   if (!strcmp(xeq, "cached"))
   {
      const char* path = args.ArgP[0];
-     int rval = myCache.LocalFilePath(path, nullptr, 0, XrdOucCache::LFP_Reason::ForInfo);
+     int rval = myCache.ConsiderCached(path);
      if (rval == 0)
      {
         rc = SFS_OK;

--- a/src/XrdPfc/XrdPfcFSctl.cc
+++ b/src/XrdPfc/XrdPfcFSctl.cc
@@ -136,7 +136,7 @@ int XrdPfcFSctl::FSctl(const int               cmd,
   {
      const char* path = args.ArgP[0];
      int rval = myCache.LocalFilePath(path, nullptr, 0, XrdOucCache::LFP_Reason::ForInfo);
-     if (rval == 0 || rval == -EREMOTE)
+     if (rval == 0)
      {
         rc = SFS_OK;
         ec = 0;

--- a/src/XrdPfc/XrdPfcFSctl.cc
+++ b/src/XrdPfc/XrdPfcFSctl.cc
@@ -35,6 +35,7 @@
 #include "XrdOfs/XrdOfsHandle.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOuc/XrdOucErrInfo.hh"
+#include "XrdOuc/XrdOucCache.hh"
 #include "XrdPfc/XrdPfc.hh"
 #include "XrdPfc/XrdPfcFSctl.hh"
 #include "XrdPfc/XrdPfcTrace.hh"
@@ -129,6 +130,23 @@ int XrdPfcFSctl::FSctl(const int               cmd,
       } else {
    ec = EINVAL;
    rc = SFS_ERROR;
+  }
+
+  if (!strcmp(xeq, "cached"))
+  {
+     const char* path = args.ArgP[0];
+     int rval = myCache.LocalFilePath(path, nullptr, 0, XrdOucCache::LFP_Reason::ForInfo);
+     if (rval == 0 || rval == -EREMOTE)
+     {
+        rc = SFS_OK;
+        ec = 0;
+     }
+     else
+     {
+        ec = ETIME;
+        rc = SFS_ERROR;
+        TRACE(Info,"Cache "<<xeq<<' '<<path<<" rc="<<ec<<" ec="<<ec<<" msg=file not in cache");
+     }
   }
 
 // Return result


### PR DESCRIPTION
This is a new implementation of  #1954 using XrdPfcFsctl object in XrdPssFile::Open()

Note: 
A stderr code ETIME is returned when cache does not exist. The ETIMEDOUT code would be interpreted as delay error in XrdOfs::Emsg().