### PR TITLE
Implemented HTTP TPC Packet Marking

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -112,6 +112,10 @@ verb(req->requestverb), headers(req->allheaders) {
     clientgroups = prot->SecEntity.vorg;
     trim(clientgroups);
   }
-  
+
+  // Get the packet marking handle and the client scitag from the XrdHttp layer
+  pmark = prot->pmarkHandle;
+  mSciTag = req->mScitag;
+
   length = req->length;
 }

--- a/src/XrdHttp/XrdHttpExtHandler.hh
+++ b/src/XrdHttp/XrdHttpExtHandler.hh
@@ -36,6 +36,8 @@
 #include <map>
 #include <string>
 
+#include "XrdNet/XrdNetPMark.hh"
+
 class XrdLink;
 class XrdSecEntity;
 class XrdHttpReq;
@@ -54,6 +56,10 @@ public:
   
   std::string clientdn, clienthost, clientgroups;
   long long length;
+
+  XrdNetPMark * pmark;
+
+  int mSciTag;
 
   // Get full client identifier
   void GetClientID(std::string &clid);

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -225,22 +225,24 @@ int XrdHttpReq::parseHost(char *line) {
 }
 
 void XrdHttpReq::parseScitag(const std::string & val) {
-  int scitag = 0;
+  // The scitag header has been populated and the packet marking was configured, the scitag will either be equal to 0
+  // or to the value passed by the client
+  mScitag = 0;
   std::string scitagS = val;
   trim(scitagS);
   if(scitagS.size()) {
     if(scitagS[0] != '-') {
       try {
-        scitag = std::stoi(scitagS.c_str(), nullptr, 10);
-        if (scitag > XrdNetPMark::maxTotID) {
-          scitag = 0;
+        mScitag = std::stoi(scitagS.c_str(), nullptr, 10);
+        if (mScitag > XrdNetPMark::maxTotID || mScitag < 0) {
+          mScitag = 0;
         }
       } catch (...) {
         //Nothing to do, scitag = 0 by default
       }
     }
   }
-  addCgi("scitag.flow", std::to_string(scitag));
+  addCgi("scitag.flow", std::to_string(mScitag));
 }
 
 int XrdHttpReq::parseFirstLine(char *line, int len) {

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -159,6 +159,7 @@ public:
     writtenbytes = 0;
     fopened = false;
     headerok = false;
+    mScitag = -1;
   };
 
   virtual ~XrdHttpReq();
@@ -302,6 +303,8 @@ public:
 
   /// In a long write, we track where we have arrived
   long long writtenbytes;
+
+  int mScitag;
 
 
 

--- a/src/XrdTpc.cmake
+++ b/src/XrdTpc.cmake
@@ -38,7 +38,8 @@ if( BUILD_TPC )
     XrdTpc/XrdTpcCurlMulti.cc     XrdTpc/XrdTpcCurlMulti.hh
     XrdTpc/XrdTpcState.cc         XrdTpc/XrdTpcState.hh
     XrdTpc/XrdTpcStream.cc        XrdTpc/XrdTpcStream.hh
-    XrdTpc/XrdTpcTPC.cc           XrdTpc/XrdTpcTPC.hh)
+    XrdTpc/XrdTpcTPC.cc           XrdTpc/XrdTpcTPC.hh
+    XrdTpc/PMarkManager.cc        XrdTpc/PMarkManager.hh)
 
   target_link_libraries(
     ${LIB_XRD_TPC}

--- a/src/XrdTpc/PMarkManager.cc
+++ b/src/XrdTpc/PMarkManager.cc
@@ -1,0 +1,72 @@
+//------------------------------------------------------------------------------
+// This file is part of XrdTpcTPC
+//
+// Copyright (c) 2023 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <ccaffy@cern.ch>
+// File Date: Oct 2023
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+
+#include <sstream>
+#include "PMarkManager.hh"
+
+PMarkManager::SocketInfo::SocketInfo(int fd, const struct sockaddr * sockP) {
+  netAddr.Set(sockP,fd);
+  client.addrInfo = static_cast<XrdNetAddrInfo*>(&netAddr);
+}
+
+PMarkManager::PMarkManager(XrdNetPMark *pmark) : mPmark(pmark), mTransferWillStart(false) {}
+
+void PMarkManager::addFd(int fd, const struct sockaddr * sockP) {
+  if(mPmark && mTransferWillStart && mReq->mSciTag >= 0) {
+    // The transfer will start and the packet marking has been configured, this socket must be registered for future packet marking
+    mSocketInfos.emplace(fd, sockP);
+  }
+}
+
+void PMarkManager::startTransfer(XrdHttpExtReq * req) {
+  mReq = req;
+  mTransferWillStart = true;
+}
+
+void PMarkManager::beginPMarks() {
+  if(!mSocketInfos.empty() && mPmarkHandles.empty()) {
+    // Create the first pmark handle that will be used as a basis for the other handles
+    // if that handle cannot be created (mPmark->Begin() would return nullptr), then the packet marking will not work
+    // This base pmark handle will be placed at the beginning of the vector of pmark handles
+    std::stringstream ss;
+    ss << "scitag.flow=" << mReq->mSciTag;
+    auto sockInfo = mSocketInfos.front();
+    mInitialFD = sockInfo.client.addrInfo->SockFD();
+    mPmarkHandles.emplace(mInitialFD,mPmark->Begin(sockInfo.client, mReq->resource.c_str(), ss.str().c_str(), "http-tpc"));
+    mSocketInfos.pop();
+  } else {
+    // The first pmark handle was created, or not. Create the other pmark handles from the other connected sockets
+    while(!mSocketInfos.empty()) {
+      auto & sockInfo = mSocketInfos.front();
+      if(mPmarkHandles[mInitialFD]){
+        mPmarkHandles.emplace(sockInfo.client.addrInfo->SockFD(),mPmark->Begin(*sockInfo.client.addrInfo, *mPmarkHandles[mInitialFD], nullptr));
+      }
+      mSocketInfos.pop();
+    }
+  }
+}
+
+void PMarkManager::endPmark(int fd) {
+  // We need to delete the PMark handle associated to the fd passed in parameter
+  // we just look for it and reset the unique_ptr to nullptr to trigger the PMark handle deletion
+  mPmarkHandles.erase(fd);
+}

--- a/src/XrdTpc/PMarkManager.hh
+++ b/src/XrdTpc/PMarkManager.hh
@@ -1,0 +1,113 @@
+//------------------------------------------------------------------------------
+// This file is part of XrdTpcTPC
+//
+// Copyright (c) 2023 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <ccaffy@cern.ch>
+// File Date: Oct 2023
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+#ifndef XROOTD_PMARKMANAGER_HH
+#define XROOTD_PMARKMANAGER_HH
+
+#include "XrdNet/XrdNetPMark.hh"
+#include "XrdSec/XrdSecEntity.hh"
+#include "XrdNet/XrdNetAddrInfo.hh"
+#include "XrdNet/XrdNetAddr.hh"
+#include "XrdHttp/XrdHttpExtHandler.hh"
+
+#include <map>
+#include <memory>
+#include <queue>
+
+/**
+ * This class will manage packet marking handles for TPC transfers
+ *
+ * Each time a socket will be opened by curl (via the opensocket_callback), the manager
+ * will register the related information to the socket.
+ *
+ * Once the transfer will start we will start the packet marking by creating XrdNetPMark::Handle
+ * objects from the socket information previously registered.
+ *
+ * In the case of multi-stream HTTP TPC transfers, a packet marking handle will be created for each stream.
+ * The first one will be created as a basic one. The other will be created using the first packet marking handle as a basis.
+ */
+class PMarkManager {
+public:
+
+  /**
+   * This class allows to create and keep a XrdSecEntity object
+   * from the socket file descriptor and address
+   * Everything is done on the constructor
+   *
+   * These infos will be used later on when we create new PMark handles
+   */
+  class SocketInfo {
+  public:
+    SocketInfo(int fd, const struct sockaddr * sockP);
+    XrdNetAddr netAddr;
+    XrdSecEntity client;
+  };
+
+  PMarkManager(XrdNetPMark * pmark);
+  /**
+   * Add the connected socket information that will be used for packet marking to this manager class
+   * Note: these info will only be added if startTransfer(...) has been called. It allows
+   * to ensure that the connection will be related to the data transfers and not for anything else. We only want
+   * to mark the traffic of the transfers.
+   * @param fd the socket file descriptor
+   * @param sockP the structure describing the address of the socket
+   */
+  void addFd(int fd, const struct sockaddr * sockP);
+
+  /**
+   * Calling this function will indicate that the connections that will happen will be related to the
+   * data transfer. The addFd(...) function will then register any socket that is created after this function
+   * will be called.
+   * @param req the request object that will be used later on to get some information about the transfer
+   */
+  void startTransfer(XrdHttpExtReq * req);
+  /**
+   * Creates the different packet marking handles allowing to mark the transfer packets
+   *
+   * Call this after the curl_multi_perform() has been called.
+   */
+  void beginPMarks();
+
+  /**
+   * This function deletes the PMark handle associated to the fd passed in parameter
+   * Use this before closing the associated socket! Otherwise the information contained in the firefly
+   * (e.g sent bytes or received bytes) will have values equal to 0.
+   * @param fd the fd of the socket to be closed
+   */
+  void endPmark(int fd);
+
+  virtual ~PMarkManager() = default;
+private:
+  // The queue of socket information from which we will create the packet marking handles
+  std::queue<SocketInfo> mSocketInfos;
+  // The map of socket FD and packet marking handles
+  std::map<int,std::unique_ptr<XrdNetPMark::Handle>> mPmarkHandles;
+  // The instance of the packet marking functionality
+  XrdNetPMark * mPmark;
+  // Is true when startTransfer(...) has been called
+  bool mTransferWillStart;
+  // The XrdHttpTPC request information
+  XrdHttpExtReq * mReq;
+  // The file descriptor used to create the first packet marking handle
+  int mInitialFD = -1;
+};
+
+
+#endif //XROOTD_PMARKMANAGER_HH

--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -281,6 +281,9 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         curl_handles.emplace_back(handles.back()->GetHandle());
     }
 
+    // Notify the packet marking manager that the transfer will start after this point
+  rec.pmarkManager.startTransfer(&req);
+
     // Create the multi-handle and add in the current transfer to it.
     MultiCurlHandler mch(handles, m_log);
     CURLM *multi_handle = mch.Get();
@@ -346,6 +349,9 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         } else if (mres != CURLM_OK) {
             break;
         }
+
+        rec.pmarkManager.beginPMarks();
+
 
         // Harvest any messages, looking for CURLMSG_DONE.
         CURLMsg *msg;

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -119,18 +119,34 @@ int TPCHandler::opensocket_callback(void *clientp,
                                     curlsocktype purpose,
                                     struct curl_sockaddr *aInfo)
 {
-// See what kind of address will be used to connect
-//
-if (purpose == CURLSOCKTYPE_IPCXN && clientp)
-   {XrdNetAddr thePeer(&(aInfo->addr));
-    ((TPCLogRecord *)clientp)->isIPv6 =  (thePeer.isIPType(XrdNetAddrInfo::IPv6)
-                                      && !thePeer.isMapped());
-   }
+  //Return a socket file descriptor (note the clo_exec flag will be set).
+  int fd = XrdSysFD_Socket(aInfo->family, aInfo->socktype, aInfo->protocol);
+  // See what kind of address will be used to connect
+  //
+  if(fd < 0) {
+    return CURL_SOCKET_BAD;
+  }
+  TPCLogRecord * rec = (TPCLogRecord *)clientp;
+  if (purpose == CURLSOCKTYPE_IPCXN && clientp)
+  {XrdNetAddr thePeer(&(aInfo->addr));
+    rec->isIPv6 =  (thePeer.isIPType(XrdNetAddrInfo::IPv6)
+                    && !thePeer.isMapped());
+    // Register the socket to the packet marking manager
+    rec->pmarkManager.addFd(fd,&aInfo->addr);
+  }
 
-// Return a socket file descriptor (note the clo_exec flag will be set).
-//
-   int fd = XrdSysFD_Socket(aInfo->family, aInfo->socktype, aInfo->protocol);
-   return (fd >= 0 ? fd : CURL_SOCKET_BAD);
+  return fd;
+}
+
+int TPCHandler::closesocket_callback(void *clientp, curl_socket_t fd) {
+  TPCLogRecord * rec = (TPCLogRecord *)clientp;
+
+  // Destroy the PMark handle associated to the file descriptor before closing it.
+  // Otherwise, we would lose the socket usage information if the socket is closed before
+  // the PMark handle is closed.
+  rec->pmarkManager.endPmark(fd);
+
+  return close(fd);
 }
 
 /******************************************************************************/
@@ -644,6 +660,8 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
             }
             last_marker = now;
         }
+        // The transfer will start after this point, notify the packet marking manager
+      rec.pmarkManager.startTransfer(&req);
         mres = curl_multi_perform(multi_handle, &running_handles);
         if (mres == CURLM_CALL_MULTI_PERFORM) {
             // curl_multi_perform should be called again immediately.  On newer
@@ -654,6 +672,8 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
         } else if (running_handles == 0) {
             break;
         }
+
+        rec.pmarkManager.beginPMarks();
         //printf("There are %d running handles\n", running_handles);
 
         // Harvest any messages, looking for CURLMSG_DONE.
@@ -828,7 +848,7 @@ int TPCHandler::RunCurlBasic(CURL *curl, XrdHttpExtReq &req, State &state,
 /******************************************************************************/
   
 int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req) {
-    TPCLogRecord rec;
+    TPCLogRecord rec(req.pmark);
     rec.log_prefix = "PushRequest";
     rec.local = req.resource;
     rec.remote = resource;
@@ -849,6 +869,8 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
 //  curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_setcloexec_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &rec);
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket_callback);
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, &rec);
     auto query_header = req.headers.find("xrd-http-fullresource");
     std::string redirect_resource = req.resource;
     if (query_header != req.headers.end()) {
@@ -908,7 +930,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
 /******************************************************************************/
   
 int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) {
-    TPCLogRecord rec;
+    TPCLogRecord rec(req.pmark);
     rec.log_prefix = "PullRequest";
     rec.local = req.resource;
     rec.remote = resource;
@@ -929,6 +951,8 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
 //  curl_easy_setopt(curl,CURLOPT_SOCKOPTFUNCTION,sockopt_setcloexec_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &rec);
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETFUNCTION, closesocket_callback);
+    curl_easy_setopt(curl, CURLOPT_CLOSESOCKETDATA, &rec);
     std::unique_ptr<XrdSfsFile> fh(m_sfs->newFile(name, m_monid++));
     if (!fh.get()) {
             char msg[] = "Failed to initialize internal transfer file handle";

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -10,6 +10,7 @@
 #include "XrdHttp/XrdHttpUtils.hh"
 
 #include "XrdTls/XrdTlsTempCA.hh"
+#include "PMarkManager.hh"
 
 #include <curl/curl.h>
 
@@ -55,10 +56,12 @@ private:
                                    curlsocktype purpose,
                                    struct curl_sockaddr *address);
 
+    static int closesocket_callback(void *clientp, curl_socket_t fd);
+
     struct TPCLogRecord {
 
-        TPCLogRecord() : bytes_transferred( -1 ), status( -1 ),
-                         tpc_status(-1), streams( 1 ), isIPv6(false)
+        TPCLogRecord(XrdNetPMark * pmark) : bytes_transferred( -1 ), status( -1 ),
+                         tpc_status(-1), streams( 1 ), isIPv6(false), pmarkManager(pmark)
         {
          gettimeofday(&begT, 0); // Set effective start time
         }
@@ -76,6 +79,7 @@ private:
         int tpc_status;
         unsigned int streams;
         bool isIPv6;
+        PMarkManager pmarkManager;
     };
 
     int ProcessOptionsReq(XrdHttpExtReq &req);


### PR DESCRIPTION
Hi @abh3 ,

I think this functionality is progressing well.

I've managed to have some packet marking emitted with HTTP TPC transfers PUSH and PULL single and multi (PULL) streams.

Now, by looking at the JSON of the firefly, I'm not sure this is working 100%.

If I do a PULL single stream `curl -v --capath /etc/grid-security/certificates -L -X COPY  -H "Source: $DST" -H "SciTag: 144" "$SRC"` for example, here are the JSON fireflies that is sent by the pulling server at the beginning and the end of the transfer:

```json
{"version":1,"flow-lifecycle":{"state":"start","current-time":"2023-10-19T16:06:25.224773+00:00","start-time":"2023-10-19T16:06:25.224773+00:00"},"usage":{"received":0,"sent":136},"netlink":{"rtt":0.061},"context":{"experiment-id":2,"activity-id":16,"application":"http-tpc"},"flow-id":{"afi":"ipv4","src-ip":"xxx.xxx.xxx.xx","dst-ip":"xxx.xxx.xxx.xx","protocol":"tcp","src-port":52326,"dst-port":2001}}
```

```json
{"version":1,"flow-lifecycle":{"state":"end","current-time":"2023-10-19T16:07:49.906540+00:00","start-time":"2023-10-19T16:06:25.224773+00:00","end-time":"2023-10-19T16:07:49.906540+00:00"},"usage":{"received":0,"sent":0},"netlink":{"rtt":0.000},"context":{"experiment-id":2,"activity-id":16,"application":"http-tpc"},"flow-id":{"afi":"ipv4","src-ip":"xxx.xxx.xxx.xx","dst-ip":"xxx.xxx.xxx.xx","protocol":"tcp","src-port":52326,"dst-port":2001}}
```

What puzzles me is the value of `received` and `sent` that are equal to 0. Are these normal? Otherwise, the other fields look correct to me :)

Thanks.