### PR TITLE
[XrdCrypto] Fix ODR violation reported by address sanitizer

### DIFF
--- a/src/XrdCrypto/XrdCryptoAux.cc
+++ b/src/XrdCrypto/XrdCryptoAux.cc
@@ -36,11 +36,13 @@
 // For error logging and tracing
 static XrdSysLogger Logger;
 static XrdSysError eDest(0,"crypto_");
-XrdOucTrace *cryptoTrace = 0;
+static XrdOucTrace *cryptoTraceObj = nullptr;
 //
 // Time Zone correction (wrt UTC)
 static time_t TZCorr = 0;
 static bool TZInitialized = 0;
+
+XrdOucTrace* cryptoTrace() { return cryptoTraceObj; }
 
 /******************************************************************************/
 /*  X r d C r y p t o S e t T r a c e                                         */
@@ -53,20 +55,20 @@ void XrdCryptoSetTrace(kXR_int32 trace)
    //
    // Initiate error logging and tracing
    eDest.logger(&Logger);
-   if (!cryptoTrace)
-      cryptoTrace = new XrdOucTrace(&eDest);
-   if (cryptoTrace) {
+   if (!cryptoTraceObj)
+      cryptoTraceObj = new XrdOucTrace(&eDest);
+   if (cryptoTraceObj) {
       // Set debug mask
-      cryptoTrace->What = 0;
+      cryptoTraceObj->What = 0;
       // Low level only
       if ((trace & cryptoTRACE_Notify))
-         cryptoTrace->What |= cryptoTRACE_Notify;
+         cryptoTraceObj->What |= cryptoTRACE_Notify;
       // Medium level
       if ((trace & cryptoTRACE_Debug))
-         cryptoTrace->What |= (cryptoTRACE_Notify | cryptoTRACE_Debug);
+         cryptoTraceObj->What |= (cryptoTRACE_Notify | cryptoTRACE_Debug);
       // High level
       if ((trace & cryptoTRACE_Dump))
-         cryptoTrace->What |= cryptoTRACE_ALL;
+         cryptoTraceObj->What |= cryptoTRACE_ALL;
    }
 }
 

--- a/src/XrdCrypto/XrdCryptoRSA.cc
+++ b/src/XrdCrypto/XrdCryptoRSA.cc
@@ -38,8 +38,6 @@
 
 #include "XrdCrypto/XrdCryptoRSA.hh"
 
-const char *XrdCryptoRSA::cstatus[3] = { "Invalid", "Public", "Complete" };
-
 //_____________________________________________________________________________
 void XrdCryptoRSA::Dump()
 {

--- a/src/XrdCrypto/XrdCryptoRSA.hh
+++ b/src/XrdCrypto/XrdCryptoRSA.hh
@@ -92,7 +92,8 @@ public:
    int DecryptPrivate(XrdSutBucket &buck);
 
 private:
-   static const char *cstatus[3];  // Names of status
+   // Names of status
+   const char *cstatus[3] = { "Invalid", "Public", "Complete" };
 };
 
 #endif

--- a/src/XrdCrypto/XrdCryptoTrace.hh
+++ b/src/XrdCrypto/XrdCryptoTrace.hh
@@ -36,9 +36,9 @@
 
 #include "XrdSys/XrdSysHeaders.hh"
 
-#define QTRACE(act) (cryptoTrace && (cryptoTrace->What & cryptoTRACE_ ## act))
-#define PRINT(y)    {if (cryptoTrace) {cryptoTrace->Beg(epname); \
-                                       std::cerr <<y; cryptoTrace->End();}}
+#define QTRACE(act) (cryptoTrace() && (cryptoTrace()->What & cryptoTRACE_ ## act))
+#define PRINT(y)    {if (cryptoTrace()) {cryptoTrace()->Beg(epname); \
+                                       std::cerr <<y; cryptoTrace()->End();}}
 #define TRACE(act,x) if (QTRACE(act)) PRINT(x)
 #define DEBUG(y)     TRACE(Debug,y)
 #define EPNAME(x)    static const char *epname = x;
@@ -55,6 +55,6 @@
 
 //
 // For error logging and tracing
-extern XrdOucTrace *cryptoTrace;
+XrdOucTrace* cryptoTrace();
 
 #endif

--- a/src/XrdCrypto/XrdCryptoX509.cc
+++ b/src/XrdCrypto/XrdCryptoX509.cc
@@ -41,8 +41,6 @@
 #include "XrdCrypto/XrdCryptoX509.hh"
 #include "XrdCrypto/XrdCryptoTrace.hh"
 
-const char *XrdCryptoX509::ctype[4] = { "Unknown", "CA", "EEC", "Proxy" };
-
 #define kAllowedSkew 600
 
 //_____________________________________________________________________________

--- a/src/XrdCrypto/XrdCryptoX509.hh
+++ b/src/XrdCrypto/XrdCryptoX509.hh
@@ -122,7 +122,9 @@ public:
 
 private:
 
-   static const char *ctype[4];  // Names of types
+   // Names of types
+   const char *ctype[4] = { "Unknown", "CA", "EEC", "Proxy" };
+
 };
 
 #endif


### PR DESCRIPTION
Several source files are added both into XrdCrypto and XrdUtils, including XrdCryptoAux.cc. This causes some global symbols to violate ODR because libXrdCrypto.so is linked to libXrdUtils.so.