### PR TITLE
Installed CMake files are architecture dependent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in cmake/${PROJE
   INSTALL_PREFIX
     ${CMAKE_INSTALL_PREFIX}
   INSTALL_DESTINATION
-    ${CMAKE_INSTALL_DATADIR}/xrootd/cmake
+    ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
   PATH_VARS
     CMAKE_INSTALL_INCLUDEDIR
     CMAKE_INSTALL_LIBDIR
@@ -76,7 +76,7 @@ configure_package_config_file(cmake/${PROJECT_NAME}Config.cmake.in cmake/${PROJE
 )
 
 install(DIRECTORY ${PROJECT_BINARY_DIR}/cmake/
-  DESTINATION ${CMAKE_INSTALL_DATADIR}/xrootd/cmake)
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 #-------------------------------------------------------------------------------
 # Configure an 'uninstall' target

--- a/packaging/debian/libxrootd-dev.install
+++ b/packaging/debian/libxrootd-dev.install
@@ -13,4 +13,4 @@ usr/lib/*/libXrdCrypto.so
 usr/lib/*/libXrdCryptoLite.so
 usr/lib/*/libXrdUtils.so
 usr/lib/*/libXrdXml.so
-usr/share/xrootd/cmake/XRootDConfig.cmake
+usr/lib/*/cmake/XRootD

--- a/packaging/rhel/xrootd.spec.in
+++ b/packaging/rhel/xrootd.spec.in
@@ -919,7 +919,7 @@ fi
 %{_libdir}/libXrdUtils.so
 %{_libdir}/libXrdXml.so
 %{_includedir}/xrootd/XrdXml/XrdXmlReader.hh
-%{_datadir}/xrootd/cmake
+%{_libdir}/cmake/XRootD
 
 %files client-libs
 %defattr(-,root,root,-)


### PR DESCRIPTION
The installed cmake files are now generated and contain architecture dependent information. Installing them in datadir (/usr/share) now results in conflicts if packages for more than one architecture is installed in parallel. Move the installed cmake files to libdir (/usr/lib(64)?, /usr/lib/<architecture>).

Found by Debian's MultiArch hinter.