### PR TITLE
Fix header dependencies and missing includes/declarations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -195,7 +195,7 @@ jobs:
       run: sudo sed -i -e "s/localhost/localhost $(hostname)/g" /etc/hosts
 
     - name: Install dependencies with Homebrew
-      run: brew install cmake cppunit davix googletest isa-l openssl@3 python3
+      run: brew install cppunit davix googletest isa-l
 
     - name: Install Python dependencies with pip
       run: python3 -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,9 @@ jobs:
       run: cmake --install build
 
     - name: Run post-install tests
-      run: tests/post-install.sh
+      run: |
+        tests/post-install.sh
+        tests/check-headers.sh
 
   fedora:
     name: Fedora
@@ -81,7 +83,7 @@ jobs:
 
     env:
       CMAKE_GENERATOR: Ninja
-      CMAKE_ARGS: -DCMAKE_INSTALL_RPATH='$ORIGIN/../$LIB'
+      CMAKE_ARGS: "-DCMAKE_INSTALL_PREFIX=/usr;-DCMAKE_INSTALL_RPATH='$ORIGIN/../$LIB'"
 
     steps:
     - name: Install dependencies
@@ -102,7 +104,9 @@ jobs:
       run: cmake --install build
 
     - name: Run post-install tests
-      run: tests/post-install.sh
+      run: |
+        tests/post-install.sh
+        tests/check-headers.sh
 
   ubuntu:
     name: Ubuntu
@@ -168,7 +172,9 @@ jobs:
           --use-pep517 --verbose build/bindings/python
 
     - name: Run post-install tests
-      run: tests/post-install.sh
+      run: |
+        tests/post-install.sh
+        tests/check-headers.sh
 
   macos:
     strategy:

--- a/src/Xrd/XrdLinkMatch.hh
+++ b/src/Xrd/XrdLinkMatch.hh
@@ -29,8 +29,7 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
-#include <strings.h>
-#include <cstdlib>
+#include <cstring>
   
 class XrdLinkMatch
 {

--- a/src/Xrd/XrdTcpMonPin.hh
+++ b/src/Xrd/XrdTcpMonPin.hh
@@ -42,6 +42,8 @@
     @endcode
 */
 
+class XrdNetAddrInfo;
+
 class XrdTcpMonPin
 {
 public:

--- a/src/XrdCks/XrdCksAssist.hh
+++ b/src/XrdCks/XrdCksAssist.hh
@@ -33,6 +33,8 @@
 #include <string>
 #include <vector>
 
+#include <time.h>
+
 //------------------------------------------------------------------------------
 //! This header file defines linkages to various XRootD checksum assistants.
 //! The functions described here are located in libXrdUtils.so.

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -198,7 +198,6 @@ install(
     XrdClXRootDResponses.hh
     XrdClOptional.hh
     XrdClPlugInInterface.hh
-    XrdClPlugInManager.hh
     XrdClPropertyList.hh
     XrdClLog.hh
   DESTINATION    ${CMAKE_INSTALL_INCLUDEDIR}/xrootd/XrdCl )
@@ -208,6 +207,7 @@ install(
     # Additional client headers
     XrdClJobManager.hh
     XrdClMessage.hh
+    XrdClPlugInManager.hh
     XrdClPostMaster.hh
     XrdClPostMasterInterfaces.hh
     XrdClTransportManager.hh

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -206,11 +206,13 @@ install(
 install(
   FILES
     # Additional client headers
+    XrdClJobManager.hh
     XrdClMessage.hh
     XrdClPostMaster.hh
     XrdClPostMasterInterfaces.hh
     XrdClTransportManager.hh
     XrdClResponseJob.hh
+    XrdClSyncQueue.hh
     XrdClZipArchive.hh
     XrdClZipCache.hh
     # Declarative operations
@@ -224,6 +226,8 @@ install(
     XrdClFileOperations.hh
     XrdClFileSystemOperations.hh
     XrdClFinalOperation.hh
+    XrdClUtils.hh
+    XrdClXRootDTransport.hh
     XrdClZipOperations.hh 
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xrootd/private/XrdCl )
 

--- a/src/XrdCl/XrdClArg.hh
+++ b/src/XrdCl/XrdClArg.hh
@@ -29,6 +29,7 @@
 #include "XrdCl/XrdClFwd.hh"
 #include "XrdCl/XrdClOptional.hh"
 
+#include <future>
 #include <string>
 #include <sstream>
 #include <unordered_map>

--- a/src/XrdCl/XrdClCtx.hh
+++ b/src/XrdCl/XrdClCtx.hh
@@ -27,6 +27,7 @@
 #define SRC_XRDCL_XRDCLCTX_HH_
 
 #include <memory>
+#include <stdexcept>
 
 namespace XrdCl
 {

--- a/src/XrdCl/XrdClFinalOperation.hh
+++ b/src/XrdCl/XrdClFinalOperation.hh
@@ -30,6 +30,8 @@
 
 namespace XrdCl
 {
+  class XRootDStatus;
+
   //---------------------------------------------------------------------------
   //! Final operation in the pipeline, always executed, no matter if the
   //! pipeline failed or not.

--- a/src/XrdEc/CMakeLists.txt
+++ b/src/XrdEc/CMakeLists.txt
@@ -40,15 +40,17 @@ install(
 #------------------------------------------------------------------------------
 # Install private header files
 #------------------------------------------------------------------------------
-install(
-  FILES
-    XrdEcReader.hh
-    XrdEcObjCfg.hh
-    XrdEcStrmWriter.hh
-    XrdEcWrtBuff.hh
-    XrdEcThreadPool.hh
-    XrdEcUtilities.hh
-    XrdEcObjCfg.hh
-    XrdEcConfig.hh
-    XrdEcRedundancyProvider.hh
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xrootd/private/XrdEc )
+if (USE_SYSTEM_ISAL)
+  install(
+    FILES
+      XrdEcReader.hh
+      XrdEcObjCfg.hh
+      XrdEcStrmWriter.hh
+      XrdEcWrtBuff.hh
+      XrdEcThreadPool.hh
+      XrdEcUtilities.hh
+      XrdEcObjCfg.hh
+      XrdEcConfig.hh
+      XrdEcRedundancyProvider.hh
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xrootd/private/XrdEc )
+endif()

--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -185,10 +185,15 @@ if( NOT XRDCL_ONLY )
     XrdSut/XrdSutAux.hh
     XrdSut/XrdSutBucket.hh
 
-    XrdVoms/XrdVoms.hh
-
     XrdOuc/XrdOucPgrwUtils.hh
 )
+
+  if ( BUILD_VOMS )
+    set( XROOTD_PRIVATE_HEADERS
+      ${XROOTD_PRIVATE_HEADERS}
+      XrdVoms/XrdVoms.hh
+    )
+  endif()
 endif()
 
 install_headers(

--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -128,12 +128,16 @@ set( XROOTD_PRIVATE_HEADERS
   XrdNet/XrdNetIF.hh
   XrdSecsss/XrdSecsssID.hh
   XrdSys/XrdSysPriv.hh
+  XrdOuc/XrdOucCRC32C.hh
   XrdOuc/XrdOucExport.hh
   XrdOuc/XrdOucGatherConf.hh
   XrdOuc/XrdOucPList.hh
   XrdOuc/XrdOucN2NLoader.hh
+  XrdOuc/XrdOucPinLoader.hh
+  XrdOuc/XrdOucTUtils.hh
   XrdPosix/XrdPosixMap.hh
   XrdZip/XrdZipCDFH.hh
+  XrdZip/XrdZipDataDescriptor.hh
   XrdZip/XrdZipEOCD.hh
   XrdZip/XrdZipExtra.hh
   XrdZip/XrdZipLFH.hh
@@ -172,6 +176,7 @@ if( NOT XRDCL_ONLY )
     XrdCrypto/XrdCryptoX509.hh
     XrdCrypto/XrdCryptoX509Chain.hh
     XrdCrypto/XrdCryptoAux.hh
+    XrdCrypto/XrdCryptoFactory.hh
     XrdCrypto/XrdCryptosslAux.hh
     XrdCrypto/XrdCryptoX509Crl.hh
     XrdCrypto/XrdCryptoX509Req.hh

--- a/src/XrdOuc/XrdOucPList.hh
+++ b/src/XrdOuc/XrdOucPList.hh
@@ -31,7 +31,7 @@
 /******************************************************************************/
 
 #include <cstdio>
-#include <strings.h>
+#include <cstring>
 #include <cstdlib>
   
 class XrdOucPList

--- a/src/XrdOuc/XrdOucPinObject.hh
+++ b/src/XrdOuc/XrdOucPinObject.hh
@@ -36,7 +36,7 @@
 */
 
 class XrdOucEnv;
-class XrdOucLogger;
+class XrdSysLogger;
 
 template<class T>
 class XrdOucPinObject

--- a/src/XrdPosix/XrdPosixMap.hh
+++ b/src/XrdPosix/XrdPosixMap.hh
@@ -31,10 +31,11 @@
 /* Modified by Frank Winklmeier to add the full Posix file system definition. */
 /******************************************************************************/
 
-#include <cstdint>
-
 #include "XrdCl/XrdClFileSystem.hh"
 #include "XrdCl/XrdClXRootDResponses.hh"
+
+#include <cstdint>
+#include <sys/types.h>
 
 class XrdPosixMap
 {

--- a/src/XrdPosix/XrdPosixXrootdPath.hh
+++ b/src/XrdPosix/XrdPosixXrootdPath.hh
@@ -29,6 +29,8 @@
 /* be used to endorse or promote products derived from this software without  */
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
+
+#include <cstring>
   
 class XrdPosixXrootPath
 {

--- a/src/XrdSec/XrdSecEntityPin.hh
+++ b/src/XrdSec/XrdSecEntityPin.hh
@@ -39,6 +39,9 @@
     the entity object, if a stacked plugin exists; unless you return false.
 */
 
+class XrdOucErrInfo;
+class XrdSecEntity;
+
 class XrdSecEntityPin
 {
 public:

--- a/src/XrdSfs/XrdSfsGPFile.hh
+++ b/src/XrdSfs/XrdSfsGPFile.hh
@@ -29,6 +29,8 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
+#include <cstdint>
+
 class XrdSfsGPInfo;
 
 class XrdSfsGPFile

--- a/src/XrdZip/XrdZipCDFH.hh
+++ b/src/XrdZip/XrdZipCDFH.hh
@@ -36,6 +36,8 @@
 #include <memory>
 #include <tuple>
 
+#include <sys/types.h>
+
 namespace XrdZip
 {
   //---------------------------------------------------------------------------

--- a/src/XrdZip/XrdZipDataDescriptor.hh
+++ b/src/XrdZip/XrdZipDataDescriptor.hh
@@ -25,6 +25,8 @@
 #ifndef SRC_XRDZIP_XRDZIPDATADESCRIPTOR_HH_
 #define SRC_XRDZIP_XRDZIPDATADESCRIPTOR_HH_
 
+#include <cstdint>
+
 namespace XrdZip
 {
   //---------------------------------------------------------------------------

--- a/src/XrdZip/XrdZipExtra.hh
+++ b/src/XrdZip/XrdZipExtra.hh
@@ -27,6 +27,9 @@
 
 #include "XrdZip/XrdZipUtils.hh"
 
+#include <cstdint>
+#include <sys/types.h>
+
 namespace XrdZip
 {
   //---------------------------------------------------------------------------

--- a/src/XrdZip/XrdZipUtils.hh
+++ b/src/XrdZip/XrdZipUtils.hh
@@ -25,12 +25,12 @@
 #ifndef SRC_XRDZIP_XRDZIPUTILS_HH_
 #define SRC_XRDZIP_XRDZIPUTILS_HH_
 
-#include <cstring>
-
-#include <ctime>
-#include <vector>
 #include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
 #include <iterator>
+#include <vector>
 
 namespace XrdZip
 {

--- a/tests/check-headers.sh
+++ b/tests/check-headers.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# This script checks that each installed public and private XRootD header can
+# be included individually without errors. The intention is to identify which
+# headers may have missing includes, missing forward declarations, or missing
+# header dependencies, that is, headers from XRootD which it includes, but were
+# not installed by the install target.
+
+# We need to split CXXFLAGS
+# shellcheck disable=SC2086
+
+: "${CXX:=c++}"
+: "${CXXFLAGS:=-Wall}"
+: "${INCLUDE_DIR:=${1:-/usr/include/xrootd}}"
+
+if ! command -v "${CXX}" >/dev/null; then
+	exit 1
+fi
+
+STATUS=0
+
+HEADERS=$(find "${INCLUDE_DIR}" -type f -name '*.hh')
+PUBLIC_HEADERS=$(grep -E -v '(XrdPosix|private)' <<< "${HEADERS}")
+PRIVATE_HEADERS=$(grep private <<< "${HEADERS}")
+
+# Check public headers without adding private include directory.
+# This ensures public headers do not depend on any private headers.
+
+while IFS=$'\n' read -r HEADER; do
+	"${CXX}" -fsyntax-only ${CXXFLAGS} -I"${INCLUDE_DIR}" "${HEADER}" || STATUS=1
+done <<< "${PUBLIC_HEADERS}"
+
+# Check private headers
+
+while IFS=$'\n' read -r HEADER; do
+	"${CXX}" -fsyntax-only ${CXXFLAGS} -I"${INCLUDE_DIR}"{,/private} "${HEADER}" || STATUS=1
+done <<< "${PRIVATE_HEADERS}"
+
+exit $STATUS


### PR DESCRIPTION
@apeters1971 Reported to me that some headers that he needed to develop Zip support on EOS were not installed by XRootD, so this pull request adds a script that checks that each installed public and private XRootD header can be included individually without errors. The subsequent commits are fixes for the errors reported by this script. The intention is to identify which headers may have missing includes, missing forward declarations, or missing header dependencies, that is, headers from XRootD which it includes, but were not installed by the install target.

 
