### PR TITLE
Fix maybe-uninitialized warning

### DIFF
--- a/src/XrdEc/XrdEcReader.cc
+++ b/src/XrdEc/XrdEcReader.cc
@@ -929,7 +929,7 @@ namespace XrdEc
 			}
 
 			blockMap[blkid]->state[strpid] = block_t::Loading;
-			XrdCl::StatInfo* info;
+			XrdCl::StatInfo* info = nullptr;
 			if(dataarchs[url]->Stat(objcfg.GetFileName(blkid, strpid), info).IsOK())
 				blockMap[blkid]->stripes[strpid].resize( info ->GetSize() );
 


### PR DESCRIPTION
```
.../src/XrdEc/XrdEcReader.cc:934:72: error: ‘info’ may be used uninitialized [-Werror=maybe-uninitialized]
  934 |                                 blockMap[blkid]->stripes[strpid].resize( info ->GetSize() );
      |                                                                        ^
.../src/XrdEc/XrdEcReader.cc:932:42: note: ‘info’ was declared here
  932 |                         XrdCl::StatInfo* info;
      |                                          ^
```
