### PR TITLE
Switch from using a cert file to a cert chain file

### DIFF
--- a/src/XrdTls/XrdTlsContext.cc
+++ b/src/XrdTls/XrdTlsContext.cc
@@ -719,7 +719,7 @@ XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
 
 // Load certificate
 //
-   if (SSL_CTX_use_certificate_file(pImpl->ctx, cert, SSL_FILETYPE_PEM) != 1)
+   if (SSL_CTX_use_certificate_chain_file(pImpl->ctx, cert) != 1)
       FATAL_SSL("Unable to create TLS context; invalid certificate.");
 
 // Load the private key


### PR DESCRIPTION
Outside most grid contexts, we need to present the certificate chain in the TLS handshake for the verification path through the intermediate CA to the root.

This commit switches over to the corresponding OpenSSL function call.

Fixes the ability to use most CAB CAs with XRootD.

If, for some reason, the prior behavior is desired, the host certificate file can be limited to contain only the host certificate.  I don't expected this to cause any backward compatibility issues as certificates issued by CAs needing this functionality were already broken.

Fixes #2126 