### PR TITLE
[SciTokens] Initialize SecEntity.addrInfo to avoid SEGV

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -532,6 +532,7 @@ public:
         new_secentity.grps = nullptr;
         new_secentity.role = nullptr;
         new_secentity.secMon = Entity->secMon;
+        new_secentity.addrInfo = Entity->addrInfo;
         const auto &issuer = access_rules->get_issuer();
         if (!issuer.empty()) {
             new_secentity.vorg = strdup(issuer.c_str());


### PR DESCRIPTION
Hello,

I noticed a segv; it seems to have been seen already by @bbockelm in #1986 (the trace in the second comment). In that ticket it was thought to be due to the same cause as the trace in the first comment. (Trace in first comment fixed by change in XrdHttpProtocol.cc https://github.com/xrootd/xrootd/commit/b3c667300c30709c1d929ff1fcdb2f2bc2d90ca2 / https://github.com/xrootd/xrootd/commit/14834e6d50f437e6dc33eff9c315fd985b317d6d).

Instead the crash in second comment of #1986 appears to be due similar problem in SciTokens. I've attached a patch. Brian, do you think you be able to review (or try to reproduce your original crash with/without this?)

Thank you!

(Trace from the crash I saw is below)
```
Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffeb773700 (LWP 20065)]
0x00007ffff783ce56 in XrdNetAddrInfo::Name(char const*, char const**) () from /lib64/libXrdUtils.so.3
(gdb) wher
#0  0x00007ffff783ce56 in XrdNetAddrInfo::Name(char const*, char const**) () from /lib64/libXrdUtils.so.3
#1  0x00007ffff7b87b85 in XrdAccAccess::Access(XrdSecEntity const*, char const*, Access_Operation, XrdOucEnv*) ()
   from /lib64/libXrdServer.so.3
#2  0x00007fffef0c81d8 in XrdAccSciTokens::Access(XrdSecEntity const*, char const*, Access_Operation, XrdOucEnv*)
    () from /lib64/libXrdAccSciTokens-5.so
#3  0x00007fffec5ef098 in Macaroons::Authz::Access(XrdSecEntity const*, char const*, Access_Operation, XrdOucEnv*) () from /lib64/libXrdMacaroons-5.so
#4  0x00007ffff7b5015f in XrdOfs::stat(char const*, stat*, XrdOucErrInfo&, XrdSecEntity const*, char const*) ()
   from /lib64/libXrdServer.so.3
#5  0x00007ffff7b45550 in XrdXrootdProtocol::do_Stat() () from /lib64/libXrdServer.so.3
#6  0x00007ffff7b32053 in XrdXrootdProtocol::Process2() () from /lib64/libXrdServer.so.3
#7  0x00007ffff7b36840 in XrdXrootdTransit::Process(XrdLink*) () from /lib64/libXrdServer.so.3
#8  0x00007ffff7871036 in XrdLinkXeq::DoIt() () from /lib64/libXrdUtils.so.3
#9  0x00007ffff786d5c9 in XrdLink::setProtocol(XrdProtocol*, bool, bool) () from /lib64/libXrdUtils.so.3
#10 0x00007ffff787483a in XrdScheduler::Run() () from /lib64/libXrdUtils.so.3
#11 0x00007ffff7874959 in XrdStartWorking(void*) () from /lib64/libXrdUtils.so.3
#12 0x00007ffff77fba37 in XrdSysThread_Xeq () from /lib64/libXrdUtils.so.3
#13 0x00007ffff6962ea5 in start_thread () from /lib64/libpthread.so.0
#14 0x00007ffff668bb0d in clone () from /lib64/libc.so.6
```