### PR TITLE
Avoid /tmp when running some tests

### DIFF
--- a/tests/XRootD/smoke.sh
+++ b/tests/XRootD/smoke.sh
@@ -39,7 +39,7 @@ ${XRDFS} ${HOST} statvfs /
 ${XRDFS} ${HOST} spaceinfo /
 
 # create local temporary directory
-TMPDIR=$(mktemp -d /tmp/xrdfs-test-XXXXXX)
+TMPDIR=$(mktemp -d ${PWD}/xrdfs-test-XXXXXX)
 
 # cleanup after ourselves if something fails
 trap "rm -rf ${TMPDIR}" EXIT

--- a/tests/XrdEc/MicroTest.cc
+++ b/tests/XrdEc/MicroTest.cc
@@ -32,6 +32,8 @@
 
 #include "XrdCl/XrdClMessageUtils.hh"
 
+#include "XrdSys/XrdSysPlatform.hh"
+
 #include "XrdZip/XrdZipCDFH.hh"
 
 #include <string>
@@ -323,7 +325,9 @@ void XrdEcTests::Init( bool usecrc32c )
   objcfg.reset( new ObjCfg( "test.txt", nbdata, nbparity, chsize, usecrc32c, true ) );
   rawdata.clear();
 
-  char tmpdir[32] = "/tmp/xrootd-xrdec-XXXXXX";
+  char tmpdir[MAXPATHLEN];
+  EXPECT_TRUE( getcwd(tmpdir, MAXPATHLEN - 21) );
+  strcat(tmpdir, "/xrootd-xrdec-XXXXXX");
   // create the data directory
   EXPECT_TRUE( mkdtemp(tmpdir) );
   datadir = tmpdir;

--- a/tests/XrdEcTests/MicroTest.cc
+++ b/tests/XrdEcTests/MicroTest.cc
@@ -34,6 +34,8 @@
 
 #include "XrdZip/XrdZipCDFH.hh"
 
+#include "XrdSys/XrdSysPlatform.hh"
+
 #include <string>
 #include <memory>
 #include <limits>
@@ -280,7 +282,9 @@ void MicroTest::Init( bool usecrc32c )
   objcfg.reset( new ObjCfg( "test.txt", nbdata, nbparity, chsize, usecrc32c, true ) );
   rawdata.clear();
 
-  char tmpdir[32] = "/tmp/xrootd-xrdec-XXXXXX";
+  char tmpdir[MAXPATHLEN];
+  CPPUNIT_ASSERT( getcwd(tmpdir, MAXPATHLEN - 21) );
+  strcat(tmpdir, "/xrootd-xrdec-XXXXXX");
   // create the data directory
   CPPUNIT_ASSERT( mkdtemp(tmpdir) );
   datadir = tmpdir;


### PR DESCRIPTION
Many features in xrootd require file system support for extended file attributes. Tests that run tests on these features fail if the file system does not support them. The /tmp directory in many Linux installations is using a tmpfs partition. The tmpfs file system does not support extended file attributes, so some tests that use /tmp to store files fail.

This commit changes some affected tests so that they create the temporary directory containing the test files in the current working directory instead of /tmp.

Example of failure:
```
17/34 Test #20: XrdEc::AlignedWriteTest ...................................................***Failed    0.07 sec
You have selected:

Selected tests/
  Selected tests/MicroTest::AlignedWriteTest

Running:

.F

MicroTest.cc:506:Assertion
Test name: MicroTest::AlignedWriteTest
assertion failed
- Expression: _st.IsOK()
- [*status]: [ERROR] Internal error: std::bad_alloc

Failures !!!
Run: 1   Failure total: 1   Failures: 1   Errors: 0

The following tests FAILED:
	 20 - XrdEc::AlignedWriteTest (Failed)
	 21 - XrdEc::SmallWriteTest (Failed)
	 22 - XrdEc::BigWriteTest (Failed)
	 23 - XrdEc::VectorReadTest (Failed)
	 24 - XrdEc::IllegalVectorReadTest (Failed)
	 25 - XrdEc::AlignedWrite1MissingTest (Failed)
	 26 - XrdEc::AlignedWrite2MissingTest (Failed)
	 27 - XrdEc::AlignedWriteTestIsalCrcNoMt (Failed)
	 28 - XrdEc::SmallWriteTestIsalCrcNoMt (Failed)
	 29 - XrdEc::BigWriteTestIsalCrcNoMt (Failed)
	 30 - XrdEc::AlignedWrite1MissingTestIsalCrcNoMt (Failed)
	 31 - XrdEc::AlignedWrite2MissingTestIsalCrcNoMt (Failed)
```
In addition to addressing the above failures, the commit also addresses the following warnings during the XRootD::smoke-test test:
```
34: setfattr: /tmp/xrdfs-test-ChGSEb/01.ref: Operation not supported
34: Extended attributes not supported, using downloaded checksums for server checks
34: setfattr: /tmp/xrdfs-test-ChGSEb/02.ref: Operation not supported
34: Extended attributes not supported, using downloaded checksums for server checks
34: setfattr: /tmp/xrdfs-test-ChGSEb/03.ref: Operation not supported
34: Extended attributes not supported, using downloaded checksums for server checks
```
