### PR TITLE
Fail gracefully in case of unsupported extended file attributes

### DIFF
--- a/src/XrdCl/XrdClLocalFileHandler.cc
+++ b/src/XrdCl/XrdClLocalFileHandler.cc
@@ -664,6 +664,12 @@ namespace XrdCl
       std::unique_ptr<char[]> buffer;
 
       int size = xattr->Get( name.c_str(), 0, 0, 0, fd );
+      if( size < 0 )
+      {
+        XRootDStatus status( stError, errLocalError, -size );
+        response.push_back( XAttr( *itr, "", status ) );
+        continue;
+      }
       buffer.reset( new char[size] );
       int ret = xattr->Get( name.c_str(), buffer.get(), size, 0, fd );
 


### PR DESCRIPTION
As discussed in https://github.com/xrootd/xrootd/pull/2129#issuecomment-1822270037

If extended attributes are not supported xattr->Get() returns -ENOTSUP. When this small negative value is cast to a size_t in the call to new on the following line it becomes a very large integer and the request to allocate this enormous memory block fails with a std::bad_alloc exception.

This commit adds a check on the returned size and returns an error if it is negative avoiding triggering the std::bad_alloc exception.
