### PR TITLE
Get more useful diagnostics in case of test failures

### DIFF
--- a/tests/XrdCephTests/CephParsingTest.cc
+++ b/tests/XrdCephTests/CephParsingTest.cc
@@ -69,12 +69,12 @@ void checkResult(CephFile a, CephFile b) {
             << " / " << b.name << " " << b.pool << " " << b.userId
             << " " << b.nbStripes << " " << b.stripeUnit << " " << b.objectSize
             << std::endl;
-  CPPUNIT_ASSERT(a.name == b.name);
-  CPPUNIT_ASSERT(a.pool == b.pool);
-  CPPUNIT_ASSERT(a.userId == b.userId);
-  CPPUNIT_ASSERT(a.nbStripes == b.nbStripes);
-  CPPUNIT_ASSERT(a.stripeUnit == b.stripeUnit);
-  CPPUNIT_ASSERT(a.objectSize == b.objectSize);
+  CPPUNIT_ASSERT_EQUAL(a.name, b.name);
+  CPPUNIT_ASSERT_EQUAL(a.pool, b.pool);
+  CPPUNIT_ASSERT_EQUAL(a.userId, b.userId);
+  CPPUNIT_ASSERT_EQUAL(a.nbStripes, b.nbStripes);
+  CPPUNIT_ASSERT_EQUAL(a.stripeUnit, b.stripeUnit);
+  CPPUNIT_ASSERT_EQUAL(a.objectSize, b.objectSize);
 }
 
 //------------------------------------------------------------------------------

--- a/tests/XrdCl/XrdClFileSystemTest.cc
+++ b/tests/XrdCl/XrdClFileSystemTest.cc
@@ -182,7 +182,7 @@ void FileSystemTest::LocateTest()
   LocationInfo *locations = 0;
   GTEST_ASSERT_XRDST( fs.Locate( remoteFile, OpenFlags::Refresh, locations ) );
   EXPECT_TRUE( locations );
-  EXPECT_TRUE( locations->GetSize() != 0 );
+  EXPECT_NE( locations->GetSize(), 0 );
   delete locations;
 }
 
@@ -260,7 +260,7 @@ void FileSystemTest::ServerQueryTest()
   arg.FromString( remoteFile );
   GTEST_ASSERT_XRDST( fs.Query( QueryCode::Checksum, arg, response ) );
   EXPECT_TRUE( response );
-  EXPECT_TRUE( response->GetSize() != 0 );
+  EXPECT_NE( response->GetSize(), 0 );
   delete response;
 }
 
@@ -404,7 +404,7 @@ void FileSystemTest::StatTest()
 
   struct stat localStatBuf;
   int rc = stat(localFilePath.c_str(), &localStatBuf);
-  EXPECT_TRUE( rc == 0 );
+  EXPECT_EQ( rc, 0 );
   uint64_t fileSize = localStatBuf.st_size;
 
   URL url( address );
@@ -414,7 +414,7 @@ void FileSystemTest::StatTest()
   StatInfo *response = 0;
   GTEST_ASSERT_XRDST( fs.Stat( remoteFile, response ) );
   EXPECT_TRUE( response );
-  EXPECT_TRUE( response->GetSize() == fileSize );
+  EXPECT_EQ( response->GetSize(), fileSize );
   EXPECT_TRUE( response->TestFlags( StatInfo::IsReadable ) );
   EXPECT_TRUE( response->TestFlags( StatInfo::IsWritable ) );
   EXPECT_TRUE( !response->TestFlags( StatInfo::IsDir ) );
@@ -496,7 +496,7 @@ void FileSystemTest::DeepLocateTest()
   LocationInfo *locations = 0;
   GTEST_ASSERT_XRDST( fs.DeepLocate( remoteFile, OpenFlags::Refresh, locations ) );
   EXPECT_TRUE( locations );
-  EXPECT_TRUE( locations->GetSize() != 0 );
+  EXPECT_NE( locations->GetSize(), 0 );
   LocationInfo::Iterator it = locations->Begin();
   for( ; it != locations->End(); ++it )
     EXPECT_TRUE( it->IsServer() );
@@ -534,7 +534,7 @@ void FileSystemTest::DirListTest()
   DirectoryList *list = 0;
   GTEST_ASSERT_XRDST( fs.DirList( lsPath, DirListFlags::Stat | DirListFlags::Locate, list ) );
   EXPECT_TRUE( list );
-  EXPECT_TRUE( list->GetSize() == 4000 );
+  EXPECT_EQ( list->GetSize(), 4000 );
 
   std::set<std::string> dirls1;
   for( auto itr = list->Begin(); itr != list->End(); ++itr )
@@ -575,7 +575,7 @@ void FileSystemTest::DirListTest()
   delete info;
   info = 0;
 
-  EXPECT_TRUE( dirls1 == dirls2 );
+  EXPECT_EQ( dirls1, dirls2 );
 
   //----------------------------------------------------------------------------
   // Now list an empty directory
@@ -587,7 +587,7 @@ void FileSystemTest::DirListTest()
   FileSystem fs3( info->Begin()->GetAddress() );
   GTEST_ASSERT_XRDST( fs3.DirList( emptyDirPath, DirListFlags::Stat, list ) );
   EXPECT_TRUE( list );
-  EXPECT_TRUE( list->GetSize() == 0 );
+  EXPECT_EQ( list->GetSize(), 0 );
   GTEST_ASSERT_XRDST( fs.RmDir( emptyDirPath ) );
 
   delete list;
@@ -621,7 +621,7 @@ void FileSystemTest::SendInfoTest()
   Buffer *id = 0;
   GTEST_ASSERT_XRDST( fs.SendInfo( "test stuff", id ) );
   EXPECT_TRUE( id );
-  EXPECT_TRUE( id->GetSize() == 4 );
+  EXPECT_EQ( id->GetSize(), 4 );
   delete id;
 }
 
@@ -723,8 +723,8 @@ void FileSystemTest::XAttrTest()
   {
     GTEST_ASSERT_XRDST( itr3->status );
     auto match = attributes.find( itr3->name );
-    EXPECT_TRUE( match != attributes.end() );
-    EXPECT_TRUE( match->second == itr3->value );
+    EXPECT_NE( match, attributes.end() );
+    EXPECT_EQ( match->second, itr3->value );
   }
   result2.clear();
 
@@ -738,8 +738,8 @@ void FileSystemTest::XAttrTest()
   {
     GTEST_ASSERT_XRDST( itr3->status );
     auto match = attributes.find( itr3->name );
-    EXPECT_TRUE( match != attributes.end() );
-    EXPECT_TRUE( match->second == itr3->value );
+    EXPECT_NE( match, attributes.end() );
+    EXPECT_EQ( match->second, itr3->value );
   }
 
   result2.clear();

--- a/tests/XrdCl/XrdClFileTest.cc
+++ b/tests/XrdCl/XrdClFileTest.cc
@@ -222,9 +222,9 @@ void FileTest::ReadTest()
   std::string localFilePath = localDataPath + "/srv1" + filePath;
 
   int rc = stat(localFilePath.c_str(), &localStatBuf);
-  EXPECT_TRUE( rc == 0 );
+  EXPECT_EQ( rc, 0 );
   uint64_t fileSize = localStatBuf.st_size;
-  EXPECT_TRUE( statInfo->GetSize() == fileSize );
+  EXPECT_EQ( statInfo->GetSize(), fileSize );
   EXPECT_TRUE( statInfo->TestFlags( StatInfo::IsReadable ) );
 
   delete statInfo;
@@ -235,7 +235,7 @@ void FileTest::ReadTest()
   //----------------------------------------------------------------------------
   GTEST_ASSERT_XRDST( f.Stat( true, statInfo ) );
   EXPECT_TRUE( statInfo );
-  EXPECT_TRUE( statInfo->GetSize() == fileSize );
+  EXPECT_EQ( statInfo->GetSize(), fileSize );
   EXPECT_TRUE( statInfo->TestFlags( StatInfo::IsReadable ) );
   delete statInfo;
 
@@ -244,8 +244,8 @@ void FileTest::ReadTest()
   //----------------------------------------------------------------------------
   GTEST_ASSERT_XRDST( f.Read( 5*MB, 5*MB, buffer1, bytesRead1 ) );
   GTEST_ASSERT_XRDST( f.Read( fileSize - 3*MB, 4*MB, buffer2, bytesRead2 ) );
-  EXPECT_TRUE( bytesRead1 == 5*MB );
-  EXPECT_TRUE( bytesRead2 == 3*MB );
+  EXPECT_EQ( bytesRead1, 5*MB );
+  EXPECT_EQ( bytesRead2, 3*MB );
 
   uint32_t crc = XrdClTests::Utils::ComputeCRC32( buffer1, 5*MB );
 
@@ -257,13 +257,13 @@ void FileTest::ReadTest()
   // compute and compare local file buffer crc
   uint32_t crcComp = XrdClTests::Utils::ComputeCRC32( buffer1Comp, 5*MB );
 
-  EXPECT_TRUE( crc == crcComp );
+  EXPECT_EQ( crc, crcComp );
 
   // do the same for the second buffer
   crc = XrdClTests::Utils::ComputeCRC32( buffer2, 3*MB );
   crcComp = XrdClTests::Utils::ComputeCRC32( buffer2Comp, 3*MB );
 
-  EXPECT_TRUE( crc == crcComp );
+  EXPECT_EQ( crc, crcComp );
 
   // cleanup after ourselves
   delete [] buffer1;
@@ -314,7 +314,7 @@ void FileTest::ReadTest()
               result.assign( static_cast<char*>(c.buffer), c.length );
           }
       ) );
-    EXPECT_TRUE( testset[i].expected == result );
+    EXPECT_EQ( testset[i].expected, result );
   }
 
   GTEST_ASSERT_XRDST( WaitFor( CloseArchive( zip ) ) );
@@ -358,8 +358,8 @@ void FileTest::WriteTest()
   uint32_t bytesRead2 = 0;
   File f1, f2;
 
-  EXPECT_TRUE( XrdClTests::Utils::GetRandomBytes( buffer1, 4*MB ) == 4*MB );
-  EXPECT_TRUE( XrdClTests::Utils::GetRandomBytes( buffer2, 4*MB ) == 4*MB );
+  EXPECT_EQ( XrdClTests::Utils::GetRandomBytes( buffer1, 4*MB ), 4*MB );
+  EXPECT_EQ( XrdClTests::Utils::GetRandomBytes( buffer2, 4*MB ), 4*MB );
   uint32_t crc1 = XrdClTests::Utils::ComputeCRC32( buffer1, 4*MB );
   crc1 = XrdClTests::Utils::UpdateCRC32( crc1, buffer2, 4*MB );
 
@@ -381,15 +381,15 @@ void FileTest::WriteTest()
   EXPECT_TRUE( f2.Open( fileUrl, OpenFlags::Read ).IsOK() );
   EXPECT_TRUE( f2.Stat( false, statInfo ).IsOK() );
   EXPECT_TRUE( statInfo );
-  EXPECT_TRUE( statInfo->GetSize() == 8*MB );
+  EXPECT_EQ( statInfo->GetSize(), 8*MB );
   EXPECT_TRUE( f2.Read( 0, 4*MB, buffer3, bytesRead1 ).IsOK() );
   EXPECT_TRUE( f2.Read( 4*MB, 4*MB, buffer4, bytesRead2 ).IsOK() );
-  EXPECT_TRUE( bytesRead1 == 4*MB );
-  EXPECT_TRUE( bytesRead2 == 4*MB );
+  EXPECT_EQ( bytesRead1, 4*MB );
+  EXPECT_EQ( bytesRead2, 4*MB );
   uint32_t crc2 = XrdClTests::Utils::ComputeCRC32( buffer3, 4*MB );
   crc2 = XrdClTests::Utils::UpdateCRC32( crc2, buffer4, 4*MB );
   EXPECT_TRUE( f2.Close().IsOK() );
-  EXPECT_TRUE( crc1 == crc2 );
+  EXPECT_EQ( crc1, crc2 );
 
   //----------------------------------------------------------------------------
   // Truncate test
@@ -402,7 +402,7 @@ void FileTest::WriteTest()
   StatInfo *response = 0;
   EXPECT_TRUE( fs.Stat( filePath, response ).IsOK() );
   EXPECT_TRUE( response );
-  EXPECT_TRUE( response->GetSize() == 20*MB );
+  EXPECT_EQ( response->GetSize(), 20*MB );
   EXPECT_TRUE( fs.Rm( filePath ).IsOK() );
   delete [] buffer1;
   delete [] buffer2;
@@ -447,8 +447,8 @@ void FileTest::WriteVTest()
   uint32_t bytesRead1 = 0;
   File f1, f2;
 
-  EXPECT_TRUE( XrdClTests::Utils::GetRandomBytes( buffer1, 4*MB ) == 4*MB );
-  EXPECT_TRUE( XrdClTests::Utils::GetRandomBytes( buffer2, 4*MB ) == 4*MB );
+  EXPECT_EQ( XrdClTests::Utils::GetRandomBytes( buffer1, 4*MB ), 4*MB );
+  EXPECT_EQ( XrdClTests::Utils::GetRandomBytes( buffer2, 4*MB ), 4*MB );
   uint32_t crc1 = XrdClTests::Utils::ComputeCRC32( buffer1, 4*MB );
   crc1 = XrdClTests::Utils::UpdateCRC32( crc1, buffer2, 4*MB );
 
@@ -478,13 +478,13 @@ void FileTest::WriteVTest()
   EXPECT_TRUE( f2.Open( fileUrl, OpenFlags::Read ).IsOK() );
   EXPECT_TRUE( f2.Stat( false, statInfo ).IsOK() );
   EXPECT_TRUE( statInfo );
-  EXPECT_TRUE( statInfo->GetSize() == 8*MB );
+  EXPECT_EQ( statInfo->GetSize(), 8*MB );
   EXPECT_TRUE( f2.Read( 0, 8*MB, buffer3, bytesRead1 ).IsOK() );
-  EXPECT_TRUE( bytesRead1 == 8*MB );
+  EXPECT_EQ( bytesRead1, 8*MB );
 
   uint32_t crc2 = XrdClTests::Utils::ComputeCRC32( buffer3, 8*MB );
   EXPECT_TRUE( f2.Close().IsOK() );
-  EXPECT_TRUE( crc1 == crc2 );
+  EXPECT_EQ( crc1, crc2 );
 
   FileSystem fs( url );
   EXPECT_TRUE( fs.Rm( filePath ).IsOK() );
@@ -554,37 +554,37 @@ void FileTest::VectorReadTest()
   // remote file vread1
   VectorReadInfo *info = 0;
   GTEST_ASSERT_XRDST( f.VectorRead( chunkList1, buffer1, info ) );
-  EXPECT_TRUE( info->GetSize() == 10*MB );
+  EXPECT_EQ( info->GetSize(), 10*MB );
   delete info;
 
   // local file vread1
   info = 0;
   GTEST_ASSERT_XRDST( fLocal.VectorRead( chunkList1, buffer1Comp, info ) );
-  EXPECT_TRUE( info->GetSize() == 10*MB );
+  EXPECT_EQ( info->GetSize(), 10*MB );
   delete info;
 
   // checksum comparison
   uint32_t crc = 0, crcComp = 0;
   crc = XrdClTests::Utils::ComputeCRC32( buffer1, 10*MB );
   crcComp = XrdClTests::Utils::ComputeCRC32( buffer1Comp, 10*MB );
-  EXPECT_TRUE( crc == crcComp );
+  EXPECT_EQ( crc, crcComp );
 
   // remote vread2
   info = 0;
   GTEST_ASSERT_XRDST( f.VectorRead( chunkList2, buffer2, info ) );
-  EXPECT_TRUE( info->GetSize() == 10*256000 );
+  EXPECT_EQ( info->GetSize(), 10*256000 );
   delete info;
 
   // local vread2
   info = 0;
   GTEST_ASSERT_XRDST( f.VectorRead( chunkList2, buffer2Comp, info ) );
-  EXPECT_TRUE( info->GetSize() == 10*256000 );
+  EXPECT_EQ( info->GetSize(), 10*256000 );
   delete info;
 
   // checksum comparison again
   crc = XrdClTests::Utils::ComputeCRC32( buffer2, 10*256000 );
   crcComp = XrdClTests::Utils::ComputeCRC32( buffer2Comp, 10*256000 );
-  EXPECT_TRUE( crc == crcComp );
+  EXPECT_EQ( crc, crcComp );
 
   // cleanup
   GTEST_ASSERT_XRDST( f.Close() );
@@ -704,9 +704,9 @@ void FileTest::VectorWriteTest()
   VectorReadInfo *info2 = 0;
   GTEST_ASSERT_XRDST( f.VectorRead( chunks, buffer2, info2 ) );
 
-  EXPECT_TRUE( info2->GetSize() == totalSize );
+  EXPECT_EQ( info2->GetSize(), totalSize );
   uint32_t crc32 = XrdClTests::Utils::ComputeCRC32( buffer2, totalSize );
-  EXPECT_TRUE( crc32 == expectedCrc32 );
+  EXPECT_EQ( crc32, expectedCrc32 );
 
   //----------------------------------------------------------------------------
   // And finally revert to the original state
@@ -761,7 +761,7 @@ void FileTest::VirtualRedirectorTest()
   GTEST_ASSERT_XRDST( f1.Open( mlUrl1, OpenFlags::Read ) );
   EXPECT_TRUE( f1.GetProperty( key, value ) );
   URL lastUrl( value );
-  EXPECT_TRUE( lastUrl.GetLocation() == fileUrl );
+  EXPECT_EQ( lastUrl.GetLocation(), fileUrl );
   GTEST_ASSERT_XRDST( f1.Close() );
 
   //----------------------------------------------------------------------------
@@ -771,7 +771,7 @@ void FileTest::VirtualRedirectorTest()
   GTEST_ASSERT_XRDST( f2.Open( mlUrl2, OpenFlags::Read ) );
   EXPECT_TRUE( f2.GetProperty( key, value ) );
   URL lastUrl2( value );
-  EXPECT_TRUE( lastUrl2.GetLocation() == fileUrl );
+  EXPECT_EQ( lastUrl2.GetLocation(), fileUrl );
   GTEST_ASSERT_XRDST( f2.Close() );
 
   //----------------------------------------------------------------------------
@@ -796,7 +796,7 @@ void FileTest::VirtualRedirectorTest()
   GTEST_ASSERT_XRDST( f4.Open( mlUrl4, OpenFlags::Read ) );
   EXPECT_TRUE( f4.GetProperty( key, value ) );
   URL lastUrl3( value );
-  EXPECT_TRUE( lastUrl3.GetLocation() == replica1 );
+  EXPECT_EQ( lastUrl3.GetLocation(), replica1 );
   GTEST_ASSERT_XRDST( f4.Close() );
   //----------------------------------------------------------------------------
   // Delete the replica that has been selected by the virtual redirector
@@ -809,7 +809,7 @@ void FileTest::VirtualRedirectorTest()
   GTEST_ASSERT_XRDST( f4.Open( mlUrl4, OpenFlags::Read ) );
   EXPECT_TRUE( f4.GetProperty( key, value ) );
   URL lastUrl4( value );
-  EXPECT_TRUE( lastUrl4.GetLocation() == replica2 );
+  EXPECT_EQ( lastUrl4.GetLocation(), replica2 );
   GTEST_ASSERT_XRDST( f4.Close() );
   //----------------------------------------------------------------------------
   // Recreate the deleted file
@@ -886,8 +886,8 @@ void FileTest::XAttrTest()
   {
     GTEST_ASSERT_XRDST( itr3->status );
     auto match = attributes.find( itr3->name );
-    EXPECT_TRUE( match != attributes.end() );
-    EXPECT_TRUE( match->second == itr3->value );
+    EXPECT_NE( match, attributes.end() );
+    EXPECT_EQ( match->second, itr3->value );
   }
 
   //----------------------------------------------------------------------------
@@ -900,8 +900,8 @@ void FileTest::XAttrTest()
   {
     GTEST_ASSERT_XRDST( itr3->status );
     auto match = attributes.find( itr3->name );
-    EXPECT_TRUE( match != attributes.end() );
-    EXPECT_TRUE( match->second == itr3->value );
+    EXPECT_NE( match, attributes.end() );
+    EXPECT_EQ( match->second, itr3->value );
   }
 
   //----------------------------------------------------------------------------

--- a/tests/XrdCl/XrdClLocalFileHandlerTest.cc
+++ b/tests/XrdCl/XrdClLocalFileHandlerTest.cc
@@ -91,10 +91,10 @@ void LocalFileHandlerTest::readTestFunc(bool offsetRead, uint32_t offset){
    GTEST_ASSERT_XRDST( file->Close() );
 
    std::string read( buffer, size );
-   if (offsetRead) EXPECT_TRUE( expectedRead == read );
-   else EXPECT_TRUE( toBeWritten == read );
+   if (offsetRead) EXPECT_EQ( expectedRead, read );
+   else EXPECT_EQ( toBeWritten, read );
 
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
 
    delete[] buffer;
    delete file;
@@ -115,7 +115,7 @@ TEST_F(LocalFileHandlerTest, SyncTest){
    GTEST_ASSERT_XRDST( file->Open( targetURL, flags, mode ) );
    GTEST_ASSERT_XRDST( file->Sync() );
    GTEST_ASSERT_XRDST( file->Close() );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
    delete file;
 }
 
@@ -133,7 +133,7 @@ TEST_F(LocalFileHandlerTest, OpenCloseTest){
    GTEST_ASSERT_XRDST( file->Open( targetURL, flags, mode ) );
    EXPECT_TRUE( file->IsOpen() );
    GTEST_ASSERT_XRDST( file->Close() );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
 
    //----------------------------------------------------------------------------
    // Try open non-existing file
@@ -144,7 +144,7 @@ TEST_F(LocalFileHandlerTest, OpenCloseTest){
    //----------------------------------------------------------------------------
    // Try close non-opened file, return has to be error
    //----------------------------------------------------------------------------
-   EXPECT_TRUE( file->Close().status == stError );
+   EXPECT_EQ( file->Close().status, stError );
    delete file;
 }
 
@@ -173,8 +173,8 @@ TEST_F(LocalFileHandlerTest, WriteTest){
    int rc = read( fd, buffer, int( writeSize ) );
    EXPECT_EQ( rc, int( writeSize ) );
    std::string read( (char *)buffer, writeSize );
-   EXPECT_TRUE( toBeWritten == read );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( toBeWritten, read );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
    delete[] buffer;
    delete file;
 }
@@ -207,8 +207,8 @@ TEST_F(LocalFileHandlerTest, WriteWithOffsetTest){
    int rc = read( fd, buffer, offset );
    EXPECT_EQ( rc, int( offset ) );
    std::string read( (char *)buffer, offset );
-   EXPECT_TRUE( notToBeOverwritten == read );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( notToBeOverwritten, read );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
    delete[] (char*)buffer;
    delete file;
 }
@@ -238,8 +238,8 @@ TEST_F(LocalFileHandlerTest, WriteMkdirTest){
    int rc = read( fd, buffer, writeSize );
    EXPECT_EQ( rc, int( writeSize ) );
    std::string read( buffer, writeSize );
-   EXPECT_TRUE( toBeWritten == read );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( toBeWritten, read );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
    delete[] buffer;
    delete file;
 }
@@ -278,7 +278,7 @@ TEST_F(LocalFileHandlerTest, TruncateTest){
    GTEST_ASSERT_XRDST( file->Read( 0, truncateSize + 3, buffer, bytesRead ) );
    EXPECT_EQ( truncateSize, bytesRead );
    GTEST_ASSERT_XRDST( file->Close() );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
    delete file;
    delete[] buffer;
 }
@@ -311,7 +311,7 @@ TEST_F(LocalFileHandlerTest, VectorReadTest)
    chunks.push_back( ChunkInfo( 10, 5, new char[5] ) );
    GTEST_ASSERT_XRDST( file.VectorRead( chunks, NULL, info ) );
    GTEST_ASSERT_XRDST( file.Close() );
-   EXPECT_TRUE( info->GetSize() == 10 );
+   EXPECT_EQ( info->GetSize(), 10 );
    EXPECT_EQ( 0, memcmp( "Gener",
                                     info->GetChunks()[0].buffer,
                                     info->GetChunks()[0].length ) );
@@ -334,11 +334,11 @@ TEST_F(LocalFileHandlerTest, VectorReadTest)
    GTEST_ASSERT_XRDST( file.Open( targetURL, flags, mode ) );
    GTEST_ASSERT_XRDST( file.VectorRead( chunks, buffer, info ) );
    GTEST_ASSERT_XRDST( file.Close() );
-   EXPECT_TRUE( info->GetSize() == 10 );
+   EXPECT_EQ( info->GetSize(), 10 );
    EXPECT_EQ( 0, memcmp( "GenertFile",
                                     info->GetChunks()[0].buffer,
                                     info->GetChunks()[0].length ) );
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
 
    delete[] buffer;
    delete info;
@@ -387,14 +387,14 @@ TEST_F(LocalFileHandlerTest, VectorWriteTest)
    EXPECT_EQ( 0, memcmp( buffer, "AAAAABBBBB", 10 ) );
 
    GTEST_ASSERT_XRDST( file.Close() );
-   EXPECT_TRUE( info->GetSize() == 10 );
+   EXPECT_EQ( info->GetSize(), 10 );
 
    delete[] (char*)chunks[0].buffer;
    delete[] (char*)chunks[1].buffer;
    delete[] buffer;
    delete   info;
 
-   EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+   EXPECT_EQ( remove( targetURL.c_str() ), 0 );
 }
 
 TEST_F(LocalFileHandlerTest, WriteVTest)
@@ -429,11 +429,11 @@ TEST_F(LocalFileHandlerTest, WriteVTest)
   uint32_t bytesRead = 0;
   buffer.resize( 17 );
   GTEST_ASSERT_XRDST( file.Read( 0, 17, buffer.data(), bytesRead ) );
-  EXPECT_TRUE( buffer.size() == 17 );
+  EXPECT_EQ( buffer.size(), 17 );
   std::string expected = "GenericWriteVTest";
-  EXPECT_TRUE( std::string( buffer.data(), buffer.size() ) == expected );
+  EXPECT_EQ( std::string( buffer.data(), buffer.size() ), expected );
   GTEST_ASSERT_XRDST( file.Close() );
-  EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+  EXPECT_EQ( remove( targetURL.c_str() ), 0 );
 }
 
 TEST_F(LocalFileHandlerTest, XAttrTest)
@@ -450,7 +450,7 @@ TEST_F(LocalFileHandlerTest, XAttrTest)
   std::string localDataPath;
   EXPECT_TRUE( testEnv->GetString( "LocalDataPath", localDataPath ) );
 
-  char resolved_path[MAXPATHLEN];
+  char resolved_path[PATH_MAX];
   localDataPath = realpath(localDataPath.c_str(), resolved_path);
 
   std::string targetURL = localDataPath + "/metaman/lfilehandlertestfilexattr";
@@ -487,13 +487,13 @@ TEST_F(LocalFileHandlerTest, XAttrTest)
   GTEST_ASSERT_XRDST( resp[0].status );
   GTEST_ASSERT_XRDST( resp[1].status );
 
-  EXPECT_TRUE( resp.size() == 2 );
+  EXPECT_EQ( resp.size(), 2 );
   int vid = resp[0].name == "version" ? 0 : 1;
   int did = vid == 0 ? 1 : 0;
-  EXPECT_TRUE( resp[vid].name == "version" &&
-                  resp[vid].value == "v3.3.3" );
-  EXPECT_TRUE( resp[did].name == "description" &&
-                  resp[did].value == "a very important file" );
+  EXPECT_EQ( resp[vid].name, std::string("version") );
+  EXPECT_EQ( resp[vid].value, std::string("v3.3.3") );
+  EXPECT_EQ( resp[did].name, std::string("description") );
+  EXPECT_EQ( resp[did].value, std::string("a very important file") );
 
   //----------------------------------------------------------------------------
   // Test XAttr Del
@@ -502,7 +502,7 @@ TEST_F(LocalFileHandlerTest, XAttrTest)
   names.push_back( "description" );
   st_resp.clear();
   GTEST_ASSERT_XRDST( f.DelXAttr( names, st_resp ) );
-  EXPECT_TRUE( st_resp.size() == 1 );
+  EXPECT_EQ( st_resp.size(), 1 );
   GTEST_ASSERT_XRDST( st_resp[0].status );
 
   //----------------------------------------------------------------------------
@@ -510,17 +510,17 @@ TEST_F(LocalFileHandlerTest, XAttrTest)
   //----------------------------------------------------------------------------
   resp.clear();
   GTEST_ASSERT_XRDST( f.ListXAttr( resp ) );
-  EXPECT_TRUE( resp.size() == 2 );
+  EXPECT_EQ( resp.size(), 2 );
   vid = resp[0].name == "version" ? 0 : 1;
   int cid = vid == 0 ? 1 : 0;
-  EXPECT_TRUE( resp[vid].name == "version" &&
-                  resp[vid].value == "v3.3.3" );
-  EXPECT_TRUE( resp[cid].name == "checksum" &&
-                  resp[cid].value == "0x22334455" );
+  EXPECT_EQ( resp[vid].name, std::string("version") );
+  EXPECT_EQ( resp[vid].value, std::string("v3.3.3") );
+  EXPECT_EQ( resp[cid].name, std::string("checksum") );
+  EXPECT_EQ( resp[cid].value, std::string("0x22334455") );
 
   //----------------------------------------------------------------------------
   // Cleanup
   //----------------------------------------------------------------------------
   GTEST_ASSERT_XRDST( f.Close() );
-  EXPECT_TRUE( remove( targetURL.c_str() ) == 0 );
+  EXPECT_EQ( remove( targetURL.c_str() ), 0 );
 }

--- a/tests/XrdCl/XrdClPoller.cc
+++ b/tests/XrdCl/XrdClPoller.cc
@@ -254,8 +254,8 @@ TEST(PollerTest, FunctionTest)
     EXPECT_TRUE( !poller->IsRegistered( &s[i] ) );
     stats[i] = handler->GetReceivedStats( s[i].GetSockName() );
     statsServ[i] = server.GetSentStats( s[i].GetSockName() );
-    EXPECT_TRUE( stats[i].first == statsServ[i].first );
-    EXPECT_TRUE( stats[i].second == statsServ[i].second );
+    EXPECT_EQ( stats[i].first, statsServ[i].first );
+    EXPECT_EQ( stats[i].second, statsServ[i].second );
   }
 
   for( int i = 0; i < 3; ++i )

--- a/tests/XrdCl/XrdClPostMasterTest.cc
+++ b/tests/XrdCl/XrdClPostMasterTest.cc
@@ -59,8 +59,8 @@ namespace
         XrdCl::PostMaster *pm = Get();
         pm->Stop();
         pm->Finalize();
-        EXPECT_TRUE( pm->Initialize() != 0 );
-        EXPECT_TRUE( pm->Start() != 0 );
+        EXPECT_NE( pm->Initialize(), 0 );
+        EXPECT_NE( pm->Start(), 0 );
         return pm;
       }
   };
@@ -262,9 +262,9 @@ void *TestThreadFunc( void *arg )
     XrdCl::Message msg;
     GTEST_ASSERT_XRDST( msgHandlers[i].WaitFor( msg ) );
     ServerResponse *resp = (ServerResponse *)msg.GetBuffer();
-    EXPECT_TRUE( resp != 0 );
-    EXPECT_TRUE( resp->hdr.status == kXR_ok );
-    EXPECT_TRUE( msg.GetSize() == 8 );
+    EXPECT_TRUE( resp );
+    EXPECT_EQ( resp->hdr.status, kXR_ok );
+    EXPECT_EQ( msg.GetSize(), 8 );
   }
   return 0;
 }
@@ -338,9 +338,9 @@ TEST(PostMasterTest, FunctionalTest)
 
   GTEST_ASSERT_XRDST( msgHandler1.WaitFor( m2 ) );
   ServerResponse *resp = (ServerResponse *)m2.GetBuffer();
-  EXPECT_TRUE( resp != 0 );
-  EXPECT_TRUE( resp->hdr.status == kXR_ok );
-  EXPECT_TRUE( m2.GetSize() == 8 );
+  EXPECT_TRUE( resp );
+  EXPECT_EQ( resp->hdr.status, kXR_ok );
+  EXPECT_EQ( m2.GetSize(), 8 );
 
   //----------------------------------------------------------------------------
   // Send out some stuff to a location where nothing listens
@@ -402,9 +402,9 @@ TEST(PostMasterTest, FunctionalTest)
 
   GTEST_ASSERT_XRDST( msgHandler4.WaitFor( m2 ) );
   resp = (ServerResponse *)m2.GetBuffer();
-  EXPECT_TRUE( resp != 0 );
-  EXPECT_TRUE( resp->hdr.status == kXR_ok );
-  EXPECT_TRUE( m2.GetSize() == 8 );
+  EXPECT_TRUE( resp );
+  EXPECT_EQ( resp->hdr.status, kXR_ok );
+  EXPECT_EQ( m2.GetSize(), 8 );
 
   //----------------------------------------------------------------------------
   // Sleep 10 secs waiting for iddle connection to be closed and see
@@ -418,9 +418,9 @@ TEST(PostMasterTest, FunctionalTest)
 
   GTEST_ASSERT_XRDST( msgHandler5.WaitFor( m2 ) );
   resp = (ServerResponse *)m2.GetBuffer();
-  EXPECT_TRUE( resp != 0 );
-  EXPECT_TRUE( resp->hdr.status == kXR_ok );
-  EXPECT_TRUE( m2.GetSize() == 8 );
+  EXPECT_TRUE( resp );
+  EXPECT_EQ( resp->hdr.status, kXR_ok );
+  EXPECT_EQ( m2.GetSize(), 8 );
 }
 
 
@@ -466,9 +466,9 @@ TEST(PostMasterTest, PingIPv6)
   sc = postMaster->Receive( localhost1, m2, &f1, false, 1200 );
   EXPECT_TRUE( sc.IsOK() );
   ServerResponse *resp = (ServerResponse *)m2->GetBuffer();
-  EXPECT_TRUE( resp != 0 );
-  EXPECT_TRUE( resp->hdr.status == kXR_ok );
-  EXPECT_TRUE( m2->GetSize() == 8 );
+  EXPECT_TRUE( resp );
+  EXPECT_EQ( resp->hdr.status, kXR_ok );
+  EXPECT_EQ( m2->GetSize(), 8 );
 
   //----------------------------------------------------------------------------
   // Send the message - localhost2
@@ -479,9 +479,9 @@ TEST(PostMasterTest, PingIPv6)
   sc = postMaster->Receive( localhost2, m2, &f1, 1200 );
   EXPECT_TRUE( sc.IsOK() );
   resp = (ServerResponse *)m2->GetBuffer();
-  EXPECT_TRUE( resp != 0 );
-  EXPECT_TRUE( resp->hdr.status == kXR_ok );
-  EXPECT_TRUE( m2->GetSize() == 8 );
+  EXPECT_TRUE( resp );
+  EXPECT_EQ( resp->hdr.status, kXR_ok );
+  EXPECT_EQ( m2->GetSize(), 8 );
 #endif
 }
 
@@ -568,8 +568,8 @@ TEST(PostMasterTest, MultiIPConnectionTest)
   GTEST_ASSERT_XRDST( postMaster->Send( url3, m, &msgHandler3, false, expires ) );
   GTEST_ASSERT_XRDST( msgHandler3.WaitFor( m2 ) );
   ServerResponse *resp = (ServerResponse *)m2.GetBuffer();
-  EXPECT_TRUE( resp != 0 );
-  EXPECT_TRUE( resp->hdr.status == kXR_ok );
-  EXPECT_TRUE( m2.GetSize() == 8 );
+  EXPECT_TRUE( resp );
+  EXPECT_EQ( resp->hdr.status, kXR_ok );
+  EXPECT_EQ( m2.GetSize(), 8 );
 }
 #endif

--- a/tests/XrdCl/XrdClSocket.cc
+++ b/tests/XrdCl/XrdClSocket.cc
@@ -228,10 +228,10 @@ TEST(SocketTest, TransferTest)
   EXPECT_TRUE( serv.Setup( port, 1, new RandomHandlerFactory() ) );
   EXPECT_TRUE( serv.Start() );
 
-  EXPECT_TRUE( sock.GetStatus() == Socket::Disconnected );
+  EXPECT_EQ( sock.GetStatus(), Socket::Disconnected );
   EXPECT_TRUE( sock.Initialize( AF_INET6 ).IsOK() );
   EXPECT_TRUE( sock.Connect( "localhost", port ).IsOK() );
-  EXPECT_TRUE( sock.GetStatus() == Socket::Connected );
+  EXPECT_EQ( sock.GetStatus(), Socket::Connected );
 
   //----------------------------------------------------------------------------
   // Get the number of packets
@@ -246,7 +246,7 @@ TEST(SocketTest, TransferTest)
   uint64_t receivedCounter = 0;
   uint32_t receivedChecksum = ::Utils::ComputeCRC32( 0, 0 );
   sc = sock.ReadRaw( &packets, 1, 60, bytesTransmitted );
-  EXPECT_TRUE( sc.status == stOK );
+  EXPECT_EQ( sc.status, stOK );
 
   //----------------------------------------------------------------------------
   // Read each packet
@@ -254,9 +254,9 @@ TEST(SocketTest, TransferTest)
   for( int i = 0; i < packets; ++i )
   {
     sc = sock.ReadRaw( &packetSize, 2, 60, bytesTransmitted );
-    EXPECT_TRUE( sc.status == stOK );
+    EXPECT_EQ( sc.status, stOK );
     sc = sock.ReadRaw( buffer, packetSize, 60, bytesTransmitted );
-    EXPECT_TRUE( sc.status == stOK );
+    EXPECT_EQ( sc.status, stOK );
     receivedCounter += bytesTransmitted;
     receivedChecksum = ::Utils::UpdateCRC32( receivedChecksum, buffer,
                                              bytesTransmitted );
@@ -268,17 +268,20 @@ TEST(SocketTest, TransferTest)
   packets = random() % 100;
 
   sc = sock.WriteRaw( &packets, 1, 60, bytesTransmitted );
-  EXPECT_TRUE( (sc.status == stOK) && (bytesTransmitted == 1) );
+  EXPECT_EQ( sc.status, stOK );
+  EXPECT_EQ( bytesTransmitted, 1 );
 
   for( int i = 0; i < packets; ++i )
   {
     packetSize = random() % 50000;
-    EXPECT_TRUE( ::Utils::GetRandomBytes( buffer, packetSize ) == packetSize );
+    EXPECT_EQ( ::Utils::GetRandomBytes( buffer, packetSize ), packetSize );
 
     sc = sock.WriteRaw( (char *)&packetSize, 2, 60, bytesTransmitted );
-    EXPECT_TRUE( (sc.status == stOK) && (bytesTransmitted == 2) );
+    EXPECT_EQ( sc.status, stOK );
+    EXPECT_EQ( bytesTransmitted, 2 );
     sc = sock.WriteRaw( buffer, packetSize, 60, bytesTransmitted );
-    EXPECT_TRUE( (sc.status == stOK) && (bytesTransmitted == packetSize) );
+    EXPECT_EQ( sc.status, stOK );
+    EXPECT_EQ( bytesTransmitted, packetSize );
     sentCounter += bytesTransmitted;
     sentChecksum = ::Utils::UpdateCRC32( sentChecksum, buffer,
                                          bytesTransmitted );
@@ -294,8 +297,8 @@ TEST(SocketTest, TransferTest)
 
   std::pair<uint64_t, uint32_t> sent     = serv.GetSentStats( socketName );
   std::pair<uint64_t, uint32_t> received = serv.GetReceivedStats( socketName );
-  EXPECT_TRUE( sentCounter == received.first );
-  EXPECT_TRUE( receivedCounter == sent.first );
-  EXPECT_TRUE( sentChecksum == received.second );
-  EXPECT_TRUE( receivedChecksum == sent.second );
+  EXPECT_EQ( sentCounter, received.first );
+  EXPECT_EQ( receivedCounter, sent.first );
+  EXPECT_EQ( sentChecksum, received.second );
+  EXPECT_EQ( receivedChecksum, sent.second );
 }

--- a/tests/XrdCl/XrdClThreadingTest.cc
+++ b/tests/XrdCl/XrdClThreadingTest.cc
@@ -163,7 +163,7 @@ void ThreadingTest::ReadTestFunc( TransferCallback transferCallback )
       uint32_t  bytesRead = 0;
 
       GTEST_ASSERT_XRDST( f->Read( offset, 4*MB, buffer, bytesRead ) );
-      EXPECT_TRUE( bytesRead == 4*MB );
+      EXPECT_EQ( bytesRead, 4*MB );
       threadData[j*5+i].firstBlockChecksum =
         XrdClTests::Utils::ComputeCRC32( buffer, 4*MB );
       delete [] buffer;
@@ -215,8 +215,7 @@ void ThreadingTest::ReadTestFunc( TransferCallback transferCallback )
     threadData[i].file->GetProperty( "LastURL", lastUrl );
     GTEST_ASSERT_XRDST( Utils::GetRemoteCheckSum(
                             remoteSum, "zcrc32", lastUrl ) );
-    EXPECT_TRUE( remoteSum == transferSum ); // TODO; same test repeated twice?? (check w amadio)
-    EXPECT_TRUE( remoteSum == transferSum ) << path[i];
+    EXPECT_EQ( remoteSum, transferSum ) << path[i];
   }
 
   //----------------------------------------------------------------------------
@@ -263,8 +262,8 @@ int runChild( ThreadData *td )
     uint32_t  bytesRead = 0;
 
     GTEST_ASSERT_XRDST( td[i].file->Read( offset, 4*MB, buffer, bytesRead ) );
-    EXPECT_TRUE( bytesRead == 4*MB );
-    EXPECT_TRUE( td[i].firstBlockChecksum ==
+    EXPECT_EQ( bytesRead, 4*MB );
+    EXPECT_EQ( td[i].firstBlockChecksum,
                     XrdClTests::Utils::ComputeCRC32( buffer, 4*MB ) );
     delete [] buffer;
   }
@@ -299,7 +298,7 @@ void forkAndRead( ThreadData *data )
     GTEST_ASSERT_ERRNO( waitpid( pid, &status, 0 ) != -1 );
     log->Debug( 1, "Wait done, status: %d", status );
     EXPECT_TRUE( WIFEXITED( status ) );
-    EXPECT_TRUE( WEXITSTATUS( status ) == 0 );
+    EXPECT_EQ( WEXITSTATUS( status ), 0 );
   }
 }
 

--- a/tests/XrdCl/XrdClUtilsTest.cc
+++ b/tests/XrdCl/XrdClUtilsTest.cc
@@ -185,18 +185,18 @@ TEST(UtilsTest, SIDManagerTest)
   GTEST_ASSERT_XRDST( manager->AllocateSID( sid5 ) );
 
   EXPECT_TRUE( (sid1[0] != sid2[0]) || (sid1[1] != sid2[1]) );
-  EXPECT_TRUE( manager->NumberOfTimedOutSIDs() == 0 );
+  EXPECT_EQ( manager->NumberOfTimedOutSIDs(), 0 );
   manager->TimeOutSID( sid4 );
   manager->TimeOutSID( sid5 );
-  EXPECT_TRUE( manager->NumberOfTimedOutSIDs() == 2 );
-  EXPECT_TRUE( manager->IsTimedOut( sid3 ) == false );
-  EXPECT_TRUE( manager->IsTimedOut( sid1 ) == false );
-  EXPECT_TRUE( manager->IsTimedOut( sid4 ) == true );
-  EXPECT_TRUE( manager->IsTimedOut( sid5 ) == true );
+  EXPECT_EQ( manager->NumberOfTimedOutSIDs(), 2 );
+  EXPECT_FALSE( manager->IsTimedOut( sid3 ) );
+  EXPECT_FALSE( manager->IsTimedOut( sid1 ) );
+  EXPECT_TRUE( manager->IsTimedOut( sid4 ) );
+  EXPECT_TRUE( manager->IsTimedOut( sid5 ) );
   manager->ReleaseTimedOut( sid5 );
-  EXPECT_TRUE( manager->IsTimedOut( sid5 ) == false );
+  EXPECT_FALSE( manager->IsTimedOut( sid5 ) );
   manager->ReleaseAllTimedOut();
-  EXPECT_TRUE( manager->NumberOfTimedOutSIDs() == 0 );
+  EXPECT_EQ( manager->NumberOfTimedOutSIDs(), 0 );
 }
 
 //------------------------------------------------------------------------------
@@ -213,9 +213,9 @@ TEST(UtilsTest, PropertyListTest)
   std::string s1;
 
   EXPECT_TRUE( l.Get( "s1", s1 ) );
-  EXPECT_TRUE( s1 == "test string 1" );
+  EXPECT_EQ( s1, "test string 1" );
   EXPECT_TRUE( l.Get( "i1", i1 ) );
-  EXPECT_TRUE( i1 == 123456789123ULL );
+  EXPECT_EQ( i1, 123456789123ULL );
   EXPECT_TRUE( l.HasProperty( "s1" ) );
   EXPECT_TRUE( !l.HasProperty( "s2" ) );
   EXPECT_TRUE( l.HasProperty( "i1" ) );
@@ -230,16 +230,16 @@ TEST(UtilsTest, PropertyListTest)
     EXPECT_TRUE( l.Get( "vect_int", i, num ) );
     EXPECT_TRUE( num = i+1000 );
   }
-  EXPECT_TRUE( i == 1000 );
+  EXPECT_EQ( i, 1000 );
 
   XRootDStatus st1, st2;
   st1.SetErrorMessage( "test error message" );
   l.Set( "status", st1 );
   EXPECT_TRUE( l.Get( "status", st2 ) );
-  EXPECT_TRUE( st2.status == st1.status );
-  EXPECT_TRUE( st2.code   == st1.code );
-  EXPECT_TRUE( st2.errNo  == st1.errNo );
-  EXPECT_TRUE( st2.GetErrorMessage() == st1.GetErrorMessage() );
+  EXPECT_EQ( st2.status, st1.status );
+  EXPECT_EQ( st2.code  , st1.code );
+  EXPECT_EQ( st2.errNo , st1.errNo );
+  EXPECT_EQ( st2.GetErrorMessage(), st1.GetErrorMessage() );
 
   std::vector<std::string> v1, v2;
   v1.push_back( "test string 1" );
@@ -248,5 +248,5 @@ TEST(UtilsTest, PropertyListTest)
   l.Set( "vector", v1 );
   EXPECT_TRUE( l.Get( "vector", v2 ) );
   for( size_t i = 0; i < v1.size(); ++i )
-    EXPECT_TRUE( v1[i] == v2[i] );
+    EXPECT_EQ( v1[i], v2[i] );
 }

--- a/tests/XrdCl/XrdClZip.cc
+++ b/tests/XrdCl/XrdClZip.cc
@@ -79,14 +79,14 @@ TEST_F(ZipTest, OpenFileTest){
 TEST_F(ZipTest, ListFileTest) {
   DirectoryList* dummy_list;
   GTEST_ASSERT_XRDST(zip_file.List(dummy_list));
-  EXPECT_TRUE(dummy_list != NULL);
+  EXPECT_TRUE(dummy_list);
 }
 
 TEST_F(ZipTest, GetterTests) {
   // Get file
   File* file = NULL;
   file = &(zip_file.GetFile());
-  EXPECT_TRUE(file != NULL);
+  EXPECT_TRUE(file);
 
   // Get checksum
   uint32_t cksum;


### PR DESCRIPTION
EXPECT_EQ( A, B ) provides more useful diagnostics than EXPECT_TRUE ( A == B ).

EXPECT_NE( A, B ) provides more useful diagnostics than EXPECT_TRUE ( A != B ).