### PR TITLE
Avoid null bytes in error message strings

### DIFF
--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -1202,7 +1202,7 @@ namespace XrdCl
       if( pStatus.code == errErrorResponse )
       {
         st->errNo = rsp->body.error.errnum;
-        std::string errmsg( rsp->body.error.errmsg, rsp->hdr.dlen-4 );
+        std::string errmsg( rsp->body.error.errmsg, rsp->hdr.dlen-5 );
         if( st->errNo == kXR_noReplicas && !pLastError.IsOK() )
           errmsg += " Last seen error: " + pLastError.ToString();
         st->SetErrorMessage( errmsg );


### PR DESCRIPTION
If I change a test that uses the GTEST_ASSERT_XRDST_NOTOK macro to use the wrong expected error code so that a failure is triggered, the printed error message ends with a null byte:
```
46: Value of: !_st.IsOK() && _st.code == XrdCl::errNotFound
46:   Actual: false
46: Expected: true
46: [fs.Stat( targetPath, info )]: [ERROR] Server responded with an error: [3011] No servers are available to read the file.\0
```
Note the extra \0 at the end of the string.

The reason for this is that the code that converts an error response from the server to a std::string includes the terminting null byte in the length of the string. This commit reduces the length by 1 so that the terminating null byte is not included in the string. With this change the error message is printed correctly without a null byte at the end:
```
46: Value of: !_st.IsOK() && _st.code == XrdCl::errNotFound
46:   Actual: false
46: Expected: true
46: [fs.Stat( targetPath, info )]: [ERROR] Server responded with an error: [3011] No servers are available to read the file.
```
