### PR TITLE
[XrdNet and XrdHttp] Scitag min and max value change

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -234,7 +234,7 @@ void XrdHttpReq::parseScitag(const std::string & val) {
     if(scitagS[0] != '-') {
       try {
         mScitag = std::stoi(scitagS.c_str(), nullptr, 10);
-        if (mScitag > XrdNetPMark::maxTotID || mScitag < 0) {
+        if (mScitag > XrdNetPMark::maxTotID || mScitag < XrdNetPMark::minTotID) {
           mScitag = 0;
         }
       } catch (...) {

--- a/src/XrdNet/XrdNetPMark.cc
+++ b/src/XrdNet/XrdNetPMark.cc
@@ -40,24 +40,27 @@
 bool XrdNetPMark::getEA(const char *cgi, int &ecode, int &acode)
 {
 
+  ecode = acode = 0;
 // If we have cgi, see if we can extract rge codes from there
 //
-   if (cgi)
-      {const char *stP = strstr(cgi, "scitag.flow=");
-       if (stP)
-          {char *eol;
-           int eacode = strtol(stP+12, &eol, 10);
-           if (eacode >= 0 && eacode <= XrdNetPMark::maxTotID
-           &&  (*eol == '&' || *eol ==0))
-              {ecode = eacode >> XrdNetPMark::btsActID;
-               acode = eacode &  XrdNetPMark::mskActID;
-               return true;
-              }
-          }
+  if (cgi) {
+    const char *stP = strstr(cgi, "scitag.flow=");
+    if (stP) {
+      char *eol;
+      int eacode = strtol(stP + 12, &eol, 10);
+      if (*eol == '&' || *eol == 0) {
+        if (eacode >= XrdNetPMark::minTotID && eacode <= XrdNetPMark::maxTotID) {
+          ecode = eacode >> XrdNetPMark::btsActID;
+          acode = eacode & XrdNetPMark::mskActID;
+        }
+        // According to the specification, if the provided scitag.flow has an incorrect value
+        // the packets will be marked with a scitag = 0
+        return true;
       }
+    }
+  }
 
-// No go
-//
-   ecode = acode = 0;
+   // No go
+   //
    return false;
 }

--- a/src/XrdNet/XrdNetPMark.hh
+++ b/src/XrdNet/XrdNetPMark.hh
@@ -71,19 +71,22 @@ virtual Handle *Begin(XrdNetAddrInfo &addr, Handle     &handle,
 static  bool    getEA(const char *cgi, int &ecode, int &acode);
 
                 XrdNetPMark() {}
-
-static const int maxTotID = 0x7fff;
-
-protected:
+virtual        ~XrdNetPMark() {} // This object cannot be deleted!
 
 // ID limits and specifications
 //
-static const int btsActID =   6;
-static const int mskActID =  63;
-static const int maxActID =  63;
+/**
+ * From the specifications: Valid value for scitag is a single positive integer > 64 and <65536 (16bit). Any other value is considered invalid.
+ */
+static const int minTotID = 65;
+static const int maxTotID = 65535;
 
-static const int maxExpID = 511;
+protected:
 
-virtual        ~XrdNetPMark() {} // This object cannot be deleted!
+static const int btsActID = 6;
+static const int mskActID = 63;
+static const int maxExpID = maxTotID >> btsActID;
+static const int maxActID = maxTotID & mskActID;
+
 };
 #endif

--- a/src/XrdNet/XrdNetPMark.hh
+++ b/src/XrdNet/XrdNetPMark.hh
@@ -30,6 +30,8 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
+#include <cstring>
+
 class XrdNetAddrInfo;
 class XrdSecEntity;
 
@@ -41,11 +43,11 @@ class Handle
      {public:
 
       bool        getEA(int &ec, int &ac)
-                       {if (eCode >= 0) {ec = eCode; ac = aCode; return true;}
+                       {if (Valid()) {ec = eCode; ac = aCode; return true;}
                         ec = ac = 0; return false;
                        }
-
-      bool        Valid() {return eCode >= 0;}
+                  // According to the specifications, ExpID and actID can be equal to 0 for HTTP-TPC.
+      bool        Valid() {return (eCode == 0 && aCode == 0) || (eCode >= minExpID && eCode <= maxExpID && aCode >= minActID && aCode <= maxActID);}
 
                   Handle(const char *app=0, int ecode=0, int acode=0)
                         : appName(app), eCode(ecode), aCode(acode) {}
@@ -85,6 +87,8 @@ protected:
 
 static const int btsActID = 6;
 static const int mskActID = 63;
+static const int minExpID = minTotID >> btsActID;
+static const int minActID = minTotID & mskActID;
 static const int maxExpID = maxTotID >> btsActID;
 static const int maxActID = maxTotID & mskActID;
 

--- a/src/XrdNet/XrdNetPMarkCfg.cc
+++ b/src/XrdNet/XrdNetPMarkCfg.cc
@@ -897,7 +897,7 @@ bool XrdNetPMarkCfg::LoadJson(char *buff)
    for (auto it : j_exp)
        {std::string expName = it["expName"].get<std::string>();
         if (expName.empty()) continue;
-        if (!it["expId"].is_number() || it["expId"] < 0 || it["expId"] > maxExpID)
+        if (!it["expId"].is_number() || it["expId"] < minExpID || it["expId"] > maxExpID)
            {eDest->Say("Config warning: ignoring experiment '", expName.c_str(),
                        "'; associated ID is invalid.");
             continue;
@@ -921,7 +921,7 @@ bool XrdNetPMarkCfg::LoadJson(char *buff)
             {std::string actName =  j_acts[i]["activityName"].get<std::string>();
              if (actName.empty()) continue;
              if (!j_acts[i]["activityId"].is_number()
-             ||   j_acts[i]["activityId"] < 0
+             ||   j_acts[i]["activityId"] < minActID
              ||   j_acts[i]["activityId"] > maxActID)
                 {eDest->Say("Config warning:", "ignoring ", expName.c_str(),
                             " actitivity '", actName.c_str(),


### PR DESCRIPTION
Hi @abh3 ,

I took a bit of time to work on adapting the packet marking to comply with the specification where the `scitag.flow` has to have values between 65 and 65535.

I did two commits. The first one is changing the min and max values that a scitag can have and that modifies the `XrdHttp` part to check the validity of the scitag value given by the user.

The second one also touches the configuration of the scitag configuration from a JSON file (taking into account min and max values). I also modified the validation of the PMark handle where a scitag=0 will only be valid for HTTP-TPC (according to the specs). For other protocols, the scitag given by the user will have to be between 65 and 65535, otherwise the traffic will not be tagged.

Thanks for your review!

Cheers,
Cedric