### PR TITLE
Avoid bus errors

### DIFF
--- a/src/XProtocol/XProtocol.cc
+++ b/src/XProtocol/XProtocol.cc
@@ -204,7 +204,7 @@ char* ClientFattrRequest::VVecInsert( const char *value, char *buffer )
 //
 char* ClientFattrRequest::NVecRead( char* buffer, kXR_unt16 &rc )
  {
-   rc = *reinterpret_cast<const kXR_unt16*>( buffer );
+   memcpy(&rc, buffer, sizeof(kXR_unt16));
    rc = htons( rc );
    buffer += sizeof( kXR_unt16 );
    return buffer;
@@ -223,7 +223,7 @@ char* ClientFattrRequest::NVecRead( char* buffer, char *&name )
 //
 char* ClientFattrRequest::VVecRead( char* buffer, kXR_int32 &len )
 {
-  len = *reinterpret_cast<const kXR_int32*>( buffer );
+  memcpy(&len, buffer, sizeof(kXR_int32));
   len = htonl( len );
   buffer += sizeof( kXR_int32 );
   return buffer;

--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -2445,10 +2445,10 @@ namespace XrdCl
   {
     if( sizeof( T ) > buflen ) return Status( stError, errDataError );
 
-    result = *reinterpret_cast<T*>( buffer );
+    memcpy(&result, buffer, sizeof(T));
 
     buffer += sizeof( T );
-    buflen   -= sizeof( T );
+    buflen -= sizeof( T );
 
     return Status();
   }

--- a/src/XrdZip/XrdZipCDFH.hh
+++ b/src/XrdZip/XrdZipCDFH.hh
@@ -194,22 +194,22 @@ namespace XrdZip
     //-------------------------------------------------------------------------
     CDFH( const char *buffer, const uint32_t maxSize = 0 )
     {
-      zipVersion        = *reinterpret_cast<const uint16_t*>( buffer + 4 );
-      minZipVersion     = *reinterpret_cast<const uint16_t*>( buffer + 6 );
-      generalBitFlag    = *reinterpret_cast<const uint16_t*>( buffer + 8 );
-      compressionMethod = *reinterpret_cast<const uint16_t*>( buffer + 10 );
-      timestmp.time     = *reinterpret_cast<const uint16_t*>( buffer + 12 );
-      timestmp.date     = *reinterpret_cast<const uint16_t*>( buffer + 14 );
-      ZCRC32            = *reinterpret_cast<const uint32_t*>( buffer + 16 );
-      compressedSize    = *reinterpret_cast<const uint32_t*>( buffer + 20 );
-      uncompressedSize  = *reinterpret_cast<const uint32_t*>( buffer + 24 );
-      filenameLength    = *reinterpret_cast<const uint16_t*>( buffer + 28 );
-      extraLength       = *reinterpret_cast<const uint16_t*>( buffer + 30 );
-      commentLength     = *reinterpret_cast<const uint16_t*>( buffer + 32 );
-      nbDisk            = *reinterpret_cast<const uint16_t*>( buffer + 34 );
-      internAttr        = *reinterpret_cast<const uint16_t*>( buffer + 36 );
-      externAttr        = *reinterpret_cast<const uint32_t*>( buffer + 38 );
-      offset            = *reinterpret_cast<const uint32_t*>( buffer + 42 );
+      zipVersion        = to<uint16_t>(buffer + 4);
+      minZipVersion     = to<uint16_t>(buffer + 6);
+      generalBitFlag    = to<uint16_t>(buffer + 8);
+      compressionMethod = to<uint16_t>(buffer + 10);
+      timestmp.time     = to<uint16_t>(buffer + 12);
+      timestmp.date     = to<uint16_t>(buffer + 14);
+      ZCRC32            = to<uint32_t>(buffer + 16);
+      compressedSize    = to<uint32_t>(buffer + 20);
+      uncompressedSize  = to<uint32_t>(buffer + 24);
+      filenameLength    = to<uint16_t>(buffer + 28);
+      extraLength       = to<uint16_t>(buffer + 30);
+      commentLength     = to<uint16_t>(buffer + 32);
+      nbDisk            = to<uint16_t>(buffer + 34);
+      internAttr        = to<uint16_t>(buffer + 36);
+      externAttr        = to<uint32_t>(buffer + 38);
+      offset            = to<uint32_t>(buffer + 42);
       if(maxSize > 0 && (uint32_t)(cdfhBaseSize+filenameLength + extraLength + commentLength) > maxSize){
     	  throw bad_data();
       }

--- a/src/XrdZip/XrdZipEOCD.hh
+++ b/src/XrdZip/XrdZipEOCD.hh
@@ -53,13 +53,13 @@ namespace XrdZip
     //-------------------------------------------------------------------------
     EOCD( const char *buffer, uint32_t maxSize = 0 )
     {
-      nbDisk        = *reinterpret_cast<const uint16_t*>( buffer + 4 );
-      nbDiskCd      = *reinterpret_cast<const uint16_t*>( buffer + 6 );
-      nbCdRecD      = *reinterpret_cast<const uint16_t*>( buffer + 8 );
-      nbCdRec       = *reinterpret_cast<const uint16_t*>( buffer + 10 );
-      cdSize        = *reinterpret_cast<const uint32_t*>( buffer + 12 );
-      cdOffset      = *reinterpret_cast<const uint32_t*>( buffer + 16 );
-      commentLength = *reinterpret_cast<const uint16_t*>( buffer + 20 );
+      nbDisk        = to<uint16_t>(buffer + 4);
+      nbDiskCd      = to<uint16_t>(buffer + 6);
+      nbCdRecD      = to<uint16_t>(buffer + 8);
+      nbCdRec       = to<uint16_t>(buffer + 10);
+      cdSize        = to<uint32_t>(buffer + 12);
+      cdOffset      = to<uint32_t>(buffer + 16);
+      commentLength = to<uint16_t>(buffer + 20);
       if(maxSize > 0 && (uint32_t)(eocdBaseSize + commentLength) > maxSize)
     	  throw bad_data();
       comment       = std::string( buffer + 22, commentLength );

--- a/src/XrdZip/XrdZipZIP64EOCD.hh
+++ b/src/XrdZip/XrdZipZIP64EOCD.hh
@@ -28,15 +28,15 @@ namespace XrdZip
     ZIP64_EOCD( const char* buffer ):
       extensibleDataLength( 0 )
     {
-      zip64EocdSize = *reinterpret_cast<const uint64_t*>( buffer + 4 );
-      zipVersion    = *reinterpret_cast<const uint16_t*>( buffer + 12 );
-      minZipVersion = *reinterpret_cast<const uint16_t*>( buffer + 14 );
-      nbDisk        = *reinterpret_cast<const uint32_t*>( buffer + 16 );
-      nbDiskCd      = *reinterpret_cast<const uint32_t*>( buffer + 20 );
-      nbCdRecD      = *reinterpret_cast<const uint64_t*>( buffer + 24 );
-      nbCdRec       = *reinterpret_cast<const uint64_t*>( buffer + 32 );
-      cdSize        = *reinterpret_cast<const uint64_t*>( buffer + 40 );
-      cdOffset      = *reinterpret_cast<const uint64_t*>( buffer + 48 );
+      zip64EocdSize = to<uint64_t>(buffer + 4);
+      zipVersion    = to<uint16_t>(buffer + 12);
+      minZipVersion = to<uint16_t>(buffer + 14);
+      nbDisk        = to<uint32_t>(buffer + 16);
+      nbDiskCd      = to<uint32_t>(buffer + 20);
+      nbCdRecD      = to<uint64_t>(buffer + 24);
+      nbCdRec       = to<uint64_t>(buffer + 32);
+      cdSize        = to<uint64_t>(buffer + 40);
+      cdOffset      = to<uint64_t>(buffer + 48);
 
       zip64EocdTotalSize = zip64EocdBaseSize + extensibleDataLength;
     }

--- a/src/XrdZip/XrdZipZIP64EOCDL.hh
+++ b/src/XrdZip/XrdZipZIP64EOCDL.hh
@@ -26,9 +26,9 @@ namespace XrdZip
     //-------------------------------------------------------------------------
     ZIP64_EOCDL( const char *buffer )
     {
-      nbDiskZip64Eocd = *reinterpret_cast<const uint32_t*>( buffer + 4 );
-      zip64EocdOffset = *reinterpret_cast<const uint64_t*>( buffer + 8 );
-      totalNbDisks    = *reinterpret_cast<const uint32_t*>( buffer + 16 );
+      nbDiskZip64Eocd = to<uint32_t>(buffer + 4);
+      zip64EocdOffset = to<uint64_t>(buffer + 8);
+      totalNbDisks    = to<uint32_t>(buffer + 16);
     }
 
     //-------------------------------------------------------------------------


### PR DESCRIPTION
Do not dereference unaligned pointers.

Fixes: #2131