### PR TITLE
Add #include <byteswap.h> for BSD and GNU/Hurd

### DIFF
--- a/src/XrdSys/XrdSysPlatform.hh
+++ b/src/XrdSys/XrdSysPlatform.hh
@@ -67,12 +67,18 @@
 #if defined(__FreeBSD__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 #include <sys/types.h>
 #include <sys/param.h>
+#if defined(__FreeBSD__)
+#include <sys/endian.h>
+#else
+#include <byteswap.h>
+#endif
 #define MAXNAMELEN NAME_MAX
 #endif
 
 #ifdef __GNU__
 #include <sys/types.h>
 #include <sys/param.h>
+#include <byteswap.h>
 // These are undefined on purpose in GNU/Hurd.
 // The values below are the ones used in Linux.
 // The proper fix is to rewrite the code to not use hardcoded values,
@@ -159,6 +165,12 @@ typedef off_t off64_t;
 #define bswap_16 OSSwapInt16
 #define bswap_32 OSSwapInt32
 #define bswap_64 OSSwapInt64
+#endif
+
+#if defined(__FreeBSD__)
+#define bswap_16 bswap16
+#define bswap_32 bswap32
+#define bswap_64 bswap64
 #endif
 
 static inline uint16_t bswap(uint16_t x) { return bswap_16(x); }


### PR DESCRIPTION
Here are some additional includes for Hurd and BSD.
Is it supposed to be compilable on windows? I have not tried to do anything inside the "#ifdef WIN32".
