### PR TITLE
Attempt to use restricted paths even when scope is more generic

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -350,7 +350,16 @@ public:
 
     bool apply(Access_Operation oper, std::string path) {
         for (const auto & rule : m_rules) {
-            if ((oper == rule.first) && !path.compare(0, rule.second.size(), rule.second, 0, rule.second.size())) {
+            // The rule permits if both conditions are met:
+            // - The operation type matches the requested operation,
+            // - The requested path is a substring of the ACL's permitted path, AND
+            // - Either the requested path and ACL path is the same OR the requested path is a subdir of the ACL path.
+            //
+            // The third rule implies if the rule permits read:/foo, we should NOT authorize read:/foobar.
+            if ((oper == rule.first) &&
+                !path.compare(0, rule.second.size(), rule.second, 0, rule.second.size()) &&
+                (rule.second.size() == path.length() || path[rule.second.size()]=='/'))
+            {
                 return true;
             }
         }

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -898,8 +898,12 @@ private:
                     // more possible authorizations.
                     if (!strncmp(acl_path, restricted_path.c_str(), acl_path_size)) {
                         // Only do prefix checking on full path components.  If acl_path=/foo and
-                        // restricted_path=/foobar, then we shouldn't authorize access to /foobar.
-                        if (restricted_path.size() > acl_path_size && restricted_path[acl_path_size] != '/') {
+                        // restricted_path=/foobar, then we shouldn't authorize access to /foobar. Note:
+                        // - The scitokens-cpp library guaranteees that acl_path is normalized and not
+                        //   of the form `/foo/`.
+                        // - Hence, the only time that the acl_path can end in a '/' is when it is
+                        //   set to `/`.
+                        if ((restricted_path.size() > acl_path_size && restricted_path[acl_path_size] != '/') && (acl_path_size != 1)) {
                             continue;
                         }
                         acl_paths.push_back(restricted_path);

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -862,20 +862,43 @@ private:
         int idx = 0;
         std::set<std::string> paths_write_seen;
         std::set<std::string> paths_create_or_modify_seen;
+        std::vector<std::string> acl_paths;
+        acl_paths.reserve(config.m_restricted_paths.size() + 1);
         while (acls[idx].resource && acls[idx++].authz) {
+            acl_paths.clear();
             const auto &acl_path = acls[idx-1].resource;
             const auto &acl_authz = acls[idx-1].authz;
-            if (!config.m_restricted_paths.empty()) {
-                bool found_path = false;
+            if (config.m_restricted_paths.empty()) {
+                acl_paths.push_back(acl_path);
+            } else {
+                auto acl_path_size = strlen(acl_path);
                 for (const auto &restricted_path : config.m_restricted_paths) {
+                    // See if the acl_path is more specific than the restricted path; if so, accept it
+                    // and move on to applying paths.
                     if (!strncmp(acl_path, restricted_path.c_str(), restricted_path.size())) {
-                        found_path = true;
+                        // Only do prefix checking on full path components.  If acl_path=/foobar and
+                        // restricted_path=/foo, then we shouldn't authorize access to /foobar.
+                        if (acl_path_size > restricted_path.size() && acl_path[restricted_path.size()] != '/') {
+                            continue;
+                        }
+                        acl_paths.push_back(acl_path);
                         break;
                     }
+                    // See if the restricted_path is more specific than the acl_path; if so, accept the
+                    // restricted path as the ACL.  Keep looping to see if other restricted paths add
+                    // more possible authorizations.
+                    if (!strncmp(acl_path, restricted_path.c_str(), acl_path_size)) {
+                        // Only do prefix checking on full path components.  If acl_path=/foo and
+                        // restricted_path=/foobar, then we shouldn't authorize access to /foobar.
+                        if (restricted_path.size() > acl_path_size && restricted_path[acl_path_size] != '/') {
+                            continue;
+                        }
+                        acl_paths.push_back(restricted_path);
+                    }
                 }
-                if (!found_path) {continue;}
             }
-            for (const auto &base_path : config.m_base_paths) {
+            for (const auto &acl_path : acl_paths) {
+              for (const auto &base_path : config.m_base_paths) {
                 if (!acl_path[0] || acl_path[0] != '/') {continue;}
                 std::string path;
                 MakeCanonical(base_path + acl_path, path);
@@ -901,6 +924,7 @@ private:
                 } else if (!strcmp(acl_authz, "write")) {
                     paths_write_seen.insert(path);
                 }
+              }
             }
         }
         for (const auto &write_path : paths_write_seen) {


### PR DESCRIPTION
If a token has a broad scope and all the listed restricted paths are more specific, then try to generate ACLs that include the restricted paths.

Example: suppose we have a token with scope `storage.read:/` but restricted paths `/foo` and `/bar`.  Currently, we will reject the scope and give the token no permissions.  With this commit, we will generate acls of `read:/foo` and `read:/bar`.  So, as long as the access being attempted is within the restricted path, we can permit it.

Fixes #2132