### PR TITLE
Send User-Agent as the monitor info

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -298,6 +298,9 @@ private:
 
   /// Tells that we are just logging in
   bool DoingLogin;
+
+  /// Indicates whether we've attempted to send app info.
+  bool DoneSetInfo;
   
   /// Tells that we are just waiting to have N bytes in the buffer
   long ResumeBytes;

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -198,6 +198,9 @@ int XrdHttpReq::parseLine(char *line, int len) {
       if(prot->pmarkHandle != nullptr) {
         parseScitag(val);
       }
+    } else if (!strcasecmp(key, "User-Agent")) {
+      m_user_agent = val;
+      trim(m_user_agent);
     } else {
       // Some headers need to be translated into "local" cgi info.
       auto it = std::find_if(prot->hdr2cgimap.begin(), prot->hdr2cgimap.end(),[key](const auto & item) {
@@ -2755,6 +2758,7 @@ void XrdHttpReq::reset() {
   m_req_cksum = nullptr;
 
   m_resource_with_digest = "";
+  m_user_agent = "";
 
   headerok = false;
   keepalive = true;

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -74,6 +74,9 @@ private:
   int httpStatusCode;
   std::string httpStatusText;
 
+  // The value of the user agent, if specified
+  std::string m_user_agent;
+
   // Whether transfer encoding was requested.
   bool m_transfer_encoding_chunked;
   long long m_current_chunk_offset;
@@ -190,6 +193,9 @@ public:
   void appendOpaque(XrdOucString &s, XrdSecEntity *secent, char *hash, time_t tnow);
 
   void addCgi(const std::string & key, const std::string & value);
+
+  // Return the current user agent; if none has been specified, returns an empty string
+  const std::string &userAgent() const {return m_user_agent;}
 
   // ----------------
   // Description of the request. The header/body parsing


### PR DESCRIPTION
After the initial login to the xrootd bridge (and after parsing the first request's headers), perform a `kXR_set` for the monitoring info.  The `User-Agent` header is sent as the info.

This is only done for the first request of a connection.  It is assumed that all subsequent connections belong to the same user agent.