### PR TITLE
Allow HTTP request to provide a hint about what file will be read

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -105,7 +105,10 @@ public:
   int Stats(char *buff, int blen, int do_sync = 0);
 
 
+  /// Returns true if the filesystem supports fadvise
+  bool GetSupportsFadvise() const {return SupportsFadvise;}
 
+  void SetSupportsFadvise(bool val) {SupportsFadvise = val;}
 
   /// Perform a Stat request
   int doStat(char *fname);
@@ -298,10 +301,16 @@ private:
 
   /// Tells that we are just logging in
   bool DoingLogin;
-  
+
+  /// Indicates whether we've attempted to send app info.
+  bool DoneSetInfo;
+
   /// Tells that we are just waiting to have N bytes in the buffer
   long ResumeBytes;
-  
+
+  /// Tells that we will perform a fadvise hint.
+  bool SupportsFadvise{true};
+
   /// Private SSL context
   SSL *ssl;
 


### PR DESCRIPTION
Some filesystems (notably, CephFS) see remarkable performance improvements when you provide hints about upcoming sequential access.  Since we know within the HTTP protocol that sequential access is upcoming, we add a simple command that will notify XRootD of this via the bridge.

Uses the existing query command and adds new internal behavior.  The query command is already listed as "implementation-defined" and shouldn't need documentation in the protocol.

If the fsctl isn't implemented, then the XrdHttpProtocol will never again try to send it.

Fixes #2155