### PR TITLE
force Destination address on HTTP-TPC

### DIFF
--- a/src/XrdTpc/XrdTpcConfigure.cc
+++ b/src/XrdTpc/XrdTpcConfigure.cc
@@ -56,7 +56,9 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
                 Config.Close();
                 return false;
             }
-        } else if (!strcmp("tpc.timeout", val)) {
+        } else if (!strcmp("tpc.sense", val)) {
+		m_sense = true;
+	} else if (!strcmp("tpc.timeout", val)) {
             if (!(val = Config.GetWord())) {
                 m_log.Emsg("Config","tpc.timeout value not specified.");  return false;
             }

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -1,5 +1,6 @@
 #include "XrdHttp/XrdHttpExtHandler.hh"
 #include "XrdNet/XrdNetAddr.hh"
+#include "XrdNet/XrdNetUtils.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdSec/XrdSecEntity.hh"
 #include "XrdSfs/XrdSfsInterface.hh"
@@ -321,6 +322,7 @@ TPCHandler::~TPCHandler() {
   
 TPCHandler::TPCHandler(XrdSysError *log, const char *config, XrdOucEnv *myEnv) :
         m_desthttps(false),
+        m_sense(false),
         m_timeout(60),
         m_first_timeout(120),
         m_log(log->logger(), "TPC_"),
@@ -951,6 +953,38 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
             rec.status = 500;
             logTransferEvent(LogMask::Error, rec, "PULL_FAIL", msg);
             return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
+    }
+    // ddavila 2023-01-05:
+    // The following change was required by the Rucio/SENSE project where
+    // multiple IP addresses, each from a different subnet, are assigned to a
+    // single server and routed differently by SENSE.
+    // The above requires the server to utilize the same IP, that was used to
+    // start the TPC, for the resolution of the given TPC instead of
+    // using any of the IPs available.
+    if (m_sense  == true ){
+        XrdNetAddr *nP;
+        int numIP = 0;
+        char buff[1024];
+        char * ip;
+
+        // Get the hostname used to contact the server from the http header
+        auto host_header = req.headers.find("Host");
+        std::string host_used;
+        if (host_header != req.headers.end()) {
+            host_used = host_header->second;
+        }
+
+        // Get the IP addresses associated with the above hostname
+        XrdNetUtils::GetAddrs(host_used.c_str(), &nP, numIP, XrdNetUtils::prefAuto, 0);
+        int ip_size = nP[0].Format(buff, 1024, XrdNetAddrInfo::fmtAddr,XrdNetAddrInfo::noPort);
+        ip = (char *)malloc(ip_size-1);
+
+	// Substring to get only the address, remove brackets and garbage
+        memcpy(ip, buff+1, ip_size-2);
+        ip[ip_size-2]='\0';
+        logTransferEvent(LogMask::Info, rec, "LOCAL IP", ip);
+
+        curl_easy_setopt(curl, CURLOPT_INTERFACE, ip);
     }
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 //  curl_easy_setopt(curl,CURLOPT_SOCKOPTFUNCTION,sockopt_setcloexec_callback);

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -144,6 +144,7 @@ private:
     static size_t m_block_size;
     static size_t m_small_block_size;
     bool m_desthttps;
+    bool m_sense;  // forces the destination IP to be the same used to contact the server to trigger the TPC
     int m_timeout; // the 'timeout interval'; if no bytes have been received during this time period, abort the transfer.
     int m_first_timeout; // the 'first timeout interval'; the amount of time we're willing to wait to get the first byte.
                          // Unless explicitly specified, this is 2x the timeout interval.


### PR DESCRIPTION
Committer: Diego Davila <davila.foyo@gmail.com>
This was though to work on the Rucio/SENSE context where a single host gets N IPv6 addresses assigned.
When a host has more than 1 IP address assigned, the Destination address used by the HTTP-TPC is selected randomly. We want the address to be selected based on the hostname that was used to contact the server.