### PR TITLE
Fix compilation error reported with gcc 14

### DIFF
--- a/src/XrdSecgsi/XrdSecgsitest.cc
+++ b/src/XrdSecgsi/XrdSecgsitest.cc
@@ -87,7 +87,11 @@ static void pdots(const char *t, bool ok = 1)
    unsigned int i = 0;
    unsigned int l = (t) ? strlen (t) : 0;
    unsigned int np = PRTWIDTH - l - 8;
-   printf("|| %s ", t);
+   if (l > 0) {
+      printf("|| %s ", t);
+   } else {
+      printf("||  ");
+   }
    for (; i < np ; i++) { printf("."); }
    printf("  %s\n", (ok ? "PASSED" : "FAILED"));
 }


### PR DESCRIPTION
```
/builddir/build/BUILD/xrootd-5.6.4/src/XrdSecgsi/XrdSecgsitest.cc: In function ‘pdots(char const*, bool)’:
/builddir/build/BUILD/xrootd-5.6.4/src/XrdSecgsi/XrdSecgsitest.cc:90:15: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
   90 |    printf("|| %s ", t);
      |               ^~
```
