### PR TITLE
Implement ability to have the token groups as a separate claim

### DIFF
--- a/src/XrdSciTokens/README.md
+++ b/src/XrdSciTokens/README.md
@@ -115,7 +115,9 @@ are:
    - `username_claim` (optional): Not all issuers put the desired username in the `sub` claim (sometimes the subject is
       set to a de-identified value).  To use an alternate claim as the username, such as `uid`, set this to the desired
       claim name.  If set, it overrides `map_subject` and `default_user`.
-   -  `name_mapfile` (options): If set, then the referenced file is parsed as a JSON object and the specified mappings
+   - `groups_claim` (optional): Not all issuers put the desired groups in the `wlcg.groups` claim. To use an alternate claim
+      as the groups, set this to the desired claim name. If not set, the default is `wlcg.groups`.
+   - `name_mapfile` (options): If set, then the referenced file is parsed as a JSON object and the specified mappings
       are applied to the username inside the XRootD framework.  See below for more information on the mapfile.
    -  `authorization_strategy` (optional): One or more authorizations to use from the token.  Multiple (space separated)
       items may be specified from the following valid values:
@@ -168,7 +170,8 @@ The enumerated keys are:
      For example, if the issuer's base path is `/home`, the operation is accessing `/home/bbockelm/foo`, and the path in
      the rule is `/bbockelm`, then this attribute evaluates to `true`.  Note the path value and the requested path must
      be normalized; if presented with `/home//bbockelm/`, then this is treated as if `/home/bbockelm` was given.
-   - `group`: Case-sensitive match against one of the groups in the token.
+   - `group`: Case-sensitive match against one of the groups in the token (the claim specifying the groups is configurable, controlled by the
+     `groups_claim` variable in the issuer config; default is `wlcg.groups`).
    - `ignore`: If present (regardless of the value), the rule is ignored.
    - `comment`: Ignored; reserved for adding comments from the administrator.
 

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -532,8 +532,8 @@ public:
         if (!access_rules) {
             m_log.Log(LogMask::Debug, "Access", "Token not found in recent cache; parsing.");
             try {
-		uint64_t cache_expiry;
-		AccessRulesRaw rules;
+                uint64_t cache_expiry;
+                AccessRulesRaw rules;
                 std::string username;
                 std::string token_subject;
                 std::string issuer;

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -853,7 +853,8 @@ private:
             scitoken_destroy(token);
             return false;
         }
-        const auto &config = iter->second;
+        const auto config = iter->second;
+        pthread_rwlock_unlock(&m_config_lock);
         value = nullptr;
 
         char **group_list;
@@ -876,7 +877,6 @@ private:
         }
 
         if (scitoken_get_claim_string(token, "sub", &value, &err_msg)) {
-            pthread_rwlock_unlock(&m_config_lock);
             m_log.Log(LogMask::Warning, "GenerateAcls", "Failed to get token subject:", err_msg);
             free(err_msg);
             scitoken_destroy(token);
@@ -888,7 +888,6 @@ private:
         auto tmp_username = token_subject;
         if (!config.m_username_claim.empty()) {
             if (scitoken_get_claim_string(token, config.m_username_claim.c_str(), &value, &err_msg)) {
-                pthread_rwlock_unlock(&m_config_lock);
                 m_log.Log(LogMask::Warning, "GenerateAcls", "Failed to get token username:", err_msg);
                 free(err_msg);
                 scitoken_destroy(token);
@@ -1001,8 +1000,6 @@ private:
             }
         }
         authz_strategy = config.m_authz_strategy;
-
-        pthread_rwlock_unlock(&m_config_lock);
 
         cache_expiry = expiry;
         rules = std::move(xrd_rules);

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -859,13 +859,7 @@ private:
 
         char **group_list;
         std::vector<std::string> groups_parsed;
-        const char* tmp_group_claim;
-        if (!config.m_groups_claim.empty()) {
-            tmp_group_claim = config.m_groups_claim.c_str();
-        } else {
-            tmp_group_claim = "wlcg.groups";
-        }
-        if (!scitoken_get_claim_string_list(token, tmp_group_claim, &group_list, &err_msg)) {
+        if (scitoken_get_claim_string_list(token, config.m_groups_claim.c_str(), &group_list, &err_msg) == 0) {
             for (int idx=0; group_list[idx]; idx++) {
                 groups_parsed.emplace_back(group_list[idx]);
             }
@@ -1285,7 +1279,7 @@ private:
             auto default_user = reader.Get(section, "default_user", "");
             auto map_subject = reader.GetBoolean(section, "map_subject", false);
             auto username_claim = reader.Get(section, "username_claim", "");
-            auto groups_claim = reader.Get(section, "groups_claim", "");
+            auto groups_claim = reader.Get(section, "groups_claim", "wlcg.groups");
 
             auto authz_strategy_str = reader.Get(section, "authorization_strategy", "");
             uint32_t authz_strategy = 0;

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -865,8 +865,8 @@ private:
             }
             scitoken_free_string_list(group_list);
         } else {
-            // For now, we silently ignore errors.
-            // std::cerr << "Failed to get groups: " << err_msg << std::endl;
+            // Failing to parse groups is not fatal, but we should still warn about what's wrong
+            m_log.Log(LogMask::Warning, "GenerateAcls", "Failed to get token groups:", err_msg);
             free(err_msg);
         }
 


### PR DESCRIPTION
This implements the ability to have the groups claim in the token as a separate variable `groups_claim` to be set in the config, analogous to the username claim in #1978 . If `groups_claim` is not set in the config, it defaults back to the previously hard coded `"wlcg.groups"`. 