### PR TITLE
[XrdTpcTPC] PMark - handle the cases where the PMark handle cannot be created because the socket is not yet connected

### DIFF
--- a/src/XrdTpc/XrdTpcPMarkManager.cc
+++ b/src/XrdTpc/XrdTpcPMarkManager.cc
@@ -42,6 +42,9 @@ void PMarkManager::addFd(int fd, const struct sockaddr * sockP) {
 void PMarkManager::startTransfer(XrdHttpExtReq * req) {
   mReq = req;
   mTransferWillStart = true;
+  // Empty the queue to ensure that every file descriptor that will be added to the queue will be related to the transfer
+  std::queue<SocketInfo> empty;
+  std::swap( mSocketInfos, empty );
 }
 
 void PMarkManager::beginPMarks() {


### PR DESCRIPTION
The initial implementation of the scitags for HTTP TPC transfers worked well "on my dev machine". But that's only by luck... Once I've deployed this in a test EOS cluster with storage servers not located on the same machine, I did not see any packet markers, but instead error messages like "Transport endpoint is not connected".
I therefore deduced that this was due to the fact that curl's callback on the socket open is not called when the socket is connected, but only when the socket is opened. The socket may or may not be connected despite having been opened.

The change that I propose is to actually simply retry to do the packet marking at a later stage, ensuring the transfer has started.