### PR TITLE
Fix ordering of the debug levels

### DIFF
--- a/src/XrdPosix/XrdPosixConfig.cc
+++ b/src/XrdPosix/XrdPosixConfig.cc
@@ -488,7 +488,7 @@ bool XrdPosixConfig::SetConfig(XrdOucPsx &parms)
 
 void XrdPosixConfig::SetDebug(int val)
 {
-   const std::string dbgType[] = {"Info", "Warning", "Error", "Debug", "Dump"};
+   const std::string dbgType[] = {"Error", "Warning", "Info", "Debug", "Dump"};
 
 // The default is none but once set it cannot be unset in the client
 //


### PR DESCRIPTION
The documentation says "increasing values produce more detail".  However, `DebugLevel 1` was mapped to "Info" and `DebugLevel 3` was mapped to "Error".

With this, `pss.setopt DebugLevel N` has the following meanings:

- 0: None
- 1: Error
- 2: Warning
- 3: Info
- 4: Debug
- 5: Dump

Previously, 1 and 3 were swapped.