### PR TITLE
add stat permissions to create, modify and write

### DIFF
--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -353,6 +353,12 @@ public:
             if ((oper == rule.first) && !path.compare(0, rule.second.size(), rule.second, 0, rule.second.size())) {
                 return true;
             }
+            // according to WLCG token specs, allow creation of required superfolders for a new file if requested
+            if ((oper == AOP_Stat || oper == AOP_Mkdir) && 
+              !rule.second.compare(0, path.size(), path, 0, path.size()) &&  
+              rule.second.size() >= path.length()  ) {
+                return true;
+            }
         }
         return false;
     }

--- a/src/XrdSciTokens/XrdSciTokensAccess.cc
+++ b/src/XrdSciTokens/XrdSciTokensAccess.cc
@@ -889,6 +889,7 @@ private:
                     xrd_rules.emplace_back(AOP_Mkdir, path);
                     xrd_rules.emplace_back(AOP_Rename, path);
                     xrd_rules.emplace_back(AOP_Excl_Insert, path);
+                    xrd_rules.emplace_back(AOP_Stat, path);
                 } else if (!strcmp(acl_authz, "modify")) {
                     paths_create_or_modify_seen.insert(path);
                     xrd_rules.emplace_back(AOP_Create, path);
@@ -897,6 +898,7 @@ private:
                     xrd_rules.emplace_back(AOP_Insert, path);
                     xrd_rules.emplace_back(AOP_Update, path);
                     xrd_rules.emplace_back(AOP_Chmod, path);
+                    xrd_rules.emplace_back(AOP_Stat, path);
                     xrd_rules.emplace_back(AOP_Delete, path);
                 } else if (!strcmp(acl_authz, "write")) {
                     paths_write_seen.insert(path);
@@ -911,6 +913,7 @@ private:
                 xrd_rules.emplace_back(AOP_Rename, write_path);
                 xrd_rules.emplace_back(AOP_Insert, write_path);
                 xrd_rules.emplace_back(AOP_Update, write_path);
+                xrd_rules.emplace_back(AOP_Stat, write_path);
                 xrd_rules.emplace_back(AOP_Chmod, write_path);
                 xrd_rules.emplace_back(AOP_Delete, write_path);
             }


### PR DESCRIPTION
stat permissions are implicitly required for storage systems for create, modify  and delete operations. Currently tokens with purely create and modify permissions would fail with permission denied on stat on attempts to perform those operations