### PR TITLE
[XrdTpcTPC] Send a 400 - invalid request - response when a user requests more than 100 streams for the HTTP-TPC PULL transfer

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -986,7 +986,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
             }
             if (stream_req < 0 || stream_req > 100) {
                 char msg[] = "Invalid request for number of streams";
-                rec.status = 500;
+                rec.status = 400;
                 logTransferEvent(LogMask::Info, rec, "INVALID_REQUEST", msg);
                 return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
             }


### PR DESCRIPTION
Solves https://github.com/xrootd/xrootd/issues/2186