### PR TITLE
[Tests] Use `find_package(GTest REQUIRED)`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,5 @@
-include(GoogleTest)
+find_package(GTest REQUIRED)
+
 add_subdirectory( XrdCl )
 add_subdirectory(XrdHttpTests)
 


### PR DESCRIPTION
This enables building against non-cmake gtest