### PR TITLE
[XrdTpcTPC] Packet marking - avoid infinite loop in the case the first packet marking handle created got removed after the corresponding socket got closed

### DIFF
--- a/src/XrdTpc/XrdTpcPMarkManager.hh
+++ b/src/XrdTpc/XrdTpcPMarkManager.hh
@@ -107,8 +107,6 @@ private:
   bool mTransferWillStart;
   // The XrdHttpTPC request information
   XrdHttpExtReq * mReq;
-  // The file descriptor used to create the first packet marking handle
-  int mInitialFD = -1;
 };
 } // namespace XrdTpc
 


### PR DESCRIPTION
Fixes #2192 