### PR TITLE
Flexible SciTokens authorization strategy (v2)

### DIFF
--- a/src/XrdSciTokens/README.md
+++ b/src/XrdSciTokens/README.md
@@ -117,6 +117,17 @@ are:
       claim name.  If set, it overrides `map_subject` and `default_user`.
    -  `name_mapfile` (options): If set, then the referenced file is parsed as a JSON object and the specified mappings
       are applied to the username inside the XRootD framework.  See below for more information on the mapfile.
+   -  `authorization_strategy` (optional): One or more authorizations to use from the token.  Multiple (space separated)
+      items may be specified from the following valid values:
+
+         - `capability`: Authorize based on capabilities (e.g., `storage.read:/foo`) from the token.
+         - `group`: Pass through the request if there's any group present in the token.
+         - `mapping`: Pass through the request if the user mapping was successful.
+
+      For the `group` and `mapping` cases, the username and group are set in the internal XRootD request credential,
+      but the final authorization must be done by a subsequent plugin.  The default value is `capability group mapping`.
+      *Note*: if `mapping` is present, then a token without a capability may still have authorized actions.
+
 
 Group- and Scope-based authorization
 ------------------------------------


### PR DESCRIPTION
This is the follow-up to #2122.

On a per-issuer basis, decide if the mapping information is only to be done after authorization passes or if the mapping information should be kept and passed to the subsequent plugin.

Tests performed:
1.  Scitoken containing correct scopes is authorized in default setting.
2. Scitoken containing group information passes group information to the next plugin in default setting.
3. Scitoken that is mapped in mapfile passes in default setting to next plugin.
4. Scitoken that is mapped in mapfile but has no scopes is ignored when authorization_strategy is set to `capability`
5. Scitoken containing group information and incorrect scopes (no capability-based mapping) is passed to next plugin.

Note there's no config changes in the main xrootd config file but an addition of a configuration parameter in scitokens.cfg.  The default setting if nothing present is the current behavior.  To have the behavior requested by @esindril in #2121 (_only_ capabilities can provide authorization), the following issuer block would be used:

```
[Issuer DEMO]
issuer = https://demo.scitokens.org
base_path = /
restricted_path = /protected
default_user = brian
name_mapfile = /Users/bbockelm/.config/xrootd/mapfile
authorization_strategy = capability
```

Relevant documentation is in the README.md for the module.

Note that when it's "authorized" by either mapping or group, it's not really authorizing -- it's populating the mapped username / group information into the `XrdSecEntity` and passing the information along to the next plugin in the chain.  So, if you're looking to authorize via AuthDB (or, for EOS, in the OSS object), you'll be consuming the output of the plugin.

Fixes: #2121 
