### PR TITLE
Fix argument parsing in pyxrootd's File::Stat

### DIFF
--- a/bindings/python/src/PyXRootDFile.cc
+++ b/bindings/python/src/PyXRootDFile.cc
@@ -106,14 +106,14 @@ namespace PyXRootD
   PyObject* File::Stat( File *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "force", "timeout", "callback", NULL };
-    bool                force    = false;
+    int                 force    = 0;
     uint16_t            timeout  = 0;
     PyObject           *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
     if ( !self->file->IsOpen() ) return FileClosedError();
 
-    if ( !PyArg_ParseTupleAndKeywords( args, kwds, "|iHO:stat", (char**) kwlist,
+    if ( !PyArg_ParseTupleAndKeywords( args, kwds, "|pHO:stat", (char**) kwlist,
         &force, &timeout, &callback ) ) return NULL;
 
     if ( callback && callback != Py_None ) {


### PR DESCRIPTION
On macOS I've noticed that using `File.stat` results in SIGABORT. Linux doesn't seem to be affected.

After debugging I found that the arugment parsing seems to be broken, with an `int` being placed into a `bool`.

Reproducer:

```python
from XRootD import client

f = client.File()
status, _ = f.open(
    "root://eospublic.cern.ch//eos/opendata/lhcb/Collision12/CHARM/LHCb_2012_Beam4000GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21_CHARM_MDST/00041836/0000/00041836_00009718_1.charm.mdst")
assert status.ok
print(f.stat())
```

Using 5.6.6:

```bash
$ python test.py
fish: Job 1, 'python test.py' terminated by signal SIGABRT (Abort)
```

Patching 5.6.6 with this PR:
```bash
$ python test.py
(<status: 0, code: 0, errno: 0, message: '[SUCCESS] ', shellcode: 0, error: False, fatal: False, ok: True>, <id: '7071570313412045725', size: 4038643315, flags: 48, modtime: 1698682469, modtimestr: '2023-10-30 16:14:29'>)
```