### PR TITLE
Fixes for 64 bit time_t on 32 bit systems

### DIFF
--- a/src/XrdApps/Xrdadler32.cc
+++ b/src/XrdApps/Xrdadler32.cc
@@ -88,7 +88,7 @@ int fGetXattrAdler32(int fd, const char* attr, char *value)
     int rc;
 
     if (fstat(fd, &st)) return 0;
-    sprintf(mtime, "%ld", st.st_mtime);
+    sprintf(mtime, "%lld", (long long) st.st_mtime);
 
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
     rc = fgetxattr(fd, attr, attr_val, 25);

--- a/src/XrdBwm/XrdBwmLogger.cc
+++ b/src/XrdBwm/XrdBwmLogger.cc
@@ -146,11 +146,12 @@ void XrdBwmLogger::Event(Info &eInfo)
    tp->Tlen = snprintf(tp->Text, XrdBwmLoggerMsg::msgSize,
                     "<stats id=\"bwm\"><tid>%s</tid><lfn>%s</lfn>"
                     "<lcl>%s</lcl><rmt>%s</rmt><flow>%c</flow>"
-                    "<at>%ld</at><bt>%ld</bt><ct>%ld</ct>"
+                    "<at>%lld</at><bt>%lld</bt><ct>%lld</ct>"
                     "<iq>%d</iq><oq>%d</oq><xq>%d</xq>"
                     "<sz>%lld<sz><esec>%d</esec></stats>%c",
                     eInfo.Tident, eInfo.Lfn, eInfo.lclNode, eInfo.rmtNode,
-                    eInfo.Flow, eInfo.ATime, eInfo.BTime, eInfo.CTime,
+                    eInfo.Flow, (long long) eInfo.ATime,
+                    (long long) eInfo.BTime, (long long) eInfo.CTime,
                     eInfo.numqIn, eInfo.numqOut, eInfo.numqXeq, eInfo.Size,
                     eInfo.ESec, theEOL);
 

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -656,7 +656,7 @@ void XrdHttpReq::appendOpaque(XrdOucString &s, XrdSecEntity *secent, char *hash,
 
     s += "&xrdhttptime=";
     char buf[256];
-    sprintf(buf, "%ld", tnow);
+    sprintf(buf, "%lld", (long long) tnow);
     s += buf;
 
     if (secent) {

--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -477,7 +477,7 @@ bool Cache::Config(const char *config_filename, const char *parameters)
       if (m_configuration.m_cs_UVKeep < 0)
          strcpy(uvk, "lru");
       else
-         sprintf(uvk, "%ld", m_configuration.m_cs_UVKeep);
+         sprintf(uvk, "%lld", (long long) m_configuration.m_cs_UVKeep);
       float rg = (m_configuration.m_RamAbsAvailable) / float(1024*1024*1024);
       loff = snprintf(buff, sizeof(buff), "Config effective %s pfc configuration:\n"
                       "       pfc.cschk %s uvkeep %s\n"

--- a/src/XrdPosix/XrdPosixPreload32.cc
+++ b/src/XrdPosix/XrdPosixPreload32.cc
@@ -44,6 +44,10 @@
 #ifdef  _FILE_OFFSET_BITS
 #undef  _FILE_OFFSET_BITS
 #endif
+
+#ifdef  _TIME_BITS
+#undef  _TIME_BITS
+#endif
 #endif
 
 #define XRDPOSIXPRELOAD32

--- a/src/XrdSecsss/XrdSecsssKT.cc
+++ b/src/XrdSecsss/XrdSecsssKT.cc
@@ -371,10 +371,11 @@ int XrdSecsssKT::Rewrite(int Keep, int &numKeys, int &numTot, int &numExp)
          if (ktP->Data.Exp && ktP->Data.Exp <= time(0)) {numExp++; continue;}
          if (!isKey(ktCurr, ktP, 0)) {ktCurr.NUG(ktP); numID = 0;}
             else if (Keep && numID >= Keep) continue;
-         n = sprintf(buff, "%s0 u:%s g:%s n:%s N:%lld c:%ld e:%ld f:%lld k:",
+         n = sprintf(buff, "%s0 u:%s g:%s n:%s N:%lld c:%lld e:%lld f:%lld k:",
                     (numKeys ? "\n" : ""),
                      ktP->Data.User,ktP->Data.Grup,ktP->Data.Name,ktP->Data.ID,
-                     ktP->Data.Crt, ktP->Data.Exp, ktP->Data.Flags);
+                     (long long) ktP->Data.Crt, (long long) ktP->Data.Exp,
+                     ktP->Data.Flags);
          numID++; numKeys++; keyB2X(ktP, kbuff);
          if (write(ktFD, buff, n) < 0
          ||  write(ktFD, kbuff, ktP->Data.Len*2) < 0) break;

--- a/src/XrdXrootd/XrdXrootdPrepare.cc
+++ b/src/XrdXrootd/XrdXrootdPrepare.cc
@@ -129,7 +129,8 @@ int XrdXrootdPrepare::List(XrdXrootdPrepArgs &pargs, char *resp, int resplen)
             else continue;
          if ((up = (char *) index((const char *)(up+1), (int)'_'))) *up = ' ';
             else continue;
-         return snprintf(resp, resplen-1, "%s %ld", dp->d_name, buf.st_mtime);
+         return snprintf(resp, resplen-1, "%s %lld",
+                         dp->d_name, (long long) buf.st_mtime);
         }
 
 // Completed

--- a/src/XrdXrootd/XrdXrootdProtocol.cc
+++ b/src/XrdXrootd/XrdXrootdProtocol.cc
@@ -798,8 +798,8 @@ int XrdXrootdProtocol::StatGen(struct stat &buf, char *xxBuff, int xxLen,
 
 // Format the default response: <devid> <size> <flags> <mtime>
 //
-   m = snprintf(xxBuff, xxLen, "%lld %lld %d %ld",
-                Dev.uuid, fsz, flags, buf.st_mtime);
+   m = snprintf(xxBuff, xxLen, "%lld %lld %d %lld",
+                Dev.uuid, fsz, flags, (long long) buf.st_mtime);
 // if (!xtnd || m >= xxLen) return xxLen;
 //
 
@@ -808,8 +808,9 @@ int XrdXrootdProtocol::StatGen(struct stat &buf, char *xxBuff, int xxLen,
    char *origP = xxBuff;
    char *nullP = xxBuff + m++;
    xxBuff += m; xxLen -= m;
-   n = snprintf(xxBuff, xxLen, "%ld %ld %04o ",
-                buf.st_ctime, buf.st_atime, buf.st_mode&07777);
+   n = snprintf(xxBuff, xxLen, "%lld %lld %04o ",
+                (long long) buf.st_ctime, (long long) buf.st_atime,
+                buf.st_mode&07777);
    if (n >= xxLen) return m;
    xxBuff += n; xxLen -= n;
 


### PR DESCRIPTION
Debian has enabled 64 bit time_t for most of their 32 bit architectures. This PR fixes some issues to support this.