### PR TITLE
[XrdTpc] Force HTTP 1.1 for the TPC transfers otherwise transfers fai…

### DIFF
--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -873,6 +873,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
         return req.SendSimpleResp(rec.status, NULL, NULL, msg, 0);
     }
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long) CURL_HTTP_VERSION_1_1);
 //  curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_setcloexec_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &rec);
@@ -987,6 +988,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         curl_easy_setopt(curl, CURLOPT_INTERFACE, ip);
     }
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long) CURL_HTTP_VERSION_1_1);
 //  curl_easy_setopt(curl,CURLOPT_SOCKOPTFUNCTION,sockopt_setcloexec_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETFUNCTION, opensocket_callback);
     curl_easy_setopt(curl, CURLOPT_OPENSOCKETDATA, &rec);


### PR DESCRIPTION
…l for Alma 9

In Alma 9.3 the default curl version is 7.76.1 and according to the documentation [1], starting with 7.62.0 the default HTTP protocol used is HTTP 2 TLS. This leads to the following error whenever a HTTP TPC trasfers is attempted: HTTP library failure: Stream error in the HTTP/2 framing layer

This patch will force curl to use HTTP 1.1 without even attempting HTTP 2. This is a workaround for the currently available curl version since normaly curl should be able to gracefully downgrade from HTTP 2 to 1.1 by itself.

[1] https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html