### PR TITLE
[XrdTpcTPC] PMark - Connect curl socket at socket creation

### DIFF
--- a/src/XrdNet/XrdNetPMarkFF.cc
+++ b/src/XrdNet/XrdNetPMarkFF.cc
@@ -290,6 +290,7 @@ void XrdNetPMarkFF::SockStats(struct sockStats &ss)
 #ifndef __linux__
    memset(&ss, 0, sizeof(struct sockStats));
 #else
+   EPName("SockStats");
    struct tcp_info tcpInfo;
    socklen_t  tiLen = sizeof(tcpInfo);
 
@@ -298,7 +299,10 @@ void XrdNetPMarkFF::SockStats(struct sockStats &ss)
        ss.bSent = static_cast<uint64_t>(tcpInfo.tcpi_bytes_acked);
        ss.msRTT = static_cast<uint32_t>(tcpInfo.tcpi_rtt/1000);
        ss.usRTT = static_cast<uint32_t>(tcpInfo.tcpi_rtt%1000);
-      } else memset(&ss, 0, sizeof(struct sockStats));
+      } else {
+        memset(&ss, 0, sizeof(struct sockStats));
+        DEBUG("Unable to get TCP information errno=" << strerror(errno));
+      }
 #endif
 }
 

--- a/src/XrdNet/XrdNetUtils.hh
+++ b/src/XrdNet/XrdNetUtils.hh
@@ -32,6 +32,8 @@
 
 #include <string>
 #include <vector>
+#include <sstream>
+#include <cstdint>
 
 #include "XrdOuc/XrdOucEnum.hh"
 
@@ -425,6 +427,8 @@ static int  SetAuto(AddrOpts aOpts=allIPMap);
 
 static bool Singleton(const char  *hSpec, const char **eText=0);
 
+static bool ConnectWithTimeout(int sockfd, const struct sockaddr* clientAddr, size_t clientAddrLen,uint32_t timeout_sec, std::stringstream & errMsg);
+
 //------------------------------------------------------------------------------
 //! Constructor
 //------------------------------------------------------------------------------
@@ -448,6 +452,7 @@ const char *GetHostPort(XrdNetSpace::hpSpec &aBuff, const char *hSpec, int pNum)
 static
 const char *getMyFQN(const char *&myDom);
 static int setET(const char **errtxt, int rc);
+static bool SetSockBlocking(int sockfd, bool blocking, std::stringstream & errMsg);
 static int autoFamily;
 static int autoHints;
 };

--- a/src/XrdTpc/XrdTpcMultistream.cc
+++ b/src/XrdTpc/XrdTpcMultistream.cc
@@ -282,7 +282,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
     }
 
     // Notify the packet marking manager that the transfer will start after this point
-  rec.pmarkManager.startTransfer(&req);
+    rec.pmarkManager.startTransfer();
 
     // Create the multi-handle and add in the current transfer to it.
     MultiCurlHandler mch(handles, m_log);

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -51,7 +51,7 @@ public:
 
 private:
 
-    static int sockopt_setcloexec_callback(void * clientp, curl_socket_t curlfd, curlsocktype purpose);
+    static int sockopt_callback(void * clientp, curl_socket_t curlfd, curlsocktype purpose);
     static int opensocket_callback(void *clientp,
                                    curlsocktype purpose,
                                    struct curl_sockaddr *address);
@@ -60,8 +60,8 @@ private:
 
     struct TPCLogRecord {
 
-        TPCLogRecord(XrdNetPMark * pmark) : bytes_transferred( -1 ), status( -1 ),
-                         tpc_status(-1), streams( 1 ), isIPv6(false), pmarkManager(pmark)
+        TPCLogRecord(XrdHttpExtReq & req) : bytes_transferred( -1 ), status( -1 ),
+                         tpc_status(-1), streams( 1 ), isIPv6(false), mReq(req), pmarkManager(mReq)
         {
          gettimeofday(&begT, 0); // Set effective start time
         }
@@ -79,7 +79,9 @@ private:
         int tpc_status;
         unsigned int streams;
         bool isIPv6;
+        XrdHttpExtReq & mReq;
         XrdTpc::PMarkManager pmarkManager;
+        XrdSysError * m_log;
     };
 
     int ProcessOptionsReq(XrdHttpExtReq &req);
@@ -167,5 +169,9 @@ private:
 #endif
 
     bool usingEC; // indicate if XrdEC is used
+
+    // Time to connect the curl socket to the remote server uses the linux's default value
+    // of 60 seconds
+    static const long CONNECT_TIMEOUT = 60;
 };
 }


### PR DESCRIPTION
This allows to improve HTTP-TPC transfers packet marking precision. If the packet marking is enabled and the client submitted a request with a SciTag header, then the connection of the socket will be done within a timeout of 5 seconds. The TPC transfer will fail if the socket could not be connected.

Currently, the timeout is 5 seconds, hardcoded. I can put that in a variable for sure if needed. I have no clue of what a reasonable timeout for a connection could be. I'm open to suggestions :)