### PR TITLE
[XrdCrypto] Avoid some repated calls of EVP_PKEY_check on the same key

### DIFF
--- a/src/XrdCrypto/XrdCryptosslRSA.cc
+++ b/src/XrdCrypto/XrdCryptosslRSA.cc
@@ -236,10 +236,10 @@ XrdCryptosslRSA::XrdCryptosslRSA(const XrdCryptosslRSA &r) : XrdCryptoRSA()
             }
           } else {
             if ((fEVP = PEM_read_bio_PrivateKey(bcpy,0,0,0))) {
-               // Check consistency
-               if (XrdCheckRSA(fEVP) == 1) {
-                  // Update status
-                  status = kComplete;
+               // Check consistency only if original was not marked complete
+               if (r.status == kComplete || XrdCheckRSA(fEVP) == 1) {
+                 // Update status
+                 status = kComplete;
                }
             }
          }


### PR DESCRIPTION
With openssl3 the EVP_PKEY_check() may be more computationally expensive than with previous openssl versions. Currently XrdCl can call this check multiple times for the same key, e.g. when copying constructing an XrdCryptosslRSA object. This patch is to avoid making repeated, but similar, calls to EVP_PKEY_check().