### PR TITLE
[XrdHttp] External handlers can be loaded without TLS

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -2590,10 +2590,17 @@ int XrdHttpProtocol::xexthandler(XrdOucStream &Config,
   }
   strncpy(namebuf, val, sizeof(namebuf));
   namebuf[ sizeof(namebuf)-1 ] = '\0';
-  
+
+  // Get the +notls option if it was provided
+  val = Config.GetWord();
+
+  if(val && !strcmp("+notls",val)) {
+    noTlsOK = true;
+    val = Config.GetWord();
+  }
+
   // Get the path
   //
-  val = Config.GetWord();
   if (!val || !val[0]) {
     eDest.Emsg("Config", "No http external handler plugin specified.");
     return 1;
@@ -2604,12 +2611,6 @@ int XrdHttpProtocol::xexthandler(XrdOucStream &Config,
   }
 
   strcpy(path, val);
-
-  val = Config.GetWord();
-
-  if(val && !strcmp("notls",val)) {
-    noTlsOK = true;
-  }
   
   // Everything else is a free string
   //

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -190,9 +190,9 @@ private:
         {XrdOucString extHName;  // The instance name (1 to 16 characters)
          XrdOucString extHPath;  // The shared library path
          XrdOucString extHParm;  // The parameter (sort of)
-
-         extHInfo(const char *hName, const char *hPath, const char *hParm)
-                 : extHName(hName), extHPath(hPath), extHParm(hParm) {}
+         bool extHNoTlsOK;     // If true the exthandler can be loaded if TLS has NOT been configured
+         extHInfo(const char *hName, const char *hPath, const char *hParm, const bool hNoTlsOK)
+                 : extHName(hName), extHPath(hPath), extHParm(hParm), extHNoTlsOK(hNoTlsOK) {}
         ~extHInfo() {}
   };
   /// Functions related to the configuration
@@ -235,7 +235,10 @@ private:
     XrdHttpExtHandler *ptr;
   } exthandler[MAX_XRDHTTPEXTHANDLERS];
   static int exthandlercnt;
-  
+
+  static int LoadExtHandlerNoTls(std::vector<extHInfo> &hiVec,
+                                 const char *cFN, XrdOucEnv &myEnv);
+
   // Loads the ExtHandler plugin, if available
   static int LoadExtHandler(std::vector<extHInfo> &hiVec,
                             const char *cFN, XrdOucEnv &myEnv);

--- a/src/XrdTpc/XrdTpcConfigure.cc
+++ b/src/XrdTpc/XrdTpcConfigure.cc
@@ -107,9 +107,10 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
     if ((cafile = myEnv->Get("http.cafile"))) {
         m_cafile = cafile;
     }
+
     if (!cadir && !cafile) {
+        // We do not necessary need TLS to perform HTTP TPC transfers, just log that these values were not specified
         m_log.Emsg("Config", "neither xrd.tls cadir nor certfile value specified; is TLS enabled?");
-        return false;
     }
 
     void *sfs_raw_ptr;


### PR DESCRIPTION
The XrootD server administrator can now configure HTTP handlers without having configured TLS.
They can do so by adding "notls" after the path of the library. Example: `http.exthandler xrdtpc libXrdHttpTPC.so notls`
By default, HTTP external handlers can only be loaded if TLS is enabled.

Fixes #2099 