### PR TITLE
Fix timing on the throttle plugin

### DIFF
--- a/src/XrdThrottle/XrdThrottleManager.cc
+++ b/src/XrdThrottle/XrdThrottleManager.cc
@@ -19,8 +19,7 @@ const
 int XrdThrottleManager::m_max_users = 1024;
 
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
-int clock_id;
-int XrdThrottleTimer::clock_id = clock_getcpuclockid(0, &clock_id) != ENOENT ? CLOCK_THREAD_CPUTIME_ID : CLOCK_MONOTONIC;
+clockid_t XrdThrottleTimer::clock_id = CLOCK_MONOTONIC;
 #else
 int XrdThrottleTimer::clock_id = 0;
 #endif
@@ -441,7 +440,7 @@ XrdThrottleManager::RecomputeInternal()
    while (m_stable_io_wait.tv_nsec > 1000000000)
    {
       m_stable_io_wait.tv_nsec -= 1000000000;
-      m_stable_io_wait.tv_nsec --;
+      m_stable_io_wait.tv_sec ++;
    }
    struct timespec io_wait_ts;
    io_wait_ts.tv_sec = m_stable_io_wait.tv_sec;

--- a/src/XrdThrottle/XrdThrottleManager.cc
+++ b/src/XrdThrottle/XrdThrottleManager.cc
@@ -18,7 +18,7 @@ XrdThrottleManager::TraceID = "ThrottleManager";
 const
 int XrdThrottleManager::m_max_users = 1024;
 
-#if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
+#if defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 clockid_t XrdThrottleTimer::clock_id = CLOCK_MONOTONIC;
 #else
 int XrdThrottleTimer::clock_id = 0;

--- a/src/XrdThrottle/XrdThrottleManager.hh
+++ b/src/XrdThrottle/XrdThrottleManager.hh
@@ -219,7 +219,7 @@ private:
 XrdThrottleManager &m_manager;
 struct timespec m_timer;
 
-static int clock_id;
+static clockid_t clock_id;
 };
 
 #endif

--- a/src/XrdThrottle/XrdThrottleManager.hh
+++ b/src/XrdThrottle/XrdThrottleManager.hh
@@ -167,7 +167,7 @@ public:
 void StopTimer()
 {
    struct timespec end_timer = {0, 0};
-#if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
+#if defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
    int retval = clock_gettime(clock_id, &end_timer);
 #else
    int retval = -1;
@@ -203,7 +203,7 @@ protected:
 XrdThrottleTimer(XrdThrottleManager & manager) :
    m_manager(manager)
 {
-#if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
+#if defined(__linux__) || defined(__APPLE__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
    int retval = clock_gettime(clock_id, &m_timer);
 #else
    int retval = -1;


### PR DESCRIPTION
When examining some plots of the new g-stream data, we were surprised to see the aggregate I/O time was non-monotonic (by definition, the sum of all time since start should always be monotonic!).

Two bugs were discovered:
- Incorrect handling of the timespec normalization.
- Incorrect clock used for the timer.  Switched to `CLOCK_MONOTONIC`.

Once the second item was handled, the code only uses POSIX functions so enabling Mac OS X (my main development platform) was trivial and I adjusted the defines accordingly.

I would suggest considering the patch for backport to a current release series if a subsequent release is planned.