### PR TITLE
[XrdHttp/TPC/Macaroons] Client header parsing is now case-insensitive

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -113,6 +113,7 @@ XrdNetPMark * XrdHttpProtocol::pmarkHandle = nullptr;
 XrdHttpChecksumHandler XrdHttpProtocol::cksumHandler = XrdHttpChecksumHandler();
 XrdHttpReadRangeHandler::Configuration XrdHttpProtocol::ReadRangeConfig;
 bool XrdHttpProtocol::tpcForwardCreds = false;
+bool XrdHttpProtocol::keepHeaderCase = false;
 
 XrdSysTrace XrdHttpTrace("http");
 
@@ -1080,6 +1081,7 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
       else if TS_Xeq("httpsmode", xhttpsmode);
       else if TS_Xeq("tlsreuse", xtlsreuse);
       else if TS_Xeq("auth", xauth);
+      else if TS_Xeq("keepheadercase", xkeepheadercase);
       else {
         eDest.Say("Config warning: ignoring unknown directive '", var, "'.");
         Config.Echo();
@@ -2846,6 +2848,19 @@ int XrdHttpProtocol::xauth(XrdOucStream &Config) {
     } else {
       eDest.Emsg("Config", "http.auth value is invalid"); return 1;
     }
+  }
+  return 0;
+}
+
+int XrdHttpProtocol::xkeepheadercase(XrdOucStream &Config) {
+  char *val = Config.GetWord();
+  if (!val || !val[0])
+  {eDest.Emsg("Config", "keepheadercase argument not specified"); return 1;}
+
+  if(!strcmp("yes",val)) {
+    keepHeaderCase = true;
+  } else {
+    keepHeaderCase = false;
   }
   return 0;
 }

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -220,6 +220,7 @@ private:
   static int xhttpsmode(XrdOucStream &Config);
   static int xtlsreuse(XrdOucStream &Config);
   static int xauth(XrdOucStream &Config);
+  static int xkeepheadercase(XrdOucStream &Config);
   
   static bool isRequiredXtractor; // If true treat secxtractor errors as fatal
   static XrdHttpSecXtractor *secxtractor;
@@ -447,5 +448,8 @@ protected:
 
   /// If set to true, the HTTP TPC transfers will forward the credentials to redirected hosts
   static bool tpcForwardCreds;
+
+  /// If set to true, the client-provided HTTP header keys will be inserted as-is in addition to their lower-cased version
+  static bool keepHeaderCase;
 };
 #endif

--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -202,7 +202,7 @@ int Handler::ProcessOAuthConfig(XrdHttpExtReq &req) {
     {
         return req.SendSimpleResp(405, NULL, NULL, "Only GET is valid for oauth config.", 0);
     }
-    auto header = req.headers.find("Host");
+    auto header = req.headers.find("host");
     if (header == req.headers.end())
     {
         return req.SendSimpleResp(400, NULL, NULL, "Host header is required.", 0);
@@ -235,7 +235,7 @@ int Handler::ProcessTokenRequest(XrdHttpExtReq &req)
     {
         return req.SendSimpleResp(405, NULL, NULL, "Only POST is valid for token request.", 0);
     }
-    auto header = req.headers.find("Content-Type");
+    auto header = req.headers.find("content-type");
     if (header == req.headers.end())
     {
         return req.SendSimpleResp(400, NULL, NULL, "Content-Type missing; not a valid macaroon request?", 0);
@@ -368,7 +368,7 @@ int Handler::ProcessReq(XrdHttpExtReq &req)
         return ProcessTokenRequest(req);
     }
 
-    auto header = req.headers.find("Content-Type");
+    auto header = req.headers.find("content-type");
     if (header == req.headers.end())
     {
         return req.SendSimpleResp(400, NULL, NULL, "Content-Type missing; not a valid macaroon request?", 0);
@@ -377,7 +377,7 @@ int Handler::ProcessReq(XrdHttpExtReq &req)
     {
         return req.SendSimpleResp(400, NULL, NULL, "Content-Type must be set to `application/macaroon-request' to request a macaroon", 0);
     }
-    header = req.headers.find("Content-Length");
+    header = req.headers.find("content-length");
     if (header == req.headers.end())
     {
         return req.SendSimpleResp(400, NULL, NULL, "Content-Length missing; not a valid POST", 0);

--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -97,12 +97,12 @@ void State::CopyHeaders(XrdHttpExtReq &req) {
     for (std::map<std::string, std::string>::const_iterator hdr_iter = req.headers.begin();
          hdr_iter != req.headers.end();
          hdr_iter++) {
-        if (hdr_iter->first == "Copy-Header") {
+        if (hdr_iter->first == "copy-header") {
             list = curl_slist_append(list, hdr_iter->second.c_str());
             m_headers_copy.emplace_back(hdr_iter->second);
         }
         // Note: len("TransferHeader") == 14
-        if (!hdr_iter->first.compare(0, 14, "TransferHeader")) {
+        if (!hdr_iter->first.compare(0, 14, "transferheader")) {
             std::stringstream ss;
             ss << hdr_iter->first.substr(14) << ": " << hdr_iter->second;
             list = curl_slist_append(list, ss.str().c_str());

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -170,7 +170,7 @@ static std::string prepareURL(XrdHttpExtReq &req, bool & hasSetOpaque) {
     std::map<std::string, std::string>::const_iterator iter = req.headers.find("xrd-http-query");
     if (iter == req.headers.end() || iter->second.empty()) {return req.resource;}
 
-    auto has_authz_header = req.headers.find("Authorization") != req.headers.end();
+    auto has_authz_header = req.headers.find("authorization") != req.headers.end();
 
     std::istringstream requestStream(iter->second);
     std::string token;
@@ -181,7 +181,7 @@ static std::string prepareURL(XrdHttpExtReq &req, bool & hasSetOpaque) {
             continue;
         } else if (!strncmp(token.c_str(), "authz=", 6)) {
             if (!has_authz_header) {
-                req.headers["Authorization"] = token.substr(6);
+                req.headers["authorization"] = token.substr(6);
                 has_authz_header = true;
             }
         } else if (!found_first_header) {
@@ -290,19 +290,19 @@ int TPCHandler::ProcessReq(XrdHttpExtReq &req) {
     if (req.verb == "OPTIONS") {
         return ProcessOptionsReq(req);
     }
-    auto header = req.headers.find("Credential");
+    auto header = req.headers.find("credential");
     if (header != req.headers.end()) {
         if (header->second != "none") {
             m_log.Emsg("ProcessReq", "COPY requested an unsupported credential type: ", header->second.c_str());
             return req.SendSimpleResp(400, NULL, NULL, "COPY requestd an unsupported Credential type", 0);
         }
     }
-    header = req.headers.find("Source");
+    header = req.headers.find("source");
     if (header != req.headers.end()) {
         std::string src = PrepareURL(header->second);
         return ProcessPullReq(src, req);
     }
-    header = req.headers.find("Destination");
+    header = req.headers.find("destination");
     if (header != req.headers.end()) {
         return ProcessPushReq(header->second, req);
     }
@@ -358,7 +358,7 @@ int TPCHandler::ProcessOptionsReq(XrdHttpExtReq &req) {
   
 std::string TPCHandler::GetAuthz(XrdHttpExtReq &req) {
     std::string authz;
-    auto authz_header = req.headers.find("Authorization");
+    auto authz_header = req.headers.find("authorization");
     if (authz_header != req.headers.end()) {
         char * quoted_url = quote(authz_header->second.c_str());
         std::stringstream ss;
@@ -976,7 +976,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         char * ip;
 
         // Get the hostname used to contact the server from the http header
-        auto host_header = req.headers.find("Host");
+        auto host_header = req.headers.find("host");
         std::string host_used;
         if (host_header != req.headers.end()) {
             host_used = host_header->second;
@@ -1017,13 +1017,13 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         redirect_resource = query_header->second;
     }
     XrdSfsFileOpenMode mode = SFS_O_CREAT;
-    auto overwrite_header = req.headers.find("Overwrite");
+    auto overwrite_header = req.headers.find("overwrite");
     if ((overwrite_header == req.headers.end()) || (overwrite_header->second == "T")) {
         if (! usingEC) mode = SFS_O_TRUNC;
     }
     int streams = 1;
     {
-        auto streams_header = req.headers.find("X-Number-Of-Streams");
+        auto streams_header = req.headers.find("x-number-of-streams");
         if (streams_header != req.headers.end()) {
             int stream_req = -1;
             try {


### PR DESCRIPTION
Fixes #2259

Did a separate PR, please feel free to reject the previous one :)

There's a new option that one can set in the server config file `http.keepheadercase yes`. If it is set, the headers coming from the client that are **not** lower-case will be inserted as-is in the `allheaders` map in addition to their lower-case version.