### PR TITLE
Defer or disable TLS client authentication

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -225,6 +225,7 @@ private:
   static int xhttpsmode(XrdOucStream &Config);
   static int xtlsreuse(XrdOucStream &Config);
   static int xauth(XrdOucStream &Config);
+  static int xtlsclientauth(XrdOucStream &Config);
   
   static bool isRequiredXtractor; // If true treat secxtractor errors as fatal
   static XrdHttpSecXtractor *secxtractor;

--- a/src/XrdTls/XrdTlsContext.cc
+++ b/src/XrdTls/XrdTlsContext.cc
@@ -706,7 +706,7 @@ XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
 // depth and turn on peer cert validation. For now, we don't set a callback.
 // In the future we may to grab debugging information.
 //
-   if (caDir || caFile)
+   if ((caDir || caFile) && !(opts & clcOF))
      {if (!SSL_CTX_load_verify_locations(pImpl->ctx, caFile, caDir))
          FATAL_SSL("Unable to load the CA cert file or directory.");
 
@@ -1139,4 +1139,15 @@ bool XrdTlsContext::newHostCertificateDetected() {
         }
     }
     return false;
+}
+
+void XrdTlsContext::SetTlsClientAuth(bool setting) {
+    bool LogVF = (pImpl->Parm.opts & logVF) != 0;
+    if (setting)
+       {pImpl->Parm.opts &= ~clcOF;
+        SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, (LogVF ? VerCB : 0));
+       } else
+       {pImpl->Parm.opts |= clcOF;
+        SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_NONE, 0);
+       }
 }

--- a/src/XrdTls/XrdTlsContext.hh
+++ b/src/XrdTls/XrdTlsContext.hh
@@ -174,6 +174,21 @@ void            SetDefaultCiphers(const char *ciphers);
       bool      SetCrlRefresh(int refsec=-1);
 
 //------------------------------------------------------------------------
+//! Indicate how the server should handle TLS client authentication.
+//!
+//! @param  setting true:  All clients will be asked to send a TLS client
+//!                        certificate.
+//!                 false: No clients will be asked to send a TLS client
+//!                        certificate.
+//!
+//! Note the TLS connection will not fail if the client is asked for a cert
+//! but none are provided.
+//!
+//------------------------------------------------------------------------
+
+       void     SetTlsClientAuth(bool setting);
+
+//------------------------------------------------------------------------
 //! Check if certificates are being verified.
 //!
 //! @return True if certificates are being verified, false otherwise.
@@ -239,6 +254,7 @@ static const uint64_t crlFC = 0x000000C000000000; //!< Full crl chain checking
 static const uint64_t crlRF = 0x00000000ffff0000; //!< Mask to isolate crl refresh in min
 static const int      crlRS = 16;                 //!< Bits to shift   vdept
 static const uint64_t artON = 0x0000002000000000; //!< Auto retry Handshake
+static const uint64_t clcOF = 0x0000010000000000; //!< Disable client certificate request
 
        XrdTlsContext(const char *cert=0,  const char *key=0,
                      const char *cadir=0, const char *cafile=0,

--- a/tests/XRootD/CMakeLists.txt
+++ b/tests/XRootD/CMakeLists.txt
@@ -12,8 +12,9 @@ endif()
 # Note: HAVE_SCITOKEN_CONFIG_SET_STR is required to override the CA file
 # for the scitokens library; otherwise, the test will fail with TLS errors.
 if(BUILD_SCITOKENS AND HAVE_SCITOKEN_CONFIG_SET_STR)
-  list(APPEND XROOTD_CONFIGS scitokens)
+  list(APPEND XROOTD_CONFIGS scitokens httpnoclient)
   list(APPEND scitokens_FIXTURES SciTokens)
+  list(APPEND httpnoclient_FIXTURES SciTokens)
 endif()
 
 # The cache test requires the XRootD::host fixture to be running to
@@ -57,6 +58,10 @@ endforeach()
 
 if(BUILD_SCITOKENS AND HAVE_SCITOKEN_CONFIG_SET_STR)
   set_tests_properties(XRootD::scitokens::setup
+    PROPERTIES
+      FIXTURES_REQUIRED SciTokens
+  )
+  set_tests_properties(XRootD::httpnoclient::setup
     PROPERTIES
       FIXTURES_REQUIRED SciTokens
   )

--- a/tests/XRootD/httpclientauth.authdb
+++ b/tests/XRootD/httpclientauth.authdb
@@ -1,0 +1,1 @@
+u ce275665.0 /protected lr

--- a/tests/XRootD/httpnoclient.cfg
+++ b/tests/XRootD/httpnoclient.cfg
@@ -1,0 +1,21 @@
+set name = httpnoclient
+set port = 7097
+
+set pwd = $PWD
+set src = $SOURCE_DIR
+
+
+xrootd.seclib libXrdSec.so
+xrd.protocol XrdHttp:$port libXrdHttp.so
+
+http.tlsclientauth off
+xrd.tlsca certfile $pwd/../issuer/tlsca.pem
+xrd.tls $pwd/../issuer/tls.crt $pwd/../issuer/tls.key
+
+ofs.authorize 1
+acc.authdb $src/httpclientauth.authdb
+
+sec.protocol ztn
+sec.protbind * only ztn
+
+continue $src/common.cfg

--- a/tests/XRootD/httpnoclient.sh
+++ b/tests/XRootD/httpnoclient.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+function setup_httpnoclient() {
+	require_commands curl
+
+	# Setup the issuer and protected directory
+	mkdir -p "${NAME}/xrootd/protected"
+	echo 'Hello, World' > "${NAME}/xrootd/protected/hello_world.txt"
+}
+
+function test_httpnoclient() {
+	export HOST="https://localhost:${XRD_PORT}"
+
+	assert curl --cert ../issuer/tls.crt --key ../issuer/tls.key --cacert ../issuer/tlsca.pem -o /dev/null -w "%{http_code}" "$HOST/protected/hello_world.txt" > "${NAME}/curl_output.txt"
+	assert_eq 403 "$(tail -n 1 < "${NAME}/curl_output.txt")"
+}

--- a/tests/XRootD/scitokens.authdb
+++ b/tests/XRootD/scitokens.authdb
@@ -1,1 +1,2 @@
 u * /issuer lr
+u ce275665.0 /localhost lr

--- a/tests/XRootD/scitokens.sh
+++ b/tests/XRootD/scitokens.sh
@@ -7,6 +7,8 @@ function setup_scitokens() {
 	ln -sf "$PWD/../issuer/export" scitokens/xrootd/issuer
 	mkdir -p scitokens/xrootd/protected
 	echo 'Hello, World' > scitokens/xrootd/protected/hello_world.txt
+	mkdir -p scitokens/xrootd/localhost
+	echo 'Hello, World' > scitokens/xrootd/localhost/hello_world.txt
 
 	# Override the scitoken cache location; otherwise, contents of prior test runs may be cached
 	XDG_CACHE_HOME="${NAME}/cache"
@@ -110,6 +112,11 @@ function test_scitokens() {
 
 	# from now on, we use HTTP
 	export HOST=https://localhost:7095
+
+	# Check that X509 client auth is working
+	assert curl -s --cert ../issuer/tls.crt --key ../issuer/tls.key --cacert ../issuer/tlsca.pem \
+		-o /dev/null -w "%{http_code}" "$HOST/localhost/hello_world.txt" > "${NAME}/curl_output.txt"
+	assert_eq 200 "$(tail -n 1 < "${NAME}/curl_output.txt")" "$(cat scitokens/xrootd.log)"
 
 	execute_curl "$HOST/issuer/one/issuer.jwks" 200 "$(cat scitokens/xrootd/issuer/one/issuer.jwks)"
 	execute_curl "$HOST/protected/hello_world.txt" 403 ""


### PR DESCRIPTION
When users visit XRootD-based HTTP servers in the browser, they get a pop-up request for selecting a client certificate.  This is fairly disruptive for users not working in X.509-based environments -- and completely unnecessary if X.509 authentication is not in use!

This PR adds two new options, `tlsclientauth` and `tlsrequiredprefix`, that control when the HTTPS server may request a client certificate.  Note that this only makes sense for the HTTPS protocol and hence isn't part of the generic XrdTls configuration.

<hr>

`http.tlsclientauth [on|off|defer]`

Controls the use of client certificate authentication *only* for the HTTPS protocol.  When *on* (default), the HTTPS protocol server will always request a client certificate from the client.  When *off*, it will never request a certificate.  When set to *defer*, it will only request a client certificate is it is in a path specified by `https.tlsrequiredprefix`.

It is not an error if the client does not provide a certificate.

`http.tlsrequiredprefix /prefix`

This option, which can be specified multiple times, specifies a prefix that requires the use of TLS client certificate authentication.  If a HTTP request is made for a path starting with this prefix and `http.tlsclientauth` is in defer mode, then the HTTP server will request a client certificate from the client before a response is made.

Note this only works with clients that support the post-handshake authentication option in TLS 1.3 (these include curl 7.62 or later and the curl version shipped with RHEL8 or later).