### PR TITLE
2273 regression in header parsing

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -617,19 +617,6 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
       TRACE(DEBUG, " rc:" << rc << " got hdr line: " << tmpline.c_str());
 
       if ((rc == 2) && (tmpline.length() > 1) && (tmpline[rc - 1] == '\n')) {
-        // A \r\n was detected
-        if(BuffUsed()) {
-          if(CurrentReq.request == CurrentReq.rtUnset){
-            // The first line has a "\n" at the beginning
-            // Bad request
-            return SendSimpleResp(400, nullptr, nullptr, "Got first line break before the HTTP verb", 0, false);
-          } else {
-            // We are getting the headers from the buffer and we detected the header end.
-            // Though, there is still data to read from the buffer, continue to read!
-            continue;
-          }
-        }
-        // We have detected the header end and no data remains in the buffer, we stop this loop
         CurrentReq.headerok = true;
         TRACE(DEBUG, " rc:" << rc << " detected header end.");
         break;

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -630,9 +630,14 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
           TRACE(DEBUG, " Parsing of first line failed with " << result);
           return -1;
         }
+      } else {
+        int result = CurrentReq.parseLine((char *) tmpline.c_str(), rc);
+        if(result < 0) {
+          TRACE(DEBUG, " Parsing of header line failed with " << result)
+          SendSimpleResp(400,NULL,NULL,"Malformed header line. Hint: ensure the line finishes with \"\\r\\n\"", 0, false);
+          return -1;
+        }
       }
-      else
-        CurrentReq.parseLine((char *)tmpline.c_str(), rc);
 
 
     }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -125,7 +125,7 @@ int XrdHttpReq::parseLine(char *line, int len) {
   if (!p) {
 
     request = rtMalformed;
-    return 0;
+    return -1;
   }
 
   pos = (p - line);
@@ -145,6 +145,10 @@ int XrdHttpReq::parseLine(char *line, int len) {
     // We memorize the headers also as a string                                                                                                                                              
     // because external plugins may need to process it differently                                                                                                                          
     std::string ss = val;
+    if(ss.length() >= 2 && ss.substr(ss.length() - 2, 2) != "\r\n") {
+      request = rtMalformed;
+      return -3;
+    }
     trim(ss);
     allheaders[key] = ss;
 	  


### PR DESCRIPTION
I've reverted the previous commit creating a regression and just added a check that ensures each header line provided by the client terminates with `\r\n`. If that is the case, a 400 Bad request error is replied with an error message saying that the headers are malformed.