### PR TITLE
XrdHttp: obfuscate token authz leaking to the logs

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -945,9 +945,15 @@ int XrdHttpReq::ProcessHTTPReq() {
 
     char *q = quote(hdr2cgistr.c_str());
     resourceplusopaque.append(q);
-    TRACEI(DEBUG, "Appended header fields to opaque info: '" 
-                 << hdr2cgistr.c_str() << "'");
+    if (TRACING(TRACE_DEBUG)) {
+      // The obfuscation of "authz" will only be done if the server http.header2cgi config contains something that maps a header to this "authz" cgi.
+      // Unfortunately the obfuscation code will be called no matter what is configured in http.header2cgi.
+      std::string header2cgistrObf = XrdOucUtils::obfuscate(hdr2cgistr, {"authz"}, '=', '&');
 
+      TRACEI(DEBUG, "Appended header fields to opaque info: '"
+        << header2cgistrObf.c_str() << "'");
+
+    }
     // We assume that anything appended to the CGI str should also
     // apply to the destination in case of a MOVE.
     if (strchr(destination.c_str(), '?')) destination.append("&");

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -33,6 +33,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <string>
+#include <unordered_set>
   
 class XrdSysError;
 class XrdOucString;
@@ -41,6 +42,8 @@ class XrdOucStream;
 class XrdOucUtils
 {
 public:
+
+static inline std::string OBFUSCATION_STR = "REDACTED";
 
 static const mode_t pathMode = S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH;
 
@@ -132,6 +135,8 @@ static bool PidFile(XrdSysError &eDest, const char *path);
 static int getModificationTime(const char * path, time_t & modificationTime);
 
 static void trim(std::string & str);
+
+static std::string obfuscate(const std::string & input, const std::unordered_set<std::string> & keysToObfuscate,const char keyValueDelimiter, const char listDelimiter);
 
     XrdOucUtils() {}
     ~XrdOucUtils() {}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,8 @@ add_subdirectory(XrdEc)
 
 add_subdirectory(XrdHttpTests)
 
+add_subdirectory(XrdOucTests)
+
 add_subdirectory( XrdSsiTests )
 
 if(NOT ENABLE_SERVER_TESTS)

--- a/tests/XrdOucTests/CMakeLists.txt
+++ b/tests/XrdOucTests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(xrdoucutils-unit-tests XrdOucUtilsTests.cc)
+
+target_link_libraries(xrdoucutils-unit-tests XrdUtils GTest::GTest GTest::Main)
+target_include_directories(xrdoucutils-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+gtest_discover_tests(xrdoucutils-unit-tests)

--- a/tests/XrdOucTests/XrdOucUtilsTests.cc
+++ b/tests/XrdOucTests/XrdOucUtilsTests.cc
@@ -1,0 +1,27 @@
+#undef NDEBUG
+
+#include <gtest/gtest.h>
+#include <string>
+
+#include "XrdOuc/XrdOucUtils.hh"
+
+
+using namespace testing;
+
+class XrdOucUtilsTests : public Test {};
+
+TEST(XrdOucUtilsTests, obfuscate) {
+  // General cases
+  ASSERT_EQ(std::string("scitag.flow=144&authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&test=abcd"), XrdOucUtils::obfuscate("scitag.flow=144&authz=token&test=abcd",{"authz"},'=','&'));
+  ASSERT_EQ(std::string("authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&scitag.flow=144&test=abcd"), XrdOucUtils::obfuscate("authz=token&scitag.flow=144&test=abcd",{"authz"},'=','&'));
+  ASSERT_EQ(std::string("scitag.flow=144&test=abcd&authz=") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscate("scitag.flow=144&test=abcd&authz=token",{"authz"},'=','&'));
+  // Nothing to obfuscate
+  ASSERT_EQ("test=abcd&test2=abcde",XrdOucUtils::obfuscate("test=abcd&test2=abcde",{},'=','&'));
+  ASSERT_EQ("nothingtoobfuscate",XrdOucUtils::obfuscate("nothingtoobfuscate",{"obfuscateme"},'=','\n'));
+  //Empty string obfuscation
+  ASSERT_EQ("",XrdOucUtils::obfuscate("",{"obfuscateme"},'=','&'));
+  ASSERT_EQ("",XrdOucUtils::obfuscate("",{},'=','\n'));
+  // Trimmed key obfuscation
+  ASSERT_EQ(std::string("Authorization:") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscate("Authorization: Bearer token",{"authorization"},':','\n'));
+  ASSERT_EQ(std::string("Authorization:")+ XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscate("Authorization : Bearer token",{"authorization"},':','\n'));
+}


### PR DESCRIPTION
Fixes #2222

Unit tests were added, one can see what the effect of the obfuscation is. I basically obfuscate 'Authorization', 'TransferHeaderAuthorization' headers and hdr2cgi 'authz='.