### PR TITLE
[XrdTpcTPC] Added tpc.header2cgi configuration

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -91,6 +91,9 @@ public:
     if (Resume) (*this.*Resume)();
   }
 
+  /// Use this function to parse header2cgi configurations
+  static int parseHeader2CGI(XrdOucStream &Config, XrdSysError & err, std::map<std::string, std::string> & header2cgi);
+
   /// Tells if the oustanding bytes on the socket match this protocol implementation
   XrdProtocol *Match(XrdLink *lp);
 

--- a/src/XrdTpc.cmake
+++ b/src/XrdTpc.cmake
@@ -39,7 +39,8 @@ if( BUILD_TPC )
     XrdTpc/XrdTpcState.cc         XrdTpc/XrdTpcState.hh
     XrdTpc/XrdTpcStream.cc        XrdTpc/XrdTpcStream.hh
     XrdTpc/XrdTpcTPC.cc           XrdTpc/XrdTpcTPC.hh
-    XrdTpc/XrdTpcPMarkManager.cc  XrdTpc/XrdTpcPMarkManager.hh)
+    XrdTpc/XrdTpcPMarkManager.cc  XrdTpc/XrdTpcPMarkManager.hh
+    XrdTpc/XrdTpcUtils.cc         XrdTpc/XrdTpcUtils.hh)
 
   target_link_libraries(
     ${LIB_XRD_TPC}

--- a/src/XrdTpc/XrdTpcTPC.hh
+++ b/src/XrdTpc/XrdTpcTPC.hh
@@ -143,6 +143,10 @@ private:
         const std::string &event, const std::string &message="");
 
     std::string generateClientErr(std::stringstream &err_ss, const TPCLogRecord &rec, CURLcode cCode = CURLcode::CURLE_OK);
+
+    std::string prepareURL(XrdHttpExtReq &req, bool & hasSetOpaque);
+    std::string prepareURL(XrdHttpExtReq &req);
+
     static int m_marker_period;
     static size_t m_block_size;
     static size_t m_small_block_size;
@@ -174,5 +178,8 @@ private:
     // Time to connect the curl socket to the remote server uses the linux's default value
     // of 60 seconds
     static const long CONNECT_TIMEOUT = 60;
+
+    // hdr2cgimap
+    std::map<std::string,std::string> hdr2cgimap;
 };
 }

--- a/src/XrdTpc/XrdTpcUtils.cc
+++ b/src/XrdTpc/XrdTpcUtils.cc
@@ -1,0 +1,62 @@
+//------------------------------------------------------------------------------
+// This file is part of XrdTpcTPC
+//
+// Copyright (c) 2023 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <ccaffy@cern.ch>
+// File Date: Oct 2023
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+#include "XrdTpcUtils.hh"
+#include "XrdOuc/XrdOucTUtils.hh"
+
+#include <sstream>
+
+std::string XrdTpcUtils::prepareOpenURL(const std::string & reqResource, std::map<std::string,std::string> & reqHeaders, const std::map<std::string,std::string> & hdr2cgimap, bool & hasSetOpaque) {
+  auto iter = XrdOucTUtils::caseInsensitiveFind(reqHeaders,"xrd-http-query");
+  bool found_first_header = false;
+  std::stringstream opaque;
+
+  if (iter != reqHeaders.end() && !iter->second.empty()) {
+    std::string token;
+    std::istringstream requestStream(iter->second);
+    auto has_authz_header = XrdOucTUtils::caseInsensitiveFind(reqHeaders,"authorization") != reqHeaders.end();
+    while (std::getline(requestStream, token, '&')) {
+      if (token.empty()) {
+        continue;
+      } else if (!strncmp(token.c_str(), "authz=", 6)) {
+        if (!has_authz_header) {
+          reqHeaders["Authorization"] = token.substr(6);
+          has_authz_header = true;
+        }
+      } else {
+        opaque << (found_first_header ? "&" : "?") << token;
+        found_first_header = true;
+      }
+    }
+  }
+
+  // Append CGI coming from the tpc.header2cgi parameter
+  for(auto & hdr2cgi : hdr2cgimap) {
+    auto it = std::find_if(reqHeaders.begin(),reqHeaders.end(),[&hdr2cgi](const auto & elt){
+      return !strcasecmp(elt.first.c_str(),hdr2cgi.first.c_str());
+    });
+    if(it != reqHeaders.end()) {
+      opaque << (found_first_header ? "&" : "?") << hdr2cgi.second << "=" << it->second;
+      found_first_header = true;
+    }
+  }
+  hasSetOpaque = found_first_header;
+  return reqResource + opaque.str();
+}

--- a/src/XrdTpc/XrdTpcUtils.hh
+++ b/src/XrdTpc/XrdTpcUtils.hh
@@ -1,0 +1,42 @@
+//------------------------------------------------------------------------------
+// This file is part of XrdTpcTPC
+//
+// Copyright (c) 2023 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <ccaffy@cern.ch>
+// File Date: Oct 2023
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#ifndef XROOTD_XRDTPCUTILS_HH
+#define XROOTD_XRDTPCUTILS_HH
+
+#include <string>
+#include "XrdHttp/XrdHttpExtHandler.hh"
+
+class XrdTpcUtils {
+public:
+  /**
+   * Prepares the file XRootD open URL from the request resource, the xrd-http-query header of the HTTP request and the hdr2cgi map passed in parameter
+   * @param reqResource the HTTP request resource
+   * @param the HTTP request headers
+   * @param hdr2cgimap the map containing header keys --> XRootD cgi mapping
+   * @param hasSetOpaque is set to true if the returned URL contains opaque query, false otherwise
+   * @return the XRootD open URL
+   */
+  static std::string prepareOpenURL(const std::string & reqResource, std::map<std::string,std::string> & reqHeaders, const std::map<std::string,std::string> & hdr2cgimap, bool & hasSetOpaque);
+};
+
+
+#endif //XROOTD_XRDTPCUTILS_HH

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ add_subdirectory(XrdOucTests)
 
 add_subdirectory( XrdSsiTests )
 
+add_subdirectory(XrdTpcTests)
+
 if(NOT ENABLE_SERVER_TESTS)
   return()
 endif()

--- a/tests/XrdTpcTests/CMakeLists.txt
+++ b/tests/XrdTpcTests/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(xrdtpc-unit-tests XrdTpcTests.cc)
+
+add_library(XrdTpcUtils
+        ${CMAKE_SOURCE_DIR}/src/XrdTpc/XrdTpcUtils.cc)
+
+target_link_libraries(xrdtpc-unit-tests XrdTpcUtils GTest::GTest GTest::Main)
+target_include_directories(xrdtpc-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+gtest_discover_tests(xrdtpc-unit-tests)

--- a/tests/XrdTpcTests/XrdTpcTests.cc
+++ b/tests/XrdTpcTests/XrdTpcTests.cc
@@ -1,0 +1,69 @@
+#undef NDEBUG
+
+#include "XrdTpc/XrdTpcUtils.hh"
+#include <exception>
+#include <gtest/gtest.h>
+#include <string>
+
+using namespace testing;
+
+class XrdTpcTests : public Test {};
+
+TEST(XrdTpcTests, prepareOpenURLTest) {
+  std::string resource = "/eos/test/file.txt";
+  {
+    // Nothing to set in the openURL
+    std::map<std::string, std::string> headers {{"Test","Test"}};
+    std::map<std::string, std::string> hdr2cgi {};
+    bool hasSetOpaque;
+    auto openURL = XrdTpcUtils::prepareOpenURL(resource,headers,hdr2cgi,hasSetOpaque);
+
+    ASSERT_EQ(resource,openURL);
+    ASSERT_FALSE(hasSetOpaque);
+  }
+
+  {
+    // If authz= was put in the opaque of the resource (and therefore put in the xrd-http-query header),
+    // Then the authorization header should have been set and no "authz" should be found in the opaque of
+    // the open URL
+    std::map<std::string, std::string> headers {{"xrd-http-query","authz=test&scitag.flow=144"}};
+    std::map<std::string, std::string> hdr2cgi {};
+    bool hasSetOpaque = false;
+    auto openURL = XrdTpcUtils::prepareOpenURL(resource,headers,hdr2cgi,hasSetOpaque);
+
+    ASSERT_NE(resource,openURL);
+    ASSERT_TRUE(hasSetOpaque);
+    ASSERT_TRUE(headers.find("Authorization") != headers.end());
+    ASSERT_TRUE(openURL.find("authz") == std::string::npos);
+    ASSERT_TRUE(openURL.find("scitag.flow") != std::string::npos);
+  }
+
+  {
+    // If authz= was put in the opaque of the resource (and therefore put in the xrd-http-query header),
+    // and if the the authorization header is provided, we should not override the provided authorization header
+    std::map<std::string, std::string> headers {{"xrd-http-query","authz=test&scitag.flow=144"},{"Authorization","abcd"}};
+    std::map<std::string, std::string> hdr2cgi {};
+    bool hasSetOpaque = false;
+    auto openURL = XrdTpcUtils::prepareOpenURL(resource,headers,hdr2cgi,hasSetOpaque);
+
+    ASSERT_NE(resource,openURL);
+    ASSERT_TRUE(hasSetOpaque);
+    ASSERT_TRUE(openURL.find("authz") == std::string::npos);
+    ASSERT_TRUE(openURL.find("scitag.flow") != std::string::npos);
+    ASSERT_EQ("abcd",headers["Authorization"]);
+  }
+
+  {
+    // Some hdr2cgi has been configured, we should find them in the opaque of the openURL
+    std::map<std::string, std::string> headers {{"xrd-http-query","authz=test&test1=test2"},{"Scitag","144"},{"lowercase_header","test1"} };
+    std::map<std::string, std::string> hdr2cgi {{"SciTag","scitag.flow"},{"LOWERCASE_HEADER","lowercase"}};
+    bool hasSetOpaque = false;
+    auto openURL = XrdTpcUtils::prepareOpenURL(resource,headers,hdr2cgi,hasSetOpaque);
+
+    ASSERT_TRUE(hasSetOpaque);
+    ASSERT_TRUE(openURL.find("test1=test2") != std::string::npos);
+    ASSERT_TRUE(openURL.find("scitag.flow=144") != std::string::npos);
+    ASSERT_TRUE(openURL.find("lowercase=test1") != std::string::npos);
+  }
+
+}


### PR DESCRIPTION
The administrator can now use this option in order to allow some client HTTP headers to be passed to the OFS layer as opaque information. It works exactly the same way as the http.header2cgi configuration. E.g: the active server of a HTTP/TPC PULL transfer receives the header 'ArchiveMetadata' and 'tpc.header2cgi ArchiveMetadata archivemetadata' is configured. If a client submits a 'ArchiveMetadata: test' header with their request, the opaque archivemetadata=test will be provided to the XrdSfsFile open() function.

The implementation was done as follow:
- Put the HTTP http.header2cgi parsing logic to a public static function of the XrdHttpProtocol class (`parseHeader2CGI()`)
- Add a hdr2cgimap attribute to the TPCHandler
- Call this function in both `http.header2cgi` and `tpc.header2cgi` config parsing function
- Refactor and add the logic to append opaque infos to the URL in the `TPCHandler::prepareURL(...)` function

Thanks ahead for your review!