### PR TITLE
[XrdCl] Fix hidden overloaded virtual compilation error

### DIFF
--- a/src/XrdCl/XrdClClassicCopyJob.cc
+++ b/src/XrdCl/XrdClClassicCopyJob.cc
@@ -1150,7 +1150,7 @@ namespace
       //------------------------------------------------------------------------
       //! Get extended attributes
       //------------------------------------------------------------------------
-      virtual XrdCl::XRootDStatus GetXAttr( std::vector<XrdCl::XAttr> &xattrs )
+      virtual XrdCl::XRootDStatus GetXAttr( std::vector<XrdCl::xattr_t> &xattrs )
       {
         return XrdCl::XRootDStatus();
       }


### PR DESCRIPTION
```
/builddir/build/BUILD/xrootd-5.7.0/src/XrdCl/XrdClClassicCopyJob.cc:722:35: error: ‘virtual XrdCl::XRootDStatus {anonymous}::XRootDSource::GetXAttr(std::vector<std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >&)’ was hidden [-Werror=overloaded-virtual=]
  722 |       virtual XrdCl::XRootDStatus GetXAttr( std::vector<XrdCl::xattr_t> &xattrs )
      |                                   ^~~~~~~~
/builddir/build/BUILD/xrootd-5.7.0/src/XrdCl/XrdClClassicCopyJob.cc:1153:35: note:   by ‘virtual XrdCl::XRootDStatus {anonymous}::XRootDSourceZip::GetXAttr(std::vector<XrdCl::XAttr>&)’
 1153 |       virtual XrdCl::XRootDStatus GetXAttr( std::vector<XrdCl::XAttr> &xattrs )
      |                                   ^~~~~~~~
```
