### PR TITLE
[XrdCl, XrdHttp] Obfuscated more token authz in logging

### DIFF
--- a/src/XrdCl/XrdClAsyncDiscardReader.hh
+++ b/src/XrdCl/XrdClAsyncDiscardReader.hh
@@ -59,7 +59,7 @@ namespace XrdCl
         log->Error( XRootDMsg, "[%s] Handling response to %s: "
                                "DiscardReader: we were not expecting "
                                "raw data.", url.GetHostId().c_str(),
-                               request.GetDescription().c_str() );
+                               request.GetObfuscatedDescription().c_str() );
         // Just drop the connection, we don't know if the stream is sane anymore.
         // Recover with a reconnect.
         return XRootDStatus( stError, errCorruptedHeader );

--- a/src/XrdCl/XrdClAsyncMsgWriter.hh
+++ b/src/XrdCl/XrdClAsyncMsgWriter.hh
@@ -183,7 +183,7 @@ namespace XrdCl
               }
 
               log->Dump( AsyncSockMsg, "[%s] Successfully sent message: %s (0x%x).",
-                         strmname.c_str(), outmsg->GetDescription().c_str(), outmsg );
+                         strmname.c_str(), outmsg->GetObfuscatedDescription().c_str(), outmsg );
 
               strm.OnMessageSent( substrmnb, outmsg, outmsgsize );
               return XRootDStatus();

--- a/src/XrdCl/XrdClAsyncRawReader.hh
+++ b/src/XrdCl/XrdClAsyncRawReader.hh
@@ -137,7 +137,7 @@ namespace XrdCl
                                            "response to %s: user supplied buffer is "
                                            "too small for the received data.",
                                            url.GetHostId().c_str(),
-                                           request.GetDescription().c_str() );
+                                           request.GetObfuscatedDescription().c_str() );
               // Just drop the connection, we don't know if the stream is sane
               // anymore. Recover with a reconnect.
               return XRootDStatus( stError, errCorruptedHeader );

--- a/src/XrdCl/XrdClClassicCopyJob.cc
+++ b/src/XrdCl/XrdClClassicCopyJob.cc
@@ -615,7 +615,7 @@ namespace
         using namespace XrdCl;
         Log *log = DefaultEnv::GetLog();
         log->Debug( UtilityMsg, "Opening %s for reading",
-                                pUrl->GetURL().c_str() );
+                                pUrl->GetObfuscatedURL().c_str() );
 
         std::string value;
         DefaultEnv::GetEnv()->GetString( "ReadRecovery", value );
@@ -892,7 +892,7 @@ namespace
         {
           log->Debug( UtilityMsg, "Unable read %d bytes at %ld from %s: %s",
                       ch->chunk.GetLength(), ch->chunk.GetOffset(),
-                      pUrl->GetURL().c_str(), ch->status.ToStr().c_str() );
+                      pUrl->GetObfuscatedURL().c_str(), ch->status.ToStr().c_str() );
           delete [] (char *)ch->chunk.GetBuffer();
           CleanUpChunks();
           return ch->status;
@@ -1013,7 +1013,7 @@ namespace
         using namespace XrdCl;
         Log *log = DefaultEnv::GetLog();
         log->Debug( UtilityMsg, "Opening %s for reading",
-                                pUrl->GetURL().c_str() );
+                                pUrl->GetObfuscatedURL().c_str() );
 
         std::string value;
         DefaultEnv::GetEnv()->GetString( "ReadRecovery", value );
@@ -1209,7 +1209,7 @@ namespace
         using namespace XrdCl;
         Log *log = DefaultEnv::GetLog();
         log->Debug( UtilityMsg, "Opening %s for reading",
-                                pUrl->GetURL().c_str() );
+                                pUrl->GetObfuscatedURL().c_str() );
 
         std::string value;
         DefaultEnv::GetEnv()->GetString( "ReadRecovery", value );
@@ -1752,7 +1752,7 @@ namespace
         using namespace XrdCl;
         Log *log = DefaultEnv::GetLog();
         log->Debug( UtilityMsg, "Opening %s for writing",
-                                pUrl.GetURL().c_str() );
+                                pUrl.GetObfuscatedURL().c_str() );
 
         std::string value;
         DefaultEnv::GetEnv()->GetString( "WriteRecovery", value );
@@ -1862,7 +1862,7 @@ namespace
           Log *log = DefaultEnv::GetLog();
           log->Debug( UtilityMsg, "Unable write %d bytes at %ld from %s: %s",
                       ch->chunk.GetLength(), ch->chunk.GetOffset(),
-                      pUrl.GetURL().c_str(), ch->status.ToStr().c_str() );
+                      pUrl.GetObfuscatedURL().c_str(), ch->status.ToStr().c_str() );
           delete[] (char*)ci.GetBuffer(); // we took the ownership of the buffer
           CleanUpChunks();
 
@@ -2105,7 +2105,7 @@ namespace
         using namespace XrdCl;
         Log *log = DefaultEnv::GetLog();
         log->Debug( UtilityMsg, "Opening %s for writing",
-                                pUrl.GetURL().c_str() );
+                                pUrl.GetObfuscatedURL().c_str() );
 
         std::string value;
         DefaultEnv::GetEnv()->GetString( "WriteRecovery", value );
@@ -2192,7 +2192,7 @@ namespace
           Log *log = DefaultEnv::GetLog();
           log->Debug( UtilityMsg, "Unable write %d bytes at %ld from %s: %s",
                       ch->chunk.GetLength(), ch->chunk.GetOffset(),
-                      pUrl.GetURL().c_str(), ch->status.ToStr().c_str() );
+                      pUrl.GetObfuscatedURL().c_str(), ch->status.ToStr().c_str() );
           CleanUpChunks();
 
           //--------------------------------------------------------------------
@@ -2420,7 +2420,7 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
     log->Debug( UtilityMsg, "Creating a classic copy job, from %s to %s",
-                GetSource().GetURL().c_str(), GetTarget().GetURL().c_str() );
+                GetSource().GetObfuscatedURL().c_str(), GetTarget().GetObfuscatedURL().c_str() );
   }
 
   //----------------------------------------------------------------------------

--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -31,6 +31,7 @@
 #include "XrdCl/XrdClFileSystem.hh"
 #include "XrdCl/XrdClUtils.hh"
 #include "XrdCl/XrdClDlgEnv.hh"
+#include "XrdCl/XrdClOptimizers.hh"
 #include "XrdSys/XrdSysE2T.hh"
 #include "XrdSys/XrdSysPthread.hh"
 
@@ -828,9 +829,15 @@ int main( int argc, char **argv )
 
     AppendCGI( source, config.srcOpq );
 
-    log->Dump( AppMsg, "Processing source entry: %s, type %s, target file: %s",
-               sourceFile->Path, FileType2String( sourceFile->Protocol ),
-               dest.c_str() );
+    std::string sourcePathObf = sourceFile->Path;
+    std::string destPathObf = dest;
+    if( unlikely(log->GetLevel() >= Log::DumpMsg) ) {
+      sourcePathObf = XrdOucUtils::obfuscateAuth(sourcePathObf);
+      destPathObf = XrdOucUtils::obfuscateAuth(destPathObf);
+    }
+    log->Dump( AppMsg, "Processing source entry: %s, type %s, target file: %s, logLevel = %d",
+               sourcePathObf.c_str(), FileType2String( sourceFile->Protocol ),
+               destPathObf.c_str() );
 
     //--------------------------------------------------------------------------
     // Set up the job

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -1659,7 +1659,7 @@ XRootDStatus DoTail( FileSystem                      *fs,
   if( !st.IsOK() )
   {
     log->Error( AppMsg, "Unable to open file %s: %s",
-                remoteUrl.GetURL().c_str(), st.ToStr().c_str() );
+                remoteUrl.GetObfuscatedURL().c_str(), st.ToStr().c_str() );
     return st;
   }
 
@@ -1682,7 +1682,7 @@ XRootDStatus DoTail( FileSystem                      *fs,
     if( !st.IsOK() )
     {
       log->Error( AppMsg, "Unable to read from %s: %s",
-                  remoteUrl.GetURL().c_str(), st.ToStr().c_str() );
+                  remoteUrl.GetObfuscatedURL().c_str(), st.ToStr().c_str() );
       delete [] buffer;
       return st;
     }

--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -46,6 +46,7 @@
 
 #include "XrdOuc/XrdOucCRC.hh"
 #include "XrdOuc/XrdOucPgrwUtils.hh"
+#include "XrdOuc/XrdOucUtils.hh"
 
 #include "XrdSys/XrdSysKernelBuffer.hh"
 #include "XrdSys/XrdSysPageSize.hh"
@@ -166,7 +167,7 @@ namespace
           {
             Log *log = DefaultEnv::GetLog();
             log->Info( FileMsg, "[0x%x@%s] Received corrupted page, will retry page #%d.",
-                        this, stateHandler->pFileUrl->GetURL().c_str(), pgnb );
+                        this, stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
 
             XRootDStatus st = XrdCl::FileStateHandler::PgReadRetry( stateHandler, pgoff, pgsize, pgnb, buffer, this, 0 );
             if( !st.IsOK())
@@ -257,7 +258,7 @@ namespace
         {
           Log *log = DefaultEnv::GetLog();
           log->Info( FileMsg, "[0x%x@%s] Failed to recover page #%d.",
-                      this, pgReadHandler->stateHandler->pFileUrl->GetURL().c_str(), pgnb );
+                      this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
           pgReadHandler->HandleResponseWithHosts( status, response, hostList );
           delete this;
           return;
@@ -269,7 +270,7 @@ namespace
         {
           Log *log = DefaultEnv::GetLog();
           log->Info( FileMsg, "[0x%x@%s] Failed to recover page #%d.",
-                      this, pgReadHandler->stateHandler->pFileUrl->GetURL().c_str(), pgnb );
+                      this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
           // we retry a page at a time so the length cannot exceed 4KB
           DeleteArgs( status, response, hostList );
           pgReadHandler->HandleResponseWithHosts( new XRootDStatus( stError, errDataError ), 0, 0 );
@@ -282,7 +283,7 @@ namespace
         {
           Log *log = DefaultEnv::GetLog();
           log->Info( FileMsg, "[0x%x@%s] Failed to recover page #%d.",
-                      this, pgReadHandler->stateHandler->pFileUrl->GetURL().c_str(), pgnb );
+                      this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
           DeleteArgs( status, response, hostList );
           pgReadHandler->HandleResponseWithHosts( new XRootDStatus( stError, errDataError ), 0, 0 );
           delete this;
@@ -291,7 +292,7 @@ namespace
 
         Log *log = DefaultEnv::GetLog();
         log->Info( FileMsg, "[0x%x@%s] Successfully recovered page #%d.",
-                    this, pgReadHandler->stateHandler->pFileUrl->GetURL().c_str(), pgnb );
+                    this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
 
         DeleteArgs( 0, response, hostList );
         pgReadHandler->UpdateCksum( pgnb, crcval );
@@ -817,7 +818,7 @@ namespace XrdCl
     {
       self->pDoRecoverRead = false;
       log->Debug( FileMsg, "[0x%x@%s] Read recovery procedures are disabled",
-                  self.get(), self->pFileUrl->GetURL().c_str() );
+                  self.get(), self->pFileUrl->GetObfuscatedURL().c_str() );
     }
 
     it = urlParams.find( "xrdcl.recover-writes" );
@@ -826,14 +827,14 @@ namespace XrdCl
     {
       self->pDoRecoverWrite = false;
       log->Debug( FileMsg, "[0x%x@%s] Write recovery procedures are disabled",
-                  self.get(), self->pFileUrl->GetURL().c_str() );
+                  self.get(), self->pFileUrl->GetObfuscatedURL().c_str() );
     }
 
     //--------------------------------------------------------------------------
     // Open the file
     //--------------------------------------------------------------------------
     log->Debug( FileMsg, "[0x%x@%s] Sending an open command", self.get(),
-                self->pFileUrl->GetURL().c_str() );
+                self->pFileUrl->GetObfuscatedURL().c_str() );
 
     self->pOpenMode  = mode;
     self->pOpenFlags = flags;
@@ -898,7 +899,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a close command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -974,7 +975,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a stat command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -1021,7 +1022,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a read command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message           *msg;
@@ -1076,7 +1077,7 @@ namespace XrdCl
     if( !issupported )
     {
       DefaultEnv::GetLog()->Debug( FileMsg, "[0x%x@%s] PgRead not supported; substituting with Read.",
-                                  self.get(), self->pFileUrl->GetURL().c_str() );
+                                  self.get(), self->pFileUrl->GetObfuscatedURL().c_str() );
       ResponseHandler *substitHandler = new PgReadSubstitutionHandler( self, handler );
       auto st = Read( self, offset, size, buffer, substitHandler, timeout );
       if( !st.IsOK() ) delete substitHandler;
@@ -1124,7 +1125,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a pgread command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message             *msg;
@@ -1180,7 +1181,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a write command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message            *msg;
@@ -1226,7 +1227,7 @@ namespace XrdCl
     {
       Log *log = DefaultEnv::GetLog();
       log->Info( FileMsg, "[0x%x@%s] Buffer is not page aligned (4KB), cannot "
-                 "convert it to kernel space buffer.", self.get(), self->pFileUrl->GetURL().c_str(),
+                 "convert it to kernel space buffer.", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                  *((uint32_t*)self->pFileHandle) );
 
       void     *buff = buffer.GetBuffer();
@@ -1415,20 +1416,20 @@ namespace XrdCl
                   {
                     DefaultEnv::GetLog()->Warning( FileMsg, "[0x%x@%s] Failed retransmitting corrupted "
                                                    "page: pgoff=%llu, pglen=%du, pgdigest=%du", self.get(),
-                                                   self->pFileUrl->GetURL().c_str(), pgoff, pglen, pgdigest );
+                                                   self->pFileUrl->GetObfuscatedURL().c_str(), pgoff, pglen, pgdigest );
                     pgwrt->SetStatus( new XRootDStatus( stError, errDataError, 0,
                                       "Failed to retransmit corrupted page" ) );
                   }
                   else
                     DefaultEnv::GetLog()->Info( FileMsg, "[0x%x@%s] Succesfuly retransmitted corrupted "
                                                 "page: pgoff=%llu, pglen=%du, pgdigest=%du", self.get(),
-                                                self->pFileUrl->GetURL().c_str(), pgoff, pglen, pgdigest );
+                                                self->pFileUrl->GetObfuscatedURL().c_str(), pgoff, pglen, pgdigest );
                 } );
             auto st = PgWriteRetry( self, pgoff, pglen, pgbuf, pgdigest, h, timeout );
             if( !st.IsOK() ) pgwrt->SetStatus( new XRootDStatus( st ) );
             DefaultEnv::GetLog()->Info( FileMsg, "[0x%x@%s] Retransmitting corrupted page: "
                                         "pgoff=%llu, pglen=%du, pgdigest=%du", self.get(),
-                                        self->pFileUrl->GetURL().c_str(), pgoff, pglen, pgdigest );
+                                        self->pFileUrl->GetObfuscatedURL().c_str(), pgoff, pglen, pgdigest );
           }
         } );
 
@@ -1477,7 +1478,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a pgwrite command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -1527,7 +1528,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a sync command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message           *msg;
@@ -1566,7 +1567,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a truncate command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message               *msg;
@@ -1610,7 +1611,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a vector read command for handle "
-                "0x%x to %s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "0x%x to %s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -1686,7 +1687,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a vector write command for handle "
-                "0x%x to %s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "0x%x to %s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -1762,7 +1763,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a write command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message            *msg;
@@ -1818,7 +1819,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a read command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message           *msg;
@@ -1875,7 +1876,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a fcntl command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message            *msg;
@@ -1916,7 +1917,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a visa command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message            *msg;
@@ -1956,7 +1957,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a fattr set command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -1982,7 +1983,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a fattr get command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -2008,7 +2009,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a fattr del command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -2033,7 +2034,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a fattr list command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     //--------------------------------------------------------------------------
@@ -2069,7 +2070,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a checkpoint command for "
-                "handle 0x%x to %s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "handle 0x%x to %s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message               *msg;
@@ -2120,7 +2121,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a write command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message               *msg;
@@ -2182,7 +2183,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a write command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message               *msg;
@@ -2357,8 +2358,8 @@ namespace XrdCl
         }
     }
 
-    log->Debug( FileMsg, "[0x%x@%s] Open has returned with status %s",
-                this, pFileUrl->GetURL().c_str(), status->ToStr().c_str() );
+    log->Debug(FileMsg, "[0x%x@%s] Open has returned with status %s",
+               this, pFileUrl->GetObfuscatedURL().c_str(), status->ToStr().c_str() );
 
     if( pDataServer && !pDataServer->IsLocalFile() )
     {
@@ -2383,9 +2384,9 @@ namespace XrdCl
     pStatus = *status;
     if( !pStatus.IsOK() || !openInfo )
     {
-      log->Debug( FileMsg, "[0x%x@%s] Error while opening at %s: %s",
-                  this, pFileUrl->GetURL().c_str(), lastServer.c_str(),
-                  pStatus.ToStr().c_str() );
+      log->Debug(FileMsg, "[0x%x@%s] Error while opening at %s: %s",
+                 this, pFileUrl->GetObfuscatedURL().c_str(), lastServer.c_str(),
+                 pStatus.ToStr().c_str() );
       FailQueuedMessages( pStatus );
       pFileState = Error;
 
@@ -2419,7 +2420,7 @@ namespace XrdCl
       }
 
       log->Debug( FileMsg, "[0x%x@%s] successfully opened at %s, handle: 0x%x, "
-                  "session id: %ld", this, pFileUrl->GetURL().c_str(),
+                  "session id: %ld", this, pFileUrl->GetObfuscatedURL().c_str(),
                   pDataServer->GetHostId().c_str(), *((uint32_t*)pFileHandle),
                   pSessionId );
 
@@ -2454,13 +2455,13 @@ namespace XrdCl
     Log *log = DefaultEnv::GetLog();
     XrdSysMutexHelper scopedLock( pMutex );
 
-    log->Debug( FileMsg, "[0x%x@%s] Close returned from %s with: %s", this,
-                pFileUrl->GetURL().c_str(), pDataServer->GetHostId().c_str(),
-                status->ToStr().c_str() );
+    log->Debug(FileMsg, "[0x%x@%s] Close returned from %s with: %s", this,
+               pFileUrl->GetObfuscatedURL().c_str(), pDataServer->GetHostId().c_str(),
+               status->ToStr().c_str() );
 
-    log->Dump( FileMsg, "[0x%x@%s] Items in the fly %d, queued for recovery %d",
-               this, pFileUrl->GetURL().c_str(), pInTheFly.size(),
-               pToBeRecovered.size() );
+    log->Dump(FileMsg, "[0x%x@%s] Items in the fly %d, queued for recovery %d",
+              this, pFileUrl->GetObfuscatedURL().c_str(), pInTheFly.size(),
+              pToBeRecovered.size() );
 
     MonitorClose( status );
     ResetMonitoringVars();
@@ -2505,8 +2506,8 @@ namespace XrdCl
     self->pInTheFly.erase( message );
 
     log->Dump( FileMsg, "[0x%x@%s] File state error encountered. Message %s "
-               "returned with %s", self.get(), self->pFileUrl->GetURL().c_str(),
-               message->GetDescription().c_str(), status->ToStr().c_str() );
+               "returned with %s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
+               message->GetObfuscatedDescription().c_str(), status->ToStr().c_str() );
 
     //--------------------------------------------------------------------------
     // Report to monitoring
@@ -2540,8 +2541,8 @@ namespace XrdCl
     if( !self->IsRecoverable( *status ) || sendParams.kbuff )
     {
       log->Error( FileMsg, "[0x%x@%s] Fatal file state error. Message %s "
-                 "returned with %s", self.get(), self->pFileUrl->GetURL().c_str(),
-                 message->GetDescription().c_str(), status->ToStr().c_str() );
+                 "returned with %s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
+                 message->GetObfuscatedDescription().c_str(), status->ToStr().c_str() );
 
       self->FailMessage( RequestData( message, userHandler, sendParams ), *status );
       delete status;
@@ -2600,8 +2601,8 @@ namespace XrdCl
     XrdSysMutexHelper scopedLock( self->pMutex );
 
     log->Dump( FileMsg, "[0x%x@%s] Got state response for message %s",
-               self.get(), self->pFileUrl->GetURL().c_str(),
-               message->GetDescription().c_str() );
+               self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
+               message->GetObfuscatedDescription().c_str() );
 
     //--------------------------------------------------------------------------
     // Since this message may be the last "in-the-fly" and no recovery
@@ -2719,7 +2720,7 @@ namespace XrdCl
     {
       Log *log = DefaultEnv::GetLog();
       log->Dump( FileMsg, "[0x%x@%s] Got a timer event", this,
-                 pFileUrl->GetURL().c_str() );
+                 pFileUrl->GetObfuscatedURL().c_str() );
       RequestList::iterator it;
       JobManager *jobMan = DefaultEnv::GetPostMaster()->GetJobManager();
       for( it = pToBeRecovered.begin(); it != pToBeRecovered.end(); )
@@ -2752,7 +2753,7 @@ namespace XrdCl
         (!IsReadOnly() && pDoRecoverWrite) )
     {
       log->Debug( FileMsg, "[0x%x@%s] Putting the file in recovery state in "
-                  "process %d", this, pFileUrl->GetURL().c_str(), getpid() );
+                  "process %d", this, pFileUrl->GetObfuscatedURL().c_str(), getpid() );
       pFileState = Recovering;
       pInTheFly.clear();
       pToBeRecovered.clear();
@@ -2775,7 +2776,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Reopen file at next data server.",
-                self.get(), self->pFileUrl->GetURL().c_str() );
+                self.get(), self->pFileUrl->GetObfuscatedURL().c_str() );
 
     // merge CGI
     auto lbcgi = self->pLoadBalancer->GetParams();
@@ -2919,8 +2920,8 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Dump( FileMsg, "[0x%x@%s] Putting message %s in the recovery list",
-               self.get(), self->pFileUrl->GetURL().c_str(),
-               rd.request->GetDescription().c_str() );
+               self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
+               rd.request->GetObfuscatedDescription().c_str() );
 
     Status st = RunRecovery( self );
     if( st.IsOK() )
@@ -2948,7 +2949,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Running the recovery procedure", self.get(),
-                self->pFileUrl->GetURL().c_str() );
+                self->pFileUrl->GetObfuscatedURL().c_str() );
 
     Status st;
     if( self->pStateRedirect )
@@ -3008,7 +3009,7 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
     log->Dump( FileMsg, "[0x%x@%s] Sending a recovery open command to %s",
-               self.get(), self->pFileUrl->GetURL().c_str(), url.GetURL().c_str() );
+               self.get(), self->pFileUrl->GetObfuscatedURL().c_str(), url.GetObfuscatedURL().c_str() );
 
     //--------------------------------------------------------------------------
     // Remove the kXR_delete and kXR_new flags, as we don't want the recovery
@@ -3069,8 +3070,8 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
     log->Dump( FileMsg, "[0x%x@%s] Failing message %s with %s",
-               this, pFileUrl->GetURL().c_str(),
-               rd.request->GetDescription().c_str(),
+               this, pFileUrl->GetObfuscatedURL().c_str(),
+               rd.request->GetObfuscatedDescription().c_str(),
                status.ToStr().c_str() );
 
     StatefulHandler *sh = dynamic_cast<StatefulHandler*>(rd.handler);
@@ -3078,8 +3079,8 @@ namespace XrdCl
     {
       Log *log = DefaultEnv::GetLog();
       log->Error( FileMsg, "[0x%x@%s] Internal error while recovering %s",
-                  this, pFileUrl->GetURL().c_str(),
-                  rd.request->GetDescription().c_str() );
+                  this, pFileUrl->GetObfuscatedURL().c_str(),
+                  rd.request->GetObfuscatedDescription().c_str() );
       return;
     }
 
@@ -3189,7 +3190,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Dump( FileMsg, "[0x%x@%s] Rewritten file handle for %s to 0x%x",
-               this, pFileUrl->GetURL().c_str(), msg->GetDescription().c_str(),
+               this, pFileUrl->GetObfuscatedURL().c_str(), msg->GetObfuscatedDescription().c_str(),
                *((uint32_t*)pFileHandle) );
     XRootDTransport::SetDescription( msg );
   }
@@ -3258,7 +3259,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( FileMsg, "[0x%x@%s] Sending a write command for handle 0x%x to "
-                "%s", self.get(), self->pFileUrl->GetURL().c_str(),
+                "%s", self.get(), self->pFileUrl->GetObfuscatedURL().c_str(),
                 *((uint32_t*)self->pFileHandle), self->pDataServer->GetHostId().c_str() );
 
     Message            *msg;

--- a/src/XrdCl/XrdClFileSystem.cc
+++ b/src/XrdCl/XrdClFileSystem.cc
@@ -945,7 +945,7 @@ namespace XrdCl
       XrdSysMutexHelper scopedLock( fs->pMutex );
 
       log->Dump( FileSystemMsg, "[0x%x@%s] Sending %s", fs.get(),
-                 fs->pUrl->GetHostId().c_str(), msg->GetDescription().c_str() );
+                 fs->pUrl->GetHostId().c_str(), msg->GetObfuscatedDescription().c_str() );
 
       AssignLastURLHandler *lastUrlHandler = new AssignLastURLHandler( fs, handler );
       handler = lastUrlHandler;
@@ -1098,7 +1098,7 @@ namespace XrdCl
         if( !pPlugIn )
         {
           log->Error( FileMsg, "Plug-in factory failed to produce a plug-in "
-                      "for %s, continuing without one", urlStr.c_str() );
+                      "for %s, continuing without one", url.GetObfuscatedURL().c_str() );
         }
       }
     }

--- a/src/XrdCl/XrdClMessage.hh
+++ b/src/XrdCl/XrdClMessage.hh
@@ -20,6 +20,7 @@
 #define __XRD_CL_MESSAGE_HH__
 
 #include "XrdCl/XrdClBuffer.hh"
+#include "XrdOuc/XrdOucUtils.hh"
 
 namespace XrdCl
 {
@@ -87,6 +88,7 @@ namespace XrdCl
       void SetDescription( const std::string &description )
       {
         pDescription = description;
+        pObfuscatedDescription = XrdOucUtils::obfuscateAuth(description);
       }
 
       //------------------------------------------------------------------------
@@ -95,6 +97,14 @@ namespace XrdCl
       const std::string &GetDescription() const
       {
         return pDescription;
+      }
+
+      //------------------------------------------------------------------------
+      //! Get the description of the message with authz parameter obfuscated
+      //------------------------------------------------------------------------
+      const std::string & GetObfuscatedDescription() const
+      {
+        return pObfuscatedDescription;
       }
 
       //------------------------------------------------------------------------
@@ -134,6 +144,7 @@ namespace XrdCl
       uint64_t     pSessionId;
       std::string  pDescription;
       uint16_t     pVirtReqID;
+      std::string  pObfuscatedDescription;
   };
 }
 

--- a/src/XrdCl/XrdClMessageUtils.cc
+++ b/src/XrdCl/XrdClMessageUtils.cc
@@ -57,7 +57,7 @@ namespace XrdCl
       return XRootDStatus( stError, errUninitialized );
 
     log->Dump( XRootDMsg, "[%s] Sending message %s",
-               url.GetHostId().c_str(), msg->GetDescription().c_str() );
+               url.GetHostId().c_str(), msg->GetObfuscatedDescription().c_str() );
 
     //--------------------------------------------------------------------------
     // Get an instance of SID manager object
@@ -130,7 +130,7 @@ namespace XrdCl
     {
       XRootDTransport::UnMarshallRequest( msg );
       log->Error( XRootDMsg, "[%s] Unable to send the message %s: %s",
-                  url.GetHostId().c_str(), msg->GetDescription().c_str(),
+                  url.GetHostId().c_str(), msg->GetObfuscatedDescription().c_str(),
                   st.ToString().c_str() );
 
       // we need to reassign req as its current value might have been
@@ -171,7 +171,7 @@ namespace XrdCl
       return Status( stError, errUninitialized );
 
     log->Dump( XRootDMsg, "[%s] Redirecting message %s",
-               url.GetHostId().c_str(), msg->GetDescription().c_str() );
+               url.GetHostId().c_str(), msg->GetObfuscatedDescription().c_str() );
 
     XRootDTransport::MarshallRequest( msg );
 
@@ -205,7 +205,7 @@ namespace XrdCl
     {
       XRootDTransport::UnMarshallRequest( msg );
       log->Error( XRootDMsg, "[%s] Unable to send the message %s: %s",
-                  url.GetHostId().c_str(), msg->GetDescription().c_str(),
+                  url.GetHostId().c_str(), msg->GetObfuscatedDescription().c_str(),
                   st.ToString().c_str() );
       delete msgHandler;
       delete list;

--- a/src/XrdCl/XrdClSocket.cc
+++ b/src/XrdCl/XrdClSocket.cc
@@ -530,7 +530,7 @@ namespace XrdCl
     //----------------------------------------------------------------------
     Log *log = DefaultEnv::GetLog();
     log->Dump( AsyncSockMsg, "[%s] Wrote a message: %s (0x%x), %d bytes",
-               strmname.c_str(), msg.GetDescription().c_str(),
+               strmname.c_str(), msg.GetObfuscatedDescription().c_str(),
                &msg, msg.GetSize() );
     return XRootDStatus();
   }

--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -318,13 +318,13 @@ namespace XrdCl
     {
       log->Warning( PostMasterMsg, "[%s] Unable to send message %s through "
                     "substream %d, using 0 instead", pStreamName.c_str(),
-                    msg->GetDescription().c_str(), path.up );
+                    msg->GetObfuscatedDescription().c_str(), path.up );
       path.up = 0;
     }
 
     log->Dump( PostMasterMsg, "[%s] Sending message %s (0x%x) through "
                "substream %d expecting answer at %d", pStreamName.c_str(),
-               msg->GetDescription().c_str(), msg, path.up, path.down );
+               msg->GetObfuscatedDescription().c_str(), msg, path.up, path.down );
 
     //--------------------------------------------------------------------------
     // Enable *a* path and insert the message to the right queue
@@ -522,7 +522,7 @@ namespace XrdCl
     if( action & (MsgHandler::NoProcess|MsgHandler::Ignore) )
     {
       log->Dump( PostMasterMsg, "[%s] Ignoring the processing handler for: 0x%x.",
-                 pStreamName.c_str(), msg->GetDescription().c_str() );
+                 pStreamName.c_str(), msg->GetObfuscatedDescription().c_str() );
 
       // if we are handling partial response we have to take down the timeout fence
       if( IsPartial( *msg ) )

--- a/src/XrdCl/XrdClTPFallBackCopyJob.cc
+++ b/src/XrdCl/XrdClTPFallBackCopyJob.cc
@@ -43,8 +43,8 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
     log->Debug( UtilityMsg, "Creating a third party fall back copy job, "
-                "from %s to %s", GetSource().GetURL().c_str(),
-                GetTarget().GetURL().c_str() );
+                "from %s to %s", GetSource().GetObfuscatedURL().c_str(),
+                GetTarget().GetObfuscatedURL().c_str() );
   }
 
   //------------------------------------------------------------------------

--- a/src/XrdCl/XrdClThirdPartyCopyJob.cc
+++ b/src/XrdCl/XrdClThirdPartyCopyJob.cc
@@ -168,7 +168,7 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
     log->Debug( UtilityMsg, "Creating a third party copy job, from %s to %s",
-                GetSource().GetURL().c_str(), GetTarget().GetURL().c_str() );
+                GetSource().GetObfuscatedURL().c_str(), GetTarget().GetObfuscatedURL().c_str() );
   }
 
   //----------------------------------------------------------------------------
@@ -325,8 +325,8 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     Log *log = DefaultEnv::GetLog();
     log->Debug( UtilityMsg, "Check if third party copy between %s and %s "
-                "is possible", source.GetURL().c_str(),
-                target.GetURL().c_str() );
+                "is possible", source.GetObfuscatedURL().c_str(),
+                target.GetObfuscatedURL().c_str() );
 
     if( target.GetProtocol() != "root"  &&
         target.GetProtocol() != "xroot" &&
@@ -396,7 +396,7 @@ namespace XrdCl
       params["tpc.stage"] = "placement";
       sourceURL.SetParams( params );
       log->Debug( UtilityMsg, "Trying to open %s for reading",
-                  sourceURL.GetURL().c_str() );
+                  sourceURL.GetObfuscatedURL().c_str() );
       st = sourceFile.Open( sourceURL.GetURL(), OpenFlags::Read, Access::None,
                             timeLeft );
     }
@@ -426,7 +426,7 @@ namespace XrdCl
     else
     {
       log->Info( UtilityMsg, "Cannot open source file %s: %s",
-                  source.GetURL().c_str(), st.ToStr().c_str() );
+                  source.GetObfuscatedURL().c_str(), st.ToStr().c_str() );
       if( !delegate )
       {
         //----------------------------------------------------------------------
@@ -525,7 +525,7 @@ namespace XrdCl
 
     realTarget.SetParams( params );
 
-    log->Debug( UtilityMsg, "Target url is: %s", realTarget.GetURL().c_str() );
+    log->Debug( UtilityMsg, "Target url is: %s", realTarget.GetObfuscatedURL().c_str() );
 
     //--------------------------------------------------------------------------
     // Open the target file
@@ -548,7 +548,7 @@ namespace XrdCl
     if( !st.IsOK() )
     {
       log->Error( UtilityMsg, "Unable to open target %s: %s",
-                  realTarget.GetURL().c_str(), st.ToStr().c_str() );
+                  realTarget.GetObfuscatedURL().c_str(), st.ToStr().c_str() );
       if( st.code == errErrorResponse &&
           st.errNo == kXR_FSError &&
           st.GetErrorMessage().find( "tpc not supported" ) != std::string::npos )
@@ -657,7 +657,7 @@ namespace XrdCl
     params["tpc.stage"] = "copy";
     tpcSource.SetParams( params );
 
-    log->Debug( UtilityMsg, "Source url is: %s", tpcSource.GetURL().c_str() );
+    log->Debug( UtilityMsg, "Source url is: %s", tpcSource.GetObfuscatedURL().c_str() );
 
     // Set the close timeout to the default value of the stream timeout
     int closeTimeout = 0;
@@ -697,7 +697,7 @@ namespace XrdCl
     if( !st.IsOK() )
     {
       log->Error( UtilityMsg, "Unable to open source %s: %s",
-                  tpcSource.GetURL().c_str(), st.ToStr().c_str() );
+                  tpcSource.GetObfuscatedURL().c_str(), st.ToStr().c_str() );
       XRootDStatus status = dstFile.Close( closeTimeout );
       return UpdateErrMsg( st, "source" );
     }
@@ -770,7 +770,7 @@ namespace XrdCl
     if( !st.IsOK() )
     {
       log->Error( UtilityMsg, "Third party copy from %s to %s failed: %s",
-                  GetSource().GetURL().c_str(), GetTarget().GetURL().c_str(),
+                  GetSource().GetObfuscatedURL().c_str(), GetTarget().GetObfuscatedURL().c_str(),
                   st.ToStr().c_str() );
 
       // Ignore close response
@@ -786,14 +786,14 @@ namespace XrdCl
     {
       st = (statusS.IsOK() ? statusT : statusS);
       log->Error( UtilityMsg, "Third party copy from %s to %s failed during "
-                  "close of %s: %s", GetSource().GetURL().c_str(),
-                  GetTarget().GetURL().c_str(),
+                  "close of %s: %s", GetSource().GetObfuscatedURL().c_str(),
+                  GetTarget().GetObfuscatedURL().c_str(),
                   (statusS.IsOK() ? "destination" : "source"), st.ToStr().c_str() );
       return UpdateErrMsg( st, statusS.IsOK() ? "source" : "destination" );
     }
 
     log->Debug( UtilityMsg, "Third party copy from %s to %s successful",
-                GetSource().GetURL().c_str(), GetTarget().GetURL().c_str() );
+                GetSource().GetObfuscatedURL().c_str(), GetTarget().GetObfuscatedURL().c_str() );
 
     pResults->Set( "size", sourceSize );
 
@@ -888,7 +888,7 @@ namespace XrdCl
     if( !st.IsOK() )
     {
       log->Error( UtilityMsg, "Third party copy from %s to %s failed: %s",
-                  GetSource().GetURL().c_str(), GetTarget().GetURL().c_str(),
+                  GetSource().GetObfuscatedURL().c_str(), GetTarget().GetObfuscatedURL().c_str(),
                   st.ToStr().c_str() );
 
       // Ignore close response
@@ -901,14 +901,14 @@ namespace XrdCl
     if ( !st.IsOK() )
     {
       log->Error( UtilityMsg, "Third party copy from %s to %s failed during "
-                  "close of %s: %s", GetSource().GetURL().c_str(),
-                  GetTarget().GetURL().c_str(),
+                  "close of %s: %s", GetSource().GetObfuscatedURL().c_str(),
+                  GetTarget().GetObfuscatedURL().c_str(),
                   "destination", st.ToStr().c_str() );
       return UpdateErrMsg( st, "destination" );
     }
 
     log->Debug( UtilityMsg, "Third party copy from %s to %s successful",
-                GetSource().GetURL().c_str(), GetTarget().GetURL().c_str() );
+                GetSource().GetObfuscatedURL().c_str(), GetTarget().GetObfuscatedURL().c_str() );
 
     pResults->Set( "size", sourceSize );
 

--- a/src/XrdCl/XrdClURL.cc
+++ b/src/XrdCl/XrdClURL.cc
@@ -21,6 +21,8 @@
 #include "XrdCl/XrdClConstants.hh"
 #include "XrdCl/XrdClURL.hh"
 #include "XrdCl/XrdClUtils.hh"
+#include "XrdOuc/XrdOucUtils.hh"
+#include "XrdCl/XrdClOptimizers.hh"
 
 #include <cstdlib>
 #include <vector>
@@ -155,6 +157,10 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     // Dump the url
     //--------------------------------------------------------------------------
+    std::string urlLog = url;
+    if( unlikely(log->GetLevel() >= Log::DumpMsg)) {
+      urlLog = XrdOucUtils::obfuscateAuth(urlLog);
+    }
     log->Dump( UtilityMsg,
                "URL: %s\n"
                "Protocol:  %s\n"
@@ -163,7 +169,7 @@ namespace XrdCl
                "Host Name: %s\n"
                "Port:      %d\n"
                "Path:      %s\n",
-               url.c_str(), pProtocol.c_str(), pUserName.c_str(),
+               urlLog.c_str(), pProtocol.c_str(), pUserName.c_str(),
                pPassword.c_str(), pHostName.c_str(), pPort, pPath.c_str() );
     return true;
   }
@@ -545,8 +551,10 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   void URL::ComputeURL()
   {
-    if( !IsValid() )
+    if( !IsValid() ) {
       pURL = "";
+      pObfuscatedURL = "";
+    }
 
     std::ostringstream o;
     if( !pProtocol.empty() )
@@ -571,5 +579,6 @@ namespace XrdCl
     o << GetPathWithParams();
 
     pURL = o.str();
+    pObfuscatedURL = XrdOucUtils::obfuscateAuth(pURL);
   }
 }

--- a/src/XrdCl/XrdClURL.hh
+++ b/src/XrdCl/XrdClURL.hh
@@ -89,6 +89,13 @@ namespace XrdCl
       }
 
       //------------------------------------------------------------------------
+      //! Get the URL with authz information obfuscated
+      //------------------------------------------------------------------------
+      std::string GetObfuscatedURL() const {
+        return pObfuscatedURL;
+      }
+
+      //------------------------------------------------------------------------
       //! Get the host part of the URL (user:password\@host:port)
       //------------------------------------------------------------------------
       std::string GetHostId() const
@@ -297,6 +304,7 @@ namespace XrdCl
       std::string pPath;
       ParamsMap   pParams;
       std::string pURL;
+      std::string pObfuscatedURL;
 
   };
 }

--- a/src/XrdCl/XrdClUtils.cc
+++ b/src/XrdCl/XrdClUtils.cc
@@ -23,6 +23,7 @@
 #include "XrdCl/XrdClCheckSumManager.hh"
 #include "XrdCl/XrdClRedirectorRegistry.hh"
 #include "XrdCl/XrdClMessage.hh"
+#include "XrdCl/XrdClOptimizers.hh"
 #include "XrdNet/XrdNetAddr.hh"
 
 #include <algorithm>
@@ -618,12 +619,14 @@ namespace XrdCl
                                const char         *format,
                                const PropertyList &list )
   {
-    PropertyList::PropertyMap::const_iterator it;
-    std::string keyVals;
-    for( it = list.begin(); it != list.end(); ++it )
-      keyVals += "'" + it->first + "' = '" + it->second + "', ";
-    keyVals.erase( keyVals.length()-2, 2 );
-    log->Dump( topic, format, keyVals.c_str() );
+    if( unlikely(log->GetLevel() >= Log::DumpMsg) ) {
+      PropertyList::PropertyMap::const_iterator it;
+      std::string keyVals;
+      for (it = list.begin(); it != list.end(); ++it)
+        keyVals += "'" + it->first + "' = '" + XrdOucUtils::obfuscateAuth(it->second) + "', ";
+      keyVals.erase(keyVals.length() - 2, 2);
+      log->Dump(topic, format, keyVals.c_str());
+    }
   }
 
   //----------------------------------------------------------------------------

--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -38,6 +38,7 @@
 #include "XrdCl/XrdClRedirectorRegistry.hh"
 #include "XrdCl/XrdClSocket.hh"
 #include "XrdCl/XrdClTls.hh"
+#include "XrdCl/XrdClOptimizers.hh"
 
 #include "XrdOuc/XrdOucCRC.hh"
 
@@ -123,7 +124,7 @@ namespace XrdCl
         log->Warning( ExDbgMsg, "[%s] MsgHandler is examining a response although "
                                 "it already owns a response: 0x%x (message: %s ).",
                       pUrl.GetHostId().c_str(), this,
-                      pRequest->GetDescription().c_str() );
+                      pRequest->GetObfuscatedDescription().c_str() );
       }
     }
 
@@ -184,7 +185,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got kXR_waitresp response to "
                    "message %s", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         pResponse.reset();
         return Ignore; // This must be handled synchronously!
@@ -226,7 +227,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got a kXR_oksofar response to request "
                    "%s", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         if( !pOksofarAsAnswer )
         {
@@ -261,7 +262,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got a kXR_status response to request "
                    "%s", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         uint16_t reqId = ntohs( req->header.requestid );
         if( reqId == kXR_pgwrite )
@@ -454,7 +455,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got a kXR_ok response to request %s",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
         pStatus  = Status();
         HandleResponse();
         return;
@@ -464,7 +465,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got a kXR_status response to request %s",
                     pUrl.GetHostId().c_str(),
-                    pRequest->GetDescription().c_str() );
+                    pRequest->GetObfuscatedDescription().c_str() );
         pStatus   = Status();
         HandleResponse();
         return;
@@ -477,7 +478,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got a kXR_oksofar response to request %s",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
         pStatus  = Status( stOK, suContinue );
         HandleResponse();
         return;
@@ -492,7 +493,7 @@ namespace XrdCl
         memcpy( errmsg, rsp->body.error.errmsg, rsp->hdr.dlen-4 );
         log->Dump( XRootDMsg, "[%s] Got a kXR_error response to request %s "
                    "[%d] %s", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str(), rsp->body.error.errnum,
+                   pRequest->GetObfuscatedDescription().c_str(), rsp->body.error.errnum,
                    errmsg );
         delete [] errmsg;
 
@@ -521,7 +522,7 @@ namespace XrdCl
         delete [] urlInfoBuff;
         log->Dump( XRootDMsg, "[%s] Got kXR_redirect response to "
                    "message %s: %s, port %d", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str(), urlInfo.c_str(),
+                   pRequest->GetObfuscatedDescription().c_str(), urlInfo.c_str(),
                    rsp->body.redirect.port );
 
         //----------------------------------------------------------------------
@@ -532,7 +533,7 @@ namespace XrdCl
           log->Warning( XRootDMsg, "[%s] Redirect limit has been reached for "
                      "message %s, the last known error is: %s",
                      pUrl.GetHostId().c_str(),
-                     pRequest->GetDescription().c_str(),
+                     pRequest->GetObfuscatedDescription().c_str(),
                      pLastError.ToString().c_str() );
 
 
@@ -562,7 +563,7 @@ namespace XrdCl
               log->Dump( XRootDMsg, "[%s] Current server has been assigned "
                          "as a load-balancer for message %s",
                          pUrl.GetHostId().c_str(),
-                         pRequest->GetDescription().c_str() );
+                         pRequest->GetObfuscatedDescription().c_str() );
               HostList::iterator it;
               for( it = pHosts->begin(); it != pHosts->end(); ++it )
                 it->loadBalancer = false;
@@ -744,7 +745,7 @@ namespace XrdCl
           memcpy( infoMsg, rsp->body.wait.infomsg, rsp->hdr.dlen-4 );
           log->Dump( XRootDMsg, "[%s] Got kXR_wait response of %d seconds to "
                      "message %s: %s", pUrl.GetHostId().c_str(),
-                     rsp->body.wait.seconds, pRequest->GetDescription().c_str(),
+                     rsp->body.wait.seconds, pRequest->GetObfuscatedDescription().c_str(),
                      infoMsg );
           delete [] infoMsg;
           waitSeconds = rsp->body.wait.seconds;
@@ -753,7 +754,7 @@ namespace XrdCl
         {
           log->Dump( XRootDMsg, "[%s] Got kXR_wait response of 0 seconds to "
                      "message %s", pUrl.GetHostId().c_str(),
-                     pRequest->GetDescription().c_str() );
+                     pRequest->GetObfuscatedDescription().c_str() );
         }
 
         pAggregatedWaitTime += waitSeconds;
@@ -795,7 +796,7 @@ namespace XrdCl
         {
           log->Debug( ExDbgMsg, "[%s] Scheduling WaitTask for MsgHandler: 0x%x (message: %s ).",
                       pUrl.GetHostId().c_str(), this,
-                      pRequest->GetDescription().c_str() );
+                      pRequest->GetObfuscatedDescription().c_str() );
 
           TaskManager *taskMgr = pPostMaster->GetTaskManager();
           taskMgr->RegisterTask( new WaitTask( this ), resendTime );
@@ -804,7 +805,7 @@ namespace XrdCl
         {
           log->Debug( XRootDMsg, "[%s] Wait time is too long, timing out %s",
                       pUrl.GetHostId().c_str(),
-                      pRequest->GetDescription().c_str() );
+                      pRequest->GetObfuscatedDescription().c_str() );
           HandleError( Status( stError, errOperationExpired) );
         }
         return;
@@ -830,7 +831,7 @@ namespace XrdCl
         log->Dump( XRootDMsg, "[%s] Got kXR_waitresp response of %d seconds to "
                    "message %s", pUrl.GetHostId().c_str(),
                    rsp->body.waitresp.seconds,
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
         return;
       }
 
@@ -841,7 +842,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Got unrecognized response %d to "
                    "message %s", pUrl.GetHostId().c_str(),
-                   rsp->hdr.status, pRequest->GetDescription().c_str() );
+                   rsp->hdr.status, pRequest->GetObfuscatedDescription().c_str() );
         pStatus   = Status( stError, errInvalidResponse );
         HandleResponse();
         return;
@@ -859,7 +860,7 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
     log->Dump( XRootDMsg, "[%s] Stream event reported for msg %s",
-               pUrl.GetHostId().c_str(), pRequest->GetDescription().c_str() );
+               pUrl.GetHostId().c_str(), pRequest->GetObfuscatedDescription().c_str() );
 
     if( event == Ready )
       return 0;
@@ -902,11 +903,11 @@ namespace XrdCl
     if( status.IsOK() )
     {
       log->Dump( XRootDMsg, "[%s] Message %s has been successfully sent.",
-                 pUrl.GetHostId().c_str(), message->GetDescription().c_str() );
+                 pUrl.GetHostId().c_str(), message->GetObfuscatedDescription().c_str() );
 
       log->Debug( ExDbgMsg, "[%s] Moving MsgHandler: 0x%x (message: %s ) from out-queue to in-queue.",
                   pUrl.GetHostId().c_str(), this,
-                  pRequest->GetDescription().c_str() );
+                  pRequest->GetObfuscatedDescription().c_str() );
 
       pMsgInFly = true;
       return;
@@ -917,7 +918,7 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     log->Error( XRootDMsg, "[%s] Impossible to send message %s. Trying to "
                 "recover.", pUrl.GetHostId().c_str(),
-                message->GetDescription().c_str() );
+                message->GetObfuscatedDescription().c_str() );
     HandleError( status );
   }
 
@@ -1083,7 +1084,7 @@ namespace XrdCl
       }
 
       log->Debug( XRootDMsg, "[%s] Request %s payload (kernel buffer) transferred to socket.",
-                  pUrl.GetHostId().c_str(), pRequest->GetDescription().c_str() );
+                  pUrl.GetHostId().c_str(), pRequest->GetObfuscatedDescription().c_str() );
     }
 
     return Status();
@@ -1122,7 +1123,7 @@ namespace XrdCl
     log->Debug( ExDbgMsg, "[%s] Calling MsgHandler: 0x%x (message: %s ) "
                 "with status: %s.",
                 pUrl.GetHostId().c_str(), this,
-                pRequest->GetDescription().c_str(),
+                pRequest->GetObfuscatedDescription().c_str(),
                 status->ToString().c_str() );
 
     if( status->IsOK() )
@@ -1310,7 +1311,7 @@ namespace XrdCl
 
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as "
                    "LocateInfo: %s", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str(), nullBuffer );
+                   pRequest->GetObfuscatedDescription().c_str(), nullBuffer );
         LocationInfo *data = new LocationInfo();
 
         if( data->ParseServerResponse( nullBuffer ) == false )
@@ -1347,7 +1348,7 @@ namespace XrdCl
 
           log->Dump( XRootDMsg, "[%s] Parsing the response to %s as "
                      "StatInfoVFS: %s", pUrl.GetHostId().c_str(),
-                     pRequest->GetDescription().c_str(), nullBuffer );
+                     pRequest->GetObfuscatedDescription().c_str(), nullBuffer );
 
           if( data->ParseServerResponse( nullBuffer ) == false )
           {
@@ -1373,7 +1374,7 @@ namespace XrdCl
 
           log->Dump( XRootDMsg, "[%s] Parsing the response to %s as StatInfo: "
                      "%s", pUrl.GetHostId().c_str(),
-                     pRequest->GetDescription().c_str(), nullBuffer );
+                     pRequest->GetObfuscatedDescription().c_str(), nullBuffer );
 
           if( data->ParseServerResponse( nullBuffer ) == false )
           {
@@ -1397,7 +1398,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as ProtocolInfo",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         if( rsp->hdr.dlen < 8 )
         {
@@ -1422,7 +1423,7 @@ namespace XrdCl
         AnyObject *obj = new AnyObject();
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as "
                    "DirectoryList", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         char *path = new char[req->dirlist.dlen+1];
         path[req->dirlist.dlen] = 0;
@@ -1469,7 +1470,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as OpenInfo",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         if( rsp->hdr.dlen < 4 )
         {
@@ -1488,7 +1489,7 @@ namespace XrdCl
         {
           log->Dump( XRootDMsg, "[%s] Parsing StatInfo in response to %s",
                      pUrl.GetHostId().c_str(),
-                     pRequest->GetDescription().c_str() );
+                     pRequest->GetObfuscatedDescription().c_str() );
 
           if( rsp->hdr.dlen >= 12 )
           {
@@ -1509,7 +1510,7 @@ namespace XrdCl
           {
             log->Error( XRootDMsg, "[%s] Unable to parse StatInfo in response "
                         "to %s", pUrl.GetHostId().c_str(),
-                        pRequest->GetDescription().c_str() );
+                        pRequest->GetObfuscatedDescription().c_str() );
             delete obj;
             return Status( stError, errInvalidResponse );
           }
@@ -1530,7 +1531,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as ChunkInfo",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         for( uint32_t i = 0; i < pPartialResps.size(); ++i )
         {
@@ -1560,7 +1561,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as PageInfo",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         //----------------------------------------------------------------------
         // Glue in the cached responses if necessary
@@ -1605,7 +1606,7 @@ namespace XrdCl
           log->Error( XRootDMsg, "[%s] Handling response to %s: user supplied "
                       "buffer is too small for the received data.",
                       pUrl.GetHostId().c_str(),
-                      pRequest->GetDescription().c_str() );
+                      pRequest->GetObfuscatedDescription().c_str() );
           return Status( stError, errInvalidResponse );
         }
 
@@ -1659,7 +1660,7 @@ namespace XrdCl
       {
         log->Dump( XRootDMsg, "[%s] Parsing the response to 0x%x as "
                    "VectorReadInfo", pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         for( uint32_t i = 0; i < pPartialResps.size(); ++i )
         {
@@ -1704,7 +1705,7 @@ namespace XrdCl
         AnyObject *obj = new AnyObject();
         log->Dump( XRootDMsg, "[%s] Parsing the response to %s as BinaryData",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         BinaryDataInfo *data = new BinaryDataInfo();
         data->Allocate( length );
@@ -1903,11 +1904,14 @@ namespace XrdCl
       (surl.find('?') == std::string::npos) ? (surl += '?') :
           ((*surl.rbegin() != '&') ? (surl += '&') : (surl += ""));
       surl += xrdCgi;
-
       if (!authUrl.FromString(surl))
       {
+        std::string surlLog = surl;
+        if( unlikely( log->GetLevel() >= Log::ErrorMsg ) ) {
+          surlLog = XrdOucUtils::obfuscateAuth(surlLog);
+        }
         log->Error( XRootDMsg, "[%s] Failed to build redirection URL from data:"
-		    "%s", surl.c_str());
+		    "%s", surlLog.c_str());
         return Status(stError, errInvalidRedirectURL);
       }
     }
@@ -1982,7 +1986,7 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     log->Debug( XRootDMsg, "[%s] Handling error while processing %s: %s.",
-                pUrl.GetHostId().c_str(), pRequest->GetDescription().c_str(),
+                pUrl.GetHostId().c_str(), pRequest->GetObfuscatedDescription().c_str(),
                 status.ToString().c_str() );
 
     //--------------------------------------------------------------------------
@@ -2038,7 +2042,7 @@ namespace XrdCl
     {
       log->Error( XRootDMsg, "[%s] Unable to get the response to request %s",
                   pUrl.GetHostId().c_str(),
-                  pRequest->GetDescription().c_str() );
+                  pRequest->GetObfuscatedDescription().c_str() );
       pStatus = status;
       HandleRspOrQueue();
       return;
@@ -2062,7 +2066,7 @@ namespace XrdCl
       {
         log->Info( XRootDMsg, "[%s] Retrying request: %s.",
                    pUrl.GetHostId().c_str(),
-                   pRequest->GetDescription().c_str() );
+                   pRequest->GetObfuscatedDescription().c_str() );
 
         UpdateTriedCGI( kXR_ServerError );
         HandleError( RetryAtServer( pUrl, RedirectEntry::EntryRetry ) );
@@ -2117,7 +2121,7 @@ namespace XrdCl
         {
           log->Error( XRootDMsg, "[%s] Impossible to send message %s.",
           pUrl.GetHostId().c_str(),
-          pRequest->GetDescription().c_str() );
+          pRequest->GetObfuscatedDescription().c_str() );
           return st;
         }
       }
@@ -2129,7 +2133,7 @@ namespace XrdCl
     {
       log->Debug( ExDbgMsg, "[%s] Metaling redirection for MsgHandler: 0x%x (message: %s ).",
                   pUrl.GetHostId().c_str(), this,
-                  pRequest->GetDescription().c_str() );
+                  pRequest->GetObfuscatedDescription().c_str() );
 
       return pPostMaster->Redirect( pUrl, pRequest, this );
     }
@@ -2142,7 +2146,7 @@ namespace XrdCl
     {
       log->Debug( ExDbgMsg, "[%s] Retry at server MsgHandler: 0x%x (message: %s ).",
                   pUrl.GetHostId().c_str(), this,
-                  pRequest->GetDescription().c_str() );
+                  pRequest->GetObfuscatedDescription().c_str() );
       return pPostMaster->Send( pUrl, pRequest, this, true, pExpiration );
     }
   }
@@ -2246,7 +2250,7 @@ namespace XrdCl
       Log *log = DefaultEnv::GetLog();
       log->Debug( ExDbgMsg, "[%s] Passing to the thread-pool MsgHandler: 0x%x (message: %s ).",
                   pUrl.GetHostId().c_str(), this,
-                  pRequest->GetDescription().c_str() );
+                  pRequest->GetObfuscatedDescription().c_str() );
       jobMgr->QueueJob( new HandleRspJob( this ), 0 );
     }
   }
@@ -2259,7 +2263,7 @@ namespace XrdCl
     Log *log = DefaultEnv::GetLog();
     log->Debug( ExDbgMsg, "[%s] Handling local redirect - MsgHandler: 0x%x (message: %s ).",
                 pUrl.GetHostId().c_str(), this,
-                pRequest->GetDescription().c_str() );
+                pRequest->GetObfuscatedDescription().c_str() );
 
     if( !pLFileHandler )
     {
@@ -2306,7 +2310,7 @@ namespace XrdCl
         log->Debug( XRootDMsg,
                     "[%s] Not allowed to retry open request (OpenRecovery disabled): %s.",
                     pUrl.GetHostId().c_str(),
-                    pRequest->GetDescription().c_str() );
+                    pRequest->GetObfuscatedDescription().c_str() );
         // disallow retry if it is a mutable open
         return false;
       }

--- a/src/XrdCl/XrdClXRootDMsgHandler.hh
+++ b/src/XrdCl/XrdClXRootDMsgHandler.hh
@@ -45,6 +45,7 @@
 #include "XrdSys/XrdSysPlatform.hh"
 
 #include "XrdOuc/XrdOucPgrwUtils.hh"
+#include "XrdOuc/XrdOucUtils.hh"
 
 #include <sys/uio.h>
 #include <arpa/inet.h> // for network unmarshaling stuff
@@ -184,7 +185,7 @@ namespace XrdCl
         Log *log = DefaultEnv::GetLog();
         log->Debug( ExDbgMsg, "[%s] MsgHandler created: 0x%x (message: %s ).",
                     pUrl.GetHostId().c_str(), this,
-                    pRequest->GetDescription().c_str() );
+                    pRequest->GetObfuscatedDescription().c_str() );
 
         ClientRequestHdr *hdr = (ClientRequestHdr*)pRequest->GetBuffer();
         if( ntohs( hdr->requestid ) == kXR_pgread )

--- a/src/XrdClHttp/XrdClHttpFileSystemPlugIn.cc
+++ b/src/XrdClHttp/XrdClHttpFileSystemPlugIn.cc
@@ -26,7 +26,7 @@ HttpFileSystemPlugIn::HttpFileSystemPlugIn(const std::string &url)
   SetUpLogging(logger_);
   logger_->Debug(kLogXrdClHttp,
                  "HttpFileSystemPlugIn constructed with URL: %s.",
-                 url_.GetURL().c_str());
+                 url_.GetObfuscatedURL().c_str());
   std::string origin = getenv("XRDXROOTD_PROXY")? getenv("XRDXROOTD_PROXY") : "";
   if ( origin.empty() || origin.find("=") == 0) {
       ctx_ = new Davix::Context();
@@ -94,7 +94,7 @@ XRootDStatus HttpFileSystemPlugIn::Rm(const std::string &path,
 
   logger_->Debug(kLogXrdClHttp,
                  "HttpFileSystemPlugIn::Rm - path = %s, timeout = %d",
-                 url.GetURL().c_str(), timeout);
+                 url.GetObfuscatedURL().c_str(), timeout);
 
   auto status = Posix::Unlink(*davix_client_, url.GetURL(), timeout);
 
@@ -119,7 +119,7 @@ XRootDStatus HttpFileSystemPlugIn::MkDir(const std::string &path,
   logger_->Debug(
       kLogXrdClHttp,
       "HttpFileSystemPlugIn::MkDir - path = %s, flags = %d, timeout = %d",
-      url.GetURL().c_str(), flags, timeout);
+      url.GetObfuscatedURL().c_str(), flags, timeout);
 
   auto status = Posix::MkDir(*davix_client_, url.GetURL(), flags, mode, timeout);
   if (status.IsError()) {
@@ -140,7 +140,7 @@ XRootDStatus HttpFileSystemPlugIn::RmDir(const std::string &path,
 
   logger_->Debug(kLogXrdClHttp,
                  "HttpFileSystemPlugIn::RmDir - path = %s, timeout = %d",
-                 url.GetURL().c_str(), timeout);
+                 url.GetObfuscatedURL().c_str(), timeout);
 
   auto status = Posix::RmDir(*davix_client_, url.GetURL(), timeout);
   if (status.IsError()) {

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -617,7 +617,7 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
     while ((rc = BuffgetLine(tmpline)) > 0) {
       if (TRACING(TRACE_DEBUG)) {
         std::string traceLine{tmpline.c_str()};
-        traceLine = XrdOucUtils::obfuscate(traceLine, {"authorization", "transferheaderauthorization"}, ':', '\n');
+        traceLine = XrdOucUtils::obfuscateAuth(traceLine);
         TRACE(DEBUG, " rc:" << rc << " got hdr line: " << traceLine);
       }
       if ((rc == 2) && (tmpline.length() > 1) && (tmpline[rc - 1] == '\n')) {

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -943,7 +943,7 @@ int XrdHttpReq::ProcessHTTPReq() {
     if (TRACING(TRACE_DEBUG)) {
       // The obfuscation of "authz" will only be done if the server http.header2cgi config contains something that maps a header to this "authz" cgi.
       // Unfortunately the obfuscation code will be called no matter what is configured in http.header2cgi.
-      std::string header2cgistrObf = XrdOucUtils::obfuscate(hdr2cgistr, {"authz"}, '=', '&');
+      std::string header2cgistrObf = XrdOucUtils::obfuscateAuth(hdr2cgistr);
 
       TRACEI(DEBUG, "Appended header fields to opaque info: '"
         << header2cgistrObf.c_str() << "'");

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -34,7 +34,9 @@
 #include <sys/stat.h>
 #include <string>
 #include <unordered_set>
-  
+#include <vector>
+#include <regex>
+
 class XrdSysError;
 class XrdOucString;
 class XrdOucStream;
@@ -138,7 +140,21 @@ static int getModificationTime(const char * path, time_t & modificationTime);
 
 static void trim(std::string & str);
 
-static std::string obfuscate(const std::string & input, const std::unordered_set<std::string> & keysToObfuscate,const char keyValueDelimiter, const char listDelimiter);
+/**
+ * Use this function to obfuscate any string containing key-values with XrdOucUtils::OBFUSCATION_STR
+ * @param input the string to obfuscate
+ * @param regexes the obfuscation regexes to apply to replace the value with XrdOucUtils::OBFUSCATION_STR. The key should be a regex group e.g: "(authz=)"
+ * Have a look at obfuscateAuth for more examples
+ * @return the string with values obfuscated
+ */
+static std::string obfuscate(const std::string & input, const std::vector<std::regex> & regexes);
+
+/**
+ * Obfuscates string containing authz=value key value and Authorization: value, TransferHeaderAuthorization: value, WhateverAuthorization: value
+ * in a case insensitive way
+ * @param input the string to obfuscate
+ */
+static std::string obfuscateAuth(const std::string & input);
 
     XrdOucUtils() {}
     ~XrdOucUtils() {}

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -213,7 +213,7 @@ XrdOucCacheIO *Cache::Attach(XrdOucCacheIO *io, int Options)
 
    if (Cache::GetInstance().Decide(io))
    {
-      TRACE(Info, tpfx << io->Path());
+      TRACE(Info, tpfx << XrdOucUtils::obfuscateAuth(io->Path()));
 
       IO *cio;
 

--- a/src/XrdPfc/XrdPfcTrace.hh
+++ b/src/XrdPfc/XrdPfcTrace.hh
@@ -32,7 +32,7 @@
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysTrace.hh"
 #include "XrdSys/XrdSysE2T.hh"
-
+#include "XrdOuc/XrdOucUtils.hh"
 #ifndef XRD_TRACE
 #define XRD_TRACE GetTrace()->
 #endif
@@ -57,7 +57,7 @@
 
 #define TRACEIO(act, x) \
    if (XRD_TRACE What >= TRACE_ ## act) SYSTRACE(XRD_TRACE, 0, m_traceID, 0, \
-       TRACE_STR_ ## act << x << " " << GetPath())
+       TRACE_STR_ ## act << x << " " << XrdOucUtils::obfuscateAuth(GetPath()))
 
 #define TRACEF(act, x) \
    if (XRD_TRACE What >= TRACE_ ## act) SYSTRACE(XRD_TRACE, 0, m_traceID, 0, \

--- a/src/XrdPosix/XrdPosixAdmin.hh
+++ b/src/XrdPosix/XrdPosixAdmin.hh
@@ -55,7 +55,7 @@ XrdOucECMsg&      ecMsg;
 bool           isOK() {if (Url.IsValid()) return true;
                        ecMsg.Set(EINVAL, 0);
                        ecMsg.Msgf("PosixAdmin", "url '%s' is invalid",
-                                  Url.GetURL().c_str());
+                                  Url.GetObfuscatedURL().c_str());
                        errno = EINVAL;    return false;
                       }
 

--- a/tests/XrdOucTests/XrdOucUtilsTests.cc
+++ b/tests/XrdOucTests/XrdOucUtilsTests.cc
@@ -13,20 +13,30 @@ using namespace testing;
 
 class XrdOucUtilsTests : public Test {};
 
-TEST(XrdOucUtilsTests, obfuscate) {
+TEST(XrdOucUtilsTests, obfuscateAuth) {
   // General cases
-  ASSERT_EQ(std::string("scitag.flow=144&authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&test=abcd"), XrdOucUtils::obfuscate("scitag.flow=144&authz=token&test=abcd",{"authz"},'=','&'));
-  ASSERT_EQ(std::string("authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&scitag.flow=144&test=abcd"), XrdOucUtils::obfuscate("authz=token&scitag.flow=144&test=abcd",{"authz"},'=','&'));
-  ASSERT_EQ(std::string("scitag.flow=144&test=abcd&authz=") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscate("scitag.flow=144&test=abcd&authz=token",{"authz"},'=','&'));
+  ASSERT_EQ(std::string("scitag.flow=144&authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&test=abcd"), XrdOucUtils::obfuscateAuth("scitag.flow=144&authz=token&test=abcd"));
+  ASSERT_EQ(std::string("authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&scitag.flow=144&test=abcd"), XrdOucUtils::obfuscateAuth("authz=token&scitag.flow=144&test=abcd"));
+  ASSERT_EQ(std::string("scitag.flow=144&test=abcd&authz=") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("scitag.flow=144&test=abcd&authz=token"));
   // Nothing to obfuscate
-  ASSERT_EQ("test=abcd&test2=abcde",XrdOucUtils::obfuscate("test=abcd&test2=abcde",{},'=','&'));
-  ASSERT_EQ("nothingtoobfuscate",XrdOucUtils::obfuscate("nothingtoobfuscate",{"obfuscateme"},'=','\n'));
+  ASSERT_EQ("test=abcd&test2=abcde",XrdOucUtils::obfuscateAuth("test=abcd&test2=abcde"));
+  ASSERT_EQ("nothingtoobfuscate",XrdOucUtils::obfuscateAuth("nothingtoobfuscate"));
   //Empty string obfuscation
-  ASSERT_EQ("",XrdOucUtils::obfuscate("",{"obfuscateme"},'=','&'));
-  ASSERT_EQ("",XrdOucUtils::obfuscate("",{},'=','\n'));
+  ASSERT_EQ("",XrdOucUtils::obfuscateAuth(""));
+  //2 authz to obfuscate
+  ASSERT_EQ(std::string("authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&test=test2&authz=") + XrdOucUtils::OBFUSCATION_STR,XrdOucUtils::obfuscateAuth("authz=abcd&test=test2&authz=abcdef"));
   // Trimmed key obfuscation
-  ASSERT_EQ(std::string("Authorization:") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscate("Authorization: Bearer token",{"authorization"},':','\n'));
-  ASSERT_EQ(std::string("Authorization:")+ XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscate("Authorization : Bearer token",{"authorization"},':','\n'));
+  ASSERT_EQ(std::string("Authorization: ") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("Authorization: Bearer token"));
+  ASSERT_EQ(std::string("Authorization :") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("Authorization :Bearer token"));
+  ASSERT_EQ(std::string("authorization :") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("authorization :Bearer token"));
+  ASSERT_EQ(std::string("transferHeaderauthorization :") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("transferHeaderauthorization :Bearer token"));
+  // Different obfuscation
+  ASSERT_EQ(std::string("(message: kXR_stat (path: /tmp/xrootd/public/foo?authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&pelican.timeout=3s, flags: none) )."), XrdOucUtils::obfuscateAuth("(message: kXR_stat (path: /tmp/xrootd/public/foo?authz=foo1234&pelican.timeout=3s, flags: none) )."));
+  ASSERT_EQ(std::string("(message: kXR_stat (path: /tmp/xrootd/public/foo?pelican.timeout=3s&authz=") + XrdOucUtils::OBFUSCATION_STR + std::string(", flags: none) )."), XrdOucUtils::obfuscateAuth("(message: kXR_stat (path: /tmp/xrootd/public/foo?pelican.timeout=3s&authz=foo1234, flags: none) )."));
+  ASSERT_EQ(std::string("/path/test.txt?scitag.flow=44&authz=") + XrdOucUtils::OBFUSCATION_STR + std::string(" done close."),XrdOucUtils::obfuscateAuth("/path/test.txt?scitag.flow=44&authz=abcdef done close."));
+  ASSERT_EQ(std::string("Appended header field to opaque info: 'authz=") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("Appended header field to opaque info: 'authz=Bearer abcdef'"));
+  ASSERT_EQ(std::string("Appended header fields to opaque info: 'authz=") + XrdOucUtils::OBFUSCATION_STR + std::string("&scitag.flow=65'"), XrdOucUtils::obfuscateAuth("Appended header fields to opaque info: 'authz=Bearer token&scitag.flow=65'"));
+  ASSERT_EQ(std::string("Processing source entry: /etc/passwd, type local file, target file: root://localhost:1094//tmp/passwd?authz=") + XrdOucUtils::OBFUSCATION_STR, XrdOucUtils::obfuscateAuth("Processing source entry: /etc/passwd, type local file, target file: root://localhost:1094//tmp/passwd?authz=testabcd"));
 }
 
 TEST(XrdOucUtilsTests, caseInsensitiveFind) {


### PR DESCRIPTION
Fixes #2296

I added new attributes/member functions to obfuscate the URL/description only once in a lifetime of the URL/Request object. Those functions GetDescription() and GetPath() were used everywhere in the XrdCl logging code.
They were replaced by GetObfuscatedDescription() and GetObfuscatedPath().

I also changed the way I obfuscate --> I now use regexes which simplify a lot the code. Unit tests were adapted accordingly with an addition of test cases.