### PR TITLE
Avoid calling 'stat' on HTTP GET

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1993,7 +1993,7 @@ XrdHttpReq::PostProcessListing(bool final_) {
     return keepalive ? 1 : -1;
   }
 
-  return 1;
+  return 0;
 }
 
 int

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -143,6 +143,10 @@ private:
   // the data and necessary headers, assuming multipart/byteranges content type.
   int sendReadResponsesMultiRanges(const XrdHttpIOList &received);
 
+  // If requested by the client, sends any I/O errors that occur during the transfer
+  // into a footer.
+  int sendFooterError(const std::string &);
+
   /**
    * Extract a comma separated list of checksums+metadata into a vector
    * @param checksumList the list like "0:sha1, 1:adler32, 2:md5"

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -107,6 +107,14 @@ private:
   // be included in the response.
   int PostProcessChecksum(std::string &digest_header);
 
+  // Process the listing request of a GET request against a directory
+  // - final_: True if this is the last entry in the listing.
+  int PostProcessListing(bool final_);
+
+  // Send the response for a GET request for a file read (i.e., not a directory)
+  // Invoked after the open is successful but before the first read is issued.
+  int ReturnGetHeaders();
+
   /// Cook and send the response after the bridge did something
   /// Return values:
   ///  0->everything OK, additionsl steps may be required

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -145,7 +145,7 @@ private:
 
   // If requested by the client, sends any I/O errors that occur during the transfer
   // into a footer.
-  int sendFooterError(const std::string &);
+  void sendFooterError(const std::string &);
 
   /**
    * Extract a comma separated list of checksums+metadata into a vector


### PR DESCRIPTION
This is a first attempt at "fixing" #2299.  Instead of invoking a filesystem `stat`, then opening the path, it changes the GET code to _always_ try the 'open' first.

If the open fails with an `kXR_isDirectory` (i.e., `EISDIR`), then the code falls back to doing a directory listing.

At the minimum, this will halve the number of `stat` requests the underlying storage will see as `stat` is done twice per request if the requests are sent sequentially.  At best, it'll eliminate nearly all `stat`s under high concurrency given the OFS will collapse the open files into a single handle and some OSS's will cache the results of the first `fstat`.

This state machine for GET is notoriously tricky so I'd appreciate a review by @ccaffy or @smithdh.  Tests done by hand:
- Download full file.
- Download file in single `Range` request.
- Download file in multiple `Range` requests.
- `GET` on a directory.