### PR TITLE
Do not leak file pointer on open error

### DIFF
--- a/src/XrdPosix/XrdPosixXrootd.cc
+++ b/src/XrdPosix/XrdPosixXrootd.cc
@@ -652,7 +652,12 @@ int XrdPosixXrootd::Open(const char *path, int oflags, mode_t mode,
 //
    if (cbP) {errno = EINPROGRESS; return -1;}
    if (fp->Finalize(&Status)) return fp->FDNum();
-   return XrdPosixMap::Result(Status,XrdPosixGlobals::ecMsg,true);
+   auto rc = XrdPosixMap::Result(Status,XrdPosixGlobals::ecMsg,false);
+   if (!Status.IsOK()) {
+       delete fp;
+       errno = -rc;
+   }
+   return rc;
 }
   
 /******************************************************************************/


### PR DESCRIPTION
If the file-open failed to finalize (this code path is hit in XCache when a non-existent file is attempted to be opened), then the `fp` object leaked.

This eventually fills up the file descriptor table in XrdPosix after 1M file-not-found responses from the cache, a denial of service until the xrootd server is restarted.

Fixes #2302 

@amadio - I'd suggest this is a reasonable backport to any active release branches.