### PR TITLE
[XrdOucUtils] Speed-up authz obfuscation

### DIFF
--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -114,7 +114,15 @@ int LookUp(idMap_t &idMap, unsigned int id, char *buff, int blen)
    return luRet;
 }
 }
-  
+
+std::vector<std::regex> XrdOucUtils::authObfuscationRegexes {
+  //authz=xxx&... We deal with cases like "(message: kXR_stat (path: /tmp/xrootd/public/foo?pelican.timeout=3s&authz=foo1234, flags: none)" where we do not want to obfuscate
+  // ", flags: none)" + we deal with cases where the 'authz=Bearer token' when an admin could set 'http.header2cgi Authorization authz' in the server config
+  std::regex(R"((authz=)(Bearer\s)?([^ &\",<>#%{}|\^~\[\]`]*))",std::regex_constants::optimize),
+  // HTTP Authorization, TransferHeaderAuthorization headers that with the key that can be prefixed with spaces and value prefixed by spaces
+  std::regex(R"((\s*\w*Authorization\s*:\s*)[^$]*)", std::regex_constants::icase | std::regex_constants::optimize)
+};
+
 /******************************************************************************/
 /*                               a r g L i s t                                */
 /******************************************************************************/
@@ -1447,13 +1455,7 @@ void XrdOucUtils::trim(std::string &str) {
 }
 
 std::string XrdOucUtils::obfuscateAuth(const std::string & input) {
-  return obfuscate(input,{
-    //authz=xxx&... We deal with cases like "(message: kXR_stat (path: /tmp/xrootd/public/foo?pelican.timeout=3s&authz=foo1234, flags: none)" where we do not want to obfuscate
-    // ", flags: none)" + we deal with cases where the 'authz=Bearer token' when an admin could set 'http.header2cgi Authorization authz' in the server config
-    std::regex(R"((authz=)(Bearer\s)?([^ &\",<>#%{}|\^~\[\]`]*))"),
-    // HTTP Authorization, TransferHeaderAuthorization headers that with the key that can be prefixed with spaces and value prefixed by spaces
-    std::regex(R"((\s*\w*Authorization\s*:\s*)[^$]*)", std::regex_constants::icase)
-  });
+  return obfuscate(input, authObfuscationRegexes);
 }
 
 

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -158,5 +158,10 @@ static std::string obfuscateAuth(const std::string & input);
 
     XrdOucUtils() {}
     ~XrdOucUtils() {}
+
+private:
+  // As the compilation of the regexes when the std::regex object is constructed is expensive,
+  // we initialize the auth obfuscation regexes only once in the XRootD process lifetime
+  static std::vector<std::regex> authObfuscationRegexes;
 };
 #endif


### PR DESCRIPTION
@amadio discovered that the XrdEc tests were 10 times slower than usual. This slowness came from the fact that for each call to XrdOucUtils::obfuscateAuth(...) 2 std::regex were instanciated. The instanciation of those two std::regex objects is expensive as there is a compilation logic to ensure the regex is correct. Those 2 regexes are now constructed only once in the lifetime of the XRootD process by creating a static std::vector<std::regex>.