### PR TITLE
Protect against array index out of bounds

### DIFF
--- a/src/XrdSys/XrdSysE2T.cc
+++ b/src/XrdSys/XrdSysE2T.cc
@@ -74,6 +74,9 @@ int initErrTable()
       if (EBADE - ERRNOBASE > lastGood)
          lastGood = EBADE - ERRNOBASE;
    }
+   else {
+      e2sMap[EBADE] = "authentication failed - possible invalid exchange";
+   }
 #endif
 
    // Supply generic message for missing ones

--- a/src/XrdSys/XrdSysE2T.cc
+++ b/src/XrdSys/XrdSysE2T.cc
@@ -67,11 +67,13 @@ int initErrTable()
    // EAUTH is remapped to EBADE ('invalid exchange').  Given there's no current XRootD use of a
    // syscall that can return EBADE, we assume EBADE really means authentication denied.
 #if defined(EBADE)
-   if (Errno2String[EBADE]) {
-     free((char*)Errno2String[EBADE]);
+   if (EBADE - ERRNOBASE > 0 && EBADE - ERRNOBASE < errSlots) {
+      if (Errno2String[EBADE - ERRNOBASE])
+         free((char*)Errno2String[EBADE - ERRNOBASE]);
+      Errno2String[EBADE - ERRNOBASE] = "authentication failed - possible invalid exchange";
+      if (EBADE - ERRNOBASE > lastGood)
+         lastGood = EBADE - ERRNOBASE;
    }
-
-   Errno2String[EBADE] = "authentication failed - possible invalid exchange";
 #endif
 
    // Supply generic message for missing ones


### PR DESCRIPTION
Seen on hppa Linux where EBADE is 160.
```
In function ‘int {anonymous}::initErrTable()’,
    inlined from ‘void __static_initialization_and_destruction_0()’ at /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:92:28,
    inlined from ‘(static initializers for /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc)’ at /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:128:1:
/<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:70:26: warning: array subscript 160 is above array bounds of ‘const char* [144]’ [-Warray-bounds=]
   70 |    if (Errno2String[EBADE]) {
      |        ~~~~~~~~~~~~~~~~~~^
/<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc: In function ‘(static initializers for /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc)’:
/<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:48:28: note: while referencing ‘{anonymous}::Errno2String’
   48 |        const char*         Errno2String[errSlots] = {0};
      |                            ^~~~~~~~~~~~
In function ‘int {anonymous}::initErrTable()’,
    inlined from ‘void __static_initialization_and_destruction_0()’ at /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:92:28,
    inlined from ‘(static initializers for /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc)’ at /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:128:1:
/<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:74:22: warning: array subscript 160 is above array bounds of ‘const char* [144]’ [-Warray-bounds=]
   74 |    Errno2String[EBADE] = "authentication failed - possible invalid exchange";
      |    ~~~~~~~~~~~~~~~~~~^
/<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc: In function ‘(static initializers for /<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc)’:
/<<PKGBUILDDIR>>/src/XrdSys/XrdSysE2T.cc:48:28: note: while referencing ‘{anonymous}::Errno2String’
   48 |        const char*         Errno2String[errSlots] = {0};
      |                            ^~~~~~~~~~~~
```
