### PR TITLE
Change type in XrdSutCacheArg_t to long long

### DIFF
--- a/src/XrdSut/XrdSutCache.hh
+++ b/src/XrdSut/XrdSutCache.hh
@@ -40,10 +40,10 @@
 
 typedef bool (*XrdSutCacheGet_t)(XrdSutCacheEntry *, void *);
 typedef struct {
-   long arg1;
-   long arg2;
-   long arg3;
-   long arg4;
+   long long arg1;
+   long long arg2;
+   long long arg3;
+   long long arg4;
 } XrdSutCacheArg_t;
 
 class XrdSutCache {


### PR DESCRIPTION
The XrdSutCacheArg_t type is used to pass arguments of different types. The type used must be wide enough to fit the widest of the types passed. One of the types passed is time_t, which can be 64 bits wide also on 32-bit systems. So a long, which is 32 bits wide on a 32-bit system is not sufficient.

This commit changes the type to long long.

Fixes: #2272