### PR TITLE
Reproducible doxygen output

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -492,7 +492,7 @@ LOOKUP_CACHE_SIZE      = 2
 # DOT_NUM_THREADS setting.
 # Minimum value: 0, maximum value: 32, default value: 1.
 
-NUM_PROC_THREADS       = 0
+NUM_PROC_THREADS       = 1
 
 # If the TIMESTAMP tag is set different from NO then each generated page will
 # contain the date or date and time when the page was generated. Setting this to


### PR DESCRIPTION
The files generated by doxygen whose file names contain the string unnamedN where N is a number are not generated using predictable names.

This happens when running doxygen using multiple threads.

Set NUM_PROC_THREADS=1 to work around this issue.

See: https://github.com/doxygen/doxygen/issues/11138
