### PR TITLE
Increase client timeouts for XRootD server tests

### DIFF
--- a/tests/XRootD/test.sh
+++ b/tests/XRootD/test.sh
@@ -47,9 +47,9 @@ export XRD_LOGLEVEL XRD_LOGFILE
 # Reduce default timeouts to catch errors quickly and prevent the test
 # suite from getting stuck waiting for timeouts while running.
 
-: "${XRD_REQUESTTIMEOUT:=2}"
-: "${XRD_STREAMTIMEOUT:=2}"
-: "${XRD_TIMEOUTRESOLUTION:=1}"
+: "${XRD_REQUESTTIMEOUT:=180}"
+: "${XRD_STREAMTIMEOUT:=30}"
+: "${XRD_TIMEOUTRESOLUTION:=10}"
 
 export XRD_REQUESTTIMEOUT XRD_STREAMTIMEOUT XRD_TIMEOUTRESOLUTION
 


### PR DESCRIPTION
The XRootD server tests currently uses very short settings for the client timeouts:

https://github.com/xrootd/xrootd/blob/ae3391f39bf3993dc9d767c00bf55611bd20f6a5/tests/XRootD/test.sh#L50-L52

This is a major reduction from the default values:

https://github.com/xrootd/xrootd/blob/ae3391f39bf3993dc9d767c00bf55611bd20f6a5/src/XrdCl/XrdClConstants.hh#L54-L56

According to the comment in the test script, this is done in order to "catch errors quickly and prevent the test suite from getting stuck waiting for timeouts while running".

However, the very short timeouts make some tests fail with timeout errors when run on small or slow systems.

This commit increases the timeout values to avoid errors:

 - XRD_REQUESTTIMEOUT: 180
 - XRD_STREAMTIMEOUT: 30
 - XRD_TIMEOUTRESOLUTION: 10