### PR TITLE
Avoid test failures when $RANDOM returns a multiple of 1024

### DIFF
--- a/tests/XRootD/fuse.sh
+++ b/tests/XRootD/fuse.sh
@@ -43,7 +43,7 @@ function test_fuse() {
 	FILES=$(seq -w 1 "${NFILES:-10}")
 
 	for i in ${FILES}; do
-		assert openssl rand -base64 -out "${i}.ref" $((1024 * (RANDOM % 1024)))
+		assert openssl rand -base64 -out "${i}.ref" $((1024 * ((RANDOM % 1024) + 1)))
 
 		# TODO: Fix "Resource deadlock avoided" if this sleep is removed
 		sleep 0.1


### PR DESCRIPTION
Calling `openssl rand` with 0 as the argument is an error:
```
$ openssl rand -base64 0
rand: Use -help for summary.
$ echo $?
1
```
