### PR TITLE
Change cache age logic to only indicate fully cached files

### DIFF
--- a/bindings/python/src/PyXRootDCopyProcess.cc
+++ b/bindings/python/src/PyXRootDCopyProcess.cc
@@ -101,15 +101,15 @@ namespace PyXRootD
 
     val = XrdCl::DefaultCPInitTimeout;
     env->GetInt( "CPInitTimeout", val );
-    uint16_t initTimeout = val;
+    time_t initTimeout = val;
 
     val = XrdCl::DefaultCPTPCTimeout;
     env->GetInt( "CPTPCTimeout", val );
-    uint16_t tpcTimeout = val;
+    time_t tpcTimeout = val;
 
     val = XrdCl::DefaultCPTimeout;
     env->GetInt( "CPTimeout", val );
-    uint16_t cpTimeout = val;
+    time_t cpTimeout = val;
 
     if ( !PyArg_ParseTupleAndKeywords( args, kwds, "ss|HbbbbssssbIHHHbHLLLbs:add_job",
          (char**) kwlist,

--- a/bindings/python/src/PyXRootDCopyProgressHandler.cc
+++ b/bindings/python/src/PyXRootDCopyProgressHandler.cc
@@ -32,8 +32,8 @@ namespace PyXRootD
   //----------------------------------------------------------------------------
   // Notify when a new job is about to start
   //----------------------------------------------------------------------------
-  void CopyProgressHandler::BeginJob( uint16_t          jobNum,
-                                      uint16_t          jobTotal,
+  void CopyProgressHandler::BeginJob( uint32_t          jobNum,
+                                      uint32_t          jobTotal,
                                       const XrdCl::URL *source,
                                       const XrdCl::URL *target )
   {
@@ -54,7 +54,7 @@ namespace PyXRootD
   //----------------------------------------------------------------------------
   // Notify when the previous job has finished
   //----------------------------------------------------------------------------
-  void CopyProgressHandler::EndJob( uint16_t                   jobNum,
+  void CopyProgressHandler::EndJob( uint32_t                   jobNum,
                                     const XrdCl::PropertyList *result )
   {
     PyGILState_STATE  state    = PyGILState_Ensure();
@@ -74,7 +74,7 @@ namespace PyXRootD
   //----------------------------------------------------------------------------
   // Notify about the progress of the current job
   //----------------------------------------------------------------------------
-  void CopyProgressHandler::JobProgress( uint16_t jobNum,
+  void CopyProgressHandler::JobProgress( uint32_t jobNum,
                                          uint64_t bytesProcessed,
                                          uint64_t bytesTotal )
   {
@@ -93,7 +93,7 @@ namespace PyXRootD
   //----------------------------------------------------------------------------
   // Check if the job should be canceled
   //----------------------------------------------------------------------------
-  bool CopyProgressHandler::ShouldCancel( uint16_t jobNum )
+  bool CopyProgressHandler::ShouldCancel( uint32_t jobNum )
   {
     PyGILState_STATE state = PyGILState_Ensure();
     bool             ret   = false;

--- a/bindings/python/src/PyXRootDCopyProgressHandler.hh
+++ b/bindings/python/src/PyXRootDCopyProgressHandler.hh
@@ -46,28 +46,28 @@ namespace PyXRootD
       //------------------------------------------------------------------------
       //! Notify when a new job is about to start
       //------------------------------------------------------------------------
-      virtual void BeginJob( uint16_t          jobNum,
-                             uint16_t          jobTotal,
+      virtual void BeginJob( uint32_t          jobNum,
+                             uint32_t          jobTotal,
                              const XrdCl::URL *source,
                              const XrdCl::URL *target );
 
       //------------------------------------------------------------------------
       //! Notify when the previous job has finished
       //------------------------------------------------------------------------
-      virtual void EndJob( uint16_t                   jobNum,
+      virtual void EndJob( uint32_t                   jobNum,
                            const XrdCl::PropertyList *result );
 
       //------------------------------------------------------------------------
       //! Notify about the progress of the current job
       //------------------------------------------------------------------------
-      virtual void JobProgress( uint16_t jobNum,
+      virtual void JobProgress( uint32_t jobNum,
                                 uint64_t bytesProcessed,
                                 uint64_t bytesTotal );
 
       //------------------------------------------------------------------------
       //! Determine whether the job should be canceled
       //------------------------------------------------------------------------
-      virtual bool ShouldCancel(uint16_t jobNum);
+      virtual bool ShouldCancel(uint32_t jobNum);
 
     public:
       PyObject *handler;

--- a/bindings/python/src/PyXRootDFile.cc
+++ b/bindings/python/src/PyXRootDFile.cc
@@ -43,7 +43,7 @@ namespace PyXRootD
     const  char            *url;
     XrdCl::OpenFlags::Flags flags    = XrdCl::OpenFlags::None;
     XrdCl::Access::Mode     mode     = XrdCl::Access::None;
-    uint16_t                timeout  = 0;
+    time_t                  timeout  = 0;
     PyObject               *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus     status;
 
@@ -75,7 +75,7 @@ namespace PyXRootD
   PyObject* File::Close( File *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "timeout", "callback", NULL };
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -107,7 +107,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "force", "timeout", "callback", NULL };
     int                 force    = 0;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -146,7 +146,7 @@ namespace PyXRootD
                                       NULL };
     uint64_t            offset   = 0;
     uint32_t            size     = 0;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL, *pyresponse = NULL;
     PyObject           *py_offset = NULL, *py_size = NULL, *py_timeout = NULL;
     char               *buffer   = 0;
@@ -159,7 +159,7 @@ namespace PyXRootD
 
     unsigned long long tmp_offset = 0;
     unsigned int tmp_size = 0;
-    unsigned short int tmp_timeout = 0;
+    unsigned int tmp_timeout = 0;
 
     if ( py_offset && PyObjToUllong( py_offset, &tmp_offset, "offset" ) )
       return NULL;
@@ -167,12 +167,12 @@ namespace PyXRootD
     if ( py_size && PyObjToUint(py_size, &tmp_size, "size" ) )
       return NULL;
 
-    if ( py_timeout && PyObjToUshrt(py_timeout, &tmp_timeout, "timeout" ) )
+    if ( py_timeout && PyObjToUint(py_timeout, &tmp_timeout, "timeout" ) )
       return NULL;
 
     offset = (uint64_t)tmp_offset;
     size = (uint32_t)tmp_size;
-    timeout = (uint16_t)tmp_timeout;
+    timeout = (time_t)tmp_timeout;
 
     if (!size) {
       XrdCl::StatInfo *info = 0;
@@ -426,7 +426,7 @@ namespace PyXRootD
     Py_ssize_t   buffsize;
     uint64_t     offset   = 0;
     uint32_t     size     = 0;
-    uint16_t     timeout  = 0;
+    time_t       timeout  = 0;
     PyObject    *callback = NULL, *pystatus = NULL;
     PyObject    *py_offset = NULL, *py_size = NULL, *py_timeout = NULL;
     XrdCl::XRootDStatus status;
@@ -439,7 +439,7 @@ namespace PyXRootD
 
     unsigned long long tmp_offset = 0;
     unsigned int tmp_size = 0;
-    unsigned short int tmp_timeout = 0;
+    unsigned int tmp_timeout = 0;
 
     if (py_offset && PyObjToUllong(py_offset, &tmp_offset, "offset"))
       return NULL;
@@ -447,12 +447,12 @@ namespace PyXRootD
     if (py_size && PyObjToUint(py_size, &tmp_size, "size"))
       return NULL;
 
-    if (py_timeout && PyObjToUshrt(py_timeout, &tmp_timeout, "timeout"))
+    if (py_timeout && PyObjToUint(py_timeout, &tmp_timeout, "timeout"))
       return NULL;
 
     offset = (uint64_t)tmp_offset;
     size = (uint32_t)tmp_size;
-    timeout = (uint16_t)tmp_timeout;
+    timeout = (time_t)tmp_timeout;
 
     if (!size) {
       size = buffsize;
@@ -482,7 +482,7 @@ namespace PyXRootD
   PyObject* File::Sync( File *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "timeout", "callback", NULL };
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -515,7 +515,7 @@ namespace PyXRootD
   {
     static const char *kwlist[] = { "size", "timeout", "callback", NULL };
     uint64_t           size;
-    uint16_t           timeout  = 0;
+    time_t             timeout  = 0;
     PyObject          *callback = NULL, *pystatus = NULL;
     PyObject          *py_size = NULL, *py_timeout = NULL;
     XrdCl::XRootDStatus status;
@@ -526,16 +526,16 @@ namespace PyXRootD
          (char**) kwlist, &py_size, &py_timeout, &callback ) ) return NULL;
 
     unsigned long long tmp_size = 0;
-    unsigned short int tmp_timeout = 0;
+    unsigned int tmp_timeout = 0;
 
     if ( py_size && PyObjToUllong( py_size, &tmp_size, "size" ) )
       return NULL;
 
-    if ( py_timeout && PyObjToUshrt( py_timeout, &tmp_timeout, "timeout" ) )
+    if ( py_timeout && PyObjToUint( py_timeout, &tmp_timeout, "timeout" ) )
       return NULL;
 
     size = (uint64_t)tmp_size;
-    timeout = (uint16_t)tmp_timeout;
+    timeout = (time_t)tmp_timeout;
 
     if ( callback && callback != Py_None ) {
       XrdCl::ResponseHandler *handler = GetHandler<XrdCl::AnyObject>( callback );
@@ -561,7 +561,7 @@ namespace PyXRootD
   PyObject* File::VectorRead( File *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "chunks", "timeout", "callback", NULL };
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     uint64_t            offset   = 0;
     uint32_t            length   = 0;
     PyObject           *pychunks = NULL, *callback = NULL;
@@ -574,12 +574,12 @@ namespace PyXRootD
     if ( !PyArg_ParseTupleAndKeywords( args, kwds, "O|OO:vector_read",
          (char**) kwlist, &pychunks, &py_timeout, &callback ) ) return NULL;
 
-    unsigned short int tmp_timeout = 0;
+    unsigned int tmp_timeout = 0;
 
-    if ( py_timeout && PyObjToUshrt( py_timeout, &tmp_timeout, "timeout" ) )
+    if ( py_timeout && PyObjToUint( py_timeout, &tmp_timeout, "timeout" ) )
       return NULL;
 
-    timeout = (uint16_t)tmp_timeout;
+    timeout = (time_t)tmp_timeout;
 
     if ( !PyList_Check( pychunks ) ) {
       PyErr_SetString( PyExc_TypeError, "chunks parameter must be a list" );
@@ -654,7 +654,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "arg", "timeout", "callback", NULL };
     const char         *buffer   = 0;
     Py_ssize_t          buffSize = 0;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL, *pyresponse = NULL;
     XrdCl::XRootDStatus status;
 
@@ -696,7 +696,7 @@ namespace PyXRootD
   PyObject* File::Visa( File *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "timeout", "callback", NULL };
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL, *pyresponse = NULL;
     XrdCl::XRootDStatus status;
 
@@ -782,7 +782,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "attrs", "timeout", "callback", NULL };
 
     std::vector<XrdCl::xattr_t>  attrs;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
 
     PyObject    *callback = NULL, *pystatus   = NULL;
     PyObject    *pyattrs  = NULL, *pyresponse = NULL;
@@ -853,7 +853,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "attrs", "timeout", "callback", NULL };
 
     std::vector<std::string>  attrs;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
 
     PyObject    *callback = NULL, *pystatus   = NULL;
     PyObject    *pyattrs  = NULL, *pyresponse = NULL;
@@ -912,7 +912,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "attrs", "timeout", "callback", NULL };
 
     std::vector<std::string>  attrs;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
 
     PyObject    *callback = NULL, *pystatus   = NULL;
     PyObject    *pyattrs  = NULL, *pyresponse = NULL;
@@ -970,7 +970,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "timeout", "callback", NULL };
 
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
 
     PyObject    *callback   = NULL, *pystatus = NULL;
     PyObject    *pyresponse = NULL;

--- a/bindings/python/src/PyXRootDFileSystem.cc
+++ b/bindings/python/src/PyXRootDFileSystem.cc
@@ -84,7 +84,7 @@ namespace PyXRootD
                                          NULL };
     const  char            *path;
     XrdCl::OpenFlags::Flags flags    = XrdCl::OpenFlags::None;
-    uint16_t                timeout  = 0;
+    time_t                  timeout  = 0;
     PyObject               *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus     status;
 
@@ -122,7 +122,7 @@ namespace PyXRootD
                                          NULL };
     const  char            *path;
     XrdCl::OpenFlags::Flags flags    = XrdCl::OpenFlags::None;
-    uint16_t                timeout  = 0;
+    time_t                  timeout  = 0;
     PyObject               *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus     status;
 
@@ -160,7 +160,7 @@ namespace PyXRootD
                                      NULL };
     const  char        *source;
     const  char        *dest;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -193,7 +193,7 @@ namespace PyXRootD
     static const char     *kwlist[] = { "querycode", "arg", "timeout",
                                         "callback", NULL };
     const  char           *arg;
-    uint16_t               timeout  = 0;
+    time_t                 timeout  = 0;
     PyObject              *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::QueryCode::Code queryCode;
     XrdCl::XRootDStatus    status;
@@ -234,7 +234,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "path", "size", "timeout", "callback", NULL };
     const  char        *path;
     uint64_t            size     = 0;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -266,7 +266,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "path", "timeout", "callback", NULL };
     const  char        *path;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -301,7 +301,7 @@ namespace PyXRootD
     const  char             *path;
     XrdCl::MkDirFlags::Flags flags    = XrdCl::MkDirFlags::None;
     XrdCl::Access::Mode      mode     = XrdCl::Access::None;
-    uint16_t                 timeout  = 0;
+    time_t                   timeout  = 0;
     PyObject                *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus      status;
 
@@ -333,7 +333,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "path", "timeout", "callback", NULL };
     const  char        *path;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -366,7 +366,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "path", "mode", "timeout", "callback", NULL };
     const  char        *path;
     XrdCl::Access::Mode mode     = XrdCl::Access::None;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -397,7 +397,7 @@ namespace PyXRootD
   PyObject* FileSystem::Ping( FileSystem *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "timeout", "callback", NULL };
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -429,7 +429,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "path", "timeout", "callback", NULL };
     const  char        *path;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -465,7 +465,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "path", "timeout", "callback", NULL };
     const  char        *path;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -500,7 +500,7 @@ namespace PyXRootD
   PyObject* FileSystem::Protocol( FileSystem *self, PyObject *args, PyObject *kwds )
   {
     static const char  *kwlist[] = { "timeout", "callback", NULL };
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -538,7 +538,7 @@ namespace PyXRootD
                                             "callback", NULL };
     const  char               *path;
     XrdCl::DirListFlags::Flags flags = XrdCl::DirListFlags::None;
-    uint16_t                   timeout  = 0;
+    time_t                     timeout  = 0;
     PyObject                  *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus        status;
 
@@ -574,7 +574,7 @@ namespace PyXRootD
   {
     static const char  *kwlist[] = { "info", "timeout", "callback", NULL };
     const  char        *info;
-    uint16_t            timeout  = 0;
+    time_t              timeout  = 0;
     PyObject           *callback = NULL, *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus status;
 
@@ -612,7 +612,7 @@ namespace PyXRootD
                                             "timeout", "callback", NULL };
     uint16_t                   flagval  = 0;
     uint8_t                    priority = 0;
-    uint16_t                   timeout  = 0;
+    time_t                     timeout  = 0;
     PyObject                  *pyfiles = NULL, *callback = NULL;
     PyObject                  *pyresponse = NULL, *pystatus = NULL;
     XrdCl::XRootDStatus        status;
@@ -745,7 +745,7 @@ namespace PyXRootD
 
     char *path = 0;
     std::vector<XrdCl::xattr_t>  attrs;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
     PyObject    *callback = NULL, *pystatus    = NULL;
     PyObject    *pyattrs  = NULL,  *pyresponse = NULL;
     XrdCl::XRootDStatus status;
@@ -814,7 +814,7 @@ namespace PyXRootD
 
     char *path = 0;
     std::vector<std::string>  attrs;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
     PyObject    *callback = NULL, *pystatus    = NULL;
     PyObject    *pyattrs  = NULL,  *pyresponse = NULL;
     XrdCl::XRootDStatus status;
@@ -871,7 +871,7 @@ namespace PyXRootD
 
     char *path = 0;
     std::vector<std::string>  attrs;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
     PyObject    *callback = NULL, *pystatus    = NULL;
     PyObject    *pyattrs  = NULL,  *pyresponse = NULL;
     XrdCl::XRootDStatus status;
@@ -927,7 +927,7 @@ namespace PyXRootD
     static const char  *kwlist[] = { "path", "timeout", "callback", NULL };
 
     char *path = 0;
-    uint16_t     timeout  = 0;
+    time_t timeout = 0;
     PyObject    *callback = NULL, *pystatus = NULL, *pyresponse = NULL;
     XrdCl::XRootDStatus status;
 

--- a/src/XProtocol/XProtocol.hh
+++ b/src/XProtocol/XProtocol.hh
@@ -1371,6 +1371,8 @@ static int mapError(int rc)
            case ENOSPC:        return kXR_NoSpace;
            case ENAMETOOLONG:  return kXR_ArgTooLong;
            case ENETUNREACH:   return kXR_noserver;
+           case EHOSTUNREACH:  return kXR_noserver;
+           case ECONNREFUSED:  return kXR_noserver;
            case ENOTBLK:       return kXR_NotFile;
            case ENOTSUP:       return kXR_Unsupported;
            case EISDIR:        return kXR_isDirectory;

--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -59,6 +59,7 @@
 #include "Xrd/XrdInfo.hh"
 #include "Xrd/XrdLink.hh"
 #include "Xrd/XrdLinkCtl.hh"
+#include "Xrd/XrdMonitor.hh"
 #include "Xrd/XrdPoll.hh"
 #include "Xrd/XrdScheduler.hh"
 #include "Xrd/XrdStats.hh"
@@ -264,6 +265,7 @@ XrdConfig::XrdConfig()
    AdminMode= S_IRWXU;
    HomeMode = S_IRWXU;
    Police   = 0;
+   theMon   = 0;
    Net_Opts = XRDNET_KEEPALIVE;
    TLS_Blen = 0;  // Accept OS default (leave Linux autotune in effect)
    TLS_Opts = XRDNET_KEEPALIVE | XRDNET_USETLS;
@@ -1390,7 +1392,10 @@ int XrdConfig::Setup(char *dfltp, char *libProt)
 // Now check if we have to setup automatic reporting
 //
    if (repDest[0] != 0 && repOpts) 
-      ProtInfo.Stats->Report(repDest, repInt, repOpts);
+      {ProtInfo.Stats->Report(repDest, repInt, repOpts);
+       theMon = new XrdMonitor;
+       theEnv.PutPtr("XrdMonRoll*", (XrdMonRoll*)theMon);
+      }
 
 // All done
 //

--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -1432,7 +1432,7 @@ int XrdConfig::SetupAPath()
 //
 #ifndef WIN32
    if (chmod(AdminPath, AdminMode & ~S_IWGRP))
-      {Log.Emsg("Config", errno, "set permision for admin path", AdminPath);
+      {Log.Emsg("Config", errno, "set permission for admin path", AdminPath);
        return 1;
       }
 #endif

--- a/src/Xrd/XrdConfig.hh
+++ b/src/Xrd/XrdConfig.hh
@@ -42,6 +42,7 @@ class XrdNetSecurity;
 class XrdOucStream;
 class XrdInet;
 class XrdConfigProt;
+class XrdMonitor;
 
 class XrdConfig
 {
@@ -96,6 +97,7 @@ int   xtmo(XrdSysError *edest, XrdOucStream &Config);
 static const char  *TraceID;
 XrdNetSecurity     *Police;
 XrdTcpMonInfo      *tmoInfo;
+XrdMonitor         *theMon;
 const char         *myProg;
 const char         *myName;
 const char         *myDomain;

--- a/src/Xrd/XrdMonRoll.hh
+++ b/src/Xrd/XrdMonRoll.hh
@@ -1,0 +1,88 @@
+#ifndef __XRDMONROLL__
+#define __XRDMONROLL__
+/******************************************************************************/
+/*                                                                            */
+/*                         X r d M o n R o l l . h h                          */
+/*                                                                            */
+/* (c) 2024 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*   Produced by Andrew Hanushevsky for Stanford University under contract    */
+/*              DE-AC02-76-SFO0515 with the Department of Energy              */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdSys/XrdSysRAtomic.hh"
+
+//-----------------------------------------------------------------------------
+//! XrdMonRoll
+//!
+//! This class is used to register counter sets to be included in the summary
+//! statistics that out reported as defined by the xrootd.report directive.
+//! A pointer to an instance of this object is placed in the Xrd environment
+//! with a key of "XrdMonRoll*".
+//-----------------------------------------------------------------------------
+
+class XrdMonRoll
+{
+public:
+
+//-----------------------------------------------------------------------------
+//! The setMember structure is used to define a set of counters that will be
+//! registered with this class. These counters are report in the summary.
+//!
+//! @param varName - Is the name of the variable and becomes the xml tag or
+//!                  of JSON key for the reported value.
+//! @param varValu - Is the reference to the associated counter variable
+//!                  holding the value.
+//-----------------------------------------------------------------------------
+
+struct setMember {const char* varName; RAtomic_uint& varValu;}; 
+
+//-----------------------------------------------------------------------------
+//! Register a set of counters to be reported.
+//!
+//! @param setType - Is the type of set being defined:
+//!                  Misc     - counters for miscellaneous activities.
+//!                  Protocol - counters for a protocol.
+//! @param setName - Is the name of the set of counter variables. The name
+//!                  must not already be registered. The name is reported in
+//!                  stats xml tag or JSON stats key value.
+//! @param setVec  - Is a vector of setMember items that define the set of 
+//!                  variables for the summary report. The last element of
+//!                  the vector must be initialized to {0, EOV}. The vector
+//!                  must reside in allocated storage until execution ends.
+//!
+//! @return true when the set has been registered and false if the set is
+//!         already registered (i.e. setName is in use).
+//-----------------------------------------------------------------------------
+
+static RAtomic_uint EOV; // Variable at the end of the setVec.
+
+enum rollType {Misc, Protocol};
+
+virtual bool Register(rollType setType, const char* setName, setMember setVec[])
+                     {return true;}
+
+             XrdMonRoll() {}
+            ~XrdMonRoll() {}
+};
+#endif

--- a/src/Xrd/XrdMonitor.cc
+++ b/src/Xrd/XrdMonitor.cc
@@ -1,0 +1,37 @@
+/******************************************************************************/
+/*                                                                            */
+/*                         X r d M o n i t o r . c c                          */
+/*                                                                            */
+/* (c) 2024 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*   Produced by Andrew Hanushevsky for Stanford University under contract    */
+/*              DE-AC02-76-SFO0515 with the Department of Energy              */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "Xrd/XrdMonRoll.hh"
+
+/******************************************************************************/
+/*                        S t a t i c   M e m b e r s                         */
+/******************************************************************************/
+  
+RAtomic_uint XrdMonRoll::EOV = {0};

--- a/src/Xrd/XrdMonitor.hh
+++ b/src/Xrd/XrdMonitor.hh
@@ -1,0 +1,46 @@
+#ifndef __XRDMONITOR__
+#define __XRDMONITOR__
+/******************************************************************************/
+/*                                                                            */
+/*                         X r d M o n i t o r . h h                          */
+/*                                                                            */
+/* (c) 2024 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*                            All Rights Reserved                             */
+/*   Produced by Andrew Hanushevsky for Stanford University under contract    */
+/*              DE-AC02-76-SFO0515 with the Department of Energy              */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "Xrd/XrdMonRoll.hh"
+
+class XrdMonitor : public XrdMonRoll
+{
+public:
+
+bool Register(rollType setType, const char* setName, setMember setVec[])
+              override {return true;}
+
+
+     XrdMonitor() {}
+    ~XrdMonitor() {}
+};
+#endif

--- a/src/XrdApps/XrdClProxyPlugin/ProxyPrefixFile.cc
+++ b/src/XrdApps/XrdClProxyPlugin/ProxyPrefixFile.cc
@@ -60,7 +60,7 @@ ProxyPrefixFile::Open(const std::string& url,
                       OpenFlags::Flags flags,
                       Access::Mode mode,
                       ResponseHandler* handler,
-                      uint16_t timeout)
+                      time_t timeout)
 {
   XRootDStatus st;
 

--- a/src/XrdApps/XrdClProxyPlugin/ProxyPrefixFile.hh
+++ b/src/XrdApps/XrdClProxyPlugin/ProxyPrefixFile.hh
@@ -58,13 +58,13 @@ public:
                             OpenFlags::Flags flags,
                             Access::Mode mode,
                             ResponseHandler* handler,
-                            uint16_t timeout) override;
+                            time_t timeout) override;
 
   //----------------------------------------------------------------------------
   //! Close
   //----------------------------------------------------------------------------
   virtual XRootDStatus Close(ResponseHandler* handler,
-                             uint16_t         timeout) override
+                             time_t           timeout) override
   {
     return pFile->Close(handler, timeout);
   }
@@ -74,7 +74,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Stat(bool             force,
                             ResponseHandler* handler,
-                            uint16_t         timeout) override
+                            time_t           timeout) override
   {
     return pFile->Stat(force, handler, timeout);
   }
@@ -87,7 +87,7 @@ public:
                             uint32_t         size,
                             void*            buffer,
                             ResponseHandler* handler,
-                            uint16_t         timeout) override
+                            time_t           timeout) override
   {
     return pFile->Read(offset, size, buffer, handler, timeout);
   }
@@ -99,7 +99,7 @@ public:
                                uint32_t         size,
                                void            *buffer,
                                ResponseHandler *handler,
-                               uint16_t         timeout ) override
+                               time_t           timeout ) override
   {
     return pFile->PgRead(offset, size, buffer, handler, timeout);
   }
@@ -111,7 +111,7 @@ public:
                              uint32_t         size,
                              const void*      buffer,
                              ResponseHandler* handler,
-                             uint16_t         timeout) override
+                             time_t           timeout) override
   {
     return pFile->Write(offset, size, buffer, handler, timeout);
   }
@@ -122,7 +122,7 @@ public:
   virtual XRootDStatus Write( uint64_t          offset,
                               Buffer          &&buffer,
                               ResponseHandler  *handler,
-                              uint16_t          timeout = 0 ) override
+                              time_t            timeout = 0 ) override
   {
     return pFile->Write(offset, std::move(buffer), handler, timeout);
   }
@@ -135,7 +135,7 @@ public:
                               Optional<uint64_t>  fdoff,
                               int                 fd,
                               ResponseHandler    *handler,
-                              uint16_t            timeout = 0 ) override
+                              time_t              timeout = 0 ) override
   {
     return pFile->Write(offset, size, fdoff, fd, handler, timeout);
   }
@@ -148,7 +148,7 @@ public:
                                 const void            *buffer,
                                 std::vector<uint32_t> &cksums,
                                 ResponseHandler       *handler,
-                                uint16_t               timeout ) override
+                                time_t                 timeout ) override
   {
     return pFile->PgWrite(offset, nbpgs, buffer, cksums, handler, timeout);
   }
@@ -157,7 +157,7 @@ public:
   //! Sync
   //----------------------------------------------------------------------------
   virtual XRootDStatus Sync(ResponseHandler* handler,
-                            uint16_t         timeout) override
+                            time_t           timeout) override
   {
     return pFile->Sync(handler, timeout);
   }
@@ -167,7 +167,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Truncate(uint64_t         size,
                                 ResponseHandler* handler,
-                                uint16_t         timeout) override
+                                time_t           timeout) override
   {
     return pFile->Truncate(size, handler, timeout);
   }
@@ -178,7 +178,7 @@ public:
   virtual XRootDStatus VectorRead(const ChunkList& chunks,
                                   void*            buffer,
                                   ResponseHandler* handler,
-                                  uint16_t         timeout) override
+                                  time_t           timeout) override
   {
     return pFile->VectorRead(chunks, buffer, handler, timeout);
   }
@@ -188,7 +188,7 @@ public:
   //------------------------------------------------------------------------
   virtual XRootDStatus VectorWrite( const ChunkList &chunks,
                                     ResponseHandler *handler,
-                                    uint16_t         timeout = 0 ) override
+                                    time_t           timeout = 0 ) override
   {
     return pFile->VectorWrite(chunks, handler, timeout);
   }
@@ -200,7 +200,7 @@ public:
                                const struct iovec *iov,
                                int                 iovcnt,
                                ResponseHandler    *handler,
-                               uint16_t            timeout = 0 ) override
+                               time_t              timeout = 0 ) override
   {
     return pFile->WriteV(offset, iov, iovcnt, handler, timeout);
   }
@@ -210,7 +210,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Fcntl(const Buffer&    arg,
                              ResponseHandler* handler,
-                             uint16_t         timeout) override
+                             time_t           timeout) override
   {
     return pFile->Fcntl(arg, handler, timeout);
   }
@@ -219,7 +219,7 @@ public:
   //! Visa
   //----------------------------------------------------------------------------
   virtual XRootDStatus Visa(ResponseHandler* handler,
-                            uint16_t         timeout) override
+                            time_t           timeout) override
   {
     return pFile->Visa(handler, timeout);
   }

--- a/src/XrdApps/XrdClRecordPlugin/XrdClAction.hh
+++ b/src/XrdApps/XrdClRecordPlugin/XrdClAction.hh
@@ -43,7 +43,7 @@ struct Action
   //                  (to be used as an ID)
   // @param timeout : operation timeout (common for every operation)
   //--------------------------------------------------------------------------
-  Action(void* file, uint16_t timeout)
+  Action(void* file, time_t timeout)
   : id(reinterpret_cast<uint64_t>(file))
   , timeout(timeout)
   , start(std::chrono::system_clock::now())  // register the action start time
@@ -128,7 +128,7 @@ struct Action
   virtual void Serialize(AnyObject* response) {}
 
   uint64_t                              id;         //> File object ID
-  uint16_t                              timeout;    //> operation timeout
+  time_t                                timeout;    //> operation timeout
   std::chrono::system_clock::time_point start;      //> start time
   XRootDStatus                          status;     //> operation status
   std::string                           serialrsp;  //> serialized response
@@ -141,7 +141,7 @@ struct Action
 struct OpenAction : public Action
 {
   OpenAction(
-    void* file, const std::string& url, OpenFlags::Flags flags, Access::Mode mode, uint16_t timeout)
+    void* file, const std::string& url, OpenFlags::Flags flags, Access::Mode mode, time_t timeout)
   : Action(file, timeout)
   , url(url)
   , flags(flags)
@@ -170,7 +170,7 @@ struct OpenAction : public Action
 //----------------------------------------------------------------------------
 struct CloseAction : public Action
 {
-  CloseAction(void* file, uint16_t timeout)
+  CloseAction(void* file, time_t timeout)
   : Action(file, timeout)
   {
   }
@@ -185,7 +185,7 @@ struct CloseAction : public Action
 //----------------------------------------------------------------------------
 struct StatAction : public Action
 {
-  StatAction(void* file, bool force, uint16_t timeout)
+  StatAction(void* file, bool force, time_t timeout)
   : Action(file, timeout)
   , force(force)
   {
@@ -222,7 +222,7 @@ struct StatAction : public Action
 //----------------------------------------------------------------------------
 struct ReadAction : public Action
 {
-  ReadAction(void* file, uint64_t offset, uint32_t size, uint16_t timeout)
+  ReadAction(void* file, uint64_t offset, uint32_t size, time_t timeout)
   : Action(file, timeout)
   , offset(offset)
   , size(size)
@@ -248,7 +248,7 @@ struct ReadAction : public Action
 
 struct PgReadAction : public Action
 {
-  PgReadAction(void* file, uint64_t offset, uint32_t size, uint16_t timeout)
+  PgReadAction(void* file, uint64_t offset, uint32_t size, time_t timeout)
   : Action(file, timeout)
   , offset(offset)
   , size(size)
@@ -277,7 +277,7 @@ struct PgReadAction : public Action
 //----------------------------------------------------------------------------
 struct WriteAction : public Action
 {
-  WriteAction(void* file, uint64_t offset, uint32_t size, uint16_t timeout)
+  WriteAction(void* file, uint64_t offset, uint32_t size, time_t timeout)
   : Action(file, timeout)
   , offset(offset)
   , size(size)
@@ -294,7 +294,7 @@ struct WriteAction : public Action
 
 struct PgWriteAction : public Action
 {
-  PgWriteAction(void* file, uint64_t offset, uint32_t size, uint16_t timeout)
+  PgWriteAction(void* file, uint64_t offset, uint32_t size, time_t timeout)
   : Action(file, timeout)
   , offset(offset)
   , size(size)
@@ -319,7 +319,7 @@ struct PgWriteAction : public Action
 //----------------------------------------------------------------------------
 struct SyncAction : public Action
 {
-  SyncAction(void* file, uint16_t timeout)
+  SyncAction(void* file, time_t timeout)
   : Action(file, timeout)
   {
   }
@@ -334,7 +334,7 @@ struct SyncAction : public Action
 //----------------------------------------------------------------------------
 struct TruncateAction : public Action
 {
-  TruncateAction(void* file, uint64_t size, uint16_t timeout)
+  TruncateAction(void* file, uint64_t size, time_t timeout)
   : Action(file, timeout)
   , size(size)
   {
@@ -352,7 +352,7 @@ struct TruncateAction : public Action
 //----------------------------------------------------------------------------
 struct VectorReadAction : public Action
 {
-  VectorReadAction(void* file, const ChunkList& chunks, uint16_t timeout)
+  VectorReadAction(void* file, const ChunkList& chunks, time_t timeout)
   : Action(file, timeout)
   , req(chunks)
   {
@@ -393,7 +393,7 @@ struct VectorReadAction : public Action
 //----------------------------------------------------------------------------
 struct VectorWriteAction : public Action
 {
-  VectorWriteAction(void* file, const ChunkList& chunks, uint16_t timeout)
+  VectorWriteAction(void* file, const ChunkList& chunks, time_t timeout)
   : Action(file, timeout)
   , req(chunks)
   {
@@ -420,7 +420,7 @@ struct VectorWriteAction : public Action
 //----------------------------------------------------------------------------
 struct FcntlAction : Action
 {
-  FcntlAction(void* file, const Buffer& arg, uint16_t timeout)
+  FcntlAction(void* file, const Buffer& arg, time_t timeout)
   : Action(file, timeout)
   , req(arg.GetSize())
   {

--- a/src/XrdApps/XrdClRecordPlugin/XrdClRecorder.hh
+++ b/src/XrdApps/XrdClRecordPlugin/XrdClRecorder.hh
@@ -265,7 +265,7 @@ public:
                             OpenFlags::Flags flags,
                             Access::Mode mode,
                             ResponseHandler* handler,
-                            uint16_t timeout)
+                            time_t timeout)
   {
     std::unique_ptr<Action> ptr( new OpenAction( this, url, flags, mode, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -276,7 +276,7 @@ public:
   //! Close
   //----------------------------------------------------------------------------
   virtual XRootDStatus Close(ResponseHandler* handler,
-                             uint16_t         timeout)
+                             time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new CloseAction( this, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -288,7 +288,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Stat(bool             force,
                             ResponseHandler* handler,
-                            uint16_t         timeout)
+                            time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new StatAction( this, force, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -303,7 +303,7 @@ public:
                             uint32_t         size,
                             void*            buffer,
                             ResponseHandler* handler,
-                            uint16_t         timeout)
+                            time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new ReadAction( this, offset, size, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -317,7 +317,7 @@ public:
                              uint32_t         size,
                              const void*      buffer,
                              ResponseHandler* handler,
-                             uint16_t         timeout)
+                             time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new WriteAction( this, offset, size, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -331,7 +331,7 @@ public:
                                uint32_t         size,
                                void            *buffer,
                                ResponseHandler *handler,
-                               uint16_t         timeout )
+                               time_t           timeout )
   {
     std::unique_ptr<Action> ptr( new PgReadAction( this, offset, size, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -346,7 +346,7 @@ public:
                                 const void            *buffer,
                                 std::vector<uint32_t> &cksums,
                                 ResponseHandler       *handler,
-                                uint16_t               timeout )
+                                time_t                 timeout )
   {
     std::unique_ptr<Action> ptr( new PgWriteAction( this, offset, size, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -357,7 +357,7 @@ public:
   //! Sync
   //----------------------------------------------------------------------------
   virtual XRootDStatus Sync(ResponseHandler* handler,
-                            uint16_t         timeout)
+                            time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new SyncAction( this, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -369,7 +369,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Truncate(uint64_t         size,
                                 ResponseHandler* handler,
-                                uint16_t         timeout)
+                                time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new TruncateAction( this, size, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -382,7 +382,7 @@ public:
   virtual XRootDStatus VectorRead(const ChunkList& chunks,
                                   void*            buffer,
                                   ResponseHandler* handler,
-                                  uint16_t         timeout)
+                                  time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new VectorReadAction( this, chunks, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -394,7 +394,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus VectorWrite( const ChunkList &chunks,
                                     ResponseHandler *handler,
-                                    uint16_t         timeout )
+                                    time_t           timeout )
   {
     std::unique_ptr<Action> ptr( new VectorWriteAction( this, chunks, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -406,7 +406,7 @@ public:
   //----------------------------------------------------------------------------
   virtual XRootDStatus Fcntl(const Buffer&    arg,
                              ResponseHandler* handler,
-                             uint16_t         timeout)
+                             time_t           timeout)
   {
     std::unique_ptr<Action> ptr( new FcntlAction( this, arg, timeout ) );
     RecordHandler *recHandler = new RecordHandler( output, std::move( ptr ), handler );
@@ -417,7 +417,7 @@ public:
   //! Visa
   //----------------------------------------------------------------------------
   virtual XRootDStatus Visa(ResponseHandler* handler,
-                            uint16_t         timeout)
+                            time_t           timeout)
   {
     return file.Visa(handler, timeout);
   }

--- a/src/XrdApps/XrdClRecordPlugin/XrdClReplay.cc
+++ b/src/XrdApps/XrdClRecordPlugin/XrdClReplay.cc
@@ -217,7 +217,7 @@ bool AssureFile(const std::string& url, uint64_t size, bool viatruncate, bool ve
 {
   OpenFlags::Flags flags   = OpenFlags::Read;
   Access::Mode     mode    = Access::None;
-  uint16_t         timeout = 60;
+  time_t           timeout = 60;
 
   {
     // deal with existing files
@@ -353,7 +353,7 @@ class ActionExecutor
       std::string      url;
       OpenFlags::Flags flags;
       Access::Mode     mode;
-      uint16_t         timeout;
+      time_t           timeout;
       std::tie(url, flags, mode, timeout) = GetOpenArgs();
 
       std::string lmetric;
@@ -387,7 +387,7 @@ class ActionExecutor
     }
     else if (action == "Close")  // close action
     {
-      uint16_t    timeout = GetCloseArgs();
+      time_t      timeout = GetCloseArgs();
       mytimer_t   timer;
 
       if (closing)
@@ -415,7 +415,7 @@ class ActionExecutor
     else if (action == "Stat")  // stat action
     {
       bool     force;
-      uint16_t timeout;
+      time_t   timeout;
       std::tie(force, timeout) = GetStatArgs();
       metric.ios["Stat::n"]++;
       mytimer_t timer;
@@ -439,7 +439,7 @@ class ActionExecutor
     {
       uint64_t offset;
       buffer_t buffer;
-      uint16_t timeout;
+      time_t   timeout;
       std::tie(offset, buffer, timeout) = GetReadArgs();
       metric.ios["Read::n"]++;
       metric.ios["Read::b"] += buffer->size();
@@ -469,7 +469,7 @@ class ActionExecutor
     {
       uint64_t offset;
       buffer_t buffer;
-      uint16_t timeout;
+      time_t   timeout;
       std::tie(offset, buffer, timeout) = GetPgReadArgs();
       metric.ios["PgRead::n"]++;
       metric.ios["PgRead::b"] += buffer->size();
@@ -498,7 +498,7 @@ class ActionExecutor
     {
       uint64_t offset;
       buffer_t buffer;
-      uint16_t timeout;
+      time_t   timeout;
       std::tie(offset, buffer, timeout) = GetWriteArgs();
       metric.ios["Write::n"]++;
       metric.ios["Write::b"] += buffer->size();
@@ -528,7 +528,7 @@ class ActionExecutor
     {
       uint64_t offset;
       buffer_t buffer;
-      uint16_t timeout;
+      time_t   timeout;
       std::tie(offset, buffer, timeout) = GetPgWriteArgs();
       metric.ios["PgWrite::n"]++;
       metric.ios["PgWrite::b"] += buffer->size();
@@ -555,7 +555,7 @@ class ActionExecutor
     }
     else if (action == "Sync")  // sync action
     {
-      uint16_t    timeout = GetSyncArgs();
+      time_t timeout = GetSyncArgs();
       metric.ios["Sync::n"]++;
       mytimer_t timer;
       if (!simulate)
@@ -576,7 +576,7 @@ class ActionExecutor
     else if (action == "Truncate")  // truncate action
     {
       uint64_t size;
-      uint16_t timeout;
+      time_t   timeout;
       std::tie(size, timeout) = GetTruncateArgs();
       metric.ios["Truncate::n"]++;
       if (size > metric.ios["Truncate::o"])
@@ -601,7 +601,7 @@ class ActionExecutor
     else if (action == "VectorRead")  // vector read action
     {
       ChunkList chunks;
-      uint16_t  timeout;
+      time_t    timeout;
       std::vector<buffer_t> buffers;
       std::tie(chunks, timeout, buffers) = GetVectorReadArgs();
       metric.ios["VectorRead::n"]++;
@@ -634,7 +634,7 @@ class ActionExecutor
     else if (action == "VectorWrite")  // vector write
     {
       ChunkList chunks;
-      uint16_t  timeout;
+      time_t    timeout;
       std::vector<buffer_t> buffers;
       std::tie(chunks, timeout, buffers) = GetVectorWriteArgs();
       metric.ios["VectorWrite::n"]++;
@@ -715,7 +715,7 @@ class ActionExecutor
     std::string      url     = tokens[0];
     OpenFlags::Flags flags   = static_cast<OpenFlags::Flags>(std::stoul(tokens[1]));
     Access::Mode     mode    = static_cast<Access::Mode>(std::stoul(tokens[2]));
-    uint16_t         timeout = static_cast<uint16_t>(std::stoul(tokens[3]));
+    time_t           timeout = static_cast<time_t>(std::stoul(tokens[3]));
     return std::make_tuple(url, flags, mode, timeout);
   }
 
@@ -731,7 +731,7 @@ class ActionExecutor
     if (tokens.size() != 2)
       throw std::invalid_argument("Failed to parse stat arguments.");
     bool     force   = (tokens[0] == "true");
-    uint16_t timeout = static_cast<uint16_t>(std::stoul(tokens[1]));
+    time_t   timeout = static_cast<time_t>(std::stoul(tokens[1]));
     return std::make_tuple(force, timeout);
   }
 
@@ -747,7 +747,7 @@ class ActionExecutor
     uint64_t offset  = std::stoull(tokens[0]);
     uint32_t length  = std::stoul(tokens[1]);
     auto     buffer  = BufferPool::Instance().Allocate( length );
-    uint16_t timeout = static_cast<uint16_t>(std::stoul(tokens[2]));
+    time_t   timeout = static_cast<time_t>(std::stoul(tokens[2]));
     return std::make_tuple(offset, buffer, timeout);
   }
 
@@ -781,7 +781,7 @@ class ActionExecutor
     if (tokens.size() != 2)
       throw std::invalid_argument("Failed to parse truncate arguments.");
     uint64_t size    = std::stoull(tokens[0]);
-    uint16_t timeout = static_cast<uint16_t>(std::stoul(tokens[1]));
+    time_t   timeout = static_cast<time_t>(std::stoul(tokens[1]));
     return std::make_tuple(size, timeout);
   }
 
@@ -804,7 +804,7 @@ class ActionExecutor
       chunks.emplace_back(offset, length, buffer->data());
       buffers.emplace_back( std::move( buffer ) );
     }
-    uint16_t timeout = static_cast<uint16_t>(std::stoul(tokens.back()));
+    time_t   timeout = static_cast<time_t>(std::stoul(tokens.back()));
     return std::make_tuple(std::move(chunks), timeout, std::move(buffers));
   }
 

--- a/src/XrdCks/XrdCksConfig.hh
+++ b/src/XrdCks/XrdCksConfig.hh
@@ -56,6 +56,8 @@ char   *ManLib() {return CksLib;}
 
 int     ParseLib(XrdOucStream &Config, int &libType);
 
+bool    ParseOpt(XrdOucStream &Config);
+
         XrdCksConfig(const char *cFN, XrdSysError *Eroute, int &aOK,
                      XrdVersionInfo &vInfo);
        ~XrdCksConfig() {XrdOucTList *tP;
@@ -78,5 +80,6 @@ XrdOucTList    *CksLast;
 XrdOucTList    *LibList;
 XrdOucTList    *LibLast;
 XrdVersionInfo &myVersion;
+int            CKSopts;
 };
 #endif

--- a/src/XrdCks/XrdCksManager.cc
+++ b/src/XrdCks/XrdCksManager.cc
@@ -60,6 +60,15 @@
 #endif
 
 /******************************************************************************/
+/*                         L o c a l   S t a t i c s                          */
+/******************************************************************************/
+
+namespace
+{
+int CksOpts = 0;
+}
+  
+/******************************************************************************/
 /*                           C o n s t r u c t o r                            */
 /******************************************************************************/
   
@@ -472,9 +481,11 @@ int XrdCksManager::Get(const char *Pfn, XrdCksData &Cks)
    nFault = strcmp(xCS.Attr.Cks.Name, Cks.Name);
    Cks = xCS.Attr.Cks;
 
-// Verify the file
+// Verify the file. We do this with modification time unless that check
+// has been turned off.
 //
-   if ((rc = ModTime(Pfn, MTime))) return rc;
+   if (CksOpts & Cks_nomtchk) MTime = Cks.fmTime;
+      else if ((rc = ModTime(Pfn, MTime))) return rc;
 
 // Return result
 //
@@ -614,6 +625,12 @@ int XrdCksManager::Set(const char *Pfn, XrdCksData &Cks, int myTime)
    return xCS.Set(Pfn);
 }
 
+/******************************************************************************/
+/*                               S e t O p t s                                */
+/******************************************************************************/
+
+void XrdCksManager::SetOpts(int opt) {CksOpts = opt;}
+  
 /******************************************************************************/
 /*                                   V e r                                    */
 /******************************************************************************/

--- a/src/XrdCks/XrdCksManager.hh
+++ b/src/XrdCks/XrdCksManager.hh
@@ -68,6 +68,12 @@ virtual int         Size( const char  *Name=0);
 
 virtual int         Set(  const char *Pfn, XrdCksData &Cks, int myTime=0);
 
+// Valid options and the values, The high order bit must be zero
+//
+        enum {Cks_nomtchk = 0x00000001};
+
+        void        SetOpts(int opt);
+
 virtual int         Ver(  const char *Pfn, XrdCksData &Cks);
 
                     XrdCksManager(XrdSysError *erP, int iosz,

--- a/src/XrdCl/XrdClAsyncSocketHandler.hh
+++ b/src/XrdCl/XrdClAsyncSocketHandler.hh
@@ -275,7 +275,7 @@ namespace XrdCl
       XrdNetAddr                     pSockAddr;
       std::unique_ptr<HandShakeData> pHandShakeData;
       bool                           pHandShakeDone;
-      uint16_t                       pTimeoutResolution;
+      time_t                         pTimeoutResolution;
       time_t                         pConnectionStarted;
       time_t                         pConnectionTimeout;
       time_t                         pLastActivity;

--- a/src/XrdCl/XrdClCheckpointOperation.hh
+++ b/src/XrdCl/XrdClCheckpointOperation.hh
@@ -57,10 +57,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         ChkPtCode  code    = std::get<CodeArg>( this->args ).Get();
-        uint16_t  timeout = pipelineTimeout < this->timeout ?
+        time_t    timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->file->Checkpoint( code, handler, timeout );
       }
@@ -69,7 +69,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   //! Factory for creating ReadImpl objects
   //----------------------------------------------------------------------------
-  inline CheckpointImpl<false> Checkpoint( Ctx<File> file, Arg<ChkPtCode> code, uint16_t timeout = 0 )
+  inline CheckpointImpl<false> Checkpoint( Ctx<File> file, Arg<ChkPtCode> code, time_t timeout = 0 )
   {
     return CheckpointImpl<false>( std::move( file ), std::move( code ) ).Timeout( timeout );
   }
@@ -112,12 +112,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t    off     = std::get<OffArg>( this->args ).Get();
         uint32_t    len     = std::get<LenArg>( this->args ).Get();
         const void* buf     = std::get<BufArg>( this->args ).Get();
-        uint16_t    timeout = pipelineTimeout < this->timeout ?
+        time_t      timeout = pipelineTimeout < this->timeout ?
                               pipelineTimeout : this->timeout;
         return this->file->ChkptWrt( off, len, buf, handler, timeout );
       }
@@ -128,7 +128,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline ChkptWrtImpl<false> ChkptWrt( Ctx<File> file, Arg<uint64_t> offset,
                                        Arg<uint32_t> size, Arg<const void*> buffer,
-                                       uint16_t timeout = 0 )
+                                       time_t timeout = 0 )
   {
     return ChkptWrtImpl<false>( std::move( file ), std::move( offset ),
                                 std::move( size ), std::move( buffer ) ).Timeout( timeout );
@@ -172,11 +172,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t            off     = std::get<OffArg>( this->args ).Get();
         std::vector<iovec> &stdiov  = std::get<IovecArg>( this->args ).Get();
-        uint16_t            timeout = pipelineTimeout < this->timeout ?
+        time_t              timeout = pipelineTimeout < this->timeout ?
                                       pipelineTimeout : this->timeout;
 
         int iovcnt = stdiov.size();
@@ -196,7 +196,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline ChkptWrtVImpl<false> ChkptWrtV( Ctx<File> file, Arg<uint64_t> offset,
                                          Arg<std::vector<iovec>> iov,
-                                         uint16_t timeout = 0 )
+                                         time_t timeout = 0 )
   {
     return ChkptWrtVImpl<false>( std::move( file ), std::move( offset ),
                                  std::move( iov ) ).Timeout( timeout );

--- a/src/XrdCl/XrdClClassicCopyJob.cc
+++ b/src/XrdCl/XrdClClassicCopyJob.cc
@@ -2413,7 +2413,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Constructor
   //----------------------------------------------------------------------------
-  ClassicCopyJob::ClassicCopyJob( uint16_t      jobId,
+  ClassicCopyJob::ClassicCopyJob( uint32_t      jobId,
                                   PropertyList *jobProperties,
                                   PropertyList *jobResults ):
     CopyJob( jobId, jobProperties, jobResults )

--- a/src/XrdCl/XrdClClassicCopyJob.cc
+++ b/src/XrdCl/XrdClClassicCopyJob.cc
@@ -71,13 +71,13 @@ namespace
     public:
       mytimer_t() : start( clock_t::now() ){ }
       void reset(){ start = clock_t::now(); }
-      uint64_t elapsed() const
+      time_t elapsed() const
       {
         return std::chrono::duration_cast<unit_t>( clock_t::now() - start ).count();
       }
     private:
       typedef std::chrono::high_resolution_clock clock_t;
-      typedef std::chrono::duration<uint64_t, U> unit_t;
+      typedef std::chrono::duration<int, U> unit_t;
       std::chrono::time_point<clock_t> start;
   };
 
@@ -2442,7 +2442,7 @@ namespace XrdCl
     int32_t     nbXcpSources;
     long long   xRate;
     long long   xRateThreshold;
-    uint16_t    cpTimeout;
+    time_t      cpTimeout;
     std::vector<std::string> addcksums;
 
     pProperties->Get( "checkSumMode",    checkSumMode );

--- a/src/XrdCl/XrdClClassicCopyJob.hh
+++ b/src/XrdCl/XrdClClassicCopyJob.hh
@@ -30,7 +30,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       // Constructor
       //------------------------------------------------------------------------
-      ClassicCopyJob( uint16_t      jobId,
+      ClassicCopyJob( uint32_t      jobId,
                       PropertyList *jobProperties,
                       PropertyList *jobResults );
 

--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -58,8 +58,8 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     //--------------------------------------------------------------------------
     //! Begin job
     //--------------------------------------------------------------------------
-    virtual void BeginJob( uint16_t          jobNum,
-                           uint16_t          jobTotal,
+    virtual void BeginJob( uint32_t          jobNum,
+                           uint32_t          jobTotal,
                            const XrdCl::URL *source,
                            const XrdCl::URL *destination )
     {
@@ -85,11 +85,11 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     //--------------------------------------------------------------------------
     //! End job
     //--------------------------------------------------------------------------
-    virtual void EndJob( uint16_t jobNum, const XrdCl::PropertyList *results )
+    virtual void EndJob( uint32_t jobNum, const XrdCl::PropertyList *results )
     {
       XrdSysMutexHelper scopedLock( pMutex );
 
-      std::map<uint16_t, JobData>::iterator it = pOngoingJobs.find( jobNum );
+      std::map<uint32_t, JobData>::iterator it = pOngoingJobs.find( jobNum );
       if( it == pOngoingJobs.end() )
         return;
 
@@ -189,13 +189,13 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     //--------------------------------------------------------------------------
     std::string GetSummaryBar( time_t now )
     {
-      std::map<uint16_t, JobData>::iterator it;
+      std::map<uint32_t, JobData>::iterator it;
       std::ostringstream o;
 
       for( it = pOngoingJobs.begin(); it != pOngoingJobs.end(); ++it )
       {
         JobData  &d      = it->second;
-        uint16_t  jobNum = it->first;
+        uint32_t  jobNum = it->first;
 
         uint64_t speed = 0;
         if( now-d.started )
@@ -218,7 +218,7 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     //--------------------------------------------------------------------------
     //! Job progress
     //--------------------------------------------------------------------------
-    virtual void JobProgress( uint16_t jobNum,
+    virtual void JobProgress( uint32_t jobNum,
                               uint64_t bytesProcessed,
                               uint64_t bytesTotal )
     {
@@ -231,7 +231,7 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
           return;
         pPrevious = now;
 
-        std::map<uint16_t, JobData>::iterator it = pOngoingJobs.find( jobNum );
+        std::map<uint32_t, JobData>::iterator it = pOngoingJobs.find( jobNum );
         if( it == pOngoingJobs.end() )
           return;
 
@@ -300,7 +300,7 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     bool                        pPrintSourceCheckSum;
     bool                        pPrintTargetCheckSum;
     bool                        pPrintAdditionalCheckSum;
-    std::map<uint16_t, JobData> pOngoingJobs;
+    std::map<uint32_t, JobData> pOngoingJobs;
     XrdSysRecMutex              pMutex;
 };
 
@@ -942,9 +942,9 @@ int main( int argc, char **argv )
     else
     {
       std::vector<XrdCl::PropertyList*>::iterator it;
-      uint16_t i = 1;
-      uint16_t jobsRun = 0;
-      uint16_t errors  = 0;
+      uint32_t i = 1;
+      uint32_t jobsRun = 0;
+      uint32_t errors  = 0;
       for( it = resultVect.begin(); it != resultVect.end(); ++it, ++i )
       {
         if( !(*it)->HasProperty( "status" ) )

--- a/src/XrdCl/XrdClCopyJob.hh
+++ b/src/XrdCl/XrdClCopyJob.hh
@@ -38,7 +38,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Constructor
       //------------------------------------------------------------------------
-      CopyJob( uint16_t      jobId,
+      CopyJob( uint32_t      jobId,
                PropertyList *jobProperties,
                PropertyList *jobResults ):
         pProperties( jobProperties ),
@@ -109,7 +109,7 @@ namespace XrdCl
       PropertyList *pResults;
       URL           pSource;
       URL           pTarget;
-      uint16_t      pJobId;
+      uint32_t      pJobId;
   };
 }
 

--- a/src/XrdCl/XrdClCopyProcess.cc
+++ b/src/XrdCl/XrdClCopyProcess.cc
@@ -48,8 +48,8 @@ namespace
     public:
       QueuedCopyJob( XrdCl::CopyJob             *job,
                      XrdCl::CopyProgressHandler *progress,
-                     uint16_t                    currentJob,
-                     uint16_t                    totalJobs,
+                     uint32_t                    currentJob,
+                     uint32_t                    totalJobs,
                      XrdSysSemaphore            *sem = 0 ):
         pJob(job), pProgress(progress), pCurrentJob(currentJob),
         pTotalJobs(totalJobs), pSem(sem),
@@ -188,8 +188,8 @@ namespace
     private:
       XrdCl::CopyJob             *pJob;
       XrdCl::CopyProgressHandler *pProgress;
-      uint16_t                    pCurrentJob;
-      uint16_t                    pTotalJobs;
+      uint32_t                    pCurrentJob;
+      uint32_t                    pTotalJobs;
       XrdSysSemaphore            *pSem;
       int                         pWrtRetryCnt;
       int                         pRetryCnt;
@@ -518,8 +518,8 @@ namespace XrdCl
     // Run the show
     //--------------------------------------------------------------------------
     std::vector<CopyJob *>::iterator it;
-    uint16_t currentJob = 1;
-    uint16_t totalJobs  = pImpl->pJobs.size();
+    uint32_t currentJob = 1;
+    uint32_t totalJobs  = pImpl->pJobs.size();
 
     //--------------------------------------------------------------------------
     // Single thread
@@ -548,8 +548,8 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     else
     {
-      uint16_t workers = std::min( (uint16_t)parallelThreads,
-                                   (uint16_t)pImpl->pJobs.size() );
+      uint32_t workers = std::min( (uint32_t)parallelThreads,
+                                   (uint32_t)pImpl->pJobs.size() );
       JobManager jm( workers );
       jm.Initialize();
       if( !jm.Start() )

--- a/src/XrdCl/XrdClCopyProcess.hh
+++ b/src/XrdCl/XrdClCopyProcess.hh
@@ -144,9 +144,9 @@ namespace XrdCl
       //! chunkSize      [uint32_t] - size of a copy chunks in bytes
       //! parallelChunks [uint8_t]  - number of chunks that should be requested
       //!                             in parallel
-      //! initTimeout    [uint16_t] - time limit for successfull initialization
+      //! initTimeout    [time_t]   - time limit for successfull initialization
       //!                             of the copy job
-      //! tpcTimeout     [uint16_t] - time limit for the actual copy to finish
+      //! tpcTimeout     [time_t]   - time limit for the actual copy to finish
       //! dynamicSource  [bool]     - support for the case where the size source
       //!                             file may change during reading process
       //!

--- a/src/XrdCl/XrdClCopyProcess.hh
+++ b/src/XrdCl/XrdClCopyProcess.hh
@@ -51,8 +51,8 @@ namespace XrdCl
       //! @param source         the source url of the current job
       //! @param destination    the destination url of the current job
       //------------------------------------------------------------------------
-      virtual void BeginJob( uint16_t   jobNum,
-                             uint16_t   jobTotal,
+      virtual void BeginJob( uint32_t   jobNum,
+                             uint32_t   jobTotal,
                              const URL *source,
                              const URL *destination )
       {
@@ -65,7 +65,7 @@ namespace XrdCl
       //! @param jobNum job number
       //! @param result result of the job
       //------------------------------------------------------------------------
-      virtual void EndJob( uint16_t            jobNum,
+      virtual void EndJob( uint32_t            jobNum,
                            const PropertyList *result )
       {
         (void)jobNum; (void)result;
@@ -79,7 +79,7 @@ namespace XrdCl
       //! @param bytesTotal     total number of bytes to be processed by the 
       //!                       current job
       //------------------------------------------------------------------------
-      virtual void JobProgress( uint16_t jobNum,
+      virtual void JobProgress( uint32_t jobNum,
                                 uint64_t bytesProcessed,
                                 uint64_t bytesTotal )
       {
@@ -89,7 +89,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Determine whether the job should be canceled
       //------------------------------------------------------------------------
-      virtual bool ShouldCancel( uint16_t jobNum )
+      virtual bool ShouldCancel( uint32_t jobNum )
       {
         (void)jobNum;
         return false;
@@ -126,7 +126,7 @@ namespace XrdCl
       //! Configuration properties:
       //! source         [string]   - original source URL
       //! target         [string]   - target directory or file
-      //! sourceLimit    [uint16_t] - maximum number sources
+      //! sourceLimit    [uint32_t] - maximum number sources
       //! force          [bool]     - overwrite target if exists
       //! posc           [bool]     - persistify only on successful close
       //! coerce         [bool]     - ignore locking semantics on destination

--- a/src/XrdCl/XrdClEcHandler.hh
+++ b/src/XrdCl/XrdClEcHandler.hh
@@ -139,7 +139,7 @@ namespace XrdCl
 
       XRootDStatus Open( uint16_t           flags,
                          ResponseHandler   *handler,
-                         uint16_t           timeout )
+                         time_t             timeout )
       {
         if( ( flags & OpenFlags::Write ) || ( flags & OpenFlags::Update ) )
         {
@@ -180,7 +180,7 @@ namespace XrdCl
                          OpenFlags::Flags   flags,
                          Access::Mode       mode,
                          ResponseHandler   *handler,
-                         uint16_t           timeout )
+                         time_t             timeout )
       {
         (void)url; (void)mode;
         return Open( flags, handler, timeout );
@@ -191,7 +191,7 @@ namespace XrdCl
       //!
       //------------------------------------------------------------------------
       XRootDStatus Close( ResponseHandler *handler,
-                                 uint16_t                timeout )
+                                 time_t                  timeout )
       {
         if( writer )
         {
@@ -243,7 +243,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Stat( bool             force,
                          ResponseHandler *handler,
-                         uint16_t         timeout )
+                         time_t           timeout )
       {
 
         if( !objcfg->nomtfile )
@@ -284,7 +284,7 @@ namespace XrdCl
                                 uint32_t                size,
                                 void                   *buffer,
                                 ResponseHandler *handler,
-                                uint16_t                timeout )
+                                time_t                  timeout )
       {
         if( !reader ) return XRootDStatus( stError, errInternal );
     
@@ -297,7 +297,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus PgRead(uint64_t offset, uint32_t size, void *buffer,
                                     ResponseHandler *handler,
-                                    uint16_t timeout) 
+                                    time_t timeout)
       {
         ResponseHandler *substitHandler = new EcPgReadResponseHandler( handler );
         XRootDStatus st = Read(offset, size, buffer, substitHandler, timeout);
@@ -312,7 +312,7 @@ namespace XrdCl
                                  uint32_t                size,
                                  const void             *buffer,
                                  ResponseHandler *handler,
-                                 uint16_t                timeout )
+                                 time_t                  timeout )
       {
         if( cksHelper )
           cksHelper->Update( buffer, size );
@@ -332,7 +332,7 @@ namespace XrdCl
                             const void            *buffer,
                             std::vector<uint32_t> &cksums,
                             ResponseHandler       *handler,
-                            uint16_t               timeout = 0 )
+                            time_t                 timeout = 0 )
       {
         if(! cksums.empty() )
         {

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -1430,7 +1430,7 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     //--------------------------------------------------------------------------
     // End job
     //--------------------------------------------------------------------------
-    virtual void EndJob( uint16_t jobNum, const XrdCl::PropertyList *results )
+    virtual void EndJob( uint32_t jobNum, const XrdCl::PropertyList *results )
     {
       JobProgress( jobNum, pBytesProcessed, pBytesTotal );
       std::cerr << std::endl;
@@ -1439,7 +1439,7 @@ class ProgressDisplay: public XrdCl::CopyProgressHandler
     //--------------------------------------------------------------------------
     // Job progress
     //--------------------------------------------------------------------------
-    virtual void JobProgress( uint16_t jobNum,
+    virtual void JobProgress( uint32_t jobNum,
                               uint64_t bytesProcessed,
                               uint64_t bytesTotal )
     {

--- a/src/XrdCl/XrdClFile.cc
+++ b/src/XrdCl/XrdClFile.cc
@@ -100,7 +100,7 @@ namespace XrdCl
                            OpenFlags::Flags   flags,
                            Access::Mode       mode,
                            ResponseHandler   *handler,
-                           uint16_t           timeout )
+                           time_t             timeout )
   {
     //--------------------------------------------------------------------------
     // Check if we need to install and run a plug-in for this URL
@@ -135,7 +135,7 @@ namespace XrdCl
   XRootDStatus File::Open( const std::string &url,
                            OpenFlags::Flags   flags,
                            Access::Mode       mode,
-                           uint16_t           timeout )
+                           time_t             timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Open( url, flags, mode, &handler, timeout );
@@ -149,7 +149,7 @@ namespace XrdCl
   // Close the file - async
   //----------------------------------------------------------------------------
   XRootDStatus File::Close( ResponseHandler *handler,
-                            uint16_t         timeout )
+                            time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Close( handler, timeout );
@@ -161,7 +161,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Close the file
   //----------------------------------------------------------------------------
-  XRootDStatus File::Close( uint16_t timeout )
+  XRootDStatus File::Close( time_t timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Close( &handler, timeout );
@@ -176,7 +176,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus File::Stat( bool             force,
                            ResponseHandler *handler,
-                           uint16_t         timeout )
+                           time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Stat( force, handler, timeout );
@@ -189,7 +189,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus File::Stat( bool       force,
                            StatInfo *&response,
-                           uint16_t   timeout )
+                           time_t     timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Stat( force, &handler, timeout );
@@ -207,7 +207,7 @@ namespace XrdCl
                            uint32_t         size,
                            void            *buffer,
                            ResponseHandler *handler,
-                           uint16_t         timeout )
+                           time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Read( offset, size, buffer, handler, timeout );
@@ -222,7 +222,7 @@ namespace XrdCl
                            uint32_t  size,
                            void     *buffer,
                            uint32_t &bytesRead,
-                           uint16_t  timeout )
+                           time_t    timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Read( offset, size, buffer, &handler, timeout );
@@ -246,7 +246,7 @@ namespace XrdCl
                              uint32_t         size,
                              void            *buffer,
                              ResponseHandler *handler,
-                             uint16_t         timeout )
+                             time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->PgRead( offset, size, buffer, handler, timeout );
@@ -262,7 +262,7 @@ namespace XrdCl
                              void                  *buffer,
                              std::vector<uint32_t> &cksums,
                              uint32_t              &bytesRead,
-                             uint16_t               timeout )
+                             time_t                 timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = PgRead( offset, size, buffer, &handler, timeout );
@@ -287,7 +287,7 @@ namespace XrdCl
                             uint32_t         size,
                             const void      *buffer,
                             ResponseHandler *handler,
-                            uint16_t         timeout )
+                            time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Write( offset, size, buffer, handler, timeout );
@@ -301,7 +301,7 @@ namespace XrdCl
   XRootDStatus File::Write( uint64_t    offset,
                             uint32_t    size,
                             const void *buffer,
-                            uint16_t    timeout )
+                            time_t      timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Write( offset, size, buffer, &handler, timeout );
@@ -316,7 +316,7 @@ namespace XrdCl
   XRootDStatus File::Write( uint64_t          offset,
                             Buffer          &&buffer,
                             ResponseHandler  *handler,
-                            uint16_t          timeout )
+                            time_t            timeout )
   {
     if( pPlugIn )
       return pPlugIn->Write( offset, std::move( buffer ), handler, timeout );
@@ -329,7 +329,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus File::Write( uint64_t    offset,
                             Buffer    &&buffer,
-                            uint16_t    timeout )
+                            time_t      timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Write( offset, std::move( buffer ), &handler, timeout );
@@ -348,7 +348,7 @@ namespace XrdCl
                             Optional<uint64_t>  fdoff,
                             int                 fd,
                             ResponseHandler    *handler,
-                            uint16_t            timeout )
+                            time_t              timeout )
   {
     if( pPlugIn )
       return pPlugIn->Write( offset, size, fdoff, fd, handler, timeout );
@@ -363,7 +363,7 @@ namespace XrdCl
                             uint32_t            size,
                             Optional<uint64_t>  fdoff,
                             int                 fd,
-                            uint16_t            timeout )
+                            time_t              timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Write( offset, size, fdoff, fd, &handler, timeout );
@@ -382,7 +382,7 @@ namespace XrdCl
                               const void            *buffer,
                               std::vector<uint32_t> &cksums,
                               ResponseHandler       *handler,
-                              uint16_t               timeout )
+                              time_t                 timeout )
   {
     if( pPlugIn )
       return pPlugIn->PgWrite( offset, size, buffer, cksums, handler, timeout );
@@ -397,7 +397,7 @@ namespace XrdCl
                               uint32_t               size,
                               const void            *buffer,
                               std::vector<uint32_t> &cksums,
-                              uint16_t               timeout )
+                              time_t                 timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = PgWrite( offset, size, buffer, cksums, &handler, timeout );
@@ -412,7 +412,7 @@ namespace XrdCl
   // Commit all pending disk writes - async
   //----------------------------------------------------------------------------
   XRootDStatus File::Sync( ResponseHandler *handler,
-                           uint16_t         timeout )
+                           time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Sync( handler, timeout );
@@ -423,7 +423,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Commit all pending disk writes - sync
   //----------------------------------------------------------------------------
-  XRootDStatus File::Sync( uint16_t timeout )
+  XRootDStatus File::Sync( time_t timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Sync( &handler, timeout );
@@ -439,7 +439,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus File::Truncate( uint64_t         size,
                                ResponseHandler *handler,
-                               uint16_t         timeout )
+                               time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Truncate( size, handler, timeout );
@@ -451,7 +451,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Truncate the file to a particular size - sync
   //----------------------------------------------------------------------------
-  XRootDStatus File::Truncate( uint64_t size, uint16_t timeout )
+  XRootDStatus File::Truncate( uint64_t size, time_t timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Truncate( size, &handler, timeout );
@@ -468,7 +468,7 @@ namespace XrdCl
   XRootDStatus File::VectorRead( const ChunkList &chunks,
                                  void            *buffer,
                                  ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->VectorRead( chunks, buffer, handler, timeout );
@@ -482,7 +482,7 @@ namespace XrdCl
   XRootDStatus File::VectorRead( const ChunkList  &chunks,
                                  void             *buffer,
                                  VectorReadInfo  *&vReadInfo,
-                                 uint16_t          timeout )
+                                 time_t            timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = VectorRead( chunks, buffer, &handler, timeout );
@@ -497,7 +497,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::VectorWrite( const ChunkList &chunks,
                             ResponseHandler *handler,
-                            uint16_t         timeout )
+                            time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->VectorWrite( chunks, handler, timeout );
@@ -509,7 +509,7 @@ namespace XrdCl
   // Read scattered data chunks in one operation - sync
   //------------------------------------------------------------------------
   XRootDStatus File::VectorWrite( const ChunkList  &chunks,
-                           uint16_t          timeout )
+                           time_t            timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = VectorWrite( chunks, &handler, timeout );
@@ -526,7 +526,7 @@ namespace XrdCl
                              const struct iovec *iov,
                              int                 iovcnt,
                              ResponseHandler    *handler,
-                             uint16_t            timeout )
+                             time_t              timeout )
   {
     if( pPlugIn )
       return pPlugIn->WriteV( offset, iov, iovcnt, handler, timeout );
@@ -540,7 +540,7 @@ namespace XrdCl
   XRootDStatus File::WriteV( uint64_t            offset,
                              const struct iovec *iov,
                              int                 iovcnt,
-                             uint16_t            timeout )
+                             time_t              timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = WriteV( offset, iov, iovcnt, &handler, timeout );
@@ -566,7 +566,7 @@ namespace XrdCl
                             struct iovec    *iov,
                             int              iovcnt,
                             ResponseHandler *handler,
-                            uint16_t         timeout )
+                            time_t           timeout )
   {
     return FileStateHandler::ReadV( pImpl->pStateHandler, offset, iov, iovcnt, handler, timeout );
   }
@@ -586,7 +586,7 @@ namespace XrdCl
                             struct iovec *iov,
                             int           iovcnt,
                             uint32_t     &bytesRead,
-                            uint16_t      timeout )
+                            time_t        timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = ReadV( offset, iov, iovcnt, &handler, timeout );
@@ -609,7 +609,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus File::Fcntl( const Buffer    &arg,
                             ResponseHandler *handler,
-                            uint16_t         timeout )
+                            time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Fcntl( arg, handler, timeout );
@@ -623,7 +623,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus File::Fcntl( const Buffer     &arg,
                             Buffer          *&response,
-                            uint16_t          timeout )
+                            time_t            timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Fcntl( arg, &handler, timeout );
@@ -637,7 +637,7 @@ namespace XrdCl
   //! Get access token to a file - async
   //------------------------------------------------------------------------
   XRootDStatus File::Visa( ResponseHandler *handler,
-                           uint16_t         timeout )
+                           time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Visa( handler, timeout );
@@ -649,7 +649,7 @@ namespace XrdCl
   // Get access token to a file - sync
   //----------------------------------------------------------------------------
   XRootDStatus File::Visa( Buffer   *&visa,
-                           uint16_t   timeout )
+                           time_t     timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = Visa( &handler, timeout );
@@ -664,7 +664,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::SetXAttr( const std::vector<xattr_t>  &attrs,
                                ResponseHandler             *handler,
-                               uint16_t                     timeout )
+                               time_t                       timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -677,7 +677,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::SetXAttr( const std::vector<xattr_t>  &attrs,
                                std::vector<XAttrStatus>    &result,
-                               uint16_t                     timeout )
+                               time_t                       timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = SetXAttr( attrs, &handler, timeout );
@@ -697,7 +697,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::GetXAttr( const std::vector<std::string>  &attrs,
                                ResponseHandler                 *handler,
-                               uint16_t                         timeout )
+                               time_t                           timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -710,7 +710,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::GetXAttr( const std::vector<std::string>  &attrs,
                                std::vector<XAttr>              &result,
-                               uint16_t                         timeout )
+                               time_t                           timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = GetXAttr( attrs, &handler, timeout );
@@ -730,7 +730,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::DelXAttr( const std::vector<std::string>  &attrs,
                                ResponseHandler                 *handler,
-                               uint16_t                         timeout )
+                               time_t                           timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -743,7 +743,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::DelXAttr( const std::vector<std::string>  &attrs,
                                std::vector<XAttrStatus>        &result,
-                               uint16_t                         timeout )
+                               time_t                           timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = DelXAttr( attrs, &handler, timeout );
@@ -762,7 +762,7 @@ namespace XrdCl
   // List extended attributes - async
   //------------------------------------------------------------------------
   XRootDStatus File::ListXAttr( ResponseHandler  *handler,
-                                uint16_t          timeout )
+                                time_t            timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -774,7 +774,7 @@ namespace XrdCl
   // List extended attributes - sync
   //------------------------------------------------------------------------
   XRootDStatus File::ListXAttr( std::vector<XAttr>  &result,
-                                uint16_t             timeout )
+                                time_t               timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = ListXAttr( &handler, timeout );
@@ -794,7 +794,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus File::Checkpoint( kXR_char                  code,
                                  ResponseHandler          *handler,
-                                 uint16_t                  timeout )
+                                 time_t                    timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -809,7 +809,7 @@ namespace XrdCl
                                uint32_t         size,
                                const void      *buffer,
                                ResponseHandler *handler,
-                               uint16_t         timeout )
+                               time_t           timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -824,7 +824,7 @@ namespace XrdCl
                                 const struct iovec *iov,
                                 int                 iovcnt,
                                 ResponseHandler    *handler,
-                                uint16_t            timeout )
+                                time_t              timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -835,7 +835,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   // Try different data server
   //------------------------------------------------------------------------
-  XRootDStatus File::TryOtherServer( uint16_t timeout )
+  XRootDStatus File::TryOtherServer( time_t timeout )
   {
     return FileStateHandler::TryOtherServer( pImpl->pStateHandler, timeout );
   }

--- a/src/XrdCl/XrdClFile.hh
+++ b/src/XrdCl/XrdClFile.hh
@@ -82,7 +82,7 @@ namespace XrdCl
                          OpenFlags::Flags   flags,
                          Access::Mode       mode,
                          ResponseHandler   *handler,
-                         uint16_t           timeout  = 0 )
+                         time_t             timeout  = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -98,7 +98,7 @@ namespace XrdCl
       XRootDStatus Open( const std::string &url,
                          OpenFlags::Flags   flags,
                          Access::Mode       mode    = Access::None,
-                         uint16_t           timeout = 0 )
+                         time_t             timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -110,7 +110,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Close( ResponseHandler *handler,
-                          uint16_t         timeout = 0 )
+                          time_t           timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -120,7 +120,7 @@ namespace XrdCl
       //!                used
       //! @return        status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Close( uint16_t timeout = 0 ) XRD_WARN_UNUSED_RESULT;
+      XRootDStatus Close( time_t timeout = 0 ) XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
       //! Obtain status information for this file - async
@@ -135,7 +135,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Stat( bool             force,
                          ResponseHandler *handler,
-                         uint16_t         timeout = 0 )
+                         time_t           timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -149,7 +149,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Stat( bool       force,
                          StatInfo *&response,
-                         uint16_t   timeout = 0 )
+                         time_t     timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
 
@@ -171,7 +171,7 @@ namespace XrdCl
                          uint32_t         size,
                          void            *buffer,
                          ResponseHandler *handler,
-                         uint16_t         timeout = 0 )
+                         time_t           timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -189,7 +189,7 @@ namespace XrdCl
                          uint32_t  size,
                          void     *buffer,
                          uint32_t &bytesRead,
-                         uint16_t  timeout = 0 )
+                         time_t    timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -209,7 +209,7 @@ namespace XrdCl
                            uint32_t         size,
                            void            *buffer,
                            ResponseHandler *handler,
-                           uint16_t         timeout = 0 )
+                           time_t           timeout = 0 )
                            XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -229,7 +229,7 @@ namespace XrdCl
                            void                  *buffer,
                            std::vector<uint32_t> &cksums,
                            uint32_t              &bytesRead,
-                           uint16_t               timeout = 0 )
+                           time_t                 timeout = 0 )
                            XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -250,7 +250,7 @@ namespace XrdCl
                           uint32_t         size,
                           const void      *buffer,
                           ResponseHandler *handler,
-                          uint16_t         timeout = 0 )
+                          time_t           timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -270,7 +270,7 @@ namespace XrdCl
       XRootDStatus Write( uint64_t    offset,
                           uint32_t    size,
                           const void *buffer,
-                          uint16_t    timeout = 0 )
+                          time_t      timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -287,7 +287,7 @@ namespace XrdCl
       XRootDStatus Write( uint64_t          offset,
                           Buffer          &&buffer,
                           ResponseHandler  *handler,
-                          uint16_t          timeout = 0 );
+                          time_t            timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data chunk at a given offset - sync
@@ -301,7 +301,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Write( uint64_t          offset,
                           Buffer          &&buffer,
-                          uint16_t          timeout = 0 );
+                          time_t            timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data from a given file descriptor at a given offset - async
@@ -322,7 +322,7 @@ namespace XrdCl
                           Optional<uint64_t>  fdoff,
                           int                 fd,
                           ResponseHandler    *handler,
-                          uint16_t            timeout = 0 );
+                          time_t              timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data from a given file descriptor at a given offset - sync
@@ -341,7 +341,7 @@ namespace XrdCl
                           uint32_t            size,
                           Optional<uint64_t>  fdoff,
                           int                 fd,
-                          uint16_t            timeout = 0 );
+                          time_t              timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write number of pages at a given offset - async
@@ -360,7 +360,7 @@ namespace XrdCl
                             const void            *buffer,
                             std::vector<uint32_t> &cksums,
                             ResponseHandler       *handler,
-                            uint16_t               timeout = 0 )
+                            time_t                 timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -378,7 +378,7 @@ namespace XrdCl
                             uint32_t               size,
                             const void            *buffer,
                             std::vector<uint32_t> &cksums,
-                            uint16_t               timeout = 0 )
+                            time_t                 timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -390,7 +390,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Sync( ResponseHandler *handler,
-                         uint16_t         timeout = 0 )
+                         time_t           timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
 
@@ -401,7 +401,7 @@ namespace XrdCl
       //!                used
       //! @return        status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Sync( uint16_t timeout = 0 ) XRD_WARN_UNUSED_RESULT;
+      XRootDStatus Sync( time_t timeout = 0 ) XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
       //! Truncate the file to a particular size - async
@@ -414,7 +414,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Truncate( uint64_t         size,
                              ResponseHandler *handler,
-                             uint16_t         timeout = 0 )
+                             time_t           timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
 
@@ -427,7 +427,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Truncate( uint64_t size,
-                             uint16_t timeout = 0 )
+                             time_t   timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -450,7 +450,7 @@ namespace XrdCl
       XRootDStatus VectorRead( const ChunkList &chunks,
                                void            *buffer,
                                ResponseHandler *handler,
-                               uint16_t         timeout = 0 )
+                               time_t           timeout = 0 )
                                XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -473,7 +473,7 @@ namespace XrdCl
       XRootDStatus VectorRead( const ChunkList  &chunks,
                                void             *buffer,
                                VectorReadInfo  *&vReadInfo,
-                               uint16_t          timeout = 0 )
+                               time_t            timeout = 0 )
                                XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -487,7 +487,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus VectorWrite( const ChunkList &chunks,
                                 ResponseHandler *handler,
-                                uint16_t         timeout = 0 )
+                                time_t           timeout = 0 )
                                 XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -499,7 +499,7 @@ namespace XrdCl
       //! @return          status of the operation
       //------------------------------------------------------------------------
       XRootDStatus VectorWrite( const ChunkList  &chunks,
-                               uint16_t          timeout = 0 )
+                               time_t            timeout = 0 )
                                XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -517,7 +517,7 @@ namespace XrdCl
                            const struct iovec *iov,
                            int                 iovcnt,
                            ResponseHandler    *handler,
-                           uint16_t            timeout = 0 );
+                           time_t              timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write scattered buffers in one operation - sync
@@ -532,7 +532,7 @@ namespace XrdCl
       XRootDStatus WriteV( uint64_t            offset,
                            const struct iovec *iov,
                            int                 iovcnt,
-                           uint16_t            timeout = 0 );
+                           time_t              timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read data into scattered buffers in one operation - async
@@ -549,7 +549,7 @@ namespace XrdCl
                           struct iovec    *iov,
                           int              iovcnt,
                           ResponseHandler *handler,
-                          uint16_t         timeout = 0 );
+                          time_t           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read data into scattered buffers in one operation - sync
@@ -566,7 +566,7 @@ namespace XrdCl
                           struct iovec *iov,
                           int           iovcnt,
                           uint32_t     &bytesRead,
-                          uint16_t      timeout = 0 );
+                          time_t        timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Performs a custom operation on an open file, server implementation
@@ -582,7 +582,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Fcntl( const Buffer    &arg,
                           ResponseHandler *handler,
-                          uint16_t         timeout = 0 )
+                          time_t           timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -597,7 +597,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Fcntl( const Buffer     &arg,
                           Buffer          *&response,
-                          uint16_t          timeout = 0 )
+                          time_t            timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -611,7 +611,7 @@ namespace XrdCl
       //! @return          status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Visa( ResponseHandler *handler,
-                         uint16_t         timeout = 0 )
+                         time_t           timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -623,7 +623,7 @@ namespace XrdCl
       //! @return          status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Visa( Buffer   *&visa,
-                         uint16_t   timeout = 0 )
+                         time_t     timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -640,7 +640,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SetXAttr( const std::vector<xattr_t>  &attrs,
                              ResponseHandler             *handler,
-                             uint16_t                     timeout = 0 );
+                             time_t                       timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Set extended attributes - sync
@@ -654,7 +654,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SetXAttr( const std::vector<xattr_t>  &attrs,
                              std::vector<XAttrStatus>    &result,
-                             uint16_t                     timeout = 0 );
+                             time_t                       timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get extended attributes - async
@@ -670,7 +670,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus GetXAttr( const std::vector<std::string>  &attrs,
                              ResponseHandler                 *handler,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get extended attributes - sync
@@ -684,7 +684,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus GetXAttr( const std::vector<std::string>  &attrs,
                              std::vector<XAttr>              &result,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Delete extended attributes - async
@@ -700,7 +700,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus DelXAttr( const std::vector<std::string>  &attrs,
                              ResponseHandler                 *handler,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Delete extended attributes - sync
@@ -714,7 +714,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus DelXAttr( const std::vector<std::string>  &attrs,
                              std::vector<XAttrStatus>        &result,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! List extended attributes - async
@@ -728,7 +728,7 @@ namespace XrdCl
       //! @return        : status of the operation
       //------------------------------------------------------------------------
       XRootDStatus ListXAttr( ResponseHandler           *handler,
-                              uint16_t                   timeout = 0 );
+                              time_t                     timeout = 0 );
 
       //------------------------------------------------------------------------
       //! List extended attributes - sync
@@ -740,7 +740,7 @@ namespace XrdCl
       //! @return        : status of the operation
       //------------------------------------------------------------------------
       XRootDStatus ListXAttr( std::vector<XAttr>  &result,
-                              uint16_t             timeout = 0 );
+                              time_t               timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Try different data server
@@ -750,7 +750,7 @@ namespace XrdCl
       //!
       //! @return        : status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus TryOtherServer( uint16_t timeout = 0 );
+      XRootDStatus TryOtherServer( time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Check if the file is open
@@ -808,7 +808,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Checkpoint( kXR_char                  code,
                                ResponseHandler          *handler,
-                               uint16_t                  timeout = 0 );
+                               time_t                    timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Checkpointed write - async
@@ -825,7 +825,7 @@ namespace XrdCl
                              uint32_t         size,
                              const void      *buffer,
                              ResponseHandler *handler,
-                             uint16_t         timeout = 0 );
+                             time_t           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Checkpointed WriteV - async
@@ -842,7 +842,7 @@ namespace XrdCl
                               const struct iovec *iov,
                               int                 iovcnt,
                               ResponseHandler    *handler,
-                              uint16_t            timeout = 0 );
+                              time_t              timeout = 0 );
 
       FileImpl   *pImpl;
       FilePlugIn *pPlugIn;

--- a/src/XrdCl/XrdClFileOperations.hh
+++ b/src/XrdCl/XrdClFileOperations.hh
@@ -198,12 +198,12 @@ namespace XrdCl
       //! @param pipelineTimeout : pipeline timeout
       //! @return                : status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         const std::string &url     = std::get<UrlArg>( this->args );
         OpenFlags::Flags   flags   = std::get<FlagsArg>( this->args );
         Access::Mode       mode    = std::get<ModeArg>( this->args );
-        uint16_t           timeout = pipelineTimeout < this->timeout ?
+        time_t             timeout = pipelineTimeout < this->timeout ?
                                      pipelineTimeout : this->timeout;
         return this->file->Open( url, flags, mode, handler, timeout );
       }
@@ -213,7 +213,7 @@ namespace XrdCl
   //! Factory for creating ReadImpl objects
   //----------------------------------------------------------------------------
   inline OpenImpl<false> Open( Ctx<File> file, Arg<std::string> url, Arg<OpenFlags::Flags> flags,
-                               Arg<Access::Mode> mode = Access::None, uint16_t timeout = 0 )
+                               Arg<Access::Mode> mode = Access::None, time_t timeout = 0 )
   {
     return OpenImpl<false>( std::move( file ), std::move( url ), std::move( flags ),
                             std::move( mode ) ).Timeout( timeout );
@@ -256,12 +256,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t  offset  = std::get<OffsetArg>( this->args ).Get();
         uint32_t  size    = std::get<SizeArg>( this->args ).Get();
         void     *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t  timeout = pipelineTimeout < this->timeout ?
+        time_t    timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->file->Read( offset, size, buffer, handler, timeout );
       }
@@ -271,7 +271,7 @@ namespace XrdCl
   //! Factory for creating ReadImpl objects
   //----------------------------------------------------------------------------
   inline ReadImpl<false> Read( Ctx<File> file, Arg<uint64_t> offset, Arg<uint32_t> size,
-                               Arg<void*> buffer, uint16_t timeout = 0 )
+                               Arg<void*> buffer, time_t timeout = 0 )
   {
     return ReadImpl<false>( std::move( file ), std::move( offset ), std::move( size ),
                             std::move( buffer ) ).Timeout( timeout );
@@ -314,12 +314,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t  offset  = std::get<OffsetArg>( this->args ).Get();
         uint32_t  size    = std::get<SizeArg>( this->args ).Get();
         void     *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t  timeout = pipelineTimeout < this->timeout ?
+        time_t    timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->file->PgRead( offset, size, buffer, handler, timeout );
       }
@@ -330,7 +330,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline PgReadImpl<false> PgRead( Ctx<File> file, Arg<uint64_t> offset,
                                  Arg<uint32_t> size, Arg<void*> buffer,
-                                 uint16_t timeout = 0 )
+                                 time_t timeout = 0 )
   {
     return PgReadImpl<false>( std::move( file ), std::move( offset ), std::move( size ),
                             std::move( buffer ) ).Timeout( timeout );
@@ -347,11 +347,11 @@ namespace XrdCl
 
   template<typename RSP> inline typename ReadTrait<RSP>::RET
   RdWithRsp( Ctx<File> file, Arg<uint64_t> offset, Arg<uint32_t> size,
-             Arg<void*> buffer, uint16_t timeout = 0 );
+             Arg<void*> buffer, time_t timeout = 0 );
 
   template<> inline ReadImpl<false>
   RdWithRsp<ChunkInfo>( Ctx<File> file, Arg<uint64_t> offset, Arg<uint32_t> size,
-                        Arg<void*> buffer, uint16_t timeout )
+                        Arg<void*> buffer, time_t timeout )
   {
     return Read( std::move( file ), std::move( offset ), std::move( size ),
                  std::move( buffer ), timeout );
@@ -359,7 +359,7 @@ namespace XrdCl
 
   template<> inline PgReadImpl<false>
   RdWithRsp<PageInfo>( Ctx<File> file, Arg<uint64_t> offset, Arg<uint32_t> size,
-                       Arg<void*> buffer, uint16_t timeout )
+                       Arg<void*> buffer, time_t timeout )
   {
     return PgRead( std::move( file ), std::move( offset ), std::move( size ),
                    std::move( buffer ), timeout );
@@ -402,13 +402,13 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t               offset = std::get<OffsetArg>( this->args ).Get();
         uint32_t               size   = std::get<SizeArg>( this->args ).Get();
         void                  *buffer = std::get<BufferArg>( this->args ).Get();
         std::vector<uint32_t>  cksums = std::get<CksumsArg>( this->args ).Get();
-        uint16_t  timeout = pipelineTimeout < this->timeout ?
+        time_t    timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->file->PgWrite( offset, size, buffer, cksums, handler, timeout );
       }
@@ -420,7 +420,7 @@ namespace XrdCl
   inline PgWriteImpl<false> PgWrite( Ctx<File> file, Arg<uint64_t> offset,
                                     Arg<uint32_t> size, Arg<void*> buffer,
                                     Arg<std::vector<uint32_t>> cksums,
-                                    uint16_t timeout = 0 )
+                                    time_t timeout = 0 )
   {
     return PgWriteImpl<false>( std::move( file ), std::move( offset ), std::move( size ),
                                std::move( buffer ), std::move( cksums ) ).Timeout( timeout );
@@ -431,7 +431,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline PgWriteImpl<false> PgWrite( Ctx<File> file, Arg<uint64_t> offset,
                                     Arg<uint32_t> size, Arg<void*> buffer,
-                                    uint16_t timeout = 0 )
+                                    time_t timeout = 0 )
   {
     std::vector<uint32_t> cksums;
     return PgWriteImpl<false>( std::move( file ), std::move( offset ), std::move( size ),
@@ -468,9 +468,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->file->Close( handler, timeout );
       }
@@ -479,7 +479,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   //! Factory for creating CloseImpl objects
   //----------------------------------------------------------------------------
-  inline CloseImpl<false> Close( Ctx<File> file, uint16_t timeout = 0 )
+  inline CloseImpl<false> Close( Ctx<File> file, time_t timeout = 0 )
   {
     return CloseImpl<false>( std::move( file ) ).Timeout( timeout );
   }
@@ -519,10 +519,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         bool     force   = std::get<ForceArg>( this->args ).Get();
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->file->Stat( force, handler, timeout );
       }
@@ -532,7 +532,7 @@ namespace XrdCl
   //! Factory for creating StatImpl objects (as there is another Stat in
   //! FileSystem there would be a clash of typenames).
   //----------------------------------------------------------------------------
-  inline StatImpl<false> Stat( Ctx<File> file, Arg<bool> force, uint16_t timeout = 0 )
+  inline StatImpl<false> Stat( Ctx<File> file, Arg<bool> force, time_t timeout = 0 )
   {
     return StatImpl<false>( std::move( file ), std::move( force ) ).Timeout( timeout );
   }
@@ -574,12 +574,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t    offset = std::get<OffsetArg>( this->args ).Get();
         uint32_t    size   = std::get<SizeArg>( this->args ).Get();
         const void *buffer = std::get<BufferArg>( this->args ).Get();
-        uint16_t    timeout = pipelineTimeout < this->timeout ?
+        time_t      timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->file->Write( offset, size, buffer, handler, timeout );
       }
@@ -589,7 +589,7 @@ namespace XrdCl
   //! Factory for creating WriteImpl objects
   //----------------------------------------------------------------------------
   inline WriteImpl<false> Write( Ctx<File> file, Arg<uint64_t> offset, Arg<uint32_t> size,
-                                 Arg<const void*> buffer, uint16_t timeout = 0 )
+                                 Arg<const void*> buffer, time_t timeout = 0 )
   {
     return WriteImpl<false>( std::move( file ), std::move( offset ), std::move( size ),
                              std::move( buffer ) ).Timeout( timeout );
@@ -625,9 +625,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->file->Sync( handler, timeout );
       }
@@ -636,7 +636,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   //! Factory for creating SyncImpl objects
   //----------------------------------------------------------------------------
-  inline SyncImpl<false> Sync( Ctx<File> file, uint16_t timeout = 0 )
+  inline SyncImpl<false> Sync( Ctx<File> file, time_t timeout = 0 )
   {
     return SyncImpl<false>( std::move( file ) ).Timeout( timeout );
   }
@@ -676,10 +676,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t size    = std::get<SizeArg>( this->args ).Get();
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->file->Truncate( size, handler, timeout );
       }
@@ -689,7 +689,7 @@ namespace XrdCl
   //! Factory for creating TruncateImpl objects (as there is another Stat in
   //! FileSystem there would be a clash of typenames).
   //----------------------------------------------------------------------------
-  inline TruncateImpl<false> Truncate( Ctx<File> file, Arg<uint64_t> size, uint16_t timeout )
+  inline TruncateImpl<false> Truncate( Ctx<File> file, Arg<uint64_t> size, time_t timeout )
   {
     return TruncateImpl<false>( std::move( file ), std::move( size ) ).Timeout( timeout );
   }
@@ -731,11 +731,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         ChunkList &chunks  = std::get<ChunksArg>( this->args ).Get();
         void      *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t   timeout = pipelineTimeout < this->timeout ?
+        time_t     timeout = pipelineTimeout < this->timeout ?
                              pipelineTimeout : this->timeout;
         return this->file->VectorRead( chunks, buffer, handler, timeout );
       }
@@ -745,13 +745,13 @@ namespace XrdCl
   //! Factory for creating VectorReadImpl objects
   //----------------------------------------------------------------------------
   inline VectorReadImpl<false> VectorRead( Ctx<File> file, Arg<ChunkList> chunks,
-                                           Arg<void*> buffer, uint16_t timeout = 0 )
+                                           Arg<void*> buffer, time_t timeout = 0 )
   {
     return VectorReadImpl<false>( std::move( file ), std::move( chunks ), std::move( buffer ) ).Timeout( timeout );
   }
 
   inline VectorReadImpl<false> VectorRead( Ctx<File> file, Arg<ChunkList> chunks,
-                                           uint16_t timeout = 0 )
+                                           time_t timeout = 0 )
   {
     return VectorReadImpl<false>( std::move( file ), std::move( chunks ), nullptr ).Timeout( timeout );
   }
@@ -792,10 +792,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         const ChunkList &chunks  = std::get<ChunksArg>( this->args ).Get();
-        uint16_t         timeout = pipelineTimeout < this->timeout ?
+        time_t           timeout = pipelineTimeout < this->timeout ?
                                    pipelineTimeout : this->timeout;
         return this->file->VectorWrite( chunks, handler, timeout );
       }
@@ -805,7 +805,7 @@ namespace XrdCl
   //! Factory for creating VectorWriteImpl objects
   //----------------------------------------------------------------------------
   inline VectorWriteImpl<false> VectorWrite( Ctx<File> file, Arg<ChunkList> chunks,
-                                             uint16_t timeout = 0 )
+                                             time_t timeout = 0 )
   {
     return VectorWriteImpl<false>( std::move( file ), std::move( chunks ) ).Timeout( timeout );
   }
@@ -847,11 +847,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t            offset  = std::get<OffsetArg>( this->args ).Get();
         std::vector<iovec> &stdiov  = std::get<IovArg>( this->args ).Get();
-        uint16_t            timeout = pipelineTimeout < this->timeout ?
+        time_t              timeout = pipelineTimeout < this->timeout ?
                                       pipelineTimeout : this->timeout;
 
         int iovcnt = stdiov.size();
@@ -870,7 +870,7 @@ namespace XrdCl
   //! Factory for creating WriteVImpl objects
   //----------------------------------------------------------------------------
   inline WriteVImpl<false> WriteV( Ctx<File> file, Arg<uint64_t> offset,
-                                   Arg<std::vector<iovec>> iov, uint16_t timeout = 0 )
+                                   Arg<std::vector<iovec>> iov, time_t timeout = 0 )
   {
     return WriteVImpl<false>( std::move( file ), std::move( offset ),
                               std::move( iov ) ).Timeout( timeout );
@@ -911,10 +911,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         Buffer   &arg     = std::get<BufferArg>( this->args ).Get();
-        uint16_t  timeout = pipelineTimeout < this->timeout ?
+        time_t    timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->file->Fcntl( arg, handler, timeout );
       }
@@ -951,9 +951,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->file->Visa( handler, timeout );
       }
@@ -997,7 +997,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &name  = std::get<NameArg>( this->args ).Get();
         std::string &value = std::get<ValueArg>( this->args ).Get();
@@ -1006,7 +1006,7 @@ namespace XrdCl
         attrs.push_back( xattr_t( name, value ) );
         // wrap the PipelineHandler so the response gets unpacked properly
         UnpackXAttrStatus *h = new UnpackXAttrStatus( handler );
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                      pipelineTimeout : this->timeout;
         XRootDStatus st = this->file->SetXAttr( attrs, h, timeout );
         if( !st.IsOK() ) delete h;
@@ -1061,10 +1061,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::vector<xattr_t> &attrs   = std::get<AttrsArg>( this->args ).Get();
-        uint16_t              timeout = pipelineTimeout < this->timeout ?
+        time_t                timeout = pipelineTimeout < this->timeout ?
                                         pipelineTimeout : this->timeout;
         return this->file->SetXAttr( attrs, handler, timeout );
       }
@@ -1116,7 +1116,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &name = std::get<NameArg>( this->args ).Get();
         // wrap the argument with a vector
@@ -1124,7 +1124,7 @@ namespace XrdCl
         attrs.push_back( name );
         // wrap the PipelineHandler so the response gets unpacked properly
         UnpackXAttr   *h = new UnpackXAttr( handler );
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         XRootDStatus st = this->file->GetXAttr( attrs, h, timeout );
         if( !st.IsOK() ) delete h;
@@ -1179,10 +1179,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::vector<std::string> &attrs   = std::get<NamesArg>( this->args ).Get();
-        uint16_t                  timeout = pipelineTimeout < this->timeout ?
+        time_t                    timeout = pipelineTimeout < this->timeout ?
                                             pipelineTimeout : this->timeout;
         return this->file->GetXAttr( attrs, handler, timeout );
       }
@@ -1233,7 +1233,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &name = std::get<NameArg>( this->args ).Get();
         // wrap the argument with a vector
@@ -1241,7 +1241,7 @@ namespace XrdCl
         attrs.push_back( name );
         // wrap the PipelineHandler so the response gets unpacked properly
         UnpackXAttrStatus *h = new UnpackXAttrStatus( handler );
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         XRootDStatus st = this->file->DelXAttr( attrs, h, timeout );
         if( !st.IsOK() ) delete h;
@@ -1296,10 +1296,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::vector<std::string> &attrs   = std::get<NamesArg>( this->args ).Get();
-        uint16_t                  timeout = pipelineTimeout < this->timeout ?
+        time_t                    timeout = pipelineTimeout < this->timeout ?
                                             pipelineTimeout : this->timeout;
         return this->file->DelXAttr( attrs, handler, timeout );
       }
@@ -1346,9 +1346,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->file->ListXAttr( handler, timeout );
       }

--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -749,7 +749,7 @@ namespace XrdCl
                                        uint16_t                           flags,
                                        uint16_t                           mode,
                                        ResponseHandler                   *handler,
-                                       uint16_t                           timeout )
+                                       time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -873,7 +873,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileStateHandler::Close( std::shared_ptr<FileStateHandler> &self,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout )
+                                        time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -952,7 +952,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::Stat( std::shared_ptr<FileStateHandler> &self,
                                        bool                               force,
                                        ResponseHandler                   *handler,
-                                       uint16_t                           timeout )
+                                       time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1011,7 +1011,7 @@ namespace XrdCl
                                        uint32_t         size,
                                        void            *buffer,
                                        ResponseHandler *handler,
-                                       uint16_t         timeout )
+                                       time_t           timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1057,7 +1057,7 @@ namespace XrdCl
                                          uint32_t                           size,
                                          void                              *buffer,
                                          ResponseHandler                   *handler,
-                                         uint16_t                           timeout )
+                                         time_t                             timeout )
   {
     int issupported = true;
     AnyObject obj;
@@ -1096,7 +1096,7 @@ namespace XrdCl
                                               size_t                             pgnb,
                                               void                              *buffer,
                                               PgReadHandler                     *handler,
-                                              uint16_t                           timeout )
+                                              time_t                             timeout )
   {
     if( size > (uint32_t)XrdSys::PageSize )
       return XRootDStatus( stError, errInvalidArgs, EINVAL,
@@ -1114,7 +1114,7 @@ namespace XrdCl
                                              void                              *buffer,
                                              uint16_t                           flags,
                                              ResponseHandler                   *handler,
-                                             uint16_t                           timeout )
+                                             time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1170,7 +1170,7 @@ namespace XrdCl
                                         uint32_t                           size,
                                         const void                        *buffer,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout )
+                                        time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1217,7 +1217,7 @@ namespace XrdCl
                                         uint64_t                           offset,
                                         Buffer                           &&buffer,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout )
+                                        time_t                             timeout )
   {
     //--------------------------------------------------------------------------
     // If the memory is not page (4KB) aligned we cannot use the kernel buffer
@@ -1269,7 +1269,7 @@ namespace XrdCl
                                         Optional<uint64_t>                 fdoff,
                                         int                                fd,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout )
+                                        time_t                             timeout )
   {
     //--------------------------------------------------------------------------
     // Read the data from the file descriptor into a kernel buffer
@@ -1295,7 +1295,7 @@ namespace XrdCl
                                           const void                        *buffer,
                                           std::vector<uint32_t>             &cksums,
                                           ResponseHandler                   *handler,
-                                          uint16_t                           timeout )
+                                          time_t                             timeout )
   {
     //--------------------------------------------------------------------------
     // Resolve timeout value
@@ -1384,7 +1384,7 @@ namespace XrdCl
           }
           delete s;
           // first adjust the timeout value
-          uint16_t elapsed = ::time( nullptr ) - start;
+          time_t elapsed = ::time( nullptr ) - start;
           if( elapsed >= timeout )
           {
             pgwrt->SetStatus( new XRootDStatus( stError, errOperationExpired ) );
@@ -1451,7 +1451,7 @@ namespace XrdCl
                                                const void                        *buffer,
                                                uint32_t                           digest,
                                                ResponseHandler                   *handler,
-                                               uint16_t                           timeout )
+                                               time_t                             timeout )
   {
     std::vector<uint32_t> cksums{ digest };
     return PgWriteImpl( self, offset, size, buffer, cksums, PgReadFlags::Retry, handler, timeout );
@@ -1467,7 +1467,7 @@ namespace XrdCl
                                               std::vector<uint32_t>             &cksums,
                                               kXR_char                           flags,
                                               ResponseHandler                   *handler,
-                                              uint16_t                           timeout )
+                                              time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1517,7 +1517,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileStateHandler::Sync( std::shared_ptr<FileStateHandler> &self,
                                        ResponseHandler                   *handler,
-                                       uint16_t                           timeout )
+                                       time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1556,7 +1556,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::Truncate( std::shared_ptr<FileStateHandler> &self,
                                            uint64_t                           size,
                                            ResponseHandler                   *handler,
-                                           uint16_t                           timeout )
+                                           time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1597,7 +1597,7 @@ namespace XrdCl
                                              const ChunkList                   &chunks,
                                              void                              *buffer,
                                              ResponseHandler                   *handler,
-                                             uint16_t                           timeout )
+                                             time_t                             timeout )
   {
     //--------------------------------------------------------------------------
     // Sanity check
@@ -1673,7 +1673,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::VectorWrite( std::shared_ptr<FileStateHandler> &self,
                                               const ChunkList                   &chunks,
                                               ResponseHandler                   *handler,
-                                              uint16_t                           timeout )
+                                              time_t                             timeout )
   {
     //--------------------------------------------------------------------------
     // Sanity check
@@ -1752,7 +1752,7 @@ namespace XrdCl
                                          const struct iovec                *iov,
                                          int                                iovcnt,
                                          ResponseHandler                   *handler,
-                                         uint16_t                           timeout )
+                                         time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1808,7 +1808,7 @@ namespace XrdCl
                                         struct iovec                      *iov,
                                         int                                iovcnt,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout )
+                                        time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1865,7 +1865,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::Fcntl( std::shared_ptr<FileStateHandler> &self,
                                         const Buffer                      &arg,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout )
+                                        time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1906,7 +1906,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileStateHandler::Visa( std::shared_ptr<FileStateHandler> &self,
                                        ResponseHandler                   *handler,
-                                       uint16_t                           timeout )
+                                       time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1946,7 +1946,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::SetXAttr( std::shared_ptr<FileStateHandler> &self,
                                            const std::vector<xattr_t>        &attrs,
                                            ResponseHandler                   *handler,
-                                           uint16_t                           timeout )
+                                           time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1972,7 +1972,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::GetXAttr( std::shared_ptr<FileStateHandler> &self,
                                            const std::vector<std::string>    &attrs,
                                            ResponseHandler                   *handler,
-                                           uint16_t                           timeout )
+                                           time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -1998,7 +1998,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::DelXAttr( std::shared_ptr<FileStateHandler> &self,
                                            const std::vector<std::string>    &attrs,
                                            ResponseHandler                   *handler,
-                                           uint16_t                           timeout )
+                                           time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -2023,7 +2023,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus FileStateHandler::ListXAttr( std::shared_ptr<FileStateHandler> &self,
                                             ResponseHandler  *handler,
-                                            uint16_t          timeout )
+                                            time_t            timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -2059,7 +2059,7 @@ namespace XrdCl
   XRootDStatus FileStateHandler::Checkpoint( std::shared_ptr<FileStateHandler> &self,
                                              kXR_char                           code,
                                              ResponseHandler                   *handler,
-                                             uint16_t                           timeout )
+                                             time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -2110,7 +2110,7 @@ namespace XrdCl
                                            uint32_t                           size,
                                            const void                        *buffer,
                                            ResponseHandler                   *handler,
-                                           uint16_t                           timeout )
+                                           time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -2172,7 +2172,7 @@ namespace XrdCl
                                             const struct iovec                *iov,
                                             int                                iovcnt,
                                             ResponseHandler                   *handler,
-                                            uint16_t                           timeout )
+                                            time_t                             timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -2765,7 +2765,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   // Try other data server
   //------------------------------------------------------------------------
-  XRootDStatus FileStateHandler::TryOtherServer( std::shared_ptr<FileStateHandler> &self, uint16_t timeout )
+  XRootDStatus FileStateHandler::TryOtherServer( std::shared_ptr<FileStateHandler> &self, time_t timeout )
   {
     XrdSysMutexHelper scopedLock( self->pMutex );
 
@@ -2806,7 +2806,7 @@ namespace XrdCl
                                                kXR_char                           options,
                                                const std::vector<T>              &attrs,
                                                ResponseHandler                   *handler,
-                                               uint16_t                           timeout )
+                                               time_t                             timeout )
   {
     //--------------------------------------------------------------------------
     // Issue a new fattr request
@@ -2977,7 +2977,7 @@ namespace XrdCl
   // Send a close and ignore the response
   //----------------------------------------------------------------------------
   XRootDStatus FileStateHandler::SendClose( std::shared_ptr<FileStateHandler> &self,
-                                            uint16_t                           timeout )
+                                            time_t                             timeout )
   {
     Message            *msg;
     ClientCloseRequest *req;
@@ -3005,7 +3005,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileStateHandler::ReOpenFileAtServer( std::shared_ptr<FileStateHandler> &self,
                                                      const URL                         &url,
-                                                     uint16_t                           timeout )
+                                                     time_t                             timeout )
   {
     Log *log = DefaultEnv::GetLog();
     log->Dump( FileMsg, "[0x%x@%s] Sending a recovery open command to %s",
@@ -3247,7 +3247,7 @@ namespace XrdCl
                                                     uint32_t                               length,
                                                     std::unique_ptr<XrdSys::KernelBuffer>  kbuff,
                                                     ResponseHandler                       *handler,
-                                                    uint16_t                               timeout )
+                                                    time_t                                 timeout )
   {
     //--------------------------------------------------------------------------
     // Create the write request

--- a/src/XrdCl/XrdClFileStateHandler.hh
+++ b/src/XrdCl/XrdClFileStateHandler.hh
@@ -131,7 +131,7 @@ namespace XrdCl
                                 uint16_t                           flags,
                                 uint16_t                           mode,
                                 ResponseHandler                   *handler,
-                                uint16_t                           timeout  = 0 );
+                                time_t                             timeout  = 0 );
 
       //------------------------------------------------------------------------
       //! Close the file object
@@ -143,7 +143,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       static XRootDStatus Close( std::shared_ptr<FileStateHandler> &self,
                                  ResponseHandler                   *handler,
-                                 uint16_t                           timeout = 0 );
+                                 time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Obtain status information for this file - async
@@ -159,7 +159,7 @@ namespace XrdCl
       static XRootDStatus Stat( std::shared_ptr<FileStateHandler> &self,
                                 bool                               force,
                                 ResponseHandler                   *handler,
-                                uint16_t                           timeout = 0 );
+                                time_t                             timeout = 0 );
 
 
       //------------------------------------------------------------------------
@@ -183,7 +183,7 @@ namespace XrdCl
                                 uint32_t                           size,
                                 void                              *buffer,
                                 ResponseHandler                   *handler,
-                                uint16_t                           timeout = 0 );
+                                time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read data pages at a given offset
@@ -204,7 +204,7 @@ namespace XrdCl
                                   uint32_t                           size,
                                   void                              *buffer,
                                   ResponseHandler                   *handler,
-                                  uint16_t                           timeout = 0 );
+                                  time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Retry reading one page of data at a given offset
@@ -224,7 +224,7 @@ namespace XrdCl
                                        size_t                             pgnb,
                                        void                              *buffer,
                                        PgReadHandler                     *handler,
-                                       uint16_t                           timeout = 0 );
+                                       time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read data pages at a given offset (actual implementation)
@@ -247,7 +247,7 @@ namespace XrdCl
                                       void                              *buffer,
                                       uint16_t                           flags,
                                       ResponseHandler                   *handler,
-                                      uint16_t                           timeout = 0 );
+                                      time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data chunk at a given offset - async
@@ -265,7 +265,7 @@ namespace XrdCl
                                  uint32_t                           size,
                                  const void                        *buffer,
                                  ResponseHandler                   *handler,
-                                 uint16_t                           timeout = 0 );
+                                 time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data chunk at a given offset - async
@@ -282,7 +282,7 @@ namespace XrdCl
                                  uint64_t                           offset,
                                  Buffer                           &&buffer,
                                  ResponseHandler                   *handler,
-                                 uint16_t                           timeout = 0 );
+                                 time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data from a given file descriptor at a given offset - async
@@ -304,7 +304,7 @@ namespace XrdCl
                                  Optional<uint64_t>                 fdoff,
                                  int                                fd,
                                  ResponseHandler                   *handler,
-                                 uint16_t                           timeout = 0 );
+                                 time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write number of pages at a given offset - async
@@ -324,7 +324,7 @@ namespace XrdCl
                                    const void                        *buffer,
                                    std::vector<uint32_t>             &cksums,
                                    ResponseHandler                   *handler,
-                                   uint16_t                           timeout = 0 );
+                                   time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write number of pages at a given offset - async
@@ -343,7 +343,7 @@ namespace XrdCl
                                         const void                        *buffer,
                                         uint32_t                           digest,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout = 0 );
+                                        time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write number of pages at a given offset - async
@@ -365,7 +365,7 @@ namespace XrdCl
                                        std::vector<uint32_t>             &cksums,
                                        kXR_char                           flags,
                                        ResponseHandler                   *handler,
-                                       uint16_t                           timeout = 0 );
+                                       time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Commit all pending disk writes - async
@@ -377,7 +377,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       static XRootDStatus Sync( std::shared_ptr<FileStateHandler> &self,
                                 ResponseHandler                   *handler,
-                                uint16_t                           timeout = 0 );
+                                time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Truncate the file to a particular size - async
@@ -391,7 +391,7 @@ namespace XrdCl
       static XRootDStatus Truncate( std::shared_ptr<FileStateHandler> &self,
                                     uint64_t                           size,
                                     ResponseHandler                   *handler,
-                                    uint16_t                           timeout = 0 );
+                                    time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read scattered data chunks in one operation - async
@@ -407,7 +407,7 @@ namespace XrdCl
                                       const ChunkList                   &chunks,
                                       void                              *buffer,
                                       ResponseHandler                   *handler,
-                                      uint16_t                           timeout = 0 );
+                                      time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write scattered data chunks in one operation - async
@@ -421,7 +421,7 @@ namespace XrdCl
       static XRootDStatus VectorWrite( std::shared_ptr<FileStateHandler> &self,
                                        const ChunkList                   &chunks,
                                        ResponseHandler                   *handler,
-                                       uint16_t                           timeout = 0 );
+                                       time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write scattered buffers in one operation - async
@@ -439,7 +439,7 @@ namespace XrdCl
                                   const struct iovec                *iov,
                                   int                                iovcnt,
                                   ResponseHandler                   *handler,
-                                  uint16_t                           timeout = 0 );
+                                  time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read data into scattered buffers in one operation - async
@@ -457,7 +457,7 @@ namespace XrdCl
                                  struct iovec                      *iov,
                                  int                                iovcnt,
                                  ResponseHandler                   *handler,
-                                 uint16_t                           timeout = 0 );
+                                 time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Performs a custom operation on an open file, server implementation
@@ -474,7 +474,7 @@ namespace XrdCl
       static XRootDStatus Fcntl( std::shared_ptr<FileStateHandler> &self,
                                  const Buffer                      &arg,
                                  ResponseHandler                   *handler,
-                                 uint16_t                           timeout = 0 );
+                                 time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get access token to a file - async
@@ -488,7 +488,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       static XRootDStatus Visa( std::shared_ptr<FileStateHandler> &self,
                                 ResponseHandler                   *handler,
-                                uint16_t                           timeout = 0 );
+                                time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Set extended attributes - async
@@ -505,7 +505,7 @@ namespace XrdCl
       static XRootDStatus SetXAttr( std::shared_ptr<FileStateHandler> &self,
                                     const std::vector<xattr_t>        &attrs,
                                     ResponseHandler                   *handler,
-                                    uint16_t                           timeout = 0 );
+                                    time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get extended attributes - async
@@ -522,7 +522,7 @@ namespace XrdCl
       static XRootDStatus GetXAttr( std::shared_ptr<FileStateHandler> &self,
                                     const std::vector<std::string>    &attrs,
                                     ResponseHandler                   *handler,
-                                    uint16_t                           timeout = 0 );
+                                    time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Delete extended attributes - async
@@ -539,7 +539,7 @@ namespace XrdCl
       static XRootDStatus DelXAttr( std::shared_ptr<FileStateHandler> &self,
                                     const std::vector<std::string>    &attrs,
                                     ResponseHandler                   *handler,
-                                    uint16_t                           timeout = 0 );
+                                    time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! List extended attributes - async
@@ -554,7 +554,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       static XRootDStatus ListXAttr( std::shared_ptr<FileStateHandler> &self,
                                      ResponseHandler                  *handler,
-                                     uint16_t                          timeout = 0 );
+                                     time_t                            timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Create a checkpoint
@@ -570,7 +570,7 @@ namespace XrdCl
       static XRootDStatus Checkpoint( std::shared_ptr<FileStateHandler> &self,
                                       kXR_char                           code,
                                       ResponseHandler                   *handler,
-                                      uint16_t                           timeout = 0 );
+                                      time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Checkpointed write - async
@@ -588,7 +588,7 @@ namespace XrdCl
                                     uint32_t                           size,
                                     const void                        *buffer,
                                     ResponseHandler                   *handler,
-                                    uint16_t                           timeout = 0 );
+                                    time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Checkpointed WriteV - async
@@ -606,7 +606,7 @@ namespace XrdCl
                                      const struct iovec                *iov,
                                      int                                iovcnt,
                                      ResponseHandler                   *handler,
-                                     uint16_t                           timeout = 0 );
+                                     time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Process the results of the opening operation
@@ -709,7 +709,7 @@ namespace XrdCl
       //! Try other data server
       //------------------------------------------------------------------------
       static XRootDStatus TryOtherServer( std::shared_ptr<FileStateHandler> &self,
-                                          uint16_t                           timeout );
+                                          time_t                             timeout );
 
     private:
       //------------------------------------------------------------------------
@@ -741,7 +741,7 @@ namespace XrdCl
                                         kXR_char                           options,
                                         const std::vector<T>              &attrs,
                                         ResponseHandler                   *handler,
-                                        uint16_t                           timeout = 0 );
+                                        time_t                             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Send a message to a host or put it in the recovery queue
@@ -777,7 +777,7 @@ namespace XrdCl
       // Send a close and ignore the response
       //------------------------------------------------------------------------
       static XRootDStatus SendClose( std::shared_ptr<FileStateHandler> &self,
-                                     uint16_t                           timeout );
+                                     time_t                             timeout );
 
       //------------------------------------------------------------------------
       //! Check if the file is open for read only
@@ -789,7 +789,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       static XRootDStatus ReOpenFileAtServer( std::shared_ptr<FileStateHandler> &self,
                                               const URL                         &url,
-                                              uint16_t                           timeout );
+                                              time_t                             timeout );
 
       //------------------------------------------------------------------------
       //! Fail a message
@@ -852,7 +852,7 @@ namespace XrdCl
                                              uint32_t                               length,
                                              std::unique_ptr<XrdSys::KernelBuffer>  kbuff,
                                              ResponseHandler                       *handler,
-                                             uint16_t                               timeout );
+                                             time_t                                 timeout );
 
       mutable XrdSysMutex     pMutex;
       FileStatus              pFileState;

--- a/src/XrdCl/XrdClFileSystem.cc
+++ b/src/XrdCl/XrdClFileSystem.cc
@@ -54,7 +54,7 @@ namespace
 
       XrdCl::XRootDStatus Stat( const std::string       &path,
                                 XrdCl::ResponseHandler  *handler,
-                                uint16_t                 timeout )
+                                time_t                   timeout )
       {
         using namespace XrdCl;
 
@@ -93,7 +93,7 @@ namespace
 
       XrdCl::XRootDStatus Rm( const std::string       &path,
                               XrdCl::ResponseHandler  *handler,
-                              uint16_t                 timeout )
+                              time_t                   timeout )
       {
         using namespace XrdCl;
 
@@ -1128,7 +1128,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Locate( const std::string &path,
                                    OpenFlags::Flags   flags,
                                    ResponseHandler   *handler,
-                                   uint16_t           timeout )
+                                   time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->Locate( path, flags, handler, timeout );
@@ -1157,7 +1157,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Locate( const std::string  &path,
                                    OpenFlags::Flags    flags,
                                    LocationInfo      *&response,
-                                   uint16_t            timeout )
+                                   time_t              timeout )
   {
     SyncResponseHandler handler;
     Status st = Locate( path, flags, &handler, timeout );
@@ -1173,7 +1173,7 @@ namespace XrdCl
   XRootDStatus FileSystem::DeepLocate( const std::string &path,
                                        OpenFlags::Flags   flags,
                                        ResponseHandler   *handler,
-                                       uint16_t           timeout )
+                                       time_t             timeout )
   {
     return Locate( path, flags,
                    new DeepLocateHandler( handler, path, flags, timeout ), timeout );
@@ -1185,7 +1185,7 @@ namespace XrdCl
   XRootDStatus FileSystem::DeepLocate( const std::string  &path,
                                        OpenFlags::Flags    flags,
                                        LocationInfo      *&response,
-                                       uint16_t            timeout )
+                                       time_t              timeout )
   {
     SyncResponseHandler handler;
     Status st = DeepLocate( path, flags, &handler, timeout );
@@ -1201,7 +1201,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Mv( const std::string &source,
                                const std::string &dest,
                                ResponseHandler   *handler,
-                               uint16_t           timeout )
+                               time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->Mv( source, dest, handler, timeout );
@@ -1232,7 +1232,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Mv( const std::string &source,
                                const std::string &dest,
-                               uint16_t           timeout )
+                               time_t             timeout )
   {
     SyncResponseHandler handler;
     Status st = Mv( source, dest, &handler, timeout );
@@ -1248,7 +1248,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Query( QueryCode::Code  queryCode,
                                   const Buffer    &arg,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Query( queryCode, arg, handler, timeout );
@@ -1274,7 +1274,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Query( QueryCode::Code   queryCode,
                                   const Buffer     &arg,
                                   Buffer          *&response,
-                                  uint16_t          timeout )
+                                  time_t            timeout )
   {
     SyncResponseHandler handler;
     Status st = Query( queryCode, arg, &handler, timeout );
@@ -1290,7 +1290,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Truncate( const std::string &path,
                                      uint64_t           size,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->Truncate( path, size, handler, timeout );
@@ -1317,7 +1317,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Truncate( const std::string &path,
                                      uint64_t           size,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
   {
     SyncResponseHandler handler;
     Status st = Truncate( path, size, &handler, timeout );
@@ -1332,7 +1332,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Rm( const std::string &path,
                                ResponseHandler   *handler,
-                               uint16_t           timeout )
+                               time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->Rm( path, handler, timeout );
@@ -1360,7 +1360,7 @@ namespace XrdCl
   // Remove a file - sync
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Rm( const std::string &path,
-                               uint16_t           timeout )
+                               time_t             timeout )
   {
     SyncResponseHandler handler;
     Status st = Rm( path, &handler, timeout );
@@ -1377,7 +1377,7 @@ namespace XrdCl
                                   MkDirFlags::Flags  flags,
                                   Access::Mode       mode,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->MkDir( path, flags, mode, handler, timeout );
@@ -1406,7 +1406,7 @@ namespace XrdCl
   XRootDStatus FileSystem::MkDir( const std::string &path,
                                   MkDirFlags::Flags  flags,
                                   Access::Mode       mode,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
   {
     SyncResponseHandler handler;
     Status st = MkDir( path, flags, mode, &handler, timeout );
@@ -1421,7 +1421,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::RmDir( const std::string &path,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->RmDir( path, handler, timeout );
@@ -1446,7 +1446,7 @@ namespace XrdCl
   // Remove a directory - sync
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::RmDir( const std::string &path,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
   {
     SyncResponseHandler handler;
     Status st = RmDir( path, &handler, timeout );
@@ -1462,7 +1462,7 @@ namespace XrdCl
   XRootDStatus FileSystem::ChMod( const std::string &path,
                                   Access::Mode       mode,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->ChMod( path, mode, handler, timeout );
@@ -1489,7 +1489,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::ChMod( const std::string &path,
                                   Access::Mode       mode,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
   {
     SyncResponseHandler handler;
     Status st = ChMod( path, mode, &handler, timeout );
@@ -1503,7 +1503,7 @@ namespace XrdCl
   // Check if the server is alive - async
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Ping( ResponseHandler *handler,
-                                 uint16_t        timeout )
+                                 time_t          timeout )
   {
     if( pPlugIn )
       return pPlugIn->Ping( handler, timeout );
@@ -1523,7 +1523,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Check if the server is alive - sync
   //----------------------------------------------------------------------------
-  XRootDStatus FileSystem::Ping( uint16_t timeout  )
+  XRootDStatus FileSystem::Ping( time_t   timeout  )
   {
     SyncResponseHandler handler;
     Status st = Ping( &handler, timeout );
@@ -1538,7 +1538,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Stat( const std::string &path,
                                  ResponseHandler   *handler,
-                                 uint16_t           timeout )
+                                 time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->Stat( path, handler, timeout );
@@ -1568,7 +1568,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Stat( const std::string  &path,
                                  StatInfo          *&response,
-                                 uint16_t            timeout )
+                                 time_t              timeout )
   {
     SyncResponseHandler handler;
     Status st = Stat( path, &handler, timeout );
@@ -1583,7 +1583,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::StatVFS( const std::string &path,
                                     ResponseHandler   *handler,
-                                    uint16_t           timeout )
+                                    time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->StatVFS( path, handler, timeout );
@@ -1610,7 +1610,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::StatVFS( const std::string  &path,
                                     StatInfoVFS       *&response,
-                                    uint16_t            timeout )
+                                    time_t              timeout )
   {
     SyncResponseHandler handler;
     Status st = StatVFS( path, &handler, timeout );
@@ -1624,7 +1624,7 @@ namespace XrdCl
   // Obtain server protocol information - async
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Protocol( ResponseHandler *handler,
-                                     uint16_t         timeout )
+                                     time_t           timeout )
   {
     if( pPlugIn )
       return pPlugIn->Protocol( handler, timeout );
@@ -1646,7 +1646,7 @@ namespace XrdCl
   // Obtain server protocol information - sync
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::Protocol( ProtocolInfo *&response,
-                                     uint16_t       timeout )
+                                     time_t         timeout )
   {
     SyncResponseHandler handler;
     Status st = Protocol( &handler, timeout );
@@ -1662,7 +1662,7 @@ namespace XrdCl
   XRootDStatus FileSystem::DirList( const std::string   &path,
                                     DirListFlags::Flags  flags,
                                     ResponseHandler     *handler,
-                                    uint16_t             timeout )
+                                    time_t               timeout )
   {
     if( pPlugIn )
       return pPlugIn->DirList( path, flags, handler, timeout );
@@ -1716,7 +1716,7 @@ namespace XrdCl
   XRootDStatus FileSystem::DirList( const std::string    &path,
                                     DirListFlags::Flags   flags,
                                     DirectoryList       *&response,
-                                    uint16_t              timeout )
+                                    time_t                timeout )
   {
     //--------------------------------------------------------------------------
     // Chunked response is only possible for async DirList call
@@ -1878,7 +1878,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::SendCache( const std::string &info,
                                       ResponseHandler   *handler,
-                                      uint16_t           timeout )
+                                      time_t             timeout )
   {
   // Note: adding SendCache() to the FileSystemPlugin class breaks ABI!
   // So, the class is missing this until we do a major release. TODO
@@ -1892,7 +1892,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::SendCache( const std::string  &info,
                                       Buffer            *&response,
-                                      uint16_t            timeout )
+                                      time_t              timeout )
   {
     SyncResponseHandler handler;
     Status st = SendCache( info, &handler, timeout );
@@ -1907,7 +1907,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::SendInfo( const std::string &info,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
   {
     if( pPlugIn )
       return pPlugIn->SendInfo( info, handler, timeout );
@@ -1919,7 +1919,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus FileSystem::SendInfo( const std::string  &info,
                                      Buffer            *&response,
-                                     uint16_t            timeout )
+                                     time_t              timeout )
   {
     SyncResponseHandler handler;
     Status st = SendInfo( info, &handler, timeout );
@@ -1935,7 +1935,7 @@ namespace XrdCl
   XRootDStatus FileSystem::SendSet(  const char        *prefix,
                                      const std::string &info,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
   {
 
     Message          *msg;
@@ -1961,7 +1961,7 @@ namespace XrdCl
                                     PrepareFlags::Flags             flags,
                                     uint8_t                         priority,
                                     ResponseHandler                *handler,
-                                    uint16_t                        timeout )
+                                    time_t                          timeout )
   {
     if( pPlugIn )
       return pPlugIn->Prepare( fileList, flags, priority, handler, timeout );
@@ -2001,7 +2001,7 @@ namespace XrdCl
                                     PrepareFlags::Flags              flags,
                                     uint8_t                          priority,
                                     Buffer                         *&response,
-                                    uint16_t                         timeout )
+                                    time_t                           timeout )
   {
     SyncResponseHandler handler;
     Status st = Prepare( fileList, flags, priority, &handler, timeout );
@@ -2017,7 +2017,7 @@ namespace XrdCl
   XRootDStatus FileSystem::SetXAttr( const std::string           &path,
                                      const std::vector<xattr_t>  &attrs,
                                      ResponseHandler             *handler,
-                                     uint16_t                     timeout )
+                                     time_t                       timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -2031,7 +2031,7 @@ namespace XrdCl
   XRootDStatus FileSystem::SetXAttr( const std::string           &path,
                                      const std::vector<xattr_t>  &attrs,
                                      std::vector<XAttrStatus>    &result,
-                                     uint16_t                     timeout )
+                                     time_t                       timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = SetXAttr( path, attrs, &handler, timeout );
@@ -2052,7 +2052,7 @@ namespace XrdCl
   XRootDStatus FileSystem::GetXAttr( const std::string               &path,
                                      const std::vector<std::string>  &attrs,
                                      ResponseHandler                 *handler,
-                                     uint16_t                         timeout )
+                                     time_t                           timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -2066,7 +2066,7 @@ namespace XrdCl
   XRootDStatus FileSystem::GetXAttr( const std::string               &path,
                                      const std::vector<std::string>  &attrs,
                                      std::vector<XAttr>              &result,
-                                     uint16_t                         timeout )
+                                     time_t                           timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = GetXAttr( path, attrs, &handler, timeout );
@@ -2087,7 +2087,7 @@ namespace XrdCl
   XRootDStatus FileSystem::DelXAttr( const std::string               &path,
                                      const std::vector<std::string>  &attrs,
                                      ResponseHandler                *handler,
-                                     uint16_t                        timeout )
+                                     time_t                          timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -2101,7 +2101,7 @@ namespace XrdCl
   XRootDStatus FileSystem::DelXAttr( const std::string               &path,
                                      const std::vector<std::string>  &attrs,
                                      std::vector<XAttrStatus>        &result,
-                                     uint16_t                         timeout )
+                                     time_t                           timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = DelXAttr( path, attrs, &handler, timeout );
@@ -2121,7 +2121,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus FileSystem::ListXAttr( const std::string         &path,
                                       ResponseHandler           *handler,
-                                      uint16_t                   timeout )
+                                      time_t                     timeout )
   {
     if( pPlugIn )
       return XRootDStatus( stError, errNotSupported );
@@ -2136,7 +2136,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus FileSystem::ListXAttr( const std::string    &path,
                                       std::vector<XAttr>   &result,
-                                      uint16_t              timeout )
+                                      time_t                timeout )
   {
     SyncResponseHandler handler;
     XRootDStatus st = ListXAttr( path, &handler, timeout );
@@ -2206,7 +2206,7 @@ namespace XrdCl
                                          const std::string     &path,
                                          const std::vector<T>  &attrs,
                                          ResponseHandler       *handler,
-                                         uint16_t               timeout )
+                                         time_t                 timeout )
   {
     Message            *msg;
     ClientFattrRequest *req;

--- a/src/XrdCl/XrdClFileSystem.hh
+++ b/src/XrdCl/XrdClFileSystem.hh
@@ -235,7 +235,7 @@ namespace XrdCl
       XRootDStatus Locate( const std::string &path,
                            OpenFlags::Flags   flags,
                            ResponseHandler   *handler,
-                           uint16_t           timeout = 0 )
+                           time_t             timeout = 0 )
                            XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -251,7 +251,7 @@ namespace XrdCl
       XRootDStatus Locate( const std::string  &path,
                            OpenFlags::Flags    flags,
                            LocationInfo      *&response,
-                           uint16_t            timeout  = 0 )
+                           time_t              timeout  = 0 )
                            XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -269,7 +269,7 @@ namespace XrdCl
       XRootDStatus DeepLocate( const std::string &path,
                                OpenFlags::Flags   flags,
                                ResponseHandler   *handler,
-                               uint16_t           timeout = 0 )
+                               time_t             timeout = 0 )
                                XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -285,7 +285,7 @@ namespace XrdCl
       XRootDStatus DeepLocate( const std::string  &path,
                                OpenFlags::Flags   flags,
                                LocationInfo      *&response,
-                               uint16_t            timeout  = 0 )
+                               time_t              timeout  = 0 )
                                XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -301,7 +301,7 @@ namespace XrdCl
       XRootDStatus Mv( const std::string &source,
                        const std::string &dest,
                        ResponseHandler   *handler,
-                       uint16_t           timeout = 0 )
+                       time_t             timeout = 0 )
                        XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -315,7 +315,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Mv( const std::string &source,
                        const std::string &dest,
-                       uint16_t           timeout = 0 )
+                       time_t             timeout = 0 )
                        XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -333,7 +333,7 @@ namespace XrdCl
       XRootDStatus Query( QueryCode::Code  queryCode,
                           const Buffer    &arg,
                           ResponseHandler *handler,
-                          uint16_t         timeout = 0 )
+                          time_t           timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -349,7 +349,7 @@ namespace XrdCl
       XRootDStatus Query( QueryCode::Code   queryCode,
                           const Buffer     &arg,
                           Buffer          *&response,
-                          uint16_t          timeout = 0 )
+                          time_t            timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -365,7 +365,7 @@ namespace XrdCl
       XRootDStatus Truncate( const std::string &path,
                              uint64_t           size,
                              ResponseHandler   *handler,
-                             uint16_t           timeout = 0 )
+                             time_t             timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -379,7 +379,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Truncate( const std::string &path,
                              uint64_t           size,
-                             uint16_t           timeout = 0 )
+                             time_t             timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -393,7 +393,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Rm( const std::string &path,
                        ResponseHandler   *handler,
-                       uint16_t           timeout = 0 )
+                       time_t             timeout = 0 )
                        XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -405,7 +405,7 @@ namespace XrdCl
       //! @return         status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Rm( const std::string &path,
-                       uint16_t           timeout = 0 )
+                       time_t             timeout = 0 )
                        XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -423,7 +423,7 @@ namespace XrdCl
                           MkDirFlags::Flags  flags,
                           Access::Mode       mode,
                           ResponseHandler   *handler,
-                          uint16_t           timeout = 0 )
+                          time_t             timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -439,7 +439,7 @@ namespace XrdCl
       XRootDStatus MkDir( const std::string &path,
                           MkDirFlags::Flags  flags,
                           Access::Mode       mode,
-                          uint16_t           timeout = 0 )
+                          time_t             timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -453,7 +453,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus RmDir( const std::string &path,
                           ResponseHandler   *handler,
-                          uint16_t           timeout = 0 )
+                          time_t             timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -465,7 +465,7 @@ namespace XrdCl
       //! @return         status of the operation
       //------------------------------------------------------------------------
       XRootDStatus RmDir( const std::string &path,
-                          uint16_t           timeout = 0 )
+                          time_t             timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -481,7 +481,7 @@ namespace XrdCl
       XRootDStatus ChMod( const std::string &path,
                           Access::Mode       mode,
                           ResponseHandler   *handler,
-                          uint16_t           timeout = 0 )
+                          time_t             timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -495,7 +495,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus ChMod( const std::string &path,
                           Access::Mode       mode,
-                          uint16_t           timeout = 0 )
+                          time_t             timeout = 0 )
                           XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -507,7 +507,7 @@ namespace XrdCl
       //! @return         status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Ping( ResponseHandler *handler,
-                         uint16_t         timeout = 0 )
+                         time_t           timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -517,7 +517,7 @@ namespace XrdCl
       //!                 be used
       //! @return         status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Ping( uint16_t timeout = 0 ) XRD_WARN_UNUSED_RESULT;
+      XRootDStatus Ping( time_t timeout = 0 ) XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
       //! Obtain status information for a path - async
@@ -532,7 +532,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Stat( const std::string &path,
                          ResponseHandler   *handler,
-                         uint16_t           timeout = 0 )
+                         time_t             timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -547,7 +547,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus Stat( const std::string  &path,
                          StatInfo          *&response,
-                         uint16_t            timeout = 0 )
+                         time_t              timeout = 0 )
                          XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -563,7 +563,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus StatVFS( const std::string &path,
                             ResponseHandler   *handler,
-                            uint16_t           timeout = 0 )
+                            time_t             timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -577,7 +577,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus StatVFS( const std::string  &path,
                             StatInfoVFS       *&response,
-                            uint16_t            timeout = 0 )
+                            time_t              timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -591,7 +591,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Protocol( ResponseHandler *handler,
-                             uint16_t         timeout = 0 )
+                             time_t           timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -603,7 +603,7 @@ namespace XrdCl
       //! @return         status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Protocol( ProtocolInfo *&response,
-                             uint16_t       timeout = 0 )
+                             time_t         timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -621,7 +621,7 @@ namespace XrdCl
       XRootDStatus DirList( const std::string   &path,
                             DirListFlags::Flags  flags,
                             ResponseHandler     *handler,
-                            uint16_t             timeout = 0 )
+                            time_t               timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -637,7 +637,7 @@ namespace XrdCl
       XRootDStatus DirList( const std::string    &path,
                             DirListFlags::Flags   flags,
                             DirectoryList       *&response,
-                            uint16_t              timeout = 0 )
+                            time_t                timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -653,7 +653,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SendCache( const std::string &info,
                               ResponseHandler   *handler,
-                              uint16_t           timeout = 0 )
+                              time_t             timeout = 0 )
                               XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -667,7 +667,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SendCache( const std::string  &info,
                               Buffer            *&response,
-                              uint16_t            timeout = 0 )
+                              time_t              timeout = 0 )
                               XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -683,7 +683,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SendInfo( const std::string &info,
                              ResponseHandler   *handler,
-                             uint16_t           timeout = 0 )
+                             time_t             timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -697,7 +697,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SendInfo( const std::string  &info,
                              Buffer            *&response,
-                             uint16_t            timeout = 0 )
+                             time_t              timeout = 0 )
                              XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -717,7 +717,7 @@ namespace XrdCl
                             PrepareFlags::Flags             flags,
                             uint8_t                         priority,
                             ResponseHandler                *handler,
-                            uint16_t                        timeout = 0 )
+                            time_t                          timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -735,7 +735,7 @@ namespace XrdCl
                             PrepareFlags::Flags              flags,
                             uint8_t                          priority,
                             Buffer                         *&response,
-                            uint16_t                         timeout = 0 )
+                            time_t                           timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -753,7 +753,7 @@ namespace XrdCl
       XRootDStatus SetXAttr( const std::string           &path,
                              const std::vector<xattr_t>  &attrs,
                              ResponseHandler             *handler,
-                             uint16_t                     timeout = 0 );
+                             time_t                       timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Set extended attributes - sync
@@ -768,7 +768,7 @@ namespace XrdCl
       XRootDStatus SetXAttr( const std::string           &path,
                              const std::vector<xattr_t>  &attrs,
                              std::vector<XAttrStatus>    &result,
-                             uint16_t                     timeout = 0 );
+                             time_t                       timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get extended attributes - async
@@ -785,7 +785,7 @@ namespace XrdCl
       XRootDStatus GetXAttr( const std::string               &path,
                              const std::vector<std::string>  &attrs,
                              ResponseHandler                 *handler,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get extended attributes - sync
@@ -800,7 +800,7 @@ namespace XrdCl
       XRootDStatus GetXAttr( const std::string               &path,
                              const std::vector<std::string>  &attrs,
                              std::vector<XAttr>              &result,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Delete extended attributes - async
@@ -817,7 +817,7 @@ namespace XrdCl
       XRootDStatus DelXAttr( const std::string               &path,
                              const std::vector<std::string>  &attrs,
                              ResponseHandler                 *handler,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Delete extended attributes - sync
@@ -832,7 +832,7 @@ namespace XrdCl
       XRootDStatus DelXAttr( const std::string               &path,
                              const std::vector<std::string>  &attrs,
                              std::vector<XAttrStatus>        &result,
-                             uint16_t                         timeout = 0 );
+                             time_t                           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! List extended attributes - async
@@ -847,7 +847,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus ListXAttr( const std::string         &path,
                               ResponseHandler           *handler,
-                              uint16_t                   timeout = 0 );
+                              time_t                     timeout = 0 );
 
       //------------------------------------------------------------------------
       //! List extended attributes - sync
@@ -860,7 +860,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus ListXAttr( const std::string    &path,
                               std::vector<XAttr>   &result,
-                              uint16_t              timeout = 0 );
+                              time_t                timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Set filesystem property
@@ -902,7 +902,7 @@ namespace XrdCl
       XRootDStatus SendSet( const char        *prefix,
                             const std::string &info,
                             ResponseHandler   *handler,
-                            uint16_t           timeout = 0 )
+                            time_t             timeout = 0 )
                             XRD_WARN_UNUSED_RESULT;
 
       //------------------------------------------------------------------------
@@ -920,7 +920,7 @@ namespace XrdCl
                                  const std::string    &path,
                                  const std::vector<T> &attrs,
                                  ResponseHandler      *handler,
-                                 uint16_t              timeout = 0 );
+                                 time_t                timeout = 0 );
 
       FileSystemImpl   *pImpl;   //< pointer to implementation (TODO: once we can break ABI we can use a shared pointer here, and then we can drop the FileSystemData in source file)
       FileSystemPlugIn *pPlugIn; //< file system plug-in

--- a/src/XrdCl/XrdClFileSystemOperations.hh
+++ b/src/XrdCl/XrdClFileSystemOperations.hh
@@ -124,11 +124,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
           std::string      &path    = std::get<PathArg>( this->args ).Get();
           OpenFlags::Flags  flags   = std::get<FlagsArg>( this->args ).Get();
-          uint16_t          timeout = pipelineTimeout < this->timeout ?
+          time_t            timeout = pipelineTimeout < this->timeout ?
                                       pipelineTimeout : this->timeout;
           return this->filesystem->Locate( path, flags, handler, timeout );
       }
@@ -172,11 +172,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string      &path    = std::get<PathArg>( this->args ).Get();
         OpenFlags::Flags  flags   = std::get<FlagsArg>( this->args ).Get();
-        uint16_t          timeout = pipelineTimeout < this->timeout ?
+        time_t            timeout = pipelineTimeout < this->timeout ?
                                     pipelineTimeout : this->timeout;
         return this->filesystem->DeepLocate( path, flags, handler, timeout );
       }
@@ -220,11 +220,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &source  = std::get<SourceArg>( this->args ).Get();
         std::string &dest    = std::get<DestArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->Mv( source, dest, handler, timeout );
       }
@@ -268,11 +268,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         QueryCode::Code  queryCode = std::get<QueryCodeArg>( this->args ).Get();
         const Buffer    &buffer( std::get<BufferArg>( this->args ).Get() );
-        uint16_t         timeout = pipelineTimeout < this->timeout ?
+        time_t           timeout = pipelineTimeout < this->timeout ?
                                    pipelineTimeout : this->timeout;
         return this->filesystem->Query( queryCode, buffer, handler, timeout );
       }
@@ -316,11 +316,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path    = std::get<PathArg>( this->args ).Get();
         uint64_t     size    = std::get<SizeArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->Truncate( path, size, handler, timeout );
       }
@@ -367,10 +367,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path    = std::get<PathArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                               pipelineTimeout : this->timeout;
         return this->filesystem->Rm( path, handler, timeout );
       }
@@ -414,12 +414,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string       &path    = std::get<PathArg>( this->args ).Get();
         MkDirFlags::Flags  flags   = std::get<FlagsArg>( this->args ).Get();
         Access::Mode       mode    = std::get<ModeArg>( this->args ).Get();
-        uint16_t           timeout = pipelineTimeout < this->timeout ?
+        time_t             timeout = pipelineTimeout < this->timeout ?
                                      pipelineTimeout : this->timeout;
         return this->filesystem->MkDir( path, flags, mode, handler, timeout );
       }
@@ -462,10 +462,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path    = std::get<PathArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->RmDir( path, handler, timeout );
       }
@@ -509,11 +509,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string  &path    = std::get<PathArg>( this->args ).Get();
         Access::Mode  mode    = std::get<ModeArg>( this->args ).Get();
-        uint16_t      timeout = pipelineTimeout < this->timeout ?
+        time_t        timeout = pipelineTimeout < this->timeout ?
                                 pipelineTimeout : this->timeout;
         return this->filesystem->ChMod( path, mode, handler, timeout );
       }
@@ -550,9 +550,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->filesystem->Ping( handler, timeout );
       }
@@ -596,10 +596,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path    = std::get<PathArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->Stat( path, handler, timeout );
       }
@@ -647,10 +647,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path    = std::get<PathArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->StatVFS( path, handler, timeout );
       }
@@ -688,9 +688,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->filesystem->Protocol( handler, timeout );
       }
@@ -734,11 +734,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string         &path    = std::get<PathArg>( this->args ).Get();
         DirListFlags::Flags  flags   = std::get<FlagsArg>( this->args ).Get();
-        uint16_t             timeout = pipelineTimeout < this->timeout ?
+        time_t               timeout = pipelineTimeout < this->timeout ?
                                        pipelineTimeout : this->timeout;
         return this->filesystem->DirList( path, flags, handler, timeout );
       }
@@ -782,10 +782,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &info    = std::get<InfoArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->SendInfo( info, handler, timeout );
       }
@@ -829,12 +829,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::vector<std::string> &fileList = std::get<FileListArg>( this->args ).Get();
         PrepareFlags::Flags       flags    = std::get<FlagsArg>( this->args ).Get();
         uint8_t                   priority = std::get<PriorityArg>( this->args ).Get();
-        uint16_t                  timeout  = pipelineTimeout < this->timeout ?
+        time_t                    timeout  = pipelineTimeout < this->timeout ?
                                              pipelineTimeout : this->timeout;
         return this->filesystem->Prepare( fileList, flags, priority,
             handler, timeout );
@@ -879,7 +879,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path  = std::get<PathArg>( this->args ).Get();
         std::string &name  = std::get<NameArg>( this->args ).Get();
@@ -889,7 +889,7 @@ namespace XrdCl
         attrs.push_back( xattr_t( name, value ) );
         // wrap the PipelineHandler so the response gets unpacked properly
         UnpackXAttrStatus *h = new UnpackXAttrStatus( handler );
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         XRootDStatus st = this->filesystem->SetXAttr( path, attrs, h, timeout );
         if( !st.IsOK() ) delete h;
@@ -944,11 +944,11 @@ namespace XrdCl
       //!
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string          &path    = std::get<PathArg>( this->args ).Get();
         std::vector<xattr_t> &attrs   = std::get<AttrsArg>( this->args ).Get();
-        uint16_t              timeout = pipelineTimeout < this->timeout ?
+        time_t                timeout = pipelineTimeout < this->timeout ?
                                         pipelineTimeout : this->timeout;
         return this->filesystem->SetXAttr( path, attrs, handler, timeout );
       }
@@ -999,7 +999,7 @@ namespace XrdCl
       //!
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path = std::get<PathArg>( this->args ).Get();
         std::string &name = std::get<NameArg>( this->args ).Get();
@@ -1008,7 +1008,7 @@ namespace XrdCl
         attrs.push_back( name );
         // wrap the PipelineHandler so the response gets unpacked properly
         UnpackXAttr   *h = new UnpackXAttr( handler );
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         XRootDStatus st = this->filesystem->GetXAttr( path, attrs, h, timeout );
         if( !st.IsOK() ) delete h;
@@ -1062,11 +1062,11 @@ namespace XrdCl
       //!
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string              &path    = std::get<PathArg>( this->args ).Get();
         std::vector<std::string> &attrs   = std::get<NamesArg>( this->args ).Get();
-        uint16_t                  timeout = pipelineTimeout < this->timeout ?
+        time_t                    timeout = pipelineTimeout < this->timeout ?
                                             pipelineTimeout : this->timeout;
         return this->filesystem->GetXAttr( path, attrs, handler, timeout );
       }
@@ -1119,7 +1119,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path = std::get<PathArg>( this->args ).Get();
         std::string &name = std::get<NameArg>( this->args ).Get();
@@ -1128,7 +1128,7 @@ namespace XrdCl
         attrs.push_back( name );
         // wrap the PipelineHandler so the response gets unpacked properly
         UnpackXAttrStatus *h = new UnpackXAttrStatus( handler );
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         XRootDStatus st = this->filesystem->DelXAttr( path, attrs, h, timeout );
         if( !st.IsOK() ) delete h;
@@ -1184,11 +1184,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string              &path    = std::get<PathArg>( this->args ).Get();
         std::vector<std::string> &attrs   = std::get<NamesArg>( this->args ).Get();
-        uint16_t                  timeout = pipelineTimeout < this->timeout ?
+        time_t                    timeout = pipelineTimeout < this->timeout ?
                                             pipelineTimeout : this->timeout;
         return this->filesystem->DelXAttr( path, attrs, handler, timeout );
       }
@@ -1241,10 +1241,10 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &path    = std::get<PathArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                                pipelineTimeout : this->timeout;
         return this->filesystem->ListXAttr( path, handler, timeout );
       }

--- a/src/XrdCl/XrdClLocalFileHandler.cc
+++ b/src/XrdCl/XrdClLocalFileHandler.cc
@@ -244,7 +244,7 @@ namespace XrdCl
   // Open
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Open( const std::string& url, uint16_t flags,
-      uint16_t mode, ResponseHandler* handler, uint16_t timeout )
+      uint16_t mode, ResponseHandler* handler, time_t timeout )
   {
     AnyObject *resp = 0;
     XRootDStatus st = OpenImpl( url, flags, mode, resp );
@@ -267,7 +267,7 @@ namespace XrdCl
   // Close
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Close( ResponseHandler* handler,
-      uint16_t timeout )
+      time_t timeout )
   {
     if( close( fd ) == -1 )
     {
@@ -284,7 +284,7 @@ namespace XrdCl
   // Stat
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Stat( ResponseHandler* handler,
-      uint16_t timeout )
+      time_t timeout )
   {
     Log *log = DefaultEnv::GetLog();
 
@@ -318,7 +318,7 @@ namespace XrdCl
   // Read
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Read( uint64_t offset, uint32_t size,
-      void* buffer, ResponseHandler* handler, uint16_t timeout )
+      void* buffer, ResponseHandler* handler, time_t timeout )
   {
 #if defined(__APPLE__)
     Log *log = DefaultEnv::GetLog();
@@ -358,7 +358,7 @@ namespace XrdCl
                                         struct iovec    *iov,
                                         int              iovcnt,
                                         ResponseHandler *handler,
-                                        uint16_t         timeout )
+                                        time_t           timeout )
   {
     Log *log = DefaultEnv::GetLog();
 #if defined(__APPLE__)
@@ -395,7 +395,7 @@ namespace XrdCl
   // Write
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Write( uint64_t offset, uint32_t size,
-      const void* buffer, ResponseHandler* handler, uint16_t timeout )
+      const void* buffer, ResponseHandler* handler, time_t timeout )
   {
 #if defined(__APPLE__)
     const char *buff = reinterpret_cast<const char*>( buffer );
@@ -436,7 +436,7 @@ namespace XrdCl
   // Sync
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Sync( ResponseHandler* handler,
-      uint16_t timeout )
+      time_t timeout )
   {
 #if defined(__APPLE__)
     if( fsync( fd ) )
@@ -467,7 +467,7 @@ namespace XrdCl
   // Truncate
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Truncate( uint64_t size,
-      ResponseHandler* handler, uint16_t timeout )
+      ResponseHandler* handler, time_t timeout )
   {
     if( ftruncate( fd, size ) )
     {
@@ -485,7 +485,7 @@ namespace XrdCl
   // VectorRead
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::VectorRead( const ChunkList& chunks,
-      void* buffer, ResponseHandler* handler, uint16_t timeout )
+      void* buffer, ResponseHandler* handler, time_t timeout )
   {
     std::unique_ptr<VectorReadInfo> info( new VectorReadInfo() );
     size_t totalSize = 0;
@@ -522,7 +522,7 @@ namespace XrdCl
   // VectorWrite
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::VectorWrite( const ChunkList &chunks,
-      ResponseHandler *handler, uint16_t timeout )
+      ResponseHandler *handler, time_t timeout )
   {
 
     for( auto itr = chunks.begin(); itr != chunks.end(); ++itr )
@@ -549,7 +549,7 @@ namespace XrdCl
   XRootDStatus LocalFileHandler::WriteV( uint64_t            offset,
                                          ChunkList          *chunks,
                                          ResponseHandler    *handler,
-                                         uint16_t            timeout )
+                                         time_t              timeout )
   {
     size_t iovcnt = chunks->size();
     iovec iovcp[iovcnt];
@@ -605,7 +605,7 @@ namespace XrdCl
   // Fcntl
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Fcntl( const Buffer &arg,
-      ResponseHandler *handler, uint16_t timeout )
+      ResponseHandler *handler, time_t timeout )
   {
     return XRootDStatus( stError, errNotSupported );
   }
@@ -614,7 +614,7 @@ namespace XrdCl
   // Visa
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::Visa( ResponseHandler *handler,
-      uint16_t timeout )
+      time_t timeout )
   {
     return XRootDStatus( stError, errNotSupported );
   }
@@ -624,7 +624,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::SetXAttr( const std::vector<xattr_t> &attrs,
                                            ResponseHandler            *handler,
-                                           uint16_t                    timeout )
+                                           time_t                      timeout )
   {
     XrdSysXAttr *xattr = XrdSysFAttr::Xat;
     std::vector<XAttrStatus> response;
@@ -652,7 +652,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::GetXAttr( const std::vector<std::string> &attrs,
                                            ResponseHandler                *handler,
-                                           uint16_t                        timeout )
+                                           time_t                          timeout )
   {
     XrdSysXAttr *xattr = XrdSysFAttr::Xat;
     std::vector<XAttr> response;
@@ -695,7 +695,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::DelXAttr( const std::vector<std::string> &attrs,
                                            ResponseHandler                *handler,
-                                           uint16_t                        timeout )
+                                           time_t                          timeout )
   {
     XrdSysXAttr *xattr = XrdSysFAttr::Xat;
     std::vector<XAttrStatus> response;
@@ -721,7 +721,7 @@ namespace XrdCl
   // List extended attributes - async
   //------------------------------------------------------------------------
   XRootDStatus LocalFileHandler::ListXAttr( ResponseHandler  *handler,
-                                            uint16_t          timeout )
+                                            time_t            timeout )
   {
     XrdSysXAttr *xattr = XrdSysFAttr::Xat;
     std::vector<XAttr> response;

--- a/src/XrdCl/XrdClLocalFileHandler.hh
+++ b/src/XrdCl/XrdClLocalFileHandler.hh
@@ -49,7 +49,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Open( const std::string &url, uint16_t flags, uint16_t mode,
-          ResponseHandler *handler, uint16_t timeout = 0 );
+          ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Handle local redirect to given URL triggered by the given request
@@ -64,7 +64,7 @@ namespace XrdCl
       //!                used
       //! @return        status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Close( ResponseHandler *handler, uint16_t timeout = 0 );
+      XRootDStatus Close( ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Obtain status information for this file - async
@@ -76,7 +76,7 @@ namespace XrdCl
       //!                be used
       //! @return        status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Stat( ResponseHandler *handler, uint16_t timeout = 0 );
+      XRootDStatus Stat( ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read a data chunk at a given offset - sync
@@ -95,7 +95,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Read( uint64_t offset, uint32_t size, void *buffer,
-          ResponseHandler *handler, uint16_t timeout = 0 );
+          ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read data into scattered buffers in one operation - async
@@ -112,7 +112,7 @@ namespace XrdCl
                           struct iovec    *iov,
                           int              iovcnt,
                           ResponseHandler *handler,
-                          uint16_t         timeout = 0 );
+                          time_t           timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write a data chunk at a given offset - async
@@ -126,7 +126,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Write( uint64_t offset, uint32_t size, const void *buffer,
-          ResponseHandler *handler, uint16_t timeout = 0 );
+          ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Commit all pending disk writes - async
@@ -136,7 +136,7 @@ namespace XrdCl
       //!                used
       //! @return        status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Sync( ResponseHandler *handler, uint16_t timeout = 0 );
+      XRootDStatus Sync( ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Truncate the file to a particular size - async
@@ -148,7 +148,7 @@ namespace XrdCl
       //! @return        status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Truncate( uint64_t size, ResponseHandler *handler,
-          uint16_t timeout = 0 );
+          time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Read scattered data chunks in one operation - async
@@ -161,7 +161,7 @@ namespace XrdCl
       //! @return          status of the operation
       //------------------------------------------------------------------------
       XRootDStatus VectorRead( const ChunkList &chunks, void *buffer,
-          ResponseHandler *handler, uint16_t timeout = 0 );
+          ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write scattered data chunks in one operation - async
@@ -173,7 +173,7 @@ namespace XrdCl
       //! @return          status of the operation
       //------------------------------------------------------------------------
       XRootDStatus VectorWrite( const ChunkList &chunks,
-          ResponseHandler *handler, uint16_t timeout = 0 );
+          ResponseHandler *handler, time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Write scattered buffers in one operation - async
@@ -188,7 +188,7 @@ namespace XrdCl
       XRootDStatus WriteV( uint64_t            offset,
                            ChunkList          *chunks,
                            ResponseHandler    *handler,
-                           uint16_t            timeout = 0 );
+                           time_t              timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Queues a task to the jobmanager
@@ -213,7 +213,7 @@ namespace XrdCl
       //! @return          status of the operation
       //------------------------------------------------------------------------
       XRootDStatus Fcntl( const Buffer &arg, ResponseHandler *handler,
-          uint16_t timeout = 0 );
+          time_t timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get access token to a file - async
@@ -225,7 +225,7 @@ namespace XrdCl
       //!                  be used
       //! @return          status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus Visa( ResponseHandler *handler, uint16_t timeout = 0 );
+      XRootDStatus Visa( ResponseHandler *handler, time_t timeout = 0 );
 
 
       //------------------------------------------------------------------------
@@ -242,7 +242,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus SetXAttr( const std::vector<xattr_t> &attrs,
                              ResponseHandler            *handler,
-                             uint16_t                    timeout = 0 );
+                             time_t                      timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Get extended attributes - async
@@ -258,7 +258,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus GetXAttr( const std::vector<std::string> &attrs,
                              ResponseHandler                *handler,
-                             uint16_t                        timeout = 0 );
+                             time_t                          timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Delete extended attributes - async
@@ -274,7 +274,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       XRootDStatus DelXAttr( const std::vector<std::string> &attrs,
                              ResponseHandler                *handler,
-                             uint16_t                        timeout = 0 );
+                             time_t                          timeout = 0 );
 
       //------------------------------------------------------------------------
       //! List extended attributes - async
@@ -288,7 +288,7 @@ namespace XrdCl
       //! @return        : status of the operation
       //------------------------------------------------------------------------
       XRootDStatus ListXAttr( ResponseHandler           *handler,
-                              uint16_t                   timeout = 0 );
+                              time_t                     timeout = 0 );
 
       //------------------------------------------------------------------------
       //! creates the directories specified in path

--- a/src/XrdCl/XrdClMessageUtils.hh
+++ b/src/XrdCl/XrdClMessageUtils.hh
@@ -133,7 +133,7 @@ namespace XrdCl
     MessageSendParams():
       timeout(0), expires(0), followRedirects(true), chunkedResponse(false),
       stateful(true), hostList(0), chunkList(0), redirectLimit(0), kbuff(0){}
-    uint16_t               timeout;
+    time_t                 timeout;
     time_t                 expires;
     HostInfo               loadBalancer;
     bool                   followRedirects;

--- a/src/XrdCl/XrdClOperationTimeout.hh
+++ b/src/XrdCl/XrdClOperationTimeout.hh
@@ -24,7 +24,7 @@ namespace XrdCl
       {
       }
 
-      Timeout( uint16_t timeout ): timeout( timeout ), start( time( 0 ) )
+      Timeout( time_t timeout ): timeout( timeout ), start( time( 0 ) )
       {
       }
 
@@ -39,7 +39,7 @@ namespace XrdCl
       {
       }
 
-      operator uint16_t() const
+      operator time_t() const
       {
         if( !timeout ) return 0;
         time_t elapsed = time( 0 ) - start;
@@ -49,7 +49,7 @@ namespace XrdCl
 
     private:
 
-      uint16_t timeout;
+      time_t   timeout;
       time_t   start;
   };
 

--- a/src/XrdCl/XrdClOperations.hh
+++ b/src/XrdCl/XrdClOperations.hh
@@ -190,7 +190,7 @@ namespace XrdCl
       template<bool>
       friend class Operation;
 
-      friend std::future<XRootDStatus> Async( Pipeline, uint16_t );
+      friend std::future<XRootDStatus> Async( Pipeline, time_t );
 
       friend class Pipeline;
       friend class PipelineHandler;
@@ -290,7 +290,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      virtual XRootDStatus RunImpl( PipelineHandler *handler, uint16_t timeout ) = 0;
+      virtual XRootDStatus RunImpl( PipelineHandler *handler, time_t timeout ) = 0;
 
       //------------------------------------------------------------------------
       //! Add next operation in the pipeline
@@ -324,7 +324,7 @@ namespace XrdCl
   class Pipeline
   {
       template<bool> friend class ParallelOperation;
-      friend std::future<XRootDStatus> Async( Pipeline, uint16_t );
+      friend std::future<XRootDStatus> Async( Pipeline, time_t );
       friend class PipelineHandler;
 
     public:
@@ -519,7 +519,7 @@ namespace XrdCl
   //!
   //! @return         : future status of the operation
   //----------------------------------------------------------------------------
-  inline std::future<XRootDStatus> Async( Pipeline pipeline, uint16_t timeout = 0 )
+  inline std::future<XRootDStatus> Async( Pipeline pipeline, time_t timeout = 0 )
   {
     pipeline.Run( timeout );
     return std::move( pipeline.ftr );
@@ -534,7 +534,7 @@ namespace XrdCl
   //!
   //! @return         : status of the operation
   //----------------------------------------------------------------------------
-  inline XRootDStatus WaitFor( Pipeline pipeline, uint16_t timeout = 0 )
+  inline XRootDStatus WaitFor( Pipeline pipeline, time_t timeout = 0 )
   {
     return Async( std::move( pipeline ), timeout ).get();
   }
@@ -678,7 +678,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Set operation timeout
       //------------------------------------------------------------------------
-      Derived<HasHndl> Timeout( uint16_t timeout )
+      Derived<HasHndl> Timeout( time_t timeout )
       {
         this->timeout = timeout;
         Derived<HasHndl> *me = static_cast<Derived<HasHndl>*>( this );
@@ -773,7 +773,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Operation timeout
       //------------------------------------------------------------------------
-      uint16_t timeout;
+      time_t   timeout;
     };
 }
 

--- a/src/XrdCl/XrdClParallelOperation.hh
+++ b/src/XrdCl/XrdClParallelOperation.hh
@@ -473,7 +473,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         // make sure we have a valid policy for the parallel operation
         if( !policy ) policy.reset( new AllPolicy() );
@@ -481,7 +481,7 @@ namespace XrdCl
         std::shared_ptr<Ctx> ctx =
             std::make_shared<Ctx>( handler, policy.release() );
 
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
 
         for( size_t i = 0; i < pipelines.size(); ++i )

--- a/src/XrdCl/XrdClPlugInInterface.hh
+++ b/src/XrdCl/XrdClPlugInInterface.hh
@@ -49,7 +49,7 @@ namespace XrdCl
                                  OpenFlags::Flags   flags,
                                  Access::Mode       mode,
                                  ResponseHandler   *handler,
-                                 uint16_t           timeout )
+                                 time_t             timeout )
       {
         (void)url; (void)flags; (void)mode; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -59,7 +59,7 @@ namespace XrdCl
       //! @see XrdCl::File::Close
       //------------------------------------------------------------------------
       virtual XRootDStatus Close( ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -70,7 +70,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus Stat( bool             force,
                                  ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         (void)force; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -83,7 +83,7 @@ namespace XrdCl
                                  uint32_t         size,
                                  void            *buffer,
                                  ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         (void)offset; (void)size; (void)buffer; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -97,7 +97,7 @@ namespace XrdCl
                                  Optional<uint64_t>  fdoff,
                                  int                 fd,
                                  ResponseHandler    *handler,
-                                 uint16_t            timeout = 0 )
+                                 time_t              timeout = 0 )
       {
         (void)offset; (void)size; (void)fdoff; (void)fd, (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -110,7 +110,7 @@ namespace XrdCl
                                    uint32_t         size,
                                    void            *buffer,
                                    ResponseHandler *handler,
-                                   uint16_t         timeout )
+                                   time_t           timeout )
       {
         (void)offset; (void)size; (void)buffer; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -123,7 +123,7 @@ namespace XrdCl
                                   uint32_t         size,
                                   const void      *buffer,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         (void)offset; (void)size; (void)buffer; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -135,7 +135,7 @@ namespace XrdCl
       virtual XRootDStatus Write( uint64_t          offset,
                                   Buffer          &&buffer,
                                   ResponseHandler  *handler,
-                                  uint16_t          timeout = 0 )
+                                  time_t            timeout = 0 )
       {
         (void)offset; (void)buffer; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -149,7 +149,7 @@ namespace XrdCl
                                   Optional<uint64_t>  fdoff,
                                   int                 fd,
                                   ResponseHandler    *handler,
-                                  uint16_t            timeout = 0 )
+                                  time_t              timeout = 0 )
       {
         (void)offset; (void)size; (void)fdoff; (void)fd, (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -163,7 +163,7 @@ namespace XrdCl
                                     const void            *buffer,
                                     std::vector<uint32_t> &cksums,
                                     ResponseHandler       *handler,
-                                    uint16_t               timeout )
+                                    time_t                 timeout )
       {
         (void)offset; (void)nbpgs; (void)buffer; (void)cksums, (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -173,7 +173,7 @@ namespace XrdCl
       //! @see XrdCl::File::Sync
       //------------------------------------------------------------------------
       virtual XRootDStatus Sync( ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -184,7 +184,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus Truncate( uint64_t         size,
                                      ResponseHandler *handler,
-                                     uint16_t         timeout )
+                                     time_t           timeout )
       {
         (void)size; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -196,7 +196,7 @@ namespace XrdCl
       virtual XRootDStatus VectorRead( const ChunkList &chunks,
                                        void            *buffer,
                                        ResponseHandler *handler,
-                                       uint16_t         timeout )
+                                       time_t           timeout )
       {
         (void)chunks; (void)buffer; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -207,7 +207,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus VectorWrite( const ChunkList &chunks,
                                         ResponseHandler *handler,
-                                        uint16_t         timeout = 0 )
+                                        time_t           timeout = 0 )
       {
         (void)chunks; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -221,7 +221,7 @@ namespace XrdCl
                                    const struct iovec *iov,
                                    int                 iovcnt,
                                    ResponseHandler    *handler,
-                                   uint16_t            timeout = 0 )
+                                   time_t              timeout = 0 )
       {
         (void)offset; (void)iov; (void)iovcnt; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -232,7 +232,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus Fcntl( const Buffer    &arg,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         (void)arg; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -242,7 +242,7 @@ namespace XrdCl
       //! @see XrdCl::File::Visa
       //------------------------------------------------------------------------
       virtual XRootDStatus Visa( ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -294,7 +294,7 @@ namespace XrdCl
       virtual XRootDStatus Locate( const std::string &path,
                                    OpenFlags::Flags   flags,
                                    ResponseHandler   *handler,
-                                   uint16_t           timeout )
+                                   time_t             timeout )
       {
         (void)path; (void)flags; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -306,7 +306,7 @@ namespace XrdCl
       virtual XRootDStatus DeepLocate( const std::string &path,
                                        OpenFlags::Flags   flags,
                                        ResponseHandler   *handler,
-                                       uint16_t           timeout )
+                                       time_t             timeout )
       {
         (void)path; (void)flags; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -318,7 +318,7 @@ namespace XrdCl
       virtual XRootDStatus Mv( const std::string &source,
                                const std::string &dest,
                                ResponseHandler   *handler,
-                               uint16_t           timeout )
+                               time_t             timeout )
       {
         (void)source; (void)dest; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -330,7 +330,7 @@ namespace XrdCl
       virtual XRootDStatus Query( QueryCode::Code  queryCode,
                                   const Buffer    &arg,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         (void)queryCode; (void)arg; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -342,7 +342,7 @@ namespace XrdCl
       virtual XRootDStatus Truncate( const std::string &path,
                                      uint64_t           size,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
       {
         (void)path; (void)size; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -353,7 +353,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus Rm( const std::string &path,
                                ResponseHandler   *handler,
-                               uint16_t           timeout )
+                               time_t             timeout )
       {
         (void)path; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -366,7 +366,7 @@ namespace XrdCl
                                   MkDirFlags::Flags  flags,
                                   Access::Mode       mode,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
       {
         (void)path; (void)flags; (void)mode; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -377,7 +377,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus RmDir( const std::string &path,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
       {
         (void)path; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -389,7 +389,7 @@ namespace XrdCl
       virtual XRootDStatus ChMod( const std::string &path,
                                   Access::Mode       mode,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
       {
         (void)path; (void)mode; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -399,7 +399,7 @@ namespace XrdCl
       //! @see XrdCl::FileSystem::Ping
       //------------------------------------------------------------------------
       virtual XRootDStatus Ping( ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -410,7 +410,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus Stat( const std::string &path,
                                  ResponseHandler   *handler,
-                                 uint16_t           timeout )
+                                 time_t             timeout )
       {
         (void)path; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -421,7 +421,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus StatVFS( const std::string &path,
                                     ResponseHandler   *handler,
-                                    uint16_t           timeout )
+                                    time_t             timeout )
       {
         (void)path; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -431,7 +431,7 @@ namespace XrdCl
       //! @see XrdCl::FileSystem::Protocol
       //------------------------------------------------------------------------
       virtual XRootDStatus Protocol( ResponseHandler *handler,
-                                     uint16_t         timeout = 0 )
+                                     time_t           timeout = 0 )
       {
         (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -443,7 +443,7 @@ namespace XrdCl
       virtual XRootDStatus DirList( const std::string   &path,
                                     DirListFlags::Flags  flags,
                                     ResponseHandler     *handler,
-                                    uint16_t             timeout )
+                                    time_t               timeout )
       {
         (void)path; (void)flags; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -454,7 +454,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus SendInfo( const std::string &info,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
       {
         (void)info; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -467,7 +467,7 @@ namespace XrdCl
                                     PrepareFlags::Flags             flags,
                                     uint8_t                         priority,
                                     ResponseHandler                *handler,
-                                    uint16_t                        timeout )
+                                    time_t                          timeout )
       {
         (void)fileList; (void)flags; (void)priority; (void)handler;
         (void)timeout;
@@ -480,7 +480,7 @@ namespace XrdCl
       virtual XRootDStatus SetXAttr( const std::string           &path,
                                      const std::vector<xattr_t>  &attrs,
                                      ResponseHandler             *handler,
-                                     uint16_t                     timeout )
+                                     time_t                       timeout )
       {
         (void)path; (void)attrs; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -492,7 +492,7 @@ namespace XrdCl
       virtual XRootDStatus GetXAttr( const std::string               &path,
                                      const std::vector<std::string>  &attrs,
                                      ResponseHandler                 *handler,
-                                     uint16_t                         timeout )
+                                     time_t                           timeout )
       {
         (void)path; (void)attrs; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -504,7 +504,7 @@ namespace XrdCl
       virtual XRootDStatus DelXAttr( const std::string               &path,
                                      const std::vector<std::string>  &attrs,
                                      ResponseHandler                 *handler,
-                                     uint16_t                         timeout )
+                                     time_t                           timeout )
       {
         (void)path; (void)attrs; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );
@@ -515,7 +515,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual XRootDStatus ListXAttr( const std::string         &path,
                                       ResponseHandler           *handler,
-                                      uint16_t                   timeout )
+                                      time_t                     timeout )
       {
         (void)path; (void)handler; (void)timeout;
         return XRootDStatus( stError, errNotImplemented );

--- a/src/XrdCl/XrdClPoller.hh
+++ b/src/XrdCl/XrdClPoller.hh
@@ -20,6 +20,7 @@
 #define __XRD_CL_POLLER_HH__
 
 #include <cstdint>
+#include <ctime>
 #include <string>
 
 namespace XrdCl
@@ -135,7 +136,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual bool EnableReadNotification( Socket  *socket,
                                            bool     notify,
-                                           uint16_t timeout = 60 ) = 0;
+                                           time_t   timeout = 60 ) = 0;
 
       //------------------------------------------------------------------------
       //! Notify the handler about write events
@@ -146,7 +147,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual bool EnableWriteNotification( Socket  *socket,
                                             bool     notify,
-                                            uint16_t timeout = 60 ) = 0;
+                                            time_t   timeout = 60 ) = 0;
 
       //------------------------------------------------------------------------
       //! Check whether the socket is registered with the poller

--- a/src/XrdCl/XrdClPollerBuiltIn.cc
+++ b/src/XrdCl/XrdClPollerBuiltIn.cc
@@ -46,8 +46,8 @@ namespace
     XrdSys::IOEvents::CallBack *callBack;
     bool                        readEnabled;
     bool                        writeEnabled;
-    uint16_t                    readTimeout;
-    uint16_t                    writeTimeout;
+    time_t                      readTimeout;
+    time_t                      writeTimeout;
   };
 
   //----------------------------------------------------------------------------
@@ -353,7 +353,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   bool PollerBuiltIn::EnableReadNotification( Socket  *socket,
                                               bool     notify,
-                                              uint16_t timeout )
+                                              time_t   timeout )
   {
     using namespace XrdSys::IOEvents;
     Log *log = DefaultEnv::GetLog();
@@ -438,7 +438,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   bool PollerBuiltIn::EnableWriteNotification( Socket  *socket,
                                                bool     notify,
-                                               uint16_t timeout )
+                                               time_t   timeout )
   {
     using namespace XrdSys::IOEvents;
     Log *log = DefaultEnv::GetLog();

--- a/src/XrdCl/XrdClPollerBuiltIn.hh
+++ b/src/XrdCl/XrdClPollerBuiltIn.hh
@@ -92,7 +92,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual bool EnableReadNotification( Socket  *socket,
                                            bool     notify,
-                                           uint16_t timeout = 60 );
+                                           time_t   timeout = 60 );
 
       //------------------------------------------------------------------------
       //! Notify the handler about write events
@@ -104,7 +104,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       virtual bool EnableWriteNotification( Socket  *socket,
                                             bool     notify,
-                                            uint16_t timeout = 60);
+                                            time_t   timeout = 60);
 
       //------------------------------------------------------------------------
       //! Check whether the socket is registered with the poller

--- a/src/XrdCl/XrdClSocket.cc
+++ b/src/XrdCl/XrdClSocket.cc
@@ -182,7 +182,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   XRootDStatus Socket::Connect( const std::string &host,
                                 uint16_t           port,
-                                uint16_t           timeout )
+                                time_t             timeout )
   {
     if( pSocket == -1 || pStatus == Connected || pStatus == Connecting )
       return XRootDStatus( stError, errInvalidOp );
@@ -210,7 +210,7 @@ namespace XrdCl
   // Connect to the given host
   //----------------------------------------------------------------------------
   XRootDStatus Socket::ConnectToAddress( const XrdNetAddr &addr,
-                                         uint16_t          timeout )
+                                         time_t            timeout )
   {
     if( pSocket == -1 || pStatus == Connected || pStatus == Connecting )
       return XRootDStatus( stError, errInvalidOp );

--- a/src/XrdCl/XrdClSocket.hh
+++ b/src/XrdCl/XrdClSocket.hh
@@ -97,22 +97,22 @@ namespace XrdCl
       //!
       //! @param host   name of the host to connect to
       //! @param port   port to connect to
-      //! @param timout timeout in seconds, 0 for no timeout handling (may be
+      //! @param timeout timeout in seconds, 0 for no timeout handling (may be
       //!               used for non blocking IO)
       //------------------------------------------------------------------------
       XRootDStatus Connect( const std::string &host,
                             uint16_t           port,
-                            uint16_t           timout = 10 );
+                            time_t             timeout = 10 );
 
       //------------------------------------------------------------------------
       //! Connect to the given host address
       //!
       //! @param addr   address of the host to connect to
-      //! @param timout timeout in seconds, 0 for no timeout handling (may be
+      //! @param timeout timeout in seconds, 0 for no timeout handling (may be
       //!               used for non blocking IO)
       //------------------------------------------------------------------------
       XRootDStatus ConnectToAddress( const XrdNetAddr &addr,
-                                     uint16_t          timout = 10 );
+                                     time_t            timeout = 10 );
 
       //------------------------------------------------------------------------
       //! Disconnect
@@ -140,7 +140,7 @@ namespace XrdCl
       //!
       //! @param buffer    data to be sent
       //! @param size      size of the data buffer
-      //! @param timeout   timout value in seconds, -1 to wait indefinitely
+      //! @param timeout   timeout value in seconds, -1 to wait indefinitely
       //! @param bytesRead the amount of data actually read
       //------------------------------------------------------------------------
       XRootDStatus ReadRaw( void *buffer, uint32_t size, int32_t timeout,

--- a/src/XrdCl/XrdClTPFallBackCopyJob.cc
+++ b/src/XrdCl/XrdClTPFallBackCopyJob.cc
@@ -35,7 +35,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Constructor
   //----------------------------------------------------------------------------
-  TPFallBackCopyJob::TPFallBackCopyJob( uint16_t      jobId,
+  TPFallBackCopyJob::TPFallBackCopyJob( uint32_t      jobId,
                                         PropertyList *jobProperties,
                                         PropertyList *jobResults ):
     CopyJob( jobId, jobProperties, jobResults ),

--- a/src/XrdCl/XrdClTPFallBackCopyJob.hh
+++ b/src/XrdCl/XrdClTPFallBackCopyJob.hh
@@ -36,7 +36,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Constructor
       //------------------------------------------------------------------------
-      TPFallBackCopyJob( uint16_t      jobId,
+      TPFallBackCopyJob( uint32_t      jobId,
                          PropertyList *jobProperties,
                          PropertyList *jobResults );
 

--- a/src/XrdCl/XrdClThirdPartyCopyJob.cc
+++ b/src/XrdCl/XrdClThirdPartyCopyJob.cc
@@ -110,7 +110,7 @@ namespace
   {
     public:
 
-      InitTimeoutCalc( uint16_t timeLeft ) :
+      InitTimeoutCalc( time_t timeLeft ) :
         hasInitTimeout( timeLeft ), start( time( 0 ) ), timeLeft( timeLeft )
       {
 
@@ -128,7 +128,7 @@ namespace
         return XrdCl::XRootDStatus();
       }
 
-      operator uint16_t()
+      operator time_t()
       {
         return timeLeft;
       }
@@ -136,7 +136,7 @@ namespace
     private:
       bool hasInitTimeout;
       time_t start;
-      uint16_t timeLeft;
+      time_t timeLeft;
   };
 
   static XrdCl::XRootDStatus& UpdateErrMsg( XrdCl::XRootDStatus &status, const std::string &str )
@@ -624,7 +624,7 @@ namespace XrdCl
       }
     }
 
-    initTimeout = uint16_t( timeLeft );
+    initTimeout = time_t( timeLeft );
 
     return XRootDStatus();
   }
@@ -709,7 +709,7 @@ namespace XrdCl
     XrdSysSemaphore  *sem  = statusHandler.GetXrdSysSemaphore();
     StatInfo         *info   = 0;
 
-    uint16_t tpcTimeout = 0;
+    time_t   tpcTimeout = 0;
     pProperties->Get( "tpcTimeout", tpcTimeout );
 
     st = dstFile.Sync( &statusHandler, tpcTimeout );
@@ -828,7 +828,7 @@ namespace XrdCl
     XrdSysSemaphore  *sem  = statusHandler.GetXrdSysSemaphore();
     StatInfo         *info   = 0;
 
-    uint16_t tpcTimeout = 0;
+    time_t   tpcTimeout = 0;
     pProperties->Get( "tpcTimeout", tpcTimeout );
 
     st = dstFile.Sync( &statusHandler, tpcTimeout );

--- a/src/XrdCl/XrdClThirdPartyCopyJob.cc
+++ b/src/XrdCl/XrdClThirdPartyCopyJob.cc
@@ -153,7 +153,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Constructor
   //----------------------------------------------------------------------------
-  ThirdPartyCopyJob::ThirdPartyCopyJob( uint16_t      jobId,
+  ThirdPartyCopyJob::ThirdPartyCopyJob( uint32_t      jobId,
                                         PropertyList *jobProperties,
                                         PropertyList *jobResults ):
     CopyJob( jobId, jobProperties, jobResults ),

--- a/src/XrdCl/XrdClThirdPartyCopyJob.hh
+++ b/src/XrdCl/XrdClThirdPartyCopyJob.hh
@@ -81,7 +81,7 @@ namespace XrdCl
       std::string checkSumType;
       std::string checkSumPreset;
       uint64_t    sourceSize;
-      uint16_t    initTimeout;
+      time_t      initTimeout;
       bool        force;
       bool        coerce;
       bool        delegate;

--- a/src/XrdCl/XrdClThirdPartyCopyJob.hh
+++ b/src/XrdCl/XrdClThirdPartyCopyJob.hh
@@ -33,7 +33,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Constructor
       //------------------------------------------------------------------------
-      ThirdPartyCopyJob( uint16_t      jobId,
+      ThirdPartyCopyJob( uint32_t      jobId,
                          PropertyList *jobProperties,
                          PropertyList *jobResults );
 

--- a/src/XrdCl/XrdClUtils.cc
+++ b/src/XrdCl/XrdClUtils.cc
@@ -379,7 +379,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Check if peer supports tpc
   //----------------------------------------------------------------------------
-  XRootDStatus Utils::CheckTPC( const std::string &server, uint16_t timeout )
+  XRootDStatus Utils::CheckTPC( const std::string &server, time_t timeout )
   {
     Log *log = DefaultEnv::GetLog();
     log->Debug( UtilityMsg, "Checking if the data server %s supports tpc",
@@ -423,7 +423,7 @@ namespace XrdCl
   //------------------------------------------------------------------------
   // Check if peer supports tpc / tpc lite
   //------------------------------------------------------------------------
-  XRootDStatus Utils::CheckTPCLite( const std::string &server, uint16_t timeout )
+  XRootDStatus Utils::CheckTPCLite( const std::string &server, time_t timeout )
   {
     Log *log = DefaultEnv::GetLog();
     log->Debug( UtilityMsg, "Checking if the data server %s supports tpc / tpc lite",

--- a/src/XrdCl/XrdClUtils.hh
+++ b/src/XrdCl/XrdClUtils.hh
@@ -145,7 +145,7 @@ namespace XrdCl
       //! Check if peer supports tpc
       //------------------------------------------------------------------------
       static XRootDStatus CheckTPC( const std::string &server,
-                                    uint16_t           timeout = 0 );
+                                    time_t             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Check if peer supports tpc / tpc lite
@@ -154,7 +154,7 @@ namespace XrdCl
       //!           supported, stError otherwise
       //------------------------------------------------------------------------
       static XRootDStatus CheckTPCLite( const std::string &server,
-                                        uint16_t           timeout = 0 );
+                                        time_t             timeout = 0 );
 
       //------------------------------------------------------------------------
       //! Convert the fully qualified host name to country code

--- a/src/XrdCl/XrdClZipArchive.cc
+++ b/src/XrdCl/XrdClZipArchive.cc
@@ -47,7 +47,7 @@ namespace XrdCl
                              uint32_t           size,
                              void              *usrbuff,
                              ResponseHandler   *usrHandler,
-                             uint16_t           timeout )
+                             time_t             timeout )
   {
     if( me.openstage != ZipArchive::Done || !me.archive.IsOpen() )
       return XRootDStatus( stError, errInvalidOp );
@@ -231,7 +231,7 @@ namespace XrdCl
   XRootDStatus ZipArchive::OpenOnly( const std::string  &url,
                                      bool                update,
                                      ResponseHandler    *handler,
-                                     uint16_t            timeout )
+                                     time_t              timeout )
   {
     OpenFlags::Flags flags = update ? OpenFlags::Update : OpenFlags::Read;
     Pipeline open_only = XrdCl::Open( archive, url, flags ) >>
@@ -266,7 +266,7 @@ namespace XrdCl
   XRootDStatus ZipArchive::OpenArchive( const std::string  &url,
                                         OpenFlags::Flags    flags,
                                         ResponseHandler    *handler,
-                                        uint16_t            timeout )
+                                        time_t              timeout )
   {
     Log *log = DefaultEnv::GetLog();
     Fwd<uint32_t> rdsize; // number of bytes to be read
@@ -602,7 +602,7 @@ namespace XrdCl
   // Create the central directory at the end of ZIP archive and close it
   //---------------------------------------------------------------------------
   XRootDStatus ZipArchive::CloseArchive( ResponseHandler *handler,
-                                         uint16_t         timeout )
+                                         time_t           timeout )
   {
     Log *log = DefaultEnv::GetLog();
 
@@ -696,7 +696,7 @@ namespace XrdCl
                                      uint32_t           size,
                                      void              *buffer,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
   {
     return ReadFromImpl<ChunkInfo>( *this, fn, offset, size, buffer, handler, timeout );
   }
@@ -709,7 +709,7 @@ namespace XrdCl
                                        uint32_t           size,
                                        void              *buffer,
                                        ResponseHandler   *handler,
-                                       uint16_t           timeout )
+                                       time_t             timeout )
   {
     return ReadFromImpl<PageInfo>( *this, fn, offset, size, buffer, handler, timeout );
   }
@@ -756,7 +756,7 @@ namespace XrdCl
   XRootDStatus ZipArchive::WriteImpl( uint32_t               size,
                                       const void            *buffer,
                                       ResponseHandler       *handler,
-                                      uint16_t               timeout )
+                                      time_t                 timeout )
   {
     Log *log = DefaultEnv::GetLog();
     std::vector<iovec> iov( 2 );
@@ -879,7 +879,7 @@ namespace XrdCl
                                        uint32_t           size,
                                        const void        *buffer,
                                        ResponseHandler   *handler,
-                                       uint16_t           timeout )
+                                       time_t             timeout )
   {
     Log  *log = DefaultEnv::GetLog();
     auto  itr   = cdmap.find( fn );

--- a/src/XrdCl/XrdClZipArchive.hh
+++ b/src/XrdCl/XrdClZipArchive.hh
@@ -67,7 +67,7 @@ namespace XrdCl
     friend class ::XrdEcTests;
 
     template<typename RSP>
-    friend XRootDStatus ReadFromImpl( ZipArchive&, const std::string&, uint64_t, uint32_t, void*, ResponseHandler*, uint16_t );
+    friend XRootDStatus ReadFromImpl( ZipArchive&, const std::string&, uint64_t, uint32_t, void*, ResponseHandler*, time_t );
 
     public:
       //-----------------------------------------------------------------------
@@ -92,7 +92,7 @@ namespace XrdCl
       XRootDStatus OpenArchive( const std::string  &url,
                                 OpenFlags::Flags    flags,
                                 ResponseHandler    *handler,
-                                uint16_t            timeout = 0 );
+                                time_t              timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Open a file within the ZIP Archive
@@ -123,7 +123,7 @@ namespace XrdCl
                          uint32_t         size,
                          void            *buffer,
                          ResponseHandler *handler,
-                         uint16_t         timeout = 0 )
+                         time_t           timeout = 0 )
       {
         if( openfn.empty() ) return XRootDStatus( stError, errInvalidOp );
         return ReadFrom( openfn, offset, size, buffer, handler, timeout );
@@ -144,7 +144,7 @@ namespace XrdCl
                            uint32_t         size,
                            void            *buffer,
                            ResponseHandler *handler,
-                           uint16_t         timeout = 0 )
+                           time_t           timeout = 0 )
       {
         if( openfn.empty() ) return XRootDStatus( stError, errInvalidOp );
         return PgReadFrom( openfn, offset, size, buffer, handler, timeout );
@@ -166,7 +166,7 @@ namespace XrdCl
                              uint32_t           size,
                              void              *buffer,
                              ResponseHandler   *handler,
-                             uint16_t           timeout = 0 );
+                             time_t             timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! PgRead data from a given file
@@ -184,7 +184,7 @@ namespace XrdCl
                                uint32_t           size,
                                void              *buffer,
                                ResponseHandler   *handler,
-                               uint16_t           timeout = 0 );
+                               time_t             timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Append data to a new file
@@ -198,7 +198,7 @@ namespace XrdCl
       inline XRootDStatus Write( uint32_t          size,
                                  const void       *buffer,
                                  ResponseHandler  *handler,
-                                 uint16_t          timeout = 0 )
+                                 time_t            timeout = 0 )
       {
         if( openstage != Done || openfn.empty() )
           return XRootDStatus( stError, errInvalidOp, 0, "Archive not opened." );
@@ -230,7 +230,7 @@ namespace XrdCl
                                uint32_t           size,
                                const void        *buffer,
                                ResponseHandler   *handler,
-                               uint16_t           timeout = 0 );
+                               time_t             timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Get stat info for given file
@@ -330,7 +330,7 @@ namespace XrdCl
       //! @return        : the status of the operation
       //-----------------------------------------------------------------------
       XRootDStatus CloseArchive( ResponseHandler *handler,
-                                 uint16_t         timeout = 0 );
+                                 time_t           timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Close an open file within the ZIP archive
@@ -406,7 +406,7 @@ namespace XrdCl
       XRootDStatus WriteImpl( uint32_t               size,
                               const void            *buffer,
                               ResponseHandler       *handler,
-                              uint16_t               timeout );
+                              time_t                 timeout );
 
       //-----------------------------------------------------------------------
       //! Open the ZIP archive in read-only mode without parsing the central
@@ -420,7 +420,7 @@ namespace XrdCl
       XRootDStatus OpenOnly( const std::string  &url,
                              bool                update,
                              ResponseHandler    *handler,
-                             uint16_t            timeout = 0 );
+                             time_t              timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Get a buffer with central directory of the ZIP archive

--- a/src/XrdCl/XrdClZipListHandler.cc
+++ b/src/XrdCl/XrdClZipListHandler.cc
@@ -60,7 +60,7 @@ namespace XrdCl
         delete this;
       return;
     }
-    uint16_t left = pTimeout - took;
+    time_t left = pTimeout - took;
 
     switch( pStep )
     {

--- a/src/XrdCl/XrdClZipListHandler.hh
+++ b/src/XrdCl/XrdClZipListHandler.hh
@@ -74,7 +74,7 @@ namespace XrdCl
                       const std::string   &path,
                       DirListFlags::Flags  flags,
                       ResponseHandler     *handler,
-                      uint16_t             timeout = 0 ) :
+                      time_t               timeout = 0 ) :
         pUrl( url ), pFlags( flags ), pHandler( handler ),
         pTimeout( timeout ), pStartTime( time( 0 ) ), pStep( STAT )
       {
@@ -121,7 +121,7 @@ namespace XrdCl
       URL                             pUrl;
       DirListFlags::Flags             pFlags;
       ResponseHandler                *pHandler;
-      uint16_t                        pTimeout;
+      time_t                          pTimeout;
 
       std::unique_ptr<DirectoryList>  pDirList;
       time_t                          pStartTime;

--- a/src/XrdCl/XrdClZipOperations.hh
+++ b/src/XrdCl/XrdClZipOperations.hh
@@ -107,11 +107,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string      &url     = std::get<UrlArg>( this->args ).Get();
         OpenFlags::Flags  flags   = std::get<FlagsArg>( this->args ).Get();
-        uint16_t          timeout = pipelineTimeout < this->timeout ?
+        time_t            timeout = pipelineTimeout < this->timeout ?
                                    pipelineTimeout : this->timeout;
         return this->zip->OpenArchive( url, flags, handler, timeout );
       }
@@ -121,7 +121,7 @@ namespace XrdCl
   //! Factory for creating OpenArchiveImpl objects
   //----------------------------------------------------------------------------
   inline OpenArchiveImpl<false> OpenArchive( Ctx<ZipArchive> zip, Arg<std::string> fn,
-      Arg<OpenFlags::Flags> flags, uint16_t timeout = 0 )
+      Arg<OpenFlags::Flags> flags, time_t timeout = 0 )
   {
     return OpenArchiveImpl<false>( std::move( zip ), std::move( fn ),
                                    std::move( flags ) ).Timeout( timeout );
@@ -165,7 +165,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string      &fn      = std::get<FnArg>( this->args ).Get();
         OpenFlags::Flags  flags   = std::get<FlagsArg>( this->args ).Get();
@@ -183,7 +183,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline OpenFileImpl<false> OpenFile( Ctx<ZipArchive> zip, Arg<std::string> fn,
       Arg<OpenFlags::Flags> flags = OpenFlags::None, Arg<uint64_t> size = 0,
-      Arg<uint32_t> crc32 = 0, uint16_t timeout = 0 )
+      Arg<uint32_t> crc32 = 0, time_t timeout = 0 )
   {
     return OpenFileImpl<false>( std::move( zip ), std::move( fn ), std::move( flags ),
         std::move( size ), std::move( crc32 ) ).Timeout( timeout );
@@ -227,12 +227,12 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint64_t  offset  = std::get<OffsetArg>( this->args ).Get();
         uint32_t  size    = std::get<SizeArg>( this->args ).Get();
         void     *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t  timeout = pipelineTimeout < this->timeout ?
+        time_t    timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->zip->Read( offset, size, buffer, handler, timeout );
       }
@@ -242,7 +242,7 @@ namespace XrdCl
   //! Factory for creating ArchiveReadImpl objects
   //----------------------------------------------------------------------------
   inline ZipReadImpl<false> Read( Ctx<ZipArchive> zip, Arg<uint64_t> offset, Arg<uint32_t> size,
-                                  Arg<void*> buffer, uint16_t timeout = 0 )
+                                  Arg<void*> buffer, time_t timeout = 0 )
   {
     return ZipReadImpl<false>( std::move( zip ), std::move( offset ), std::move( size ),
                                std::move( buffer ) ).Timeout( timeout );
@@ -284,13 +284,13 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &fn = std::get<FileNameArg>( this->args ).Get();
         uint64_t     offset  = std::get<OffsetArg>( this->args ).Get();
         uint32_t     size    = std::get<SizeArg>( this->args ).Get();
         void        *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                             pipelineTimeout : this->timeout;
         return this->zip->ReadFrom( fn, offset, size, buffer, handler, timeout );
       }
@@ -301,7 +301,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline ZipReadFromImpl<false> ReadFrom( Ctx<ZipArchive> zip, Arg<std::string> fn,
                                   Arg<uint64_t> offset, Arg<uint32_t> size,
-                                  Arg<void*> buffer, uint16_t timeout = 0 )
+                                  Arg<void*> buffer, time_t timeout = 0 )
   {
     return ZipReadFromImpl<false>( std::move( zip ), std::move( fn ), std::move( offset ),
                                    std::move( size ), std::move( buffer ) ).Timeout( timeout );
@@ -345,11 +345,11 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         uint32_t    size    = std::get<SizeArg>( this->args ).Get();
         const void *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t    timeout = pipelineTimeout < this->timeout ?
+        time_t      timeout = pipelineTimeout < this->timeout ?
                               pipelineTimeout : this->timeout;
         return this->zip->Write( size, buffer, handler, timeout );
       }
@@ -359,7 +359,7 @@ namespace XrdCl
   //! Factory for creating ArchiveReadImpl objects
   //----------------------------------------------------------------------------
   inline ZipWriteImpl<false> Write( Ctx<ZipArchive> zip, Arg<uint32_t> size, Arg<const void*> buffer,
-                                    uint16_t timeout = 0 )
+                                    time_t timeout = 0 )
   {
     return ZipWriteImpl<false>( std::move( zip ), std::move( size ),
                                 std::move( buffer ) ).Timeout( timeout );
@@ -403,13 +403,13 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         std::string &fn      = std::get<FnArg>( this->args ).Get();
         uint32_t     crc32   = std::get<CrcArg>( this->args ).Get();
         uint32_t     size    = std::get<SizeArg>( this->args ).Get();
         const void  *buffer  = std::get<BufferArg>( this->args ).Get();
-        uint16_t     timeout = pipelineTimeout < this->timeout ?
+        time_t       timeout = pipelineTimeout < this->timeout ?
                               pipelineTimeout : this->timeout;
         return this->zip->AppendFile( fn, crc32, size, buffer, handler, timeout );
       }
@@ -420,7 +420,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   inline AppendFileImpl<false> AppendFile( Ctx<ZipArchive> zip, Arg<std::string> fn,
                                            Arg<uint32_t> crc32, Arg<uint32_t> size,
-                                           Arg<const void*> buffer, uint16_t timeout = 0 )
+                                           Arg<const void*> buffer, time_t timeout = 0 )
   {
     return AppendFileImpl<false>( std::move( zip ), std::move( fn ), std::move( crc32 ),
                                   std::move( size ), std::move( buffer ) ).Timeout( timeout );
@@ -464,7 +464,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         XRootDStatus st = this->zip->CloseFile();
         if( !st.IsOK() ) return st;
@@ -505,7 +505,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         StatInfo *info = nullptr;
         XRootDStatus st = this->zip->Stat( info );
@@ -556,7 +556,7 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
         DirectoryList *list = nullptr;
         XRootDStatus st = this->zip->List( list );
@@ -607,9 +607,9 @@ namespace XrdCl
       //!                  previous operation
       //! @return       :  status of the operation
       //------------------------------------------------------------------------
-      XRootDStatus RunImpl( PipelineHandler *handler, uint16_t pipelineTimeout )
+      XRootDStatus RunImpl( PipelineHandler *handler, time_t pipelineTimeout )
       {
-        uint16_t timeout = pipelineTimeout < this->timeout ?
+        time_t   timeout = pipelineTimeout < this->timeout ?
                            pipelineTimeout : this->timeout;
         return this->zip->CloseArchive( handler, timeout );
       }
@@ -618,7 +618,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   //! Factory for creating CloseFileImpl objects
   //----------------------------------------------------------------------------
-  inline CloseArchiveImpl<false> CloseArchive( Ctx<ZipArchive> zip, uint16_t timeout = 0 )
+  inline CloseArchiveImpl<false> CloseArchive( Ctx<ZipArchive> zip, time_t timeout = 0 )
   {
     return CloseArchiveImpl<false>( std::move( zip ) ).Timeout( timeout );
   }

--- a/src/XrdClHttp/XrdClHttpFilePlugIn.cc
+++ b/src/XrdClHttp/XrdClHttpFilePlugIn.cc
@@ -83,7 +83,7 @@ HttpFilePlugIn::~HttpFilePlugIn() noexcept {
 
 XRootDStatus HttpFilePlugIn::Open(const std::string &url,
                                   OpenFlags::Flags flags, Access::Mode /*mode*/,
-                                  ResponseHandler *handler, uint16_t timeout) {
+                                  ResponseHandler *handler, time_t timeout) {
   if (is_open_) {
     logger_->Error(kLogXrdClHttp, "URL %s already open", url.c_str());
     return XRootDStatus(stError, errInvalidOp);
@@ -179,7 +179,7 @@ XRootDStatus HttpFilePlugIn::Open(const std::string &url,
 }
 
 XRootDStatus HttpFilePlugIn::Close(ResponseHandler *handler,
-                                   uint16_t /*timeout*/) {
+                                   time_t /*timeout*/) {
   if (!is_open_) {
     logger_->Error(kLogXrdClHttp,
                    "Cannot close. URL hasn't been previously opened");
@@ -204,7 +204,7 @@ XRootDStatus HttpFilePlugIn::Close(ResponseHandler *handler,
 }
 
 XRootDStatus HttpFilePlugIn::Stat(bool /*force*/, ResponseHandler *handler,
-                                  uint16_t timeout) {
+                                  time_t timeout) {
   if (!is_open_) {
     logger_->Error(kLogXrdClHttp,
                    "Cannot stat. URL hasn't been previously opened");
@@ -238,7 +238,7 @@ XRootDStatus HttpFilePlugIn::Stat(bool /*force*/, ResponseHandler *handler,
 
 XRootDStatus HttpFilePlugIn::Read(uint64_t offset, uint32_t size, void *buffer,
                                   ResponseHandler *handler,
-                                  uint16_t /*timeout*/) {
+                                  time_t /*timeout*/) {
   if (!is_open_) {
     logger_->Error(kLogXrdClHttp,
                    "Cannot read. URL hasn't previously been opened");
@@ -343,7 +343,7 @@ class PgReadSubstitutionHandler : public XrdCl::ResponseHandler {
 
 XRootDStatus HttpFilePlugIn::PgRead(uint64_t offset, uint32_t size, void *buffer,
                                     ResponseHandler *handler,
-                                    uint16_t timeout) {
+                                    time_t timeout) {
   ResponseHandler *substitHandler = new PgReadSubstitutionHandler( handler, isChannelEncrypted );
   XRootDStatus st = Read(offset, size, buffer, substitHandler, timeout);
   return st;
@@ -351,7 +351,7 @@ XRootDStatus HttpFilePlugIn::PgRead(uint64_t offset, uint32_t size, void *buffer
 
 XRootDStatus HttpFilePlugIn::Write(uint64_t offset, uint32_t size,
                                    const void *buffer, ResponseHandler *handler,
-                                   uint16_t timeout) {
+                                   time_t timeout) {
   if (!is_open_) {
     logger_->Error(kLogXrdClHttp,
                    "Cannot write. URL hasn't previously been opened");
@@ -385,12 +385,12 @@ XRootDStatus HttpFilePlugIn::PgWrite( uint64_t               offset,
                                       const void            *buffer,
                                       std::vector<uint32_t> &cksums,
                                       ResponseHandler       *handler,
-                                      uint16_t               timeout )
+                                      time_t                 timeout )
 {   (void)cksums;
     return Write(offset, size, buffer, handler, timeout);
 }
 
-XRootDStatus HttpFilePlugIn::Sync(ResponseHandler *handler, uint16_t timeout) {
+XRootDStatus HttpFilePlugIn::Sync(ResponseHandler *handler, time_t timeout) {
   (void)handler;
   (void)timeout;
 
@@ -402,7 +402,7 @@ XRootDStatus HttpFilePlugIn::Sync(ResponseHandler *handler, uint16_t timeout) {
 
 XRootDStatus HttpFilePlugIn::VectorRead(const ChunkList &chunks, void *buffer,
                                         ResponseHandler *handler,
-                                        uint16_t /*timeout*/) {
+                                        time_t /*timeout*/) {
   if (!is_open_) {
     logger_->Error(kLogXrdClHttp,
                    "Cannot read. URL hasn't previously been opened");

--- a/src/XrdClHttp/XrdClHttpFilePlugIn.hh
+++ b/src/XrdClHttp/XrdClHttpFilePlugIn.hh
@@ -42,20 +42,20 @@ class HttpFilePlugIn : public FilePlugIn {
                              OpenFlags::Flags   flags,
                              Access::Mode       mode,
                              ResponseHandler   *handler,
-                             uint16_t           timeout ) override;
+                             time_t             timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::Close
   //------------------------------------------------------------------------
   virtual XRootDStatus Close( ResponseHandler *handler,
-                              uint16_t         timeout ) override;
+                              time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::Stat
   //------------------------------------------------------------------------
   virtual XRootDStatus Stat( bool             force,
                              ResponseHandler *handler,
-                             uint16_t         timeout ) override;
+                             time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::Read
@@ -64,7 +64,7 @@ class HttpFilePlugIn : public FilePlugIn {
                              uint32_t         size,
                              void            *buffer,
                              ResponseHandler *handler,
-                             uint16_t         timeout ) override;
+                             time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::PgRead - async
@@ -73,7 +73,7 @@ class HttpFilePlugIn : public FilePlugIn {
                                uint32_t         size,
                                void            *buffer,
                                ResponseHandler *handler,
-                               uint16_t         timeout ) override;
+                               time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::Write
@@ -82,7 +82,7 @@ class HttpFilePlugIn : public FilePlugIn {
                               uint32_t         size,
                               const void      *buffer,
                               ResponseHandler *handler,
-                              uint16_t         timeout ) override;
+                              time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::PgWrite - async
@@ -92,13 +92,13 @@ class HttpFilePlugIn : public FilePlugIn {
                                 const void            *buffer,
                                 std::vector<uint32_t> &cksums,
                                 ResponseHandler       *handler,
-                                uint16_t               timeout ) override;
+                                time_t                 timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::Sync
   //------------------------------------------------------------------------
   virtual XRootDStatus Sync( ResponseHandler *handler,
-                             uint16_t         timeout ) override;
+                             time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::VectorRead
@@ -106,7 +106,7 @@ class HttpFilePlugIn : public FilePlugIn {
   virtual XRootDStatus VectorRead( const ChunkList &chunks,
                                    void            *buffer,
                                    XrdCl::ResponseHandler *handler,
-                                   uint16_t         timeout ) override;
+                                   time_t           timeout ) override;
 
   //------------------------------------------------------------------------
   //! @see XrdCl::File::IsOpen

--- a/src/XrdClHttp/XrdClHttpFileSystemPlugIn.cc
+++ b/src/XrdClHttp/XrdClHttpFileSystemPlugIn.cc
@@ -64,7 +64,7 @@ HttpFileSystemPlugIn::~HttpFileSystemPlugIn() noexcept {
 XRootDStatus HttpFileSystemPlugIn::Mv(const std::string &source,
                                       const std::string &dest,
                                       ResponseHandler *handler,
-                                      uint16_t timeout) {
+                                      time_t timeout) {
   //const auto full_source_path = url_.GetLocation() + source;
   //const auto full_dest_path = url_.GetLocation() + dest;
   const auto full_source_path = url_.GetProtocol() + "://"
@@ -95,7 +95,7 @@ XRootDStatus HttpFileSystemPlugIn::Mv(const std::string &source,
 
 XRootDStatus HttpFileSystemPlugIn::Rm(const std::string &path,
                                       ResponseHandler *handler,
-                                      uint16_t timeout) {
+                                      time_t timeout) {
   auto url = url_;
   url.SetPath(path);
 
@@ -119,7 +119,7 @@ XRootDStatus HttpFileSystemPlugIn::MkDir(const std::string &path,
                                          MkDirFlags::Flags flags,
                                          Access::Mode mode,
                                          ResponseHandler *handler,
-                                         uint16_t timeout) {
+                                         time_t timeout) {
   auto url = url_;
   url.SetPath(path);
 
@@ -141,7 +141,7 @@ XRootDStatus HttpFileSystemPlugIn::MkDir(const std::string &path,
 
 XRootDStatus HttpFileSystemPlugIn::RmDir(const std::string &path,
                                          ResponseHandler *handler,
-                                         uint16_t timeout) {
+                                         time_t timeout) {
   auto url = url_;
   url.SetPath(path);
 
@@ -162,7 +162,7 @@ XRootDStatus HttpFileSystemPlugIn::RmDir(const std::string &path,
 XRootDStatus HttpFileSystemPlugIn::DirList(const std::string &path,
                                            DirListFlags::Flags flags,
                                            ResponseHandler *handler,
-                                           uint16_t timeout) {
+                                           time_t timeout) {
   auto url = url_;
   url.SetPath(path);
   const auto full_path = url.GetLocation();
@@ -193,7 +193,7 @@ XRootDStatus HttpFileSystemPlugIn::DirList(const std::string &path,
 
 XRootDStatus HttpFileSystemPlugIn::Stat(const std::string &path,
                                         ResponseHandler *handler,
-                                        uint16_t timeout) {
+                                        time_t timeout) {
   //const auto full_path = url_.GetLocation() + path;
   const auto full_path = url_.GetProtocol() + "://" +
                          url_.GetHostName() + ":" +

--- a/src/XrdClHttp/XrdClHttpFileSystemPlugIn.hh
+++ b/src/XrdClHttp/XrdClHttpFileSystemPlugIn.hh
@@ -21,25 +21,25 @@ class HttpFileSystemPlugIn : public FileSystemPlugIn {
   virtual ~HttpFileSystemPlugIn() noexcept;
 
   virtual XRootDStatus Mv(const std::string &source, const std::string &dest,
-                          ResponseHandler *handler, uint16_t timeout) override;
+                          ResponseHandler *handler, time_t timeout) override;
 
   virtual XRootDStatus Rm(const std::string &path, ResponseHandler *handler,
-                          uint16_t timeout) override;
+                          time_t timeout) override;
 
   virtual XRootDStatus MkDir(const std::string &path, MkDirFlags::Flags flags,
                              Access::Mode mode, ResponseHandler *handler,
-                             uint16_t timeout) override;
+                             time_t timeout) override;
 
   virtual XRootDStatus RmDir(const std::string &path, ResponseHandler *handler,
-                             uint16_t timeout) override;
+                             time_t timeout) override;
 
   virtual XRootDStatus DirList(const std::string &path,
                                DirListFlags::Flags flags,
                                ResponseHandler *handler,
-                               uint16_t timeout) override;
+                               time_t timeout) override;
 
   virtual XRootDStatus Stat(const std::string &path, ResponseHandler *handler,
-                            uint16_t timeout) override;
+                            time_t timeout) override;
 
   virtual bool SetProperty(const std::string &name,
                            const std::string &value) override;

--- a/src/XrdClHttp/XrdClHttpPosix.cc
+++ b/src/XrdClHttp/XrdClHttpPosix.cc
@@ -44,7 +44,7 @@ std::vector<std::string> SplitString(const std::string& input,
   return result;
 }
 
-void SetTimeout(Davix::RequestParams& params, uint16_t timeout) {
+void SetTimeout(Davix::RequestParams& params, time_t timeout) {
 /*
  * At NERSC archive portal, we get error when setOperationTimeout()
  *
@@ -199,7 +199,7 @@ using namespace XrdCl;
 
 std::pair<DAVIX_FD*, XRootDStatus> Open(Davix::DavPosix& davix_client,
                                         const std::string& url, int flags,
-                                        uint16_t timeout) {
+                                        time_t timeout) {
   Davix::RequestParams params;
   SetTimeout(params, timeout);
   SetAuthz(params);
@@ -231,7 +231,7 @@ XRootDStatus Close(Davix::DavPosix& davix_client, DAVIX_FD* fd) {
 
 XRootDStatus MkDir(Davix::DavPosix& davix_client, const std::string& path,
                    XrdCl::MkDirFlags::Flags flags, XrdCl::Access::Mode /*mode*/,
-                   uint16_t timeout) {
+                   time_t timeout) {
 
   return XRootDStatus();
 
@@ -280,7 +280,7 @@ XRootDStatus MkDir(Davix::DavPosix& davix_client, const std::string& path,
 }
 
 XRootDStatus RmDir(Davix::DavPosix& davix_client, const std::string& path,
-                   uint16_t timeout) {
+                   time_t timeout) {
   Davix::RequestParams params;
   SetTimeout(params, timeout);
   SetAuthz(params);
@@ -298,7 +298,7 @@ XRootDStatus RmDir(Davix::DavPosix& davix_client, const std::string& path,
 
 std::pair<XrdCl::DirectoryList*, XrdCl::XRootDStatus> DirList(
     Davix::DavPosix& davix_client, const std::string& path, bool details,
-    bool /*recursive*/, uint16_t timeout) {
+    bool /*recursive*/, time_t timeout) {
   Davix::RequestParams params;
   SetTimeout(params, timeout);
   SetAuthz(params);
@@ -354,7 +354,7 @@ std::pair<XrdCl::DirectoryList*, XrdCl::XRootDStatus> DirList(
 }
 
 XRootDStatus Rename(Davix::DavPosix& davix_client, const std::string& source,
-                    const std::string& dest, uint16_t timeout) {
+                    const std::string& dest, time_t timeout) {
 
   // most s3 storage systems either:
   // 1. do not support rename, especially for files that were uploaded using multi-part
@@ -379,7 +379,7 @@ XRootDStatus Rename(Davix::DavPosix& davix_client, const std::string& source,
 }
 
 XRootDStatus Stat(Davix::DavPosix& davix_client, const std::string& url,
-                  uint16_t timeout, StatInfo* stat_info) {
+                  time_t timeout, StatInfo* stat_info) {
   Davix::RequestParams params;
   SetTimeout(params, timeout);
   SetAuthz(params);
@@ -403,7 +403,7 @@ XRootDStatus Stat(Davix::DavPosix& davix_client, const std::string& url,
 }
 
 XRootDStatus Unlink(Davix::DavPosix& davix_client, const std::string& url,
-                    uint16_t timeout) {
+                    time_t timeout) {
   Davix::RequestParams params;
   SetTimeout(params, timeout);
   SetAuthz(params);
@@ -480,7 +480,7 @@ std::pair<int, XrdCl::XRootDStatus> PReadVec(Davix::DavPosix& davix_client,
 std::pair<int, XrdCl::XRootDStatus> PWrite(Davix::DavPosix& davix_client,
                                            DAVIX_FD* fd, uint64_t offset,
                                            uint32_t size, const void* buffer,
-                                           uint16_t timeout) {
+                                           time_t timeout) {
   Davix::DavixError* err = nullptr;
   off_t new_offset = davix_client.lseek(fd, offset, SEEK_SET, &err);
   if (uint64_t(new_offset) != offset) {

--- a/src/XrdClHttp/XrdClHttpPosix.hh
+++ b/src/XrdClHttp/XrdClHttpPosix.hh
@@ -22,31 +22,31 @@ namespace Posix {
 
 std::pair<DAVIX_FD*, XrdCl::XRootDStatus> Open(Davix::DavPosix& davix_client,
                                                const std::string& url,
-                                               int flags, uint16_t timeout);
+                                               int flags, time_t timeout);
 
 XrdCl::XRootDStatus Close(Davix::DavPosix& davix_client, DAVIX_FD* fd);
 
 XrdCl::XRootDStatus MkDir(Davix::DavPosix& davix_client,
                           const std::string& path,
                           XrdCl::MkDirFlags::Flags flags,
-                          XrdCl::Access::Mode mode, uint16_t timeout);
+                          XrdCl::Access::Mode mode, time_t timeout);
 
 XrdCl::XRootDStatus RmDir(Davix::DavPosix& davix_client,
-                          const std::string& path, uint16_t timeout);
+                          const std::string& path, time_t timeout);
 
 std::pair<XrdCl::DirectoryList*, XrdCl::XRootDStatus> DirList(
     Davix::DavPosix& davix_client, const std::string& path, bool details,
-    bool recursive, uint16_t timeout);
+    bool recursive, time_t timeout);
 
 XrdCl::XRootDStatus Rename(Davix::DavPosix& davix_client,
                            const std::string& source, const std::string& dest,
-                           uint16_t timeout);
+                           time_t timeout);
 
 XrdCl::XRootDStatus Stat(Davix::DavPosix& davix_client, const std::string& url,
-                         uint16_t timeout, XrdCl::StatInfo* stat_info);
+                         time_t timeout, XrdCl::StatInfo* stat_info);
 
 XrdCl::XRootDStatus Unlink(Davix::DavPosix& davix_client,
-                           const std::string& url, uint16_t timeout);
+                           const std::string& url, time_t timeout);
 
 std::pair<int, XrdCl::XRootDStatus> Read(Davix::DavPosix& davix_client,
                                          DAVIX_FD* fd, void* buffer,
@@ -64,7 +64,7 @@ std::pair<int, XrdCl::XRootDStatus> PReadVec(Davix::DavPosix& davix_client,
 std::pair<int, XrdCl::XRootDStatus> PWrite(Davix::DavPosix& davix_client,
                                            DAVIX_FD* fd, uint64_t offset,
                                            uint32_t size, const void* buffer,
-                                           uint16_t timeout);
+                                           time_t timeout);
 
 }  // namespace Posix
 

--- a/src/XrdEc/XrdEcReader.cc
+++ b/src/XrdEc/XrdEcReader.cc
@@ -89,11 +89,11 @@ namespace XrdEc
       // @return       :  status of the operation
       //-----------------------------------------------------------------------
       XrdCl::XRootDStatus RunImpl( XrdCl::PipelineHandler *handler,
-                                   uint16_t                pipelineTimeout )
+                                   time_t                  pipelineTimeout )
       {
         std::string      url     = std::get<UrlArg>( this->args ).Get();
         bool             updt    = std::get<UpdtArg>( this->args ).Get();
-        uint16_t         timeout = pipelineTimeout < this->timeout ?
+        time_t           timeout = pipelineTimeout < this->timeout ?
                                    pipelineTimeout : this->timeout;
         return this->zip->OpenOnly( url, updt, handler, timeout );
       }
@@ -105,7 +105,7 @@ namespace XrdEc
   inline OpenOnlyImpl<false> OpenOnly( XrdCl::Ctx<XrdCl::ZipArchive> zip,
                                        XrdCl::Arg<std::string>       fn,
                                        XrdCl::Arg<bool>              updt,
-                                       uint16_t                      timeout = 0 )
+                                       time_t                        timeout = 0 )
   {
     return OpenOnlyImpl<false>( std::move( zip ), std::move( fn ),
                                 std::move( updt ) ).Timeout( timeout );
@@ -155,7 +155,7 @@ namespace XrdEc
                       uint32_t                  size,
                       char                     *usrbuff,
                       callback_t                usrcb,
-                      uint16_t                  timeout )
+                      time_t                    timeout )
     {
       std::unique_lock<std::mutex> lck( self->mtx );
 
@@ -431,7 +431,7 @@ namespace XrdEc
   //---------------------------------------------------------------------------
   // Open the erasure coded / striped object
   //---------------------------------------------------------------------------
-  void Reader::Open( XrdCl::ResponseHandler *handler, uint16_t timeout )
+  void Reader::Open( XrdCl::ResponseHandler *handler, time_t timeout )
   {
     const size_t size = objcfg.plgr.size();
     std::vector<XrdCl::Pipeline> opens; opens.reserve( size );
@@ -491,7 +491,7 @@ namespace XrdEc
                      uint32_t                length,
                      void                   *buffer,
                      XrdCl::ResponseHandler *handler,
-                     uint16_t                timeout )
+                     time_t                  timeout )
   {
     if( objcfg.nomtfile )
     {
@@ -585,7 +585,7 @@ namespace XrdEc
   //-----------------------------------------------------------------------
   // Close the data object
   //-----------------------------------------------------------------------
-  void Reader::Close( XrdCl::ResponseHandler *handler, uint16_t timeout )
+  void Reader::Close( XrdCl::ResponseHandler *handler, time_t timeout )
   {
     //---------------------------------------------------------------------
     // prepare the pipelines ...
@@ -613,7 +613,7 @@ namespace XrdEc
   //-------------------------------------------------------------------------
   // on-definition is not allowed here beforeiven stripes from given block
   //-------------------------------------------------------------------------
-  void Reader::Read( size_t blknb, size_t strpnb, buffer_t &buffer, callback_t cb, uint16_t timeout )
+  void Reader::Read( size_t blknb, size_t strpnb, buffer_t &buffer, callback_t cb, time_t timeout )
   {
     // generate the file name (blknb/strpnb)
     std::string fn = objcfg.GetFileName( blknb, strpnb );
@@ -851,7 +851,7 @@ namespace XrdEc
 	                 };
   }
 
-  void Reader::MissingVectorRead(std::shared_ptr<block_t> &currentBlock, size_t blkid, size_t strpid, uint16_t timeout){
+  void Reader::MissingVectorRead(std::shared_ptr<block_t> &currentBlock, size_t blkid, size_t strpid, time_t timeout){
 	  {
 		std::unique_lock<std::mutex> lk(missingChunksMutex);
 		missingChunksVectorRead.emplace_back(
@@ -865,7 +865,7 @@ namespace XrdEc
   }
 
 
-  void Reader::VectorRead(const XrdCl::ChunkList &chunks, void *buffer, XrdCl::ResponseHandler *handler, uint16_t timeout){
+  void Reader::VectorRead(const XrdCl::ChunkList &chunks, void *buffer, XrdCl::ResponseHandler *handler, time_t timeout){
 	  if(chunks.size() > 1024) {
 		  if(handler) handler->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, XrdCl::errInvalidArgs), nullptr);
 		  return;

--- a/src/XrdEc/XrdEcReader.hh
+++ b/src/XrdEc/XrdEcReader.hh
@@ -82,7 +82,7 @@ namespace XrdEc
       //!
       //! @param handler : user callback
       //-----------------------------------------------------------------------
-      void Open( XrdCl::ResponseHandler *handler, uint16_t timeout = 0 );
+      void Open( XrdCl::ResponseHandler *handler, time_t timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Read data from the data object
@@ -96,7 +96,7 @@ namespace XrdEc
                  uint32_t                length,
                  void                   *buffer,
                  XrdCl::ResponseHandler *handler,
-                 uint16_t                timeout );
+                 time_t                  timeout );
 
       /*
        * Read multiple locations and lengths of data
@@ -108,12 +108,12 @@ namespace XrdEc
       void VectorRead( 	const XrdCl::ChunkList 	&chunks,
     		  	  	  	void 					*buffer,
 					    XrdCl::ResponseHandler 	*handler,
-						uint16_t 				timeout);
+						time_t   				timeout);
 
       //-----------------------------------------------------------------------
       //! Close the data object
       //-----------------------------------------------------------------------
-      void Close( XrdCl::ResponseHandler *handler, uint16_t timeout = 0 );
+      void Close( XrdCl::ResponseHandler *handler, time_t timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! @return : get file size
@@ -134,7 +134,7 @@ namespace XrdEc
       //! @param cb      : callback
       //! @param timeout : operation timeout
       //-----------------------------------------------------------------------
-      void Read( size_t blknb, size_t strpnb, buffer_t &buffer, callback_t cb, uint16_t timeout = 0 );
+      void Read( size_t blknb, size_t strpnb, buffer_t &buffer, callback_t cb, time_t timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Read metadata for the object
@@ -171,7 +171,7 @@ namespace XrdEc
 
       inline static callback_t ErrorCorrected(Reader *reader, std::shared_ptr<block_t> &self, size_t blkid, size_t strpid);
 
-      void MissingVectorRead(std::shared_ptr<block_t> &block, size_t blkid, size_t strpid, uint16_t timeout = 0);
+      void MissingVectorRead(std::shared_ptr<block_t> &block, size_t blkid, size_t strpid, time_t timeout = 0);
 
       typedef std::unordered_map<std::string, std::shared_ptr<XrdCl::ZipArchive>> dataarchs_t;
       typedef std::unordered_map<std::string, buffer_t> metadata_t;

--- a/src/XrdEc/XrdEcStrmWriter.cc
+++ b/src/XrdEc/XrdEcStrmWriter.cc
@@ -41,7 +41,7 @@ namespace XrdEc
   //---------------------------------------------------------------------------
   // Open the data object for writting
   //---------------------------------------------------------------------------
-  void StrmWriter::Open( XrdCl::ResponseHandler *handler, uint16_t timeout )
+  void StrmWriter::Open( XrdCl::ResponseHandler *handler, time_t timeout )
   {
     const size_t size = objcfg.plgr.size();
 
@@ -105,7 +105,7 @@ namespace XrdEc
   //---------------------------------------------------------------------------
   // Close the data object
   //---------------------------------------------------------------------------
-  void StrmWriter::Close( XrdCl::ResponseHandler *handler, uint16_t timeout )
+  void StrmWriter::Close( XrdCl::ResponseHandler *handler, time_t timeout )
   {
     //-------------------------------------------------------------------------
     // First, check the global status, if we are in an error state just
@@ -273,7 +273,7 @@ namespace XrdEc
   //---------------------------------------------------------------------------
   // Close the data object (implementation)
   //---------------------------------------------------------------------------
-  void StrmWriter::CloseImpl( XrdCl::ResponseHandler *handler, uint16_t timeout )
+  void StrmWriter::CloseImpl( XrdCl::ResponseHandler *handler, time_t timeout )
   {
     //-------------------------------------------------------------------------
     // First, check the global status, if we are in an error state just

--- a/src/XrdEc/XrdEcStrmWriter.hh
+++ b/src/XrdEc/XrdEcStrmWriter.hh
@@ -84,7 +84,7 @@ namespace XrdEc
       //!
       //! @param handler : user callback
       //-----------------------------------------------------------------------
-      void Open( XrdCl::ResponseHandler *handler, uint16_t timeout = 0 );
+      void Open( XrdCl::ResponseHandler *handler, time_t timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! Write data to the data object
@@ -100,7 +100,7 @@ namespace XrdEc
       //!
       //! @param handler : user callback
       //-----------------------------------------------------------------------
-      void Close( XrdCl::ResponseHandler *handler, uint16_t timeout = 0 );
+      void Close( XrdCl::ResponseHandler *handler, time_t timeout = 0 );
 
       //-----------------------------------------------------------------------
       //! @return : get file size
@@ -162,7 +162,7 @@ namespace XrdEc
         //---------------------------------------------------------------------
         // Indicate that the user issued close
         //---------------------------------------------------------------------
-        void issue_close( XrdCl::ResponseHandler *handler, uint16_t timeout )
+        void issue_close( XrdCl::ResponseHandler *handler, time_t timeout )
         {
           std::unique_lock<std::recursive_mutex> lck( mtx );
           //-------------------------------------------------------------------
@@ -279,7 +279,7 @@ namespace XrdEc
       //!
       //! @param handler : user callback
       //-----------------------------------------------------------------------
-      void CloseImpl( XrdCl::ResponseHandler *handler, uint16_t timeout = 0 );
+      void CloseImpl( XrdCl::ResponseHandler *handler, time_t timeout = 0 );
 
       const ObjCfg                                    &objcfg;
       std::unique_ptr<WrtBuff>                         wrtbuff;            //< current write buffer

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1578,6 +1578,7 @@ int XrdHttpProtocol::StartSimpleResp(int code, const char *desc, const char *hea
     else if (code == 405) ss << "Method Not Allowed";
     else if (code == 416) ss << "Range Not Satisfiable";
     else if (code == 500) ss << "Internal Server Error";
+    else if (code == 502) ss << "Bad Gateway";
     else if (code == 504) ss << "Gateway Timeout";
     else ss << "Unknown";
   }

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -904,6 +904,9 @@ void XrdHttpReq::mapXrdErrorToHttpStatus() {
       case kXR_InvalidRequest:
         httpStatusCode = 405; httpStatusText = "Method is not allowed";
         break;
+      case kXR_noserver:
+        httpStatusCode = 502; httpStatusText = "Bad Gateway";
+        break;
       case kXR_TimerExpired:
         httpStatusCode = 504; httpStatusText = "Gateway timeout";
         break;

--- a/src/XrdNet/XrdNetPMarkFF.cc
+++ b/src/XrdNet/XrdNetPMarkFF.cc
@@ -85,8 +85,8 @@ const char *ffFmt1 =
 const char *ffFmt2 =
   "\"flow-id\":{"
     "\"afi\":\"ipv%c\","            //-> ipv4 | ipv6
-    "\"src-ip\":\"%s\","            //   source which is always server (us)
-    "\"dst-ip\":\"%s\","            //   dest   which is always client
+    "\"src-ip\":\"%s\","            //   source which is always client
+    "\"dst-ip\":\"%s\","            //   dest   which is always server (us)
     "\"protocol\":\"tcp\","
     "\"src-port\":%d,"
     "\"dst-port\":%d"
@@ -294,9 +294,14 @@ void XrdNetPMarkFF::SockStats(struct sockStats &ss)
    struct tcp_info tcpInfo;
    socklen_t  tiLen = sizeof(tcpInfo);
 
+// Note that by convention FF packets must look client generated packets.
+// So, bytes received by the server and actually bytes sent by the client
+// and bytes sent by the server are actually bytes received by the client.
+// This is accomplished by reversing the meaning of sent and received.
+//
    if (getsockopt(sockFD, IPPROTO_TCP, TCP_INFO, (void *)&tcpInfo, &tiLen) == 0)
-      {ss.bRecv = static_cast<uint64_t>(tcpInfo.tcpi_bytes_received);
-       ss.bSent = static_cast<uint64_t>(tcpInfo.tcpi_bytes_acked);
+      {ss.bSent = static_cast<uint64_t>(tcpInfo.tcpi_bytes_received);
+       ss.bRecv = static_cast<uint64_t>(tcpInfo.tcpi_bytes_acked);
        ss.msRTT = static_cast<uint32_t>(tcpInfo.tcpi_rtt/1000);
        ss.usRTT = static_cast<uint32_t>(tcpInfo.tcpi_rtt%1000);
       } else {
@@ -386,9 +391,12 @@ bool XrdNetPMarkFF::Start(XrdNetAddrInfo &addr)
        return false;
       }
 
+// Note that by convention FF packets must look client generated packets.
+// This, source is always he client and destination is alays the server.
+//
    char bseg2[256];
    int len2 = snprintf(bseg2, sizeof(bseg2), ffFmt2,
-                              clType, svIP, clIP, svPort, clPort);
+                              clType, clIP, svIP, clPort, svPort);
    if (len2 >= (int)sizeof(bseg2))
       {eDest->Emsg("PMarkFF", "invalid json; cl bseg2 truncated.");
        return false;

--- a/src/XrdOfs/XrdOfs.cc
+++ b/src/XrdOfs/XrdOfs.cc
@@ -225,6 +225,7 @@ XrdOfs::XrdOfs() : dMask{0000,0775}, fMask{0000,0775}, // Legacy
    DirRdr    = false;
    reProxy   = false;
    OssHasPGrw= false;
+   tryXERT   = false;
 }
 
 /******************************************************************************/
@@ -285,11 +286,19 @@ int XrdOfsDirectory::open(const char              *dir_path, // In
               {fname = strdup(dir_path);
                return SFS_OK;
               }
-              else {delete dp; dp = 0;}
+
+// Handle extended error information
+//
+   std::string eText;
+   const char* etP = 0;
+   if (dp && XrdOfsFS->tryXERT)
+      {if (dp->getErrMsg(eText)) etP = eText.c_str();
+       delete dp; dp = 0;
+      }
 
 // Encountered an error
 //
-   return XrdOfsFS->Emsg(epname, error, retc, "open directory", dir_path);
+   return XrdOfsFS->Emsg(epname, error, retc, "open directory", dir_path, etP);
 }
 
 /******************************************************************************/
@@ -333,7 +342,10 @@ const char *XrdOfsDirectory::nextEntry()
 // Read the next directory entry
 //
    if ((retc = dp->Readdir(dname, sizeof(dname))) < 0)
-      {XrdOfsFS->Emsg(epname, error, retc, "read directory", fname);
+      {std::string eText;
+       const char* etP = 0;
+       if (XrdOfsFS->tryXERT && dp->getErrMsg(eText)) etP = eText.c_str();
+       XrdOfsFS->Emsg(epname, error, retc, "read directory", fname, etP);
        return 0;
       }
 
@@ -383,8 +395,11 @@ int XrdOfsDirectory::close()
 // Close this directory
 //
     if ((retc = dp->Close()))
-       retc = XrdOfsFS->Emsg(epname, error, retc, "close", fname);
-       else retc = SFS_OK;
+      {std::string eText;
+       const char* etP = 0;
+       if (XrdOfsFS->tryXERT && dp->getErrMsg(eText)) etP = eText.c_str();
+       retc = XrdOfsFS->Emsg(epname, error, retc, "close", fname, etP);
+      }  else retc = SFS_OK;
 
 // All done
 //
@@ -582,7 +597,8 @@ int XrdOfsFile::open(const char          *path,      // In
 // Preset TPC handling and if not allowed, complain
 //
    if (tpcKey && (open_mode & SFS_O_NOTPC))
-      return XrdOfsFS->Emsg(epname, error, EPROTOTYPE, "tpc", path);
+      return XrdOfsFS->Emsg(epname, error, EPROTOTYPE, "tpc", path,
+                            "+TPC prohibited due to security configuration");
 
 // Create the file if so requested o/w try to attach the file
 //
@@ -618,7 +634,8 @@ int XrdOfsFile::open(const char          *path,      // In
        if (isPosc)
           {bool isNew = (open_mode & SFS_O_TRUNC) == 0;
            if ((oP.poscNum = XrdOfsFS->poscQ->Add(tident, path, isNew)) < 0)
-              return XrdOfsFS->Emsg(epname, error, oP.poscNum, "pcreate", path);
+              return XrdOfsFS->Emsg(epname, error, oP.poscNum, "pcreate", path,
+                     "+ofs_open: failed to enter file into posc queue");
           }
 
        // Create the file. If ENOTSUP is returned, promote the creation to
@@ -676,7 +693,8 @@ int XrdOfsFile::open(const char          *path,      // In
    if (tpcKey && isRW)
       {char pfnbuff[MAXPATHLEN+8]; const char *pfnP;
        if (!(pfnP = XrdOfsOss->Lfn2Pfn(path, pfnbuff, MAXPATHLEN, retc)))
-          return XrdOfsFS->Emsg(epname, error, retc, "open", path);
+          return XrdOfsFS->Emsg(epname, error, retc, "open", path,
+                           "+ofs_open: mapping tpc target lfn to pfn failed");
        XrdOfsTPC::Facts Args(client, &error, &Open_Env, tpcKey, path, pfnP);
        if ((retc = XrdOfsTPC::Validate(&myTPC, Args))) return retc;
       }
@@ -688,7 +706,8 @@ int XrdOfsFile::open(const char          *path,      // In
       {if (!isRW) return XrdOfsFS->Stall(error, -1, path);
        if ((retc = oP.hP->PoscSet(tident, oP.poscNum, theMode)))
           {if (retc > 0) XrdOfsFS->poscQ->Del(path, retc);
-              else return XrdOfsFS->Emsg(epname, error, retc, "access", path);
+              else return XrdOfsFS->Emsg(epname, error, retc, "access", path,
+                                    "+ofs_open: posc mode initiation failed");
           }
       }
 
@@ -699,7 +718,8 @@ int XrdOfsFile::open(const char          *path,      // In
    if (!(oP.hP->Inactive()))
       {dorawio = (oh->isCompressed && open_mode & SFS_O_RAWIO ? 1 : 0);
        if (tpcKey && isRW)
-          return XrdOfsFS->Emsg(epname, error, EALREADY, "tpc", path);
+          return XrdOfsFS->Emsg(epname, error, EALREADY, "tpc", path,
+                           "+ofs_open: this tpc is already in progress");
        XrdOfsFS->ocMutex.Lock(); oh = oP.hP; XrdOfsFS->ocMutex.UnLock();
        FTRACE(open, "attach use=" <<oh->Usage());
        if (oP.poscNum > 0) XrdOfsFS->poscQ->Commit(path, oP.poscNum);
@@ -740,14 +760,18 @@ int XrdOfsFile::open(const char          *path,      // In
           }
        if (XrdOfsFS->Balancer && retc == -ENOENT)
           XrdOfsFS->Balancer->Removed(path);
-       return XrdOfsFS->Emsg(epname, error, retc, "open", path);
+       const char* etP = 0;
+       std::string eText;
+       if (XrdOfsFS->tryXERT && oP.fP->getErrMsg(eText)) etP = eText.c_str();
+       return XrdOfsFS->Emsg(epname, error, retc, "open", path, etP);
       }
 
 // Verify that we can actually use this file
 //
    if (oP.poscNum > 0)
       {if ((retc = oP.fP->Fchmod(static_cast<mode_t>(theMode|XRDSFS_POSCPEND))))
-          return XrdOfsFS->Emsg(epname, error, retc, "fchmod", path);
+          return XrdOfsFS->Emsg(epname, error, retc, "fchmod", path,
+                                "+ofs_open: POSC file designation failed");
        XrdOfsFS->poscQ->Commit(path, oP.poscNum);
       }
 
@@ -768,7 +792,7 @@ int XrdOfsFile::open(const char          *path,      // In
        int theFD =  oP.fP->getFD();
        if (theFD >= 0 && fadFails < 4096)
           if (posix_fadvise(theFD, 0, 0, POSIX_FADV_SEQUENTIAL) < 0)
-             {OfsEroute.Emsg(epname, errno, "fadsize for sequential I/O.");
+             {OfsEroute.Emsg(epname, errno, "fadvise for sequential I/O.");
               fadFails++;
              }
       }
@@ -1011,13 +1035,15 @@ int            XrdOfsFile::CreateCKP()
 // Verify that this file is open r/w mode
 //
    if (!(oh->isRW)) return XrdOfsFS->Emsg("CreateCKP", error, ENOTTY,
-                           "create checkpoint for R/O", oh->Name());
+                           "create checkpoint for R/O", oh->Name(),
+                           "+ofs_CreateCKP: file is not open in r/w mode");
 
 // POSC and checkpoints are mutally exclusive
 //
    if (oh->isRW == XrdOfsHandle::opPC)
       return XrdOfsFS->Emsg("CreateCKP", error, ENOTTY,
-                            "create checkpoint for POSC file", oh->Name());
+                            "create checkpoint for POSC file", oh->Name(),
+                            "+ofs_CreateCKP: POSC file cannot be checkpointed");
 
 // Get a new checkpoint object
 //
@@ -1130,7 +1156,7 @@ XrdSfsXferSize XrdOfsFile::pgRead(XrdSfsFileOffset   offset,
    nbytes = (XrdSfsXferSize)(oh->Select().pgRead((void *)buffer,
                             (off_t)offset, (size_t)rdlen, csvec, pgOpts));
    if (nbytes < 0)
-      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "pgRead", oh->Name());
+      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "pgRead", oh);
 
 // Return number of bytes read
 //
@@ -1174,7 +1200,7 @@ XrdSfsXferSize XrdOfsFile::pgRead(XrdSfsAio *aioparm, uint64_t opts)
 // Issue the read. Only true errors are returned here.
 //
    if ((rc = oh->Select().pgRead(aioparm, pgOpts)) < 0)
-      return XrdOfsFS->Emsg(epname, error, rc, "pgRead", oh->Name());
+      return XrdOfsFS->Emsg(epname, error, rc, "pgRead", oh);
 
 // All done
 //
@@ -1211,7 +1237,7 @@ XrdSfsXferSize XrdOfsFile::pgWrite(XrdSfsFileOffset   offset,
 //
 #if _FILE_OFFSET_BITS!=64
    if (offset >  0x000000007fffffff)
-      return  XrdOfsFS->Emsg(epname, error, EFBIG, "pgwrite", oh);
+      return  XrdOfsFS->Emsg(epname, error, EFBIG, "pgwrite", oh, true);
 #endif
 
 // Silly Castor stuff
@@ -1230,7 +1256,7 @@ XrdSfsXferSize XrdOfsFile::pgWrite(XrdSfsFileOffset   offset,
    nbytes = (XrdSfsXferSize)(oh->Select().pgWrite((void *)buffer,
                             (off_t)offset, (size_t)wrlen, csvec, pgOpts));
    if (nbytes < 0)
-      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "pgwrite", oh);
+      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "pgwrite", oh, true);
 
 // Return number of bytes written
 //
@@ -1276,7 +1302,7 @@ XrdSfsXferSize XrdOfsFile::pgWrite(XrdSfsAio *aioparm, uint64_t opts)
 //
 #if _FILE_OFFSET_BITS!=64
    if (aiop->sfsAio.aio_offset >  0x000000007fffffff)
-      return  XrdOfsFS->Emsg(epname, error, EFBIG, "pgwrite", oh->Name());
+      return  XrdOfsFS->Emsg(epname, error, EFBIG, "pgwrite", oh, true);
 #endif
 
 // Silly Castor stuff
@@ -1293,7 +1319,7 @@ XrdSfsXferSize XrdOfsFile::pgWrite(XrdSfsAio *aioparm, uint64_t opts)
 //
    oh->isPending = 1;
    if ((rc = oh->Select().pgWrite(aioparm, pgOpts)) < 0)
-       return XrdOfsFS->Emsg(epname, error, rc, "pgwrite", oh->Name());
+       return XrdOfsFS->Emsg(epname, error, rc, "pgwrite", oh, true);
 
 // All done
 //
@@ -1332,7 +1358,7 @@ int            XrdOfsFile::read(XrdSfsFileOffset  offset,    // In
 // Now preread the actual number of bytes
 //
    if ((retc = oh->Select().Read((off_t)offset, (size_t)blen)) < 0)
-      return XrdOfsFS->Emsg(epname, error, (int)retc, "preread", oh->Name());
+      return XrdOfsFS->Emsg(epname, error, (int)retc, "preread", oh);
 
 // Return number of bytes read
 //
@@ -1380,7 +1406,7 @@ XrdSfsXferSize XrdOfsFile::read(XrdSfsFileOffset  offset,    // In
           : (XrdSfsXferSize)(oh->Select().Read((void *)buff,
                             (off_t)offset, (size_t)blen)));
    if (nbytes < 0)
-      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "read", oh->Name());
+      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "read", oh);
 
 // Return number of bytes read
 //
@@ -1410,7 +1436,7 @@ XrdSfsXferSize XrdOfsFile::readv(XrdOucIOVec     *readV,     // In
 
    XrdSfsXferSize nbytes = oh->Select().ReadV(readV, readCount);
    if (nbytes < 0)
-       return XrdOfsFS->Emsg(epname, error, (int)nbytes, "readv", oh->Name());
+       return XrdOfsFS->Emsg(epname, error, (int)nbytes, "readv", oh);
 
    return nbytes;
 
@@ -1458,7 +1484,7 @@ int XrdOfsFile::read(XrdSfsAio *aiop)
 // Issue the read. Only true errors are returned here.
 //
    if ((rc = oh->Select().Read(aiop)) < 0)
-      return XrdOfsFS->Emsg(epname, error, rc, "read", oh->Name());
+      return XrdOfsFS->Emsg(epname, error, rc, "read", oh);
 
 // All done
 //
@@ -1498,7 +1524,7 @@ XrdSfsXferSize XrdOfsFile::write(XrdSfsFileOffset  offset,    // In
 //
 #if _FILE_OFFSET_BITS!=64
    if (offset >  0x000000007fffffff)
-      return  XrdOfsFS->Emsg(epname, error, EFBIG, "write", oh);
+      return  XrdOfsFS->Emsg(epname, error, EFBIG, "write", oh, true);
 #endif
 
 // Silly Castor stuff
@@ -1512,7 +1538,7 @@ XrdSfsXferSize XrdOfsFile::write(XrdSfsFileOffset  offset,    // In
    nbytes = (XrdSfsXferSize)(oh->Select().Write((const void *)buff,
                             (off_t)offset, (size_t)blen));
    if (nbytes < 0)
-      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "write", oh);
+      return XrdOfsFS->Emsg(epname, error, (int)nbytes, "write", oh, true);
 
 // Return number of bytes written
 //
@@ -1549,7 +1575,7 @@ int XrdOfsFile::write(XrdSfsAio *aiop)
 //
 #if _FILE_OFFSET_BITS!=64
    if (aiop->sfsAio.aio_offset >  0x000000007fffffff)
-      return  XrdOfsFS->Emsg(epname, error, EFBIG, "write", oh->Name());
+      return  XrdOfsFS->Emsg(epname, error, EFBIG, "write", oh, true);
 #endif
 
 // Silly Castor stuff
@@ -1561,7 +1587,7 @@ int XrdOfsFile::write(XrdSfsAio *aiop)
 //
    oh->isPending = 1;
    if ((rc = oh->Select().Write(aiop)) < 0)
-       return XrdOfsFS->Emsg(epname, error, rc, "write", oh->Name());
+       return XrdOfsFS->Emsg(epname, error, rc, "write", oh, true);
 
 // All done
 //
@@ -1612,7 +1638,7 @@ int XrdOfsFile::stat(struct stat     *buf)         // Out
 // Perform the function
 //
    if ((retc = oh->Select().Fstat(buf)) < 0)
-      return XrdOfsFS->Emsg(epname,error,retc,"get state for",oh->Name());
+      return XrdOfsFS->Emsg(epname,error,retc,"get state for",oh);
 
    return SFS_OK;
 }
@@ -1657,7 +1683,7 @@ int XrdOfsFile::sync()  // In
 //
    if ((retc = oh->Select().Fsync()))
       {oh->isPending = 1;
-       return XrdOfsFS->Emsg(epname, error, retc, "synchronize", oh);
+       return XrdOfsFS->Emsg(epname, error, retc, "synchronize", oh, true);
       }
 
 // Indicate all went well
@@ -1707,7 +1733,7 @@ int XrdOfsFile::truncate(XrdSfsFileOffset  flen)  // In
 // Make sure the offset is not too large
 //
    if (sizeof(off_t) < sizeof(flen) && flen >  0x000000007fffffff)
-      return  XrdOfsFS->Emsg(epname, error, EFBIG, "truncate", oh);
+      return  XrdOfsFS->Emsg(epname, error, EFBIG, "truncate", oh, true);
 
 // Silly Castor stuff
 //
@@ -1718,7 +1744,7 @@ int XrdOfsFile::truncate(XrdSfsFileOffset  flen)  // In
 //
    oh->isPending = 1;
    if ((retc = oh->Select().Ftruncate(flen)))
-      return XrdOfsFS->Emsg(epname, error, retc, "truncate", oh);
+      return XrdOfsFS->Emsg(epname, error, retc, "truncate", oh, true);
 
 // Indicate Success
 //
@@ -1850,7 +1876,8 @@ int XrdOfs::chksum(      csFunc            Func,   // In
 // At this point we need to convert the lfn to a pfn
 //
    if (CksPfn && !(Path = XrdOfsOss->Lfn2Pfn(Path, buff, MAXPATHLEN, rc)))
-      return Emsg(epname, einfo, rc, "checksum", Path);
+      return Emsg(epname, einfo, rc, "checksum", Path,
+                  "+ofs_chksum: lfn to pfn mapping failed");
 
 // Originally we only passed he env pointer for proxy servers. Due to popular
 // demand, we always pass the env as it points to the SecEntity object unless
@@ -1884,7 +1911,7 @@ int XrdOfs::chksum(      csFunc            Func,   // In
 
 // We failed
 //
-   return Emsg(epname, einfo, rc, "checksum", Path);
+   return Emsg(epname, einfo, rc, "checksum", Path, "?");
 }
   
 /******************************************************************************/
@@ -1935,7 +1962,7 @@ int XrdOfs::chmod(const char             *path,    // In
 // We need to adjust the mode based on whether this is a file or directory.
 //
    if ((retc = XrdOfsOss->Stat(path, &Stat, 0, &chmod_Env)))
-      return XrdOfsFS->Emsg(epname, einfo, retc, "change", path);
+      return XrdOfsFS->Emsg(epname, einfo, retc, "stat", path, "?");
    if (S_ISDIR(Stat.st_mode)) acc_mode = (acc_mode | dMask[0]) & dMask[1];
       else acc_mode = (acc_mode | fMask[0]) & fMask[1];
 
@@ -1952,7 +1979,7 @@ int XrdOfs::chmod(const char             *path,    // In
 
 // An error occurred, return the error info
 //
-   return XrdOfsFS->Emsg(epname, einfo, retc, "change", path);
+   return XrdOfsFS->Emsg(epname, einfo, retc, "chmod", path, "?");
 }
 
 /******************************************************************************/
@@ -2041,7 +2068,7 @@ int XrdOfs::exists(const char                *path,        // In
 
 // An error occurred, return the error info
 //
-   return XrdOfsFS->Emsg(epname, einfo, retc, "locate", path);
+   return XrdOfsFS->Emsg(epname, einfo, retc, "locate", path, "?");
 }
 
 /******************************************************************************/
@@ -2118,7 +2145,7 @@ int XrdOfs::mkdir(const char             *path,    // In
 // Perform the actual operation
 //
     if ((retc = XrdOfsOss->Mkdir(path, acc_mode, mkpath, &mkdir_Env)))
-       return XrdOfsFS->Emsg(epname, einfo, retc, "mkdir", path);
+       return XrdOfsFS->Emsg(epname, einfo, retc, "mkdir", path, "?");
 
 // Check if we should generate an event
 //
@@ -2244,7 +2271,7 @@ int XrdOfs::remove(const char              type,    // In
 //
     retc = (type=='d' ? XrdOfsOss->Remdir(path, 0,   &rem_Env)
                       : XrdOfsOss->Unlink(path, Opt, &rem_Env));
-    if (retc) return XrdOfsFS->Emsg(epname, einfo, retc, "remove", path);
+    if (retc) return XrdOfsFS->Emsg(epname, einfo, retc, "remove", path, "?");
     if (type == 'f') XrdOfsHandle::Hide(path);
     if (Balancer) Balancer->Removed(path);
     return SFS_OK;
@@ -2345,7 +2372,7 @@ int XrdOfs::rename(const char             *old_name,  // In
 // Perform actual rename operation
 //
    if ((retc = XrdOfsOss->Rename(old_name, new_name, &old_Env, &new_Env)))
-      {return XrdOfsFS->Emsg(epname, einfo, retc, "rename", old_name);
+      {return XrdOfsFS->Emsg(epname, einfo, retc, "rename", old_name, "?");
       }
    XrdOfsHandle::Hide(old_name);
    if (Balancer) {Balancer->Removed(old_name);
@@ -2394,7 +2421,7 @@ int XrdOfs::stat(const char             *path,        // In
 // Now try to find the file or directory
 //
    if ((retc = XrdOfsOss->Stat(path, buf, 0, &stat_Env)))
-      return XrdOfsFS->Emsg(epname, einfo, retc, "locate", path);
+      return XrdOfsFS->Emsg(epname, einfo, retc, "locate", path, "?");
    return SFS_OK;
 }
 
@@ -2443,7 +2470,7 @@ int XrdOfs::stat(const char             *path,        // In
    if (!(retc = XrdOfsOss->Stat(path, &buf, XRDOSS_resonly, &stat_Env)))
        mode=buf.st_mode;
       else if ((-ENOMSG) != retc)
-              return XrdOfsFS->Emsg(epname, einfo, retc, "locate", path);
+              return XrdOfsFS->Emsg(epname, einfo, retc, "locate", path, "?");
    return SFS_OK;
 }
 
@@ -2503,7 +2530,7 @@ int XrdOfs::truncate(const char             *path,    // In
 
 // An error occurred, return the error info
 //
-   return XrdOfsFS->Emsg(epname, einfo, retc, "trunc", path);
+   return XrdOfsFS->Emsg(epname, einfo, retc, "trunc", path, "?");
 }
 
 /******************************************************************************/
@@ -2514,18 +2541,29 @@ int XrdOfs::Emsg(const char    *pfx,    // Message prefix value
                  XrdOucErrInfo &einfo,  // Place to put text & error code
                  int            ecode,  // The error code
                  const char    *op,     // Operation being performed
-                 XrdOfsHandle  *hP)     // The target handle
+                 XrdOfsHandle  *hP,     // The target handle
+                 bool           posChk) // Unpersist if in posc mode
 {
+   const char* etP = 0;
    int rc;
+
+// Screen out non-errors
+//
+   if ((rc = EmsgType(ecode)) != SFS_ERROR) return rc;
+
+// Get any extended information
+//
+   std::string eText;
+   if (XrdOfsFS->tryXERT && hP->Select().getErrMsg(eText)) etP = eText.c_str();
 
 // First issue the error message so if we have to unpersist it makes sense
 //
-   if ((rc = Emsg(pfx, einfo, ecode, op, hP->Name())) != SFS_ERROR) return rc;
+   rc = Emsg(pfx, einfo, ecode, op, hP->Name(), etP);
 
 // If this is a POSC file then we need to unpersist it. Note that we are always
 // called with the handle **unlocked**
 //
-   if (hP->isRW == XrdOfsHandle::opPC)
+   if (posChk && hP->isRW == XrdOfsHandle::opPC)
       {hP->Lock();
        XrdOfsFS->Unpersist(hP);
        hP->UnLock();
@@ -2533,7 +2571,7 @@ int XrdOfs::Emsg(const char    *pfx,    // Message prefix value
 
 // Now return the error
 //
-   return SFS_ERROR;
+   return rc;
 }
 
 /******************************************************************************/
@@ -2542,36 +2580,80 @@ int XrdOfs::Emsg(const char    *pfx,    // Message prefix value
                  XrdOucErrInfo &einfo,  // Place to put text & error code
                  int            ecode,  // The error code
                  const char    *op,     // Operation being performed
-                 const char    *target) // The target (e.g., fname)
+                 const char    *target, // The target (e.g., fname)
+                 const char    *xtra)   // Optional extra error information
 {
-   char buffer[MAXPATHLEN+80];
+   char* buffer;
+   int buflen, rc;
+   bool msgDone = false;
+
+// Screen out non-errors
+//
+   if ((rc = EmsgType(ecode)) != SFS_ERROR) return rc;
+
+// Setup message handling
+//
+   if (einfo.extData()) einfo.Reset();
+   buffer = einfo.getMsgBuff(buflen);
+   std::string eText;
+
+// Check for extended information
+//
+    if (xtra)
+       switch(*xtra)
+             {case '?': xtra = 0;
+                        if (XrdOfsFS->tryXERT && XrdOfsOss->getErrMsg(eText))
+                           {if (eText.find("Unable") != std::string::npos)
+                               {einfo.setErrInfo(ecode, eText.c_str());
+                                msgDone = true;
+                               } else xtra = eText.c_str();
+                           }
+                        break;
+              case '+': xtra++;
+                        break;
+              default:  einfo.setErrInfo(ecode, xtra);
+                        msgDone = true;
+                        break;
+             }
+
+// Format the error message if it has not been already set
+//
+   if (!msgDone)
+      {XrdOucERoute::Format(buffer, buflen, ecode, op, target, xtra);
+       einfo.setErrCode(ecode);
+      }
+
+// Print it out
+//
+    OfsEroute.Emsg(pfx, einfo.getErrUser(), buffer);
+
+// Return an error
+//
+    return SFS_ERROR;
+}
+
+/******************************************************************************/
+/*                              E m s g T y p e                               */
+/******************************************************************************/
+
+int XrdOfs::EmsgType(int ecode)  // The error code
+{
 
 // If the error is EBUSY then we just need to stall the client. This is
 // a hack in order to provide for proxy support
 //
-    if (ecode < 0) ecode = -ecode;
-    if (ecode == EBUSY) return 5;  // A hack for proxy support
+   if (ecode < 0) ecode = -ecode;
+   if (ecode == EBUSY) return 5;  // A hack for proxy support
 
 // Check for timeout conditions that require a client delay
 //
    if (ecode == ETIMEDOUT) return OSSDelay;
 
-// Format the error message
+// This is a real error
 //
-   XrdOucERoute::Format(buffer, sizeof(buffer), ecode, op, target);
-
-// Print it out if debugging is enabled
-//
-#ifndef NODEBUG
-    OfsEroute.Emsg(pfx, einfo.getErrUser(), buffer);
-#endif
-
-// Place the error message in the error object and return
-//
-    einfo.setErrInfo(ecode, buffer);
-    return SFS_ERROR;
+   return SFS_ERROR;
 }
-
+  
 /******************************************************************************/
 /*                     P R I V A T E    S E C T I O N                         */
 /******************************************************************************/

--- a/src/XrdOfs/XrdOfs.hh
+++ b/src/XrdOfs/XrdOfs.hh
@@ -430,9 +430,10 @@ XrdCmsClient *Finder;         // ->Cluster Management Service
 
 virtual int   ConfigXeq(char *var, XrdOucStream &, XrdSysError &);
 static  int   Emsg(const char *, XrdOucErrInfo  &, int, const char *x,
-                   XrdOfsHandle *hP);
+                   XrdOfsHandle *hP, bool posChk=false);
 static  int   Emsg(const char *, XrdOucErrInfo  &, int, const char *x,
-                   const char *y="");
+                   const char *y="", const char* xtra=0);
+static  int   EmsgType(int ecode);
 static  int   fsError(XrdOucErrInfo &myError, int rc);
 const char   *Split(const char *Args, const char **Opq, char *Path, int Plen);
         int   Stall(XrdOucErrInfo  &, int, const char *);
@@ -481,6 +482,7 @@ XrdSysMutex              ocMutex; // Global mutex for open/close
 bool              DirRdr;         // Opendir() can be redirected.
 bool              reProxy;        // Reproxying required for TPC
 bool              OssHasPGrw;     // True: oss implements full rgRead/Write
+bool              tryXERT;        // Try using extended error text from OSS
 
 /******************************************************************************/
 /*                            O t h e r   D a t a                             */

--- a/src/XrdOfs/XrdOfsConfig.cc
+++ b/src/XrdOfs/XrdOfsConfig.cc
@@ -279,6 +279,7 @@ int XrdOfs::Configure(XrdSysError &Eroute, XrdOucEnv *EnvInfo) {
             if (ossFeatures & XRDOSS_HASNOSF)  FeatureSet |= XrdSfs::hasNOSF;
             if (ossFeatures & XRDOSS_HASCACH)  FeatureSet |= XrdSfs::hasCACH;
             if (ossFeatures & XRDOSS_HASNAIO)  FeatureSet |= XrdSfs::hasNAIO;
+            if (ossFeatures & XRDOSS_HASXERT)  tryXERT = true;
             if (xrdEnv) xrdEnv->PutPtr("XrdOss*", XrdOfsOss);
             ofsConfig->Plugin(Cks);
             CksPfn = !ofsConfig->OssCks();

--- a/src/XrdOss/XrdOss.hh
+++ b/src/XrdOss/XrdOss.hh
@@ -33,6 +33,7 @@
 #include <dirent.h>
 #include <cerrno>
 #include <cstdint>
+#include <string>
 #include <strings.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -418,6 +419,21 @@ static const int Fctl_utimes = 1;
 virtual int     Fctl(int cmd, int alen, const char *args, char **resp=0);
 
 //-----------------------------------------------------------------------------
+//! Obtain detailed error message text for the immediately preceeding 
+//! directory or file error (see also XrdOss::getErrMsg()).
+//!
+//! @param  eText  - Where the message text is to be returned.
+//!
+//! @return True if message text is available, false otherwise.
+//!
+//! @note This method should be called using the same thread that encountered
+//!       the error; otherwise, missleading error text may be returned.
+//! @note Upon return, the internal error message text is cleared.
+//-----------------------------------------------------------------------------
+
+virtual bool    getErrMsg(std::string& eText) {return false;}
+
+//-----------------------------------------------------------------------------
 //! Return the underlying file descriptor.
 //!
 //! @return -1 if there is no file descriptor or a non-negative FD number.
@@ -597,6 +613,21 @@ virtual uint64_t  Features();
 //-----------------------------------------------------------------------------
 
 virtual int       FSctl(int cmd, int alen, const char *args, char **resp=0);
+
+//-----------------------------------------------------------------------------
+//! Obtain detailed error message text for the immediately preceeding error
+//! returned by any method in this class.
+//!
+//! @param  eText  - Where the message text is to be returned.
+//!
+//! @return True if message text is available, false otherwise.
+//!
+//! @note This method should be called using the same thread that encountered
+//!       the error; otherwise, missleading error text may be returned.
+//! @note Upon return, the internal error message text is cleared.
+//-----------------------------------------------------------------------------
+
+virtual bool    getErrMsg(std::string& eText) {return false;}
 
 //-----------------------------------------------------------------------------
 //! Initialize the storage system V1 (deprecated).

--- a/src/XrdOuc/XrdOucECMsg.hh
+++ b/src/XrdOuc/XrdOucECMsg.hh
@@ -59,6 +59,7 @@ XrdOucECMsg& Append(char dlm='\n') {Delim = dlm; return *this;}
 //-----------------------------------------------------------------------------
 
 int   Get(std::string& ecm, bool rst=true);
+int   Get() {return eCode;}
 
 //-----------------------------------------------------------------------------
 //! Determine if an error text message exists.

--- a/src/XrdOuc/XrdOucERoute.cc
+++ b/src/XrdOuc/XrdOucERoute.cc
@@ -42,9 +42,11 @@
 /******************************************************************************/
   
 int XrdOucERoute::Format(char *buff, int blen, int ecode, const char *etxt1,
-                                                          const char *etxt2)
+                                                          const char *etxt2,
+                                                          const char *xtra)
 {
    const char *esep = " ", *estr = XrdSysError::ec2text(ecode);
+   const char *xsep = "";
    char ebuff[256];
    int n;
 
@@ -60,10 +62,13 @@ int XrdOucERoute::Format(char *buff, int blen, int ecode, const char *etxt1,
 // Set format elements
 //
    if (!etxt2) etxt2 = esep = "";
+   if (xtra) xsep = "\nAdditional context: ";
+      else   xtra = "";
 
 // Format the message
 //
-   n = snprintf(buff, blen, "Unable to %s%s%s; %s",etxt1,esep,etxt2,estr);
+   n = snprintf(buff, blen, "Unable to %s%s%s; %s%s%s",etxt1,esep,etxt2,estr,
+                                                       xsep, xtra);
    return (n < blen ? n : blen-1);
 }
 

--- a/src/XrdOuc/XrdOucERoute.hh
+++ b/src/XrdOuc/XrdOucERoute.hh
@@ -46,12 +46,14 @@ public:
 //! @param  ecode   the error number associated iwth the error.
 //! @param  etxt1   associated text token #1.
 //! @param  etxt2   associated text token #2 (optional).
+//! @param  xtra    Optional additional text to include on the next line
 //!
 //! @return <int>   The number of characters placed in the buffer less null.
 //-----------------------------------------------------------------------------
 
 static int Format(char *buff, int blen, int ecode, const char *etxt1,
-                                                   const char *etxt2=0);
+                                                   const char *etxt2=0,
+                                                   const char *xtra =0);
 
 //-----------------------------------------------------------------------------
 //! Format an error message using Format() and route it as requested.

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -41,6 +41,7 @@
 #include "XrdSys/XrdWin32.hh"
 #else
 #include <fcntl.h>
+#include <math.h>
 #include <pwd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -637,6 +638,37 @@ int XrdOucUtils::GroupName(gid_t gID, char *gName, int gNsz)
    return glen;
 }
 
+/******************************************************************************/
+/*                                 H S i z e                                  */
+/******************************************************************************/
+
+const char *HSize(size_t bytes, char* buff, int bsz)
+{
+
+// Do fast conversion of the quantity is less than 1K
+//
+   if (bytes < 1024)
+      {snprintf(buff, bsz, "%zu", bytes);
+       return buff;
+      }
+
+// Scale this down
+//
+   const char *suffix = " KMGTPEYZ";
+   double dBytes = static_cast<double>(bytes);
+
+do{dBytes /= 1024.0; suffix++;
+  }  while(dBytes >= 1024.0 && *(suffix+1));
+
+
+// Format and return result. Include fractions only if they meaningfully exist.
+//
+   double whole, frac = modf(dBytes, &whole);
+   if (frac >= .005) snprintf(buff, bsz, "%.02lf%c", dBytes, *suffix);
+      else snprintf(buff, bsz, "%g%c", whole, *suffix);
+   return buff;
+}
+  
 /******************************************************************************/
 /*                                i 2 b s t r                                 */
 /******************************************************************************/

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -642,7 +642,7 @@ int XrdOucUtils::GroupName(gid_t gID, char *gName, int gNsz)
 /*                                 H S i z e                                  */
 /******************************************************************************/
 
-const char *HSize(size_t bytes, char* buff, int bsz)
+const char *XrdOucUtils::HSize(size_t bytes, char* buff, int bsz)
 {
 
 // Do fast conversion of the quantity is less than 1K

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -80,6 +80,8 @@ static int   GroupName(gid_t gID, char *gName, int gNsz);
 
 static const char *i2bstr(char *buff, int blen, int val, bool pad=false);
 
+static const char *HSize(size_t bytes, char* buff, int bsz);
+
 static char *Ident(long long  &mySID, char *iBuff, int iBlen,
                    const char *iHost, const char *iProg, const char *iName,
                    int Port);

--- a/src/XrdPss/XrdPss.cc
+++ b/src/XrdPss/XrdPss.cc
@@ -163,7 +163,8 @@ XrdOss *XrdOssGetStorageSystem2(XrdOss       *native_oss,
   
 XrdPssSys::XrdPssSys() : HostArena(0), LocalRoot(0), theN2N(0), DirFlags(0),
                          myVersion(&XrdVERSIONINFOVAR(XrdOssGetStorageSystem2)),
-                         myFeatures(XRDOSS_HASPRXY|XRDOSS_HASPGRW|XRDOSS_HASNOSF)
+                         myFeatures(XRDOSS_HASPRXY|XRDOSS_HASPGRW|
+                         XRDOSS_HASNOSF|XRDOSS_HASXERT)
                          {}
 
 /******************************************************************************/
@@ -311,6 +312,19 @@ void        XrdPssSys::EnvInfo(XrdOucEnv *envP)
 }
   
 /******************************************************************************/
+/*                             g e t E r r M s g                              */
+/******************************************************************************/
+  
+bool        XrdPssSys::getErrMsg(std::string& eText)
+{
+// Return what we have but make sure to reset whatever we have
+//
+   if (XrdProxy::ecMsg.Get() <= 0 || !XrdProxy::ecMsg.hasMsg()) return false;
+   XrdProxy::ecMsg.Get(eText);
+   return true;
+}
+  
+/******************************************************************************/
 /*                               L f n 2 P f n                                */
 /******************************************************************************/
   
@@ -411,7 +425,7 @@ int XrdPssSys::Remdir(const char *path, int Opts, XrdOucEnv *eP)
 
 // Issue unlink and return result
 //
-   return (XrdPosixXrootd::Rmdir(pbuff) ? -errno : XrdOssOK);
+   return (XrdPosixXrootd::Rmdir(pbuff) ? Info(errno) : XrdOssOK);
 }
 
 /******************************************************************************/
@@ -455,7 +469,7 @@ int XrdPssSys::Rename(const char *oldname, const char *newname,
 
 // Execute the rename and return result
 //
-   return (XrdPosixXrootd::Rename(oldName, newName) ? -errno : XrdOssOK);
+   return (XrdPosixXrootd::Rename(oldName, newName) ? Info(errno) : XrdOssOK);
 }
 
 /******************************************************************************/
@@ -508,7 +522,7 @@ int XrdPssSys::Stat(const char *path, struct stat *buff, int Opts, XrdOucEnv *eP
 
 // Return proxied stat
 //
-   return (XrdPosixXrootd::Stat(pbuff, buff) ? -errno : XrdOssOK);
+   return (XrdPosixXrootd::Stat(pbuff, buff) ? Info(errno) : XrdOssOK);
 }
 
 /******************************************************************************/
@@ -565,7 +579,7 @@ int XrdPssSys::Truncate(const char *path, unsigned long long flen,
 // Return proxied truncate. We only do this on a single machine because the
 // redirector will forbid the trunc() if multiple copies exist.
 //
-   return (XrdPosixXrootd::Truncate(pbuff, flen) ? -errno : XrdOssOK);
+   return (XrdPosixXrootd::Truncate(pbuff, flen) ? Info(errno) : XrdOssOK);
 }
   
 /******************************************************************************/
@@ -609,7 +623,7 @@ int XrdPssSys::Unlink(const char *path, int Opts, XrdOucEnv *envP)
 
 // Unlink the file and return result.
 //
-   return (XrdPosixXrootd::Unlink(pbuff) ? -errno : XrdOssOK);
+   return (XrdPosixXrootd::Unlink(pbuff) ? Info(errno) : XrdOssOK);
 }
 
 /******************************************************************************/
@@ -658,7 +672,11 @@ int XrdPssDir::Opendir(const char *dir_path, XrdOucEnv &Env)
 // Open the directory
 //
    myDir = XrdPosixXrootd::Opendir(pbuff);
-   if (!myDir) return -errno;
+   if (!myDir)
+      {rc = -errno;
+       lastEtrc = XrdPosixXrootd::QueryError(lastEtext);
+       return rc;
+      }
    return XrdOssOK;
 }
 
@@ -688,7 +706,10 @@ int XrdPssDir::Readdir(char *buff, int blen)
    if (myDir)
       {dirent *entP, myEnt;
        int    rc = XrdPosixXrootd::Readdir_r(myDir, &myEnt, &entP);
-       if (rc) return -rc;
+       if (rc)
+          {lastEtrc = XrdPosixXrootd::QueryError(lastEtext, myDir);
+           return -rc;
+          }
        if (!entP) *buff = 0;
           else strlcpy(buff, myEnt.d_name, blen);
        return XrdOssOK;
@@ -719,7 +740,11 @@ int XrdPssDir::Close(long long *retsz)
 //
    if ((theDir = myDir))
       {myDir = 0;
-       if (XrdPosixXrootd::Closedir(theDir)) return -errno;
+       if (XrdPosixXrootd::Closedir(theDir))
+          {int rc = errno;
+           lastEtrc = XrdPosixXrootd::QueryError(lastEtext);
+           return -rc;
+          }
        return XrdOssOK;
       }
 
@@ -727,7 +752,22 @@ int XrdPssDir::Close(long long *retsz)
 //
    return -XRDOSS_E8002;
 }
-
+  
+/******************************************************************************/
+/*                             g e t E r r M s g                              */
+/******************************************************************************/
+  
+bool XrdPssDir::getErrMsg(std::string& eText)
+{
+// Return what we have but make sure to reset whatever we have
+//
+   if (lastEtrc <= 0 || lastEtext.empty()) return false;
+   eText = lastEtext;
+   lastEtext.clear();
+   lastEtrc = 0;
+   return true;
+}
+  
 /******************************************************************************/
 /*                     o o s s _ F i l e   M e t h o d s                      */
 /******************************************************************************/
@@ -850,7 +890,11 @@ int XrdPssFile::Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &Env)
 // Try to open and if we failed, return an error
 //
    if (!XrdPssSys::dcaCheck || !ioCache)
-      {if ((fd = XrdPosixXrootd::Open(pbuff,Oflag,Mode)) < 0) return -errno;
+      {if ((fd = XrdPosixXrootd::Open(pbuff,Oflag,Mode)) < 0)
+          {rc = -errno;
+           lastEtrc = XrdPosixXrootd::QueryError(lastEtext);
+           return rc;
+          }
       } else {
        XrdPosixInfo Info;
        Info.ffReady = XrdPssSys::dcaWorld;
@@ -859,7 +903,11 @@ int XrdPssFile::Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &Env)
            return -EDESTADDRREQ;
           }
        fd = Info.fileFD;
-       if (fd < 0) return -errno;
+       if (fd < 0)
+          {rc = -errno;
+           lastEtrc = XrdPosixXrootd::QueryError(lastEtext);
+           return rc;
+          }
       }
 
 // All done
@@ -898,7 +946,25 @@ int XrdPssFile::Close(long long *retsz)
 //
     rc = XrdPosixXrootd::Close(fd);
     fd = -1;
-    return (rc == 0 ? XrdOssOK : -errno);
+    if (rc == 0) return XrdOssOK;
+    rc = -errno;
+    lastEtrc = XrdPosixXrootd::QueryError(lastEtext);
+    return rc;
+}
+  
+/******************************************************************************/
+/*                             g e t E r r M s g                              */
+/******************************************************************************/
+  
+bool XrdPssFile::getErrMsg(std::string& eText)
+{
+// Return what we have but make sure to reset whatever we have
+//
+   if (lastEtrc <= 0 || lastEtext.empty()) return false;
+   eText = lastEtext;
+   lastEtext.clear();
+   lastEtrc = 0;
+   return true;
 }
 
 /******************************************************************************/
@@ -940,7 +1006,10 @@ ssize_t XrdPssFile::pgRead(void     *buffer,
 // Issue the pgread
 //
    if ((bytes = XrdPosixExtra::pgRead(fd,buffer,offset,rdlen,vecCS,psxOpts)) < 0)
-      return (ssize_t)-errno;
+      {int rc = -errno;
+       lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+       return (ssize_t)rc;
+      }
 
 // Copy out the checksum vector
 //
@@ -991,7 +1060,11 @@ ssize_t XrdPssFile::pgWrite(void     *buffer,
       {XrdOucPgrwUtils::dataInfo dInfo((const char*)buffer,csvec,offset,wrlen);
        off_t bado;
        int   badc;
-       if (!XrdOucPgrwUtils::csVer(dInfo, bado, badc)) return -EDOM;
+       if (!XrdOucPgrwUtils::csVer(dInfo, bado, badc))
+          {lastEtext = "pgWrite checksum verification failed.";
+           lastEtrc = EDOM;
+           return -EDOM;
+          }
       }
 
 // Check if caller want checksum generated and possibly returned
@@ -1012,7 +1085,12 @@ ssize_t XrdPssFile::pgWrite(void     *buffer,
 
 // Return result
 //
-   return (bytes < 0 ? (ssize_t)-errno : bytes);
+   if (bytes < 0)
+      {int rc = -errno;
+       lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+       return (ssize_t)rc;
+      }
+   return bytes;
 }
 
 /******************************************************************************/
@@ -1058,8 +1136,12 @@ ssize_t XrdPssFile::Read(void *buff, off_t offset, size_t blen)
 
      if (fd < 0) return (ssize_t)-XRDOSS_E8004;
 
-     return (retval = XrdPosixXrootd::Pread(fd, buff, blen, offset)) < 0
-            ? (ssize_t)-errno : retval;
+     if ((retval = XrdPosixXrootd::Pread(fd, buff, blen, offset)) < 0)
+        {int rc = -errno;
+         lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+         return (ssize_t)rc;
+        }
+     return retval;
 }
 
 /******************************************************************************/
@@ -1085,7 +1167,12 @@ ssize_t XrdPssFile::ReadV(XrdOucIOVec     *readV,     // In
 
     if (fd < 0) return (ssize_t)-XRDOSS_E8004;
 
-    return (retval = XrdPosixXrootd::VRead(fd, readV, readCount)) < 0 ? (ssize_t)-errno : retval;;
+    if ((retval = XrdPosixXrootd::VRead(fd, readV, readCount)) < 0)
+       {int rc = -errno;
+        lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+        return (ssize_t)rc;
+       }
+    return (ssize_t)retval;;
 }
 
 /******************************************************************************/
@@ -1130,8 +1217,12 @@ ssize_t XrdPssFile::Write(const void *buff, off_t offset, size_t blen)
 
      if (fd < 0) return (ssize_t)-XRDOSS_E8004;
 
-     return (retval = XrdPosixXrootd::Pwrite(fd, buff, blen, offset)) < 0
-            ? (ssize_t)-errno : retval;
+     if ((retval = XrdPosixXrootd::Pwrite(fd, buff, blen, offset)) < 0)
+        {int rc = -errno;
+         lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+         return (ssize_t)rc;
+        }
+     return (ssize_t)retval;
 }
 
 /******************************************************************************/
@@ -1152,7 +1243,12 @@ int XrdPssFile::Fstat(struct stat *buff)
 
 // If we have a file descriptor then return a stat for it
 //
-   if (fd >= 0) return (XrdPosixXrootd::Fstat(fd, buff) ? -errno : XrdOssOK);
+   if (fd >= 0)
+      {if (XrdPosixXrootd::Fstat(fd, buff) == 0) return XrdOssOK;
+       int rc = -errno;
+       lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+       return (ssize_t)rc;
+      }
 
 // Otherwise, if this is not a tpc of any kind, return an error
 //
@@ -1236,7 +1332,10 @@ int XrdPssFile::Fsync(void)
 {
     if (fd < 0) return -XRDOSS_E8004;
 
-    return (XrdPosixXrootd::Fsync(fd) ? -errno : XrdOssOK);
+    if (XrdPosixXrootd::Fsync(fd) == 0) return XrdOssOK;
+    int rc = -errno;
+    lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+    return (ssize_t)rc;
 }
 
 /******************************************************************************/
@@ -1265,7 +1364,10 @@ int XrdPssFile::Ftruncate(unsigned long long flen)
 {
     if (fd < 0) return -XRDOSS_E8004;
 
-    return (XrdPosixXrootd::Ftruncate(fd, flen) ?  -errno : XrdOssOK);
+    if (XrdPosixXrootd::Ftruncate(fd, flen) == 0) return XrdOssOK;
+    int rc = -errno;
+    lastEtrc = XrdPosixXrootd::QueryError(lastEtext, fd);
+    return (ssize_t)rc;
 }
   
 /******************************************************************************/
@@ -1274,7 +1376,7 @@ int XrdPssFile::Ftruncate(unsigned long long flen)
 
 int XrdPssSys::Info(int rc)
 {
-   XrdPosixXrootd::QueryError(XrdProxy::ecMsg.Msg());
+   XrdProxy::ecMsg = XrdPosixXrootd::QueryError(XrdProxy::ecMsg.Msg());
    return -rc;
 }
   

--- a/src/XrdPss/XrdPss.hh
+++ b/src/XrdPss/XrdPss.hh
@@ -82,28 +82,28 @@ public:
 // The following two are virtual functions to allow for upcasting derivations
 // of this implementation
 //
-virtual int     Close(long long *retsz=0);
-virtual int     Open(const char *, int, mode_t, XrdOucEnv &);
+virtual int     Close(long long *retsz=0) override;
+virtual int     Open(const char *, int, mode_t, XrdOucEnv &) override;
 
-int     Fchmod(mode_t mode) {return XrdOssOK;}
-int     Fstat(struct stat *);
-int     Fsync();
-int     Fsync(XrdSfsAio *aiop);
-int     Ftruncate(unsigned long long);
+int     Fchmod(mode_t mode) override {return XrdOssOK;}
+int     Fstat(struct stat *) override;
+int     Fsync() override;
+int     Fsync(XrdSfsAio *aiop) override;
+int     Ftruncate(unsigned long long) override;
 bool    getErrMsg(std::string& eText) override;
 ssize_t pgRead (void* buffer, off_t offset, size_t rdlen,
-                uint32_t* csvec, uint64_t opts);
-int     pgRead (XrdSfsAio* aioparm, uint64_t opts);
+                uint32_t* csvec, uint64_t opts) override;
+int     pgRead (XrdSfsAio* aioparm, uint64_t opts) override;
 ssize_t pgWrite(void* buffer, off_t offset, size_t wrlen,
-                uint32_t* csvec, uint64_t opts);
-int     pgWrite(XrdSfsAio* aioparm, uint64_t opts);
-ssize_t Read(               off_t, size_t);
-ssize_t Read(       void *, off_t, size_t);
-int     Read(XrdSfsAio *aiop);
-ssize_t ReadV(XrdOucIOVec *readV, int n);
-ssize_t ReadRaw(    void *, off_t, size_t);
-ssize_t Write(const void *, off_t, size_t);
-int     Write(XrdSfsAio *aiop);
+                uint32_t* csvec, uint64_t opts) override;
+int     pgWrite(XrdSfsAio* aioparm, uint64_t opts) override;
+ssize_t Read(               off_t, size_t) override;
+ssize_t Read(       void *, off_t, size_t) override;
+int     Read(XrdSfsAio *aiop) override;
+ssize_t ReadV(XrdOucIOVec *readV, int n) override;
+ssize_t ReadRaw(    void *, off_t, size_t) override;
+ssize_t Write(const void *, off_t, size_t) override;
+int     Write(XrdSfsAio *aiop) override;
  
          // Constructor and destructor
          XrdPssFile(const char *tid)

--- a/src/XrdPss/XrdPss.hh
+++ b/src/XrdPss/XrdPss.hh
@@ -33,6 +33,7 @@
 #include <cerrno>
 #include <unistd.h>
 #include <sys/types.h>
+#include <string>
 #include <vector>
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdOuc/XrdOucECMsg.hh"
@@ -49,18 +50,21 @@
 class XrdPssDir : public XrdOssDF
 {
 public:
-int     Close(long long *retsz=0);
-int     Opendir(const char *, XrdOucEnv &);
-int     Readdir(char *buff, int blen);
+int     Close(long long *retsz=0) override;
+bool    getErrMsg(std::string& eText) override;
+int     Opendir(const char *, XrdOucEnv &) override;
+int     Readdir(char *buff, int blen) override;
 
         // Constructor and destructor
         XrdPssDir(const char *tid)
                  : XrdOssDF(tid, XrdOssDF::DF_isDir|XrdOssDF::DF_isProxy),
-                   myDir(0) {}
+                   myDir(0), lastEtrc(0) {}
 
        ~XrdPssDir() {if (myDir) Close();}
 private:
          DIR       *myDir;
+    std::string    lastEtext;
+         int       lastEtrc;
 };
   
 /******************************************************************************/
@@ -86,6 +90,7 @@ int     Fstat(struct stat *);
 int     Fsync();
 int     Fsync(XrdSfsAio *aiop);
 int     Ftruncate(unsigned long long);
+bool    getErrMsg(std::string& eText) override;
 ssize_t pgRead (void* buffer, off_t offset, size_t rdlen,
                 uint32_t* csvec, uint64_t opts);
 int     pgRead (XrdSfsAio* aioparm, uint64_t opts);
@@ -103,7 +108,7 @@ int     Write(XrdSfsAio *aiop);
          // Constructor and destructor
          XrdPssFile(const char *tid)
                    : XrdOssDF(tid, XrdOssDF::DF_isFile|XrdOssDF::DF_isProxy),
-                     rpInfo(0), tpcPath(0), entity(0) {}
+                     rpInfo(0), tpcPath(0), entity(0), lastEtrc(0) {}
 
 virtual ~XrdPssFile() {if (fd >= 0) Close();
                        if (rpInfo) delete(rpInfo);
@@ -126,6 +131,8 @@ struct tprInfo
 
       char         *tpcPath;
 const XrdSecEntity *entity;
+std::string         lastEtext;
+int                 lastEtrc;
 };
 
 /******************************************************************************/
@@ -160,6 +167,7 @@ virtual
 int       Create(const char *, const char *, mode_t, XrdOucEnv &, int opts=0) override;
 void      EnvInfo(XrdOucEnv *envP) override;
 uint64_t  Features() override {return myFeatures;}
+bool      getErrMsg(std::string& eText) override;
 int       Init(XrdSysLogger *, const char *) override {return -ENOTSUP;}
 int       Init(XrdSysLogger *, const char *, XrdOucEnv *envP) override;
 int       Lfn2Pfn(const char *Path, char *buff, int blen) override;

--- a/src/XrdSut/XrdSutCache.hh
+++ b/src/XrdSut/XrdSutCache.hh
@@ -40,10 +40,10 @@
 
 typedef bool (*XrdSutCacheGet_t)(XrdSutCacheEntry *, void *);
 typedef struct {
-   long arg1;
-   long arg2;
-   long arg3;
-   long arg4;
+   long long arg1;
+   long long arg2;
+   long long arg3;
+   long long arg4;
 } XrdSutCacheArg_t;
 
 class XrdSutCache {

--- a/src/XrdSys/XrdSysE2T.cc
+++ b/src/XrdSys/XrdSysE2T.cc
@@ -74,6 +74,9 @@ int initErrTable()
       if (EBADE - ERRNOBASE > lastGood)
          lastGood = EBADE - ERRNOBASE;
    }
+   else {
+      e2sMap[EBADE] = "authentication failed - possible invalid exchange";
+   }
 #endif
 
    // Supply generic message for missing ones

--- a/src/XrdSys/XrdSysE2T.cc
+++ b/src/XrdSys/XrdSysE2T.cc
@@ -67,11 +67,13 @@ int initErrTable()
    // EAUTH is remapped to EBADE ('invalid exchange').  Given there's no current XRootD use of a
    // syscall that can return EBADE, we assume EBADE really means authentication denied.
 #if defined(EBADE)
-   if (Errno2String[EBADE]) {
-     free((char*)Errno2String[EBADE]);
+   if (EBADE - ERRNOBASE > 0 && EBADE - ERRNOBASE < errSlots) {
+      if (Errno2String[EBADE - ERRNOBASE])
+         free((char*)Errno2String[EBADE - ERRNOBASE]);
+      Errno2String[EBADE - ERRNOBASE] = "authentication failed - possible invalid exchange";
+      if (EBADE - ERRNOBASE > lastGood)
+         lastGood = EBADE - ERRNOBASE;
    }
-
-   Errno2String[EBADE] = "authentication failed - possible invalid exchange";
 #endif
 
    // Supply generic message for missing ones

--- a/src/XrdUtils.cmake
+++ b/src/XrdUtils.cmake
@@ -216,6 +216,8 @@ set ( XrdSources
   Xrd/XrdLinkXeq.cc             Xrd/XrdLinkXeq.hh
   Xrd/XrdLinkMatch.cc           Xrd/XrdLinkMatch.hh
   Xrd/XrdGlobals.cc
+  Xrd/XrdMonitor.cc             Xrd/XrdMonRoll.hh
+                                Xrd/XrdMonRoll.hh
   Xrd/XrdObject.icc             Xrd/XrdObject.hh
   Xrd/XrdPoll.cc                Xrd/XrdPoll.hh
                                 Xrd/XrdPollE.hh

--- a/tests/XRootD/fuse.sh
+++ b/tests/XRootD/fuse.sh
@@ -43,7 +43,7 @@ function test_fuse() {
 	FILES=$(seq -w 1 "${NFILES:-10}")
 
 	for i in ${FILES}; do
-		assert openssl rand -base64 -out "${i}.ref" $((1024 * (RANDOM % 1024)))
+		assert openssl rand -base64 -out "${i}.ref" $((1024 * ((RANDOM % 1024) + 1)))
 
 		# TODO: Fix "Resource deadlock avoided" if this sleep is removed
 		sleep 0.1

--- a/tests/XrdCl/IdentityPlugIn.cc
+++ b/tests/XrdCl/IdentityPlugIn.cc
@@ -67,7 +67,7 @@ namespace
                                  OpenFlags::Flags   flags,
                                  Access::Mode       mode,
                                  ResponseHandler   *handler,
-                                 uint16_t           timeout )
+                                 time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Open" );
@@ -78,7 +78,7 @@ namespace
       // Close
       //------------------------------------------------------------------------
       virtual XRootDStatus Close( ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Close" );
@@ -90,7 +90,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus Stat( bool             force,
                                  ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Stat" );
@@ -105,7 +105,7 @@ namespace
                                  uint32_t         size,
                                  void            *buffer,
                                  ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Read" );
@@ -119,7 +119,7 @@ namespace
                                   uint32_t         size,
                                   const void      *buffer,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Write" );
@@ -130,7 +130,7 @@ namespace
       // Sync
       //------------------------------------------------------------------------
       virtual XRootDStatus Sync( ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Sync" );
@@ -142,7 +142,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus Truncate( uint64_t         size,
                                      ResponseHandler *handler,
-                                     uint16_t         timeout )
+                                     time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Truncate" );
@@ -155,7 +155,7 @@ namespace
       virtual XRootDStatus VectorRead( const ChunkList &chunks,
                                        void            *buffer,
                                        ResponseHandler *handler,
-                                       uint16_t         timeout )
+                                       time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::VectorRead" );
@@ -167,7 +167,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus Fcntl( const Buffer    &arg,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Fcntl" );
@@ -178,7 +178,7 @@ namespace
       // Visa
       //------------------------------------------------------------------------
       virtual XRootDStatus Visa( ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFile::Visa" );
@@ -253,7 +253,7 @@ namespace
       virtual XRootDStatus Locate( const std::string &path,
                                    OpenFlags::Flags   flags,
                                    ResponseHandler   *handler,
-                                   uint16_t           timeout )
+                                   time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Locate" );
@@ -266,7 +266,7 @@ namespace
       virtual XRootDStatus Mv( const std::string &source,
                                const std::string &dest,
                                ResponseHandler   *handler,
-                               uint16_t           timeout )
+                               time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Mv" );
@@ -279,7 +279,7 @@ namespace
       virtual XRootDStatus Query( QueryCode::Code  queryCode,
                                   const Buffer    &arg,
                                   ResponseHandler *handler,
-                                  uint16_t         timeout )
+                                  time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Query" );
@@ -292,7 +292,7 @@ namespace
       virtual XRootDStatus Truncate( const std::string &path,
                                      uint64_t           size,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Truncate" );
@@ -304,7 +304,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus Rm( const std::string &path,
                                ResponseHandler   *handler,
-                               uint16_t           timeout )
+                               time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Rm" );
@@ -318,7 +318,7 @@ namespace
                                   MkDirFlags::Flags  flags,
                                   Access::Mode       mode,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::MkDir" );
@@ -330,7 +330,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus RmDir( const std::string &path,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::RmDir" );
@@ -343,7 +343,7 @@ namespace
       virtual XRootDStatus ChMod( const std::string &path,
                                   Access::Mode       mode,
                                   ResponseHandler   *handler,
-                                  uint16_t           timeout )
+                                  time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::ChMod" );
@@ -354,7 +354,7 @@ namespace
       // Ping
       //------------------------------------------------------------------------
       virtual XRootDStatus Ping( ResponseHandler *handler,
-                                 uint16_t         timeout )
+                                 time_t           timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Ping" );
@@ -366,7 +366,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus Stat( const std::string &path,
                                  ResponseHandler   *handler,
-                                 uint16_t           timeout )
+                                 time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Stat" );
@@ -378,7 +378,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus StatVFS( const std::string &path,
                                     ResponseHandler   *handler,
-                                    uint16_t           timeout )
+                                    time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::StatVFS" );
@@ -389,7 +389,7 @@ namespace
       // Protocol
       //------------------------------------------------------------------------
       virtual XRootDStatus Protocol( ResponseHandler *handler,
-                                     uint16_t         timeout = 0 )
+                                     time_t           timeout = 0 )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Protocol" );
@@ -402,7 +402,7 @@ namespace
       virtual XRootDStatus DirList( const std::string   &path,
                                     DirListFlags::Flags  flags,
                                     ResponseHandler     *handler,
-                                    uint16_t             timeout )
+                                    time_t               timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::DirList" );
@@ -414,7 +414,7 @@ namespace
       //------------------------------------------------------------------------
       virtual XRootDStatus SendInfo( const std::string &info,
                                      ResponseHandler   *handler,
-                                     uint16_t           timeout )
+                                     time_t             timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::SendInfo" );
@@ -428,7 +428,7 @@ namespace
                                     PrepareFlags::Flags             flags,
                                     uint8_t                         priority,
                                     ResponseHandler                *handler,
-                                    uint16_t                        timeout )
+                                    time_t                          timeout )
       {
         XrdCl::Log *log = TestEnv::GetLog();
         log->Debug( 1, "Calling IdentityFileSystem::Prepare" );

--- a/tests/XrdCl/XrdClFileCopyTest.cc
+++ b/tests/XrdCl/XrdClFileCopyTest.cc
@@ -288,7 +288,7 @@ namespace
       //------------------------------------------------------------------------
       // Job progress
       //------------------------------------------------------------------------
-      virtual void JobProgress( uint16_t jobNum,
+      virtual void JobProgress( uint32_t jobNum,
                                 uint64_t bytesProcessed,
                                 uint64_t bytesTotal )
       {
@@ -299,7 +299,7 @@ namespace
       //------------------------------------------------------------------------
       // Determine whether the job should be canceled
       //------------------------------------------------------------------------
-      virtual bool ShouldCancel( uint16_t jobNum ) { return pCancel; }
+      virtual bool ShouldCancel( uint32_t jobNum ) { return pCancel; }
 
     private:
       bool pCancel;


### PR DESCRIPTION
The cache mtime logic (whose sole use is to have the `Age` header set) was fairly misleading: a `HEAD` (or `stat`) request would cause the cinfo file to be written, and the cache to indicate it had the data.

This was not useful: the object was indicated as cached even when not a single byte of data was present.

This takes the opposite approach: mtime and ctime are only set (and hence the `Age` header is returned) only if the file is complete.  This means a `GET` only returns the `Age` header if there is data available!

@amadio - I think this would be appropriate for backporting.  I think the current behavior is a bug.