### PR TITLE
[XrdHttp] GET - Do not send a double response to a single request

### DIFF
--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -150,6 +150,14 @@ private:
    */
   static void determineXRootDChecksumFromUserDigest(const std::string & userDigest, std::vector<std::string> & xrootdChecksums);
 
+  /**
+   * Sends a message to the client in the trailer/footer of the HTTP response.
+   * @param httpStatusCde the http status code to be printed
+   * @param infos the error text to be printed
+   * @return 0 upon success, -1 upon failure
+   */
+  int sendTrailerInfos(int httpStatusCde, const std::string & infos);
+
 public:
   XrdHttpReq(XrdHttpProtocol *protinstance, const XrdHttpReadRangeHandler::Configuration &rcfg) :
       readRangeHandler(rcfg), keepalive(true) {


### PR DESCRIPTION
After 200 OK is sent to the client, the server should not send another response in case a failure happens. This breaks the HTTP protocol.

Fixes #2351

I've just put the logic of sending trailer to the client in a function and call that function in case an error happens.