### PR TITLE
[Pfc] Reduce verbosity of errors originating from remote block reads.

### DIFF
--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -15,6 +15,11 @@
 
 #include <fcntl.h>
 
+namespace XrdPfc
+{
+   const char *trace_what_strings[] = {"","error ","warning ","info ","debug ","dump "};
+}
+
 using namespace XrdPfc;
 
 XrdVERSIONINFO(XrdOucGetCache, XrdPfc);

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -78,6 +78,7 @@ struct ReadRequest
 
    long long   m_bytes_read = 0;
    int         m_error_cond = 0; // to be set to -errno
+   int         m_error_count = 0;
    Stats       m_stats;
 
    int         m_n_chunk_reqs = 0;
@@ -88,7 +89,7 @@ struct ReadRequest
       m_io(io), m_rh(rh)
    {}
 
-   void update_error_cond(int ec) { if (m_error_cond == 0 ) m_error_cond = ec; }
+   void update_error_cond(int ec) { ++m_error_count; if (m_error_cond == 0 ) m_error_cond = ec; }
 
    bool is_complete()  const { return m_n_chunk_reqs == 0 && m_sync_done && m_direct_done; }
    int  return_value() const { return m_error_cond ? m_error_cond : m_bytes_read; }
@@ -311,7 +312,7 @@ private:
    static const char *m_traceID;
 
    int            m_ref_cnt;            //!< number of references from IO or sync
-   
+
    XrdOssDF      *m_data_file;          //!< file handle for data file on disk
    XrdOssDF      *m_info_file;          //!< file handle for data-info file on disk
    Info           m_cfi;                //!< download status of file blocks and access statistics

--- a/src/XrdPfc/XrdPfcIO.hh
+++ b/src/XrdPfc/XrdPfcIO.hh
@@ -77,6 +77,7 @@ private:
 
    void SetInput(XrdOucCacheIO*);
 
+protected:
    // Variables used by File to store IO-relates state. Managed under
    // File::m_state_cond mutex.
    friend class File;
@@ -85,6 +86,15 @@ private:
    int    m_active_prefetches {0};
    bool   m_allow_prefetching {true};
    bool   m_in_detach         {false};
+
+   int                m_incomplete_count {0};
+   std::map<int, int> m_error_counts;
+   bool register_incomplete_read() {
+      return m_incomplete_count++ == 0;
+   }
+   bool register_block_error(int res) {
+      return m_error_counts[res]++ == 0;
+   }
 };
 }
 

--- a/src/XrdPfc/XrdPfcIO.hh
+++ b/src/XrdPfc/XrdPfcIO.hh
@@ -77,7 +77,6 @@ private:
 
    void SetInput(XrdOucCacheIO*);
 
-protected:
    // Variables used by File to store IO-relates state. Managed under
    // File::m_state_cond mutex.
    friend class File;
@@ -87,6 +86,7 @@ protected:
    bool   m_allow_prefetching {true};
    bool   m_in_detach         {false};
 
+protected:
    int                m_incomplete_count {0};
    std::map<int, int> m_error_counts;
    bool register_incomplete_read() {

--- a/src/XrdPfc/XrdPfcIOFile.cc
+++ b/src/XrdPfc/XrdPfcIOFile.cc
@@ -153,10 +153,29 @@ void IOFile::DetachFinalize()
 {
    // Effectively a destructor.
 
-   TRACE(Info, "DetachFinalize() " << this);
+   TRACE(Debug, "DetachFinalize() " << this);
 
    m_file->RequestSyncOfDetachStats();
    Cache::GetInstance().ReleaseFile(m_file, this);
+
+#ifndef NODEBUG
+   if (( ! m_error_counts.empty() || m_incomplete_count > 0) && XRD_TRACE What >= TRACE_Error) {
+      char info[1024];
+      int pos = 0, cap = 1024;
+      bool truncated = false;
+      for (auto [err, cnt] : m_error_counts) {
+         int len = snprintf(&info[pos], cap, " ( %d : %d)", err, cnt);
+         if (len >= cap) {
+            truncated = true;
+            break;
+         }
+         pos += len;
+         cap -= len;
+      }
+      TRACE(Error, "DetachFinalize() " << this << " n_incomplete_reads=" << m_incomplete_count
+            << ", block (error : count) report:" << info << (truncated ? " - truncated" : ""));
+   }
+#endif
 
    delete this;
 }
@@ -273,9 +292,9 @@ int IOFile::ReadEnd(int retval, ReadReqRH *rh)
    TRACEIO(Dump, "ReadEnd() " << (rh->m_iocb ? "a" : "") << "sync " << this << " sid: " << Xrd::hex1 << rh->m_seq_id << " retval: " << retval << " expected_size: " << rh->m_expected_size);
 
    if (retval < 0) {
-      TRACEIO(Warning, "ReadEnd() error in File::Read(), exit status=" << retval << ", error=" << XrdSysE2T(-retval) << " sid: " << Xrd::hex1 << rh->m_seq_id);
+      TRACEIO(Debug, "ReadEnd() error in File::Read(), exit status=" << retval << ", error=" << XrdSysE2T(-retval) << " sid: " << Xrd::hex1 << rh->m_seq_id);
    } else if (retval < rh->m_expected_size) {
-      TRACEIO(Warning, "ReadEnd() bytes missed " << rh->m_expected_size - retval << " sid: " << Xrd::hex1 << rh->m_seq_id);
+      TRACEIO(Debug, "ReadEnd() bytes missed " << rh->m_expected_size - retval << " sid: " << Xrd::hex1 << rh->m_seq_id);
    }
    if (rh->m_iocb)
       rh->m_iocb->Done(retval);
@@ -362,9 +381,9 @@ int IOFile::ReadVEnd(int retval, ReadReqRH *rh)
                  " retval: " << retval << " n_chunks: " << rh->m_n_chunks << " expected_size: " << rh->m_expected_size);
 
    if (retval < 0) {
-      TRACEIO(Warning, "ReadVEnd() error in File::ReadV(), exit status=" << retval << ", error=" << XrdSysE2T(-retval));
+      TRACEIO(Debug, "ReadVEnd() error in File::ReadV(), exit status=" << retval << ", error=" << XrdSysE2T(-retval));
    } else if (retval < rh->m_expected_size) {
-      TRACEIO(Warning, "ReadVEnd() bytes missed " << rh->m_expected_size - retval);
+      TRACEIO(Debug, "ReadVEnd() bytes missed " << rh->m_expected_size - retval);
    }
    if (rh->m_iocb)
       rh->m_iocb->Done(retval);

--- a/src/XrdPfc/XrdPfcIOFile.cc
+++ b/src/XrdPfc/XrdPfcIOFile.cc
@@ -158,7 +158,6 @@ void IOFile::DetachFinalize()
    m_file->RequestSyncOfDetachStats();
    Cache::GetInstance().ReleaseFile(m_file, this);
 
-#ifndef NODEBUG
    if (( ! m_error_counts.empty() || m_incomplete_count > 0) && XRD_TRACE What >= TRACE_Error) {
       char info[1024];
       int pos = 0, cap = 1024;
@@ -175,7 +174,6 @@ void IOFile::DetachFinalize()
       TRACE(Error, "DetachFinalize() " << this << " n_incomplete_reads=" << m_incomplete_count
             << ", block (error : count) report:" << info << (truncated ? " - truncated" : ""));
    }
-#endif
 
    delete this;
 }

--- a/src/XrdPfc/XrdPfcIOFile.hh
+++ b/src/XrdPfc/XrdPfcIOFile.hh
@@ -88,8 +88,6 @@ private:
 
    struct stat *m_localStat;
    int initCachedStat();
-
-
 };
 
 }

--- a/src/XrdPfc/XrdPfcTrace.hh
+++ b/src/XrdPfc/XrdPfcTrace.hh
@@ -64,6 +64,11 @@
    if (XRD_TRACE What >= TRACE_ ## act) SYSTRACE(XRD_TRACE, 0, m_traceID, 0, \
        TRACE_STR_ ## act << x << " " << GetLocalPath())
 
+#define TRACEF_INT(act, x) \
+   if (XRD_TRACE What >= act) \
+   {static const char* t_what[]={"","error ","warning ","info ","debug ","dump "};\
+    SYSTRACE(XRD_TRACE, 0, m_traceID, 0, t_what[act] << x << " " << GetLocalPath())}
+
 #else
 
 #define ERRNO_AND_ERRSTR(err_code)
@@ -71,6 +76,7 @@
 #define TRACE_PC(act, pre_code, x)
 #define TRACEIO(act, x)
 #define TRACEF(act, x)
+#define TRACEF_INT(act, x)
 
 #endif
 

--- a/src/XrdPfc/XrdPfcTrace.hh
+++ b/src/XrdPfc/XrdPfcTrace.hh
@@ -38,6 +38,11 @@
 #define XRD_TRACE GetTrace()->
 #endif
 
+namespace XrdPfc
+{
+   extern const char *trace_what_strings[];
+}
+
 #define ERRNO_AND_ERRSTR(err_code) ", err_code=" << err_code << ", err_str=" << XrdSysE2T(err_code)
 
 #define TRACE(act, x) \
@@ -46,8 +51,7 @@
 
 #define TRACE_INT(act, x) \
    if (XRD_TRACE What >= act) \
-   {static const char* t_what[]={"","error ","warning ","info ","debug ","dump "};\
-    SYSTRACE(XRD_TRACE, 0, m_traceID, 0, t_what[act] << x)}
+       SYSTRACE(XRD_TRACE, 0, m_traceID, 0, trace_what_strings[act] << x)
 
 #define TRACE_TEST(act, x) \
     SYSTRACE(XRD_TRACE, 0, m_traceID, 0, TRACE_STR_ ## act << x)
@@ -66,8 +70,7 @@
 
 #define TRACEF_INT(act, x) \
    if (XRD_TRACE What >= act) \
-   {static const char* t_what[]={"","error ","warning ","info ","debug ","dump "};\
-    SYSTRACE(XRD_TRACE, 0, m_traceID, 0, t_what[act] << x << " " << GetLocalPath())}
+       SYSTRACE(XRD_TRACE, 0, m_traceID, 0, trace_what_strings[act] << x << " " << GetLocalPath())
 
 #else
 


### PR DESCRIPTION
Report each error only once for each IO object, then report total counts for each error type once the IO object is detached.

Previous repeating errors have been downgraded to Debug level.

This addresses #2327.

Targeting 5.7.2.
