### PR TITLE
[Pfc] Stat call: fix behavior and improve performance, part of #2349

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -31,6 +31,7 @@
 #include "XrdSys/XrdSysPthread.hh"
 #include "XrdSys/XrdSysTimer.hh"
 #include "XrdSys/XrdSysTrace.hh"
+#include "XrdSys/XrdSysXAttr.hh"
 
 #include "XrdXrootd/XrdXrootdGStream.hh"
 
@@ -42,6 +43,8 @@
 #include "XrdPfcInfo.hh"
 #include "XrdPfcIOFile.hh"
 #include "XrdPfcIOFileBlock.hh"
+
+extern XrdSysXAttr *XrdSysXAttrActive;
 
 using namespace XrdPfc;
 
@@ -411,7 +414,7 @@ void Cache::ReleaseRAM(char* buf, long long size)
 
 File* Cache::GetFile(const std::string& path, IO* io, long long off, long long filesize)
 {
-   // Called from virtual IO::Attach
+   // Called from virtual IOFile constructor.
    
    TRACE(Debug, "GetFile " << path << ", io " << io);
 
@@ -447,6 +450,7 @@ File* Cache::GetFile(const std::string& path, IO* io, long long off, long long f
       }
    }
 
+   // This is always true, now that IOFileBlock is unsupported.
    if (filesize == 0)
    {
       struct stat st;
@@ -504,7 +508,7 @@ void Cache::ReleaseFile(File* f, IO* io)
    dec_ref_cnt(f, true);
 }
 
-  
+
 namespace
 {
 
@@ -581,7 +585,8 @@ void Cache::inc_ref_cnt(File* f, bool lock, bool high_debug)
 
 void Cache::dec_ref_cnt(File* f, bool high_debug)
 {
-   // Called from ReleaseFile() or DiskSync callback.
+   // NOT under active lock.
+   // Called from ReleaseFile(), DiskSync callback and stat-like functions.
 
    int tlvl = high_debug ? TRACE_Debug : TRACE_Dump;
    int cnt;
@@ -590,6 +595,7 @@ void Cache::dec_ref_cnt(File* f, bool high_debug)
      XrdSysCondVarHelper lock(&m_active_cond);
 
      cnt = f->get_ref_cnt();
+     TRACE_INT(tlvl, "dec_ref_cnt " << f->GetLocalPath() << ", cnt at entry = " << cnt);
 
      if (f->is_in_emergency_shutdown())
      {
@@ -607,12 +613,14 @@ void Cache::dec_ref_cnt(File* f, bool high_debug)
            TRACE_INT(tlvl, "dec_ref_cnt " << f->GetLocalPath() << " is in shutdown, ref_cnt = " << cnt
                      << " -- waiting");
         }
-
+        return;
+     }
+     if (cnt > 1)
+     {
+        f->dec_ref_cnt();
         return;
      }
    }
-
-   TRACE_INT(tlvl, "dec_ref_cnt " << f->GetLocalPath() << ", cnt at entry = " << cnt);
 
    if (cnt == 1)
    {
@@ -900,6 +908,78 @@ int Cache::LocalFilePath(const char *curl, char *buff, int blen,
 }
 
 //______________________________________________________________________________
+// If supported, write file_size as xattr to cinfo file.
+//------------------------------------------------------------------------------
+void Cache::WriteFileSizeXAttr(int cinfo_fd, long long file_size)
+{
+   if (m_metaXattr) {
+      int res = XrdSysXAttrActive->Set("pfc.fsize", &file_size, sizeof(long long), 0, cinfo_fd, 0);
+      if (res != 0) {
+         TRACE(Debug, "WriteFileSizeXAttr error setting xattr " << res);
+      }
+   }
+}
+
+//______________________________________________________________________________
+// Determine full size of the data file from the corresponding cinfo-file name.
+// Attempts to read xattr first and falls back to reading of the cinfo file.
+// Returns -error on failure.
+//------------------------------------------------------------------------------
+long long Cache::DetermineFullFileSize(const std::string &cinfo_fname)
+{
+   if (m_metaXattr) {
+      char pfn[4096];
+      m_oss->Lfn2Pfn(cinfo_fname.c_str(), pfn, 4096);
+      long long fsize = -1ll;
+      int res = XrdSysXAttrActive->Get("pfc.fsize", &fsize, sizeof(long long), pfn);
+      if (res == sizeof(long long))
+      {
+         return fsize;
+      }
+      else
+      {
+         TRACE(Debug, "DetermineFullFileSize error getting xattr " << res);
+      }
+   }
+
+   XrdOssDF *infoFile = m_oss->newFile(m_configuration.m_username.c_str());
+   XrdOucEnv env;
+   int res = infoFile->Open(cinfo_fname.c_str(), O_RDONLY, 0600, env);
+   if (res < 0)
+      return res;
+   Info info(m_trace, 0);
+   if ( ! info.Read(infoFile, cinfo_fname.c_str()))
+      return -EBADF;
+   return info.GetFileSize();
+}
+
+//______________________________________________________________________________
+// Calculate if the file is to be considered cached for the purposes of
+// only-if-cached and setting of atime of the Stat() calls.
+// Returns true if the file is to be conidered cached.
+//------------------------------------------------------------------------------
+bool Cache::DecideIfConsideredCached(long long file_size, long long bytes_on_disk)
+{
+   if (file_size == 0 || bytes_on_disk >= file_size)
+      return true;
+
+   double frac_on_disk = (double) bytes_on_disk / file_size;
+
+   if (file_size <= m_configuration.m_onlyIfCachedMinSize)
+   {
+      if (frac_on_disk >= m_configuration.m_onlyIfCachedMinFrac)
+         return true;
+   }
+   else
+   {
+      if (bytes_on_disk >= m_configuration.m_onlyIfCachedMinSize &&
+          frac_on_disk  >= m_configuration.m_onlyIfCachedMinFrac)
+         return true;
+   }
+   return false;
+}
+
+//______________________________________________________________________________
 // Check if the file is cached including m_onlyIfCachedMinSize and m_onlyIfCachedMinFrac
 // pfc configuration parameters. The logic of accessing the Info file is the same
 // as in Cache::LocalFilePath.
@@ -907,108 +987,58 @@ int Cache::LocalFilePath(const char *curl, char *buff, int blen,
 //!                  the buffer, if it has been supllied.
 //!
 //! @return <0     - the request could not be fulfilled. The return value is
-//!                  -errno describing why. If a buffer was supplied and a
-//!                  path could be generated it is returned only if "why" is
-//!                  ForCheck or ForInfo. Otherwise, a null path is returned.
+//!                  -errno describing why.
 //!
 //! @return >0     - Reserved for future use.
 //------------------------------------------------------------------------------
 int Cache::ConsiderCached(const char *curl)
 {
-   TRACE(Debug, "ConsiderFileCached '" << curl << "'" );
+   static const char* tpfx = "ConsiderCached ";
+
+   TRACE(Debug, tpfx << curl);
 
    XrdCl::URL url(curl);
    std::string f_name = url.GetPath();
-   std::string i_name = f_name + Info::s_infoExtension;
 
+   File *file = nullptr;
    {
       XrdSysCondVarHelper lock(&m_active_cond);
-      m_purge_delay_set.insert(f_name);
+      auto it = m_active.find(f_name);
+      if (it != m_active.end()) {
+         file = it->second;
+         inc_ref_cnt(file, false, false);
+      }
+   }
+   if (file) {
+      struct stat sbuff;
+      int res = file->Fstat(sbuff);
+      dec_ref_cnt(file, false);
+      if (res)
+         return res;
+      // DecideIfConsideredCached() already called in File::Fstat().
+      return sbuff.st_atime > 0 ? 0 : -EREMOTE;
    }
 
-   struct stat sbuff, sbuff2;
-   if (m_oss->Stat(f_name.c_str(), &sbuff) == XrdOssOK &&
-       m_oss->Stat(i_name.c_str(), &sbuff2) == XrdOssOK)
+   struct stat sbuff;
+   int res = m_oss->Stat(f_name.c_str(), &sbuff);
+   if (res != XrdOssOK) {
+      TRACE(Debug, tpfx << curl << " -> " << res);
+      return res;
+   }
+   if (S_ISDIR(sbuff.st_mode))
    {
-      if (S_ISDIR(sbuff.st_mode))
-      {
-         TRACE(Info, "ConsiderCached '" << curl << ", why=ForInfo" << " -> EISDIR");
-         return -EISDIR;
-      }
-      else
-      {
-         bool read_ok = false;
-         bool is_cached = false;
-
-         // Lock and check if the file is active. If NOT, keep the lock
-         // and add dummy access after successful reading of info file.
-         // If it IS active, just release the lock, this ongoing access will
-         // assure the file continues to exist.
-
-         // XXXX How can I just loop over the cinfo file when active?
-         // Can I not get is_complete from the existing file?
-         // Do I still want to inject access record?
-         // Oh, it writes only if not active .... still let's try to use existing File.
-
-         m_active_cond.Lock();
-
-         bool is_active = m_active.find(f_name) != m_active.end();
-
-         if (is_active)
-            m_active_cond.UnLock();
-
-         XrdOssDF *infoFile = m_oss->newFile(m_configuration.m_username.c_str());
-         XrdOucEnv myEnv;
-         int res = infoFile->Open(i_name.c_str(), O_RDWR, 0600, myEnv);
-         if (res >= 0)
-         {
-            Info info(m_trace, 0);
-            if (info.Read(infoFile, i_name.c_str()))
-            {
-               read_ok = true;
-
-               if (info.IsComplete())
-               {
-                  is_cached = true;
-               }
-               else if (info.GetFileSize() == 0)
-               {
-                  is_cached = true;
-               }
-               else
-               {
-                  long long fileSize = info.GetFileSize();
-                  long long bytesRead = info.GetNDownloadedBytes();
-
-                  if (fileSize < m_configuration.m_onlyIfCachedMinSize)
-                  {
-                     if ((float)bytesRead / fileSize > m_configuration.m_onlyIfCachedMinFrac)
-                        is_cached = true;
-                  }
-                  else
-                  {
-                     if (bytesRead > m_configuration.m_onlyIfCachedMinSize &&
-                         (float)bytesRead / fileSize > m_configuration.m_onlyIfCachedMinFrac)
-                        is_cached = true;
-                  }
-               }
-            }
-            infoFile->Close();
-         }
-         delete infoFile;
-
-         if (!is_active) m_active_cond.UnLock();
-
-         if (read_ok)
-         {
-            TRACE(Info, "ConsiderCached '" << curl << "', why=ForInfo" << (is_cached ? " -> FILE_COMPLETE_IN_CACHE" : " -> EREMOTE"));
-            return is_cached ? 0 : -EREMOTE;
-         }
-      }
+      TRACE(Debug, tpfx << curl << " -> EISDIR");
+      return -EISDIR;
    }
 
-   TRACE(Info, "ConsiderCached '" << curl << "', why=ForInfo" << " -> ENOENT");
-   return -ENOENT;
+   long long file_size = DetermineFullFileSize(f_name + Info::s_infoExtension);
+   if (file_size < 0) {
+      TRACE(Debug, tpfx << curl << " -> " << file_size);
+      return (int) file_size;
+   }
+   bool is_cached = DecideIfConsideredCached(file_size, sbuff.st_blocks * 512ll);
+
+   return is_cached ? 0 : -EREMOTE;
 }
 
 //______________________________________________________________________________
@@ -1053,8 +1083,7 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
    }
 
    struct stat sbuff;
-   int res = m_oss->Stat(i_name.c_str(), &sbuff);
-   if (res == 0)
+   if (m_oss->Stat(i_name.c_str(), &sbuff) == XrdOssOK)
    {
       TRACE(Dump, "Prepare defer open " << f_name);
       return 1;
@@ -1075,44 +1104,51 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
 
 int Cache::Stat(const char *curl, struct stat &sbuff)
 {
+   const char *tpfx = "Stat ";
+
    XrdCl::URL url(curl);
    std::string f_name = url.GetPath();
 
+   File *file = nullptr;
    {
       XrdSysCondVarHelper lock(&m_active_cond);
-      m_purge_delay_set.insert(f_name);
+      auto it = m_active.find(f_name);
+      if (it != m_active.end()) {
+         file = it->second;
+         inc_ref_cnt(file, false, false);
+      }
+   }
+   if (file) {
+      int res = file->Fstat(sbuff);
+      dec_ref_cnt(file, false);
+      TRACE(Debug, tpfx << "from active file " << curl << " -> " << res);
+      return res;
    }
 
-   if (m_oss->Stat(f_name.c_str(), &sbuff) == XrdOssOK)
+   int res = m_oss->Stat(f_name.c_str(), &sbuff);
+   if (res != XrdOssOK) {
+      TRACE(Debug, tpfx << curl << " -> " << res);
+      return res;
+   }
+   if (S_ISDIR(sbuff.st_mode))
    {
-      if (S_ISDIR(sbuff.st_mode))
-      {
-         return 0;
-      }
-      else
-      {
-         bool success = false;
-         XrdOssDF* infoFile = m_oss->newFile(m_configuration.m_username.c_str());
-         XrdOucEnv myEnv;
-
-         f_name += Info::s_infoExtension;
-         int res = infoFile->Open(f_name.c_str(), O_RDONLY, 0600, myEnv);
-         if (res >= 0)
-         {
-            Info info(m_trace, 0);
-            if (info.Read(infoFile, f_name.c_str()))
-            {
-               sbuff.st_size = info.GetFileSize();
-               success = true;
-            }
-         }
-         infoFile->Close();
-         delete infoFile;
-         return success ? 0 : 1;
-      }
+      TRACE(Debug, tpfx << curl << " -> EISDIR");
+      return -EISDIR;
    }
 
-   return 1;
+   long long file_size = DetermineFullFileSize(f_name + Info::s_infoExtension);
+   if (file_size < 0) {
+      TRACE(Debug, tpfx << curl << " -> " << file_size);
+      return (int) file_size;
+   }
+   sbuff.st_size = file_size;
+   bool is_cached = DecideIfConsideredCached(file_size, sbuff.st_blocks * 512ll);
+   if ( ! is_cached)
+      sbuff.st_atime = 0;
+
+   TRACE(Debug, tpfx << "from disk " << curl << " -> " << res);
+
+   return 0;
 }
 
 //______________________________________________________________________________

--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -300,6 +300,10 @@ public:
    //---------------------------------------------------------------------
    virtual int ConsiderCached(const char *url);
 
+   bool DecideIfConsideredCached(long long file_size, long long bytes_on_disk);
+   void WriteFileSizeXAttr(int cinfo_fd, long long file_size);
+   long long DetermineFullFileSize(const std::string &cinfo_fname);
+
    //--------------------------------------------------------------------
    //! \brief Makes decision if the original XrdOucCacheIO should be cached.
    //!
@@ -409,6 +413,7 @@ private:
    bool xcschk(XrdOucStream &);
    bool xdlib(XrdOucStream &);
    bool xtrace(XrdOucStream &);
+   bool test_oss_basics_and_features();
 
    bool cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name);
 
@@ -437,6 +442,8 @@ private:
    int              m_RAM_std_size;
 
    bool        m_isClient;                  //!< True if running as client
+   bool        m_dataXattr = false;         //!< True if xattrs are available on the data space
+   bool        m_metaXattr = false;         //!< True if xattrs are available on the meta space
 
    struct WriteQ
    {

--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -10,10 +10,13 @@
 #include "XrdOuc/XrdOucPinLoader.hh"
 #include "XrdOuc/XrdOuca2x.hh"
 
-#include "XrdOfs/XrdOfsConfigPI.hh"
 #include "XrdVersion.hh"
+#include "XrdOfs/XrdOfsConfigPI.hh"
+#include "XrdSys/XrdSysXAttr.hh"
 
 #include <fcntl.h>
+
+extern XrdSysXAttr *XrdSysXAttrActive;
 
 namespace XrdPfc
 {
@@ -268,6 +271,76 @@ bool Cache::xtrace(XrdOucStream &Config)
    return false;
 }
 
+// Determine if oss spaces are operational and if they support xattrs.
+bool Cache::test_oss_basics_and_features()
+{
+   static const char *epfx = "test_oss_basics_and_features()";
+
+   const auto &conf = m_configuration;
+   const char *user = conf.m_username.c_str();
+   XrdOucEnv   env;
+
+   auto check_space = [&](const char *space, bool &has_xattr)
+   {
+      std::string fname("__prerun_test_pfc_");
+      fname += space;
+      fname += "_space__";
+      env.Put("oss.cgroup", space);
+
+      int res = m_oss->Create(user, fname.c_str(), 0600, env, XRDOSS_mkpath);
+      if (res != XrdOssOK) {
+         m_log.Emsg(epfx, "Can not create a file on space", space);
+         return false;
+      }
+      XrdOssDF *oss_file = m_oss->newFile(user);
+      res = oss_file->Open(fname.c_str(), O_RDWR, 0600, env);
+      if (res != XrdOssOK) {
+         m_log.Emsg(epfx, "Can not open a file on space", space);
+         return false;
+      }
+      res = oss_file->Write(fname.data(), 0, fname.length());
+      if (res != (int) fname.length()) {
+         m_log.Emsg(epfx, "Can not write into a file on space", space);
+         return false;
+      }
+
+      has_xattr = true;
+      long long fsize = fname.length();
+      res = XrdSysXAttrActive->Set("pfc.fsize", &fsize, sizeof(long long), 0, oss_file->getFD(), 0);
+      if (res != 0) {
+         m_log.Emsg(epfx, "Can not write xattr to a file on space", space);
+         has_xattr = false;
+      }
+
+      oss_file->Close();
+
+      if (has_xattr) {
+         char pfn[4096];
+         m_oss->Lfn2Pfn(fname.c_str(), pfn, 4096);
+         fsize = -1ll;
+         res = XrdSysXAttrActive->Get("pfc.fsize", &fsize, sizeof(long long), pfn);
+         if (res != sizeof(long long) || fsize != (long long) fname.length())
+         {
+            m_log.Emsg(epfx, "Can not read xattr from a file on space", space);
+            has_xattr = false;
+         }
+      }
+
+      res = m_oss->Unlink(fname.c_str());
+      if (res != XrdOssOK) {
+         m_log.Emsg(epfx, "Can not unlink a file on space", space);
+         return false;
+      }
+
+      return true;
+   };
+
+   bool aOK = true;
+   aOK &= check_space(conf.m_data_space.c_str(), m_dataXattr);
+   aOK &= check_space(conf.m_meta_space.c_str(), m_metaXattr);
+
+   return aOK;
+}
 
 //______________________________________________________________________________
 /* Function: Config
@@ -384,6 +457,9 @@ bool Cache::Config(const char *config_filename, const char *parameters)
       return false;
    }
 
+   // Test if OSS is operational, determine optional features.
+   aOK &= test_oss_basics_and_features();
+
    // sets default value for disk usage
    XrdOssVSInfo sP;
    {
@@ -428,6 +504,7 @@ bool Cache::Config(const char *config_filename, const char *parameters)
         else aOK = false;
       }
    }
+
    // sets flush frequency
    if ( ! tmpc.m_flushRaw.empty())
    {
@@ -461,7 +538,6 @@ bool Cache::Config(const char *config_filename, const char *parameters)
    }
    // Setup number of standard-size blocks not released back to the system to 5% of total RAM.
    m_configuration.m_RamKeepStdBlocks = (m_configuration.m_RamAbsAvailable / m_configuration.m_bufferSize + 1) * 5 / 100;
-   
 
    // Set tracing to debug if this is set in environment
    char* cenv = getenv("XRDDEBUG");

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -295,6 +295,8 @@ public:
    long long          GetPrefetchedBytes()   const { return m_prefetch_bytes; }
    const Stats&       RefStats()             const { return m_stats; }
 
+   int Fstat(struct stat &sbuff);
+
    // These three methods are called under Cache's m_active lock
    int get_ref_cnt() { return   m_ref_cnt; }
    int inc_ref_cnt() { return ++m_ref_cnt; }

--- a/src/XrdPfc/XrdPfcIOFile.hh
+++ b/src/XrdPfc/XrdPfcIOFile.hh
@@ -86,8 +86,7 @@ private:
    int ReadVBegin(const XrdOucIOVec *readV, int n, ReadReqRH *rh);
    int ReadVEnd(int retval, ReadReqRH *rh);
 
-   struct stat *m_localStat;
-   int initCachedStat();
+   int initialStat(struct stat &sbuff);
 };
 
 }


### PR DESCRIPTION
`PFC` part of addressing #2349.

### Notes:
1. the branch is on xroot.git so it's potentially easier to manipulate by @abh3  and @amadio.
2. the PR is agianst master -- it is targeting 5.7.2.

### Changes

- For most parts, uses stat of the data file for reporting.

- st_size is always set to the full size of the remote file. This is either obtained from cinfo file or from xattr variable created when the file is initially placed into cache (this is a new optimization).

- st_atim is set to 0 when the file is not considered to be fully cached, as determined by the pfc.onlyifcached config settings.


### Open questions:

1. XrdPfc::Cache::Stat() now always returns 0 (success) or an -errno
code. Specification in XrdOucCahce::Stat() says it should return > 0 (ie, 1)
if the operation is to be forwarded to the federation. It is questionable if
this is indeed even desired -- but could be part of an extended protocol or
additional opaques parameters / flags.

2. st_atime is set to 0 if file is to be considered not fully cached. This is
set both for when stat is called on an currently open file and when it is
performed from the disk. Arguably, in the first case, when file currently
active, this setting could (should?) be avoided.

3. Should Stat() call protect the file from immediate purging? This means it
is guranteed to stick around at least for the purge-interval, 5 min or so.
This could be further tuned.
