### PR TITLE
[Pfc] Add num bytes written to disk and bytes prefetched to the gstream record

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -648,12 +648,14 @@ void Cache::dec_ref_cnt(File* f, bool high_debug)
             int  len = snprintf(buf, 4096, "{\"event\":\"file_close\","
                                  "\"lfn\":\"%s\",\"size\":%lld,\"blk_size\":%d,\"n_blks\":%d,\"n_blks_done\":%d,"
                                  "\"access_cnt\":%lu,\"attach_t\":%lld,\"detach_t\":%lld,\"remotes\":%s,"
-                                 "\"b_hit\":%lld,\"b_miss\":%lld,\"b_bypass\":%lld,\"n_cks_errs\":%d}",
+                                 "\"b_hit\":%lld,\"b_miss\":%lld,\"b_bypass\":%lld,"
+                                 "\"b_todisk\":%lld,\"b_prefetch\":%lld,\"n_cks_errs\":%d}",
                                  f->GetLocalPath().c_str(), f->GetFileSize(), f->GetBlockSize(),
                                  f->GetNBlocks(), f->GetNDownloadedBlocks(),
                                  (unsigned long) f->GetAccessCnt(), (long long) as->AttachTime, (long long) as->DetachTime,
                                  f->GetRemoteLocations().c_str(),
-                                 as->BytesHit, as->BytesMissed, as->BytesBypassed, st.m_NCksumErrors
+                                 as->BytesHit, as->BytesMissed, as->BytesBypassed,
+                                 st.m_BytesWritten, f->GetPrefetchedBytes(), st.m_NCksumErrors
             );
             bool suc = false;
             if (len < 4096)

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -68,6 +68,7 @@ File::File(const std::string& path, long long iOffset, long long iFileSize) :
    m_block_size(0),
    m_num_blocks(0),
    m_prefetch_state(kOff),
+   m_prefetch_bytes(0),
    m_prefetch_read_cnt(0),
    m_prefetch_hit_cnt(0),
    m_prefetch_score(0)
@@ -1320,6 +1321,7 @@ void File::ProcessBlockResponse(Block *b, int res)
             m_state_cond.UnLock();
             return;
          }
+         m_prefetch_bytes += b->get_size();
       }
       else
       {

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -291,6 +291,7 @@ public:
    int                GetBlockSize()         const { return m_cfi.GetBufferSize(); }
    int                GetNBlocks()           const { return m_cfi.GetNBlocks(); }
    int                GetNDownloadedBlocks() const { return m_cfi.GetNDownloadedBlocks(); }
+   long long          GetPrefetchedBytes()   const { return m_prefetch_bytes; }
    const Stats&       RefStats()             const { return m_stats; }
 
    // These three methods are called under Cache's m_active lock
@@ -364,6 +365,7 @@ private:
 
    PrefetchState_e m_prefetch_state;
 
+   long long m_prefetch_bytes;
    int   m_prefetch_read_cnt;
    int   m_prefetch_hit_cnt;
    float m_prefetch_score;              // cached


### PR DESCRIPTION
Made against master branch -- targeting 5.7.2.

Resolve #2366 by adding two new gstream fields:
- `b_todisk`: number of bytes written to disk; and
- `b_prefetch`: number of bytes requested via prefetching.

One can now determine the amount of data cache read from the remote (`b_todisk + b_bypass`) and also how much of this transfer was driven by prefetching (`b_prefetch`).

Note that `b_todisk` includes `b_prefetch` -- number of bytes for which explicit remote read calls had to be issued is `b_todisk + b_bypass - b_prefetch`.