### PR TITLE
[XrdHttp] Set oss.asize if object size is known

### DIFF
--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -281,7 +281,9 @@ public:
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;
   bool m_appended_hdr2cgistr;
-  
+  /// Track whether we already appended the oss.asize argument for PUTs.
+  bool m_appended_asize{false};
+
   //
   // Area for coordinating request and responses to/from the bridge
   //

--- a/tests/XRootD/http.cfg
+++ b/tests/XRootD/http.cfg
@@ -4,6 +4,8 @@ set port = 7094
 set pwd = $PWD
 set src = $SOURCE_DIR
 
+xrootd.trace all
+
 xrootd.seclib libXrdSec.so
 xrd.protocol XrdHttp:8094 libXrdHttp.so
 

--- a/tests/XRootD/test.sh
+++ b/tests/XRootD/test.sh
@@ -58,6 +58,15 @@ export XRD_LOGLEVEL XRD_LOGFILE
 
 export XRD_REQUESTTIMEOUT XRD_STREAMTIMEOUT XRD_TIMEOUTRESOLUTION
 
+# Expose the location of the server logfile to the tests.
+# Allows us to test side-effects that are easily visible through logs
+# but difficult to expose otherwise (the driving case is checking that
+# the OSS layer is called with specific CGI set.
+
+XROOTD_SERVER_LOGFILE="${PWD}/${NAME}/xrootd.log"
+
+export XROOTD_SERVER_LOGFILE
+
 # Source directory is the directory where this script is located
 : "${SOURCE_DIR:="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"}"
 


### PR DESCRIPTION
If the client declares the expected size of the uploaded object, then pass this information on to the OSS layer via the `oss.asize` CGI.

This is relevant for the S3 backend as the S3 protocol requires object sizes to be declared ahead of time.  If XRootD doesn't provide this information, then the S3 OSS backend has to buffer the uploaded object to know the final size, costing both in overall throughput and memory usage.