### PR TITLE
[XrdHttp] Allow XrdHttp to provide the values of multiple headers

### DIFF
--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -48,6 +48,7 @@
 
 #include <vector>
 #include <string>
+#include <unordered_map>
 #include <map>
 
 //#include <libxml/parser.h>
@@ -196,6 +197,7 @@ public:
   void appendOpaque(XrdOucString &s, XrdSecEntity *secent, char *hash, time_t tnow);
 
   void addCgi(const std::string & key, const std::string & value);
+  void addMultiCgi(const std::string & key, const std::string_view value);
 
   // Return the current user agent; if none has been specified, returns an empty string
   const std::string &userAgent() const {return m_user_agent;}
@@ -271,7 +273,13 @@ public:
 
   /// Additional opaque info that may come from the hdr2cgi directive
   std::string hdr2cgistr;
+  /// Opaque information from the hdr2cgi directive where multiple headers are turned
+  /// into comma-separated values
+  std::unordered_map<std::string, std::string> hdr2cgimultistr;
   bool m_appended_hdr2cgistr;
+
+  /// Whether the multi-valued headers have been appended to the CGI strings
+  bool m_appended_multihdr2cgistr{false};
   
   //
   // Area for coordinating request and responses to/from the bridge

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -164,18 +164,9 @@ private:
 
 public:
   XrdHttpReq(XrdHttpProtocol *protinstance, const XrdHttpReadRangeHandler::Configuration &rcfg) :
-      readRangeHandler(rcfg), keepalive(true) {
-
-    prot = protinstance;
-    length = 0;
-    //xmlbody = 0;
-    depth = 0;
-    opaque = 0;
-    writtenbytes = 0;
-    fopened = false;
-    headerok = false;
-    mScitag = -1;
-  };
+    prot(protinstance),
+    readRangeHandler(rcfg)
+  {}
 
   virtual ~XrdHttpReq();
 
@@ -243,21 +234,21 @@ public:
   /// The resource specified by the request, stripped of opaque data
   XrdOucString resource;
   /// The opaque data, after parsing
-  XrdOucEnv *opaque;
+  XrdOucEnv *opaque{nullptr};
   /// The resource specified by the request, including all the opaque data
   XrdOucString resourceplusopaque;
   
   
   /// Tells if we have finished reading the header
-  bool headerok;
+  bool headerok{false};
 
   /// Tracking the next ranges of data to read during GET
   XrdHttpReadRangeHandler   readRangeHandler;
   bool                      readClosing;
 
-  bool keepalive;
-  long long length;  // Total size from client for PUT; total length of response TO client for GET.
-  int depth;
+  bool keepalive{true};
+  long long length{0};  // Total size from client for PUT; total length of response TO client for GET.
+  int depth{0};
   bool sendcontinue;
 
   /// The host field specified in the req
@@ -311,7 +302,7 @@ public:
   long filemodtime;
   long filectime;
   char fhandle[4];
-  bool fopened;
+  bool fopened{false};
 
   /// If we want to give a string as a response, we compose it here
   std::string stringresp;
@@ -320,9 +311,9 @@ public:
   int reqstate;
 
   /// In a long write, we track where we have arrived
-  long long writtenbytes;
+  long long writtenbytes{0};
 
-  int mScitag;
+  int mScitag{-1};
 
 
 

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -1417,6 +1417,22 @@ void XrdOucUtils::trim(std::string &str) {
         str.resize (str.size () - 1);
 }
 
+std::string_view XrdOucUtils::trim_view(std::string_view str) {
+    // Trim leading non-letters
+    auto iter = std::find_if(str.begin(), str.end(), isgraph);
+    if (iter == str.end()) {
+      return std::string_view();
+    }
+    str = str.substr(std::distance(str.begin(), iter));
+
+    // Trim trailing non-letters
+    auto iter2 = std::find_if(str.rbegin(), str.rend(), isgraph);
+    if (iter2 == str.rend()) {
+      return str;
+    }
+    return str.substr(0, str.size() - std::distance(str.rbegin(), iter2));
+}
+
 /**
  * Returns a boolean indicating whether 'c' is a valid token character or not.
  * See https://datatracker.ietf.org/doc/html/rfc6750#section-2.1 for details.
@@ -1427,7 +1443,7 @@ static bool is_token_character(int c)
   if (isalnum(c))
     return true;
 
-  static constexpr char token_chars[] = "-._~+/=:";
+  static constexpr char token_chars[] = "-._~+/=:,";
 
   for (char ch : token_chars)
     if (c == ch)

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -135,6 +135,9 @@ static int getModificationTime(const char * path, time_t & modificationTime);
 
 static void trim(std::string & str);
 
+// Trim a string view of whitespace characters from left and right.
+static std::string_view trim_view(std::string_view str);
+
     XrdOucUtils() {}
     ~XrdOucUtils() {}
 

--- a/src/XrdTpc/XrdTpcConfigure.cc
+++ b/src/XrdTpc/XrdTpcConfigure.cc
@@ -74,7 +74,7 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
             }
         } else if (!strcmp("tpc.header2cgi",val)) {
             // header2cgi parsing
-            if(XrdHttpProtocol::parseHeader2CGI(Config,m_log,hdr2cgimap)){
+            if(XrdHttpProtocol::parseHeader2CGI(Config,m_log,hdr2cgimap,nullptr)){
               Config.Close();
               return false;
             }

--- a/tests/XrdOucTests/XrdOucUtilsTests.cc
+++ b/tests/XrdOucTests/XrdOucUtilsTests.cc
@@ -103,7 +103,7 @@ static const std::string authz_strings[] = {
   "/path/test.txt?scitag.flow=44&authz=REDACTED done close.",
   "/path/test.txt?authz=REDACTED&scitag.flow=44 done close.",
   "(message: kXR_stat (path: /tmp/xrootd/public/foo?authz=REDACTED&pelican.timeout=3s, flags: none) ).",
-  "(message: kXR_stat (path: /tmp/xrootd/public/foo?pelican.timeout=3s&authz=REDACTED, flags: none) ).",
+  "(message: kXR_stat (path: /tmp/xrootd/public/foo?pelican.timeout=3s&authz=REDACTED flags: none) ).",
   "Appended header field to opaque info: 'authz=REDACTED'",
   "Processing source entry: /etc/passwd, target file: root://localhost:1094//tmp/passwd?authz=REDACTED",
   "240919 08:11:07 20995 unknown.3:33@[::1] Pss_Stat: url=pelican://p0@F4HP7QL65F.local:" /* no comma! */


### PR DESCRIPTION
In HTTP, headers can be provided multiple times.  However, in our current header-to-CGI translation, only one copy of the value makes it through (the query parameter string is successfully constructed with multiple parameters but this is later put into a hash inside XRootD).
    
This provides a new flag to the header2cgi command, `-multi`, that will translate multiple values to a comma-separated string.  So if we set:

```
http.header2cgi -multi Authorization authz
```

in the configuration then the following headers in a request:

```
Authorization: foo
Authorization: bar
```

would become the query string `?authz=foo,bar`.

Note the obfuscation routine is tweaked to allow `,` to be a character expected in the token.  This allows multiple authorization headers to be correctly obfuscated.