### PR TITLE
Add type checking to format strings used in the client library logging routines and fix the errors that it triggers

### DIFF
--- a/src/XrdCl/XrdClAsyncVectorReader.hh
+++ b/src/XrdCl/XrdClAsyncVectorReader.hh
@@ -135,7 +135,7 @@ namespace XrdCl
               if( !chfound )
               {
                 log->Error( XRootDMsg, "[%s] VectorReader: Impossible to find chunk "
-                            "buffer corresponding to %d bytes at %ld",
+                            "buffer corresponding to %d bytes at %lld",
                             url.GetHostId().c_str(), rdlst.rlen, rdlst.offset );
                 readstage = ReadDiscard;
                 continue;
@@ -181,7 +181,7 @@ namespace XrdCl
               if( !st.IsOK() || st.code == suRetry )
                  return st;
 
-              log->Dump( XRootDMsg, "[%s] VectorReader: read buffer for chunk %d@%ld",
+              log->Dump( XRootDMsg, "[%s] VectorReader: read buffer for chunk %d@%lld",
                          url.GetHostId().c_str(), rdlst.rlen, rdlst.offset );
 
               //----------------------------------------------------------------

--- a/src/XrdCl/XrdClClassicCopyJob.cc
+++ b/src/XrdCl/XrdClClassicCopyJob.cc
@@ -890,8 +890,8 @@ namespace
 
         if( !ch->status.IsOK() )
         {
-          log->Debug( UtilityMsg, "Unable read %d bytes at %ld from %s: %s",
-                      ch->chunk.GetLength(), ch->chunk.GetOffset(),
+          log->Debug( UtilityMsg, "Unable read %d bytes at %llu from %s: %s",
+                      ch->chunk.GetLength(), (unsigned long long) ch->chunk.GetOffset(),
                       pUrl->GetObfuscatedURL().c_str(), ch->status.ToStr().c_str() );
           delete [] (char *)ch->chunk.GetBuffer();
           CleanUpChunks();
@@ -1458,7 +1458,7 @@ namespace
         {
           ss << *itr << ", ";
         }
-        log->Debug( XrdCl::UtilityMsg, ss.str().c_str() );
+        log->Debug( XrdCl::UtilityMsg, "%s", ss.str().c_str() );
 
         pXCpCtx = new XrdCl::XCpCtx( pReplicas, pBlockSize, pNbSrc, pChunkSize, pParallelChunks, fileSize );
 
@@ -1619,7 +1619,7 @@ namespace
         if( pCurrentOffset != ci.GetOffset() )
         {
           log->Error( UtilityMsg, "Got out-of-bounds chunk, expected offset:"
-                      " %ld, got %ld", pCurrentOffset, ci.GetOffset() );
+                      " %llu, got %llu", (unsigned long long) pCurrentOffset, (unsigned long long) ci.GetOffset() );
           return XRootDStatus( stError, errInternal );
         }
 
@@ -1860,8 +1860,8 @@ namespace
         if( !ch->status.IsOK() )
         {
           Log *log = DefaultEnv::GetLog();
-          log->Debug( UtilityMsg, "Unable write %d bytes at %ld from %s: %s",
-                      ch->chunk.GetLength(), ch->chunk.GetOffset(),
+          log->Debug( UtilityMsg, "Unable write %d bytes at %llu from %s: %s",
+                      ch->chunk.GetLength(), (unsigned long long) ch->chunk.GetOffset(),
                       pUrl.GetObfuscatedURL().c_str(), ch->status.ToStr().c_str() );
           delete[] (char*)ci.GetBuffer(); // we took the ownership of the buffer
           CleanUpChunks();
@@ -2190,8 +2190,8 @@ namespace
         if( !ch->status.IsOK() )
         {
           Log *log = DefaultEnv::GetLog();
-          log->Debug( UtilityMsg, "Unable write %d bytes at %ld from %s: %s",
-                      ch->chunk.GetLength(), ch->chunk.GetOffset(),
+          log->Debug( UtilityMsg, "Unable write %d bytes at %llu from %s: %s",
+                      ch->chunk.GetLength(), (unsigned long long) ch->chunk.GetOffset(),
                       pUrl.GetObfuscatedURL().c_str(), ch->status.ToStr().c_str() );
           CleanUpChunks();
 
@@ -2702,8 +2702,8 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     if( src->GetSize() >= 0 && size != total_processed )
     {
-      log->Error( UtilityMsg, "The declared source size is %ld bytes, but "
-                  "received %ld bytes.", size, total_processed );
+      log->Error( UtilityMsg, "The declared source size is %llu bytes, but "
+                  "received %llu bytes.", (unsigned long long) size, (unsigned long long) total_processed );
       return SetResult( stError, errDataError );
     }
     pResults->Set( "size", total_processed );

--- a/src/XrdCl/XrdClCopyProcess.cc
+++ b/src/XrdCl/XrdClCopyProcess.cc
@@ -368,7 +368,7 @@ namespace XrdCl
     Log *log = DefaultEnv::GetLog();
     std::vector<PropertyList>::iterator it;
 
-    log->Debug( UtilityMsg, "CopyProcess: %llu jobs to prepare",
+    log->Debug( UtilityMsg, "CopyProcess: %zu jobs to prepare",
                 pImpl->pJobProperties.size() );
 
     std::map<std::string, uint32_t> targetFlags;

--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -166,8 +166,8 @@ namespace
           if( crcval != cksums[pgnb] )
           {
             Log *log = DefaultEnv::GetLog();
-            log->Info( FileMsg, "[%p@%s] Received corrupted page, will retry page #%llu.",
-                        this, stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
+            log->Info( FileMsg, "[%p@%s] Received corrupted page, will retry page #%zu.",
+                       this, stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
 
             XRootDStatus st = XrdCl::FileStateHandler::PgReadRetry( stateHandler, pgoff, pgsize, pgnb, buffer, this, 0 );
             if( !st.IsOK())
@@ -257,8 +257,8 @@ namespace
         if( !status->IsOK() )
         {
           Log *log = DefaultEnv::GetLog();
-          log->Info( FileMsg, "[%p@%s] Failed to recover page #%llu.",
-                      this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
+          log->Info( FileMsg, "[%p@%s] Failed to recover page #%zu.",
+                     this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
           pgReadHandler->HandleResponseWithHosts( status, response, hostList );
           delete this;
           return;
@@ -269,8 +269,8 @@ namespace
         if( pginf->GetLength() > (uint32_t)XrdSys::PageSize || pginf->GetCksums().size() != 1 )
         {
           Log *log = DefaultEnv::GetLog();
-          log->Info( FileMsg, "[%p@%s] Failed to recover page #%llu.",
-                      this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
+          log->Info( FileMsg, "[%p@%s] Failed to recover page #%zu.",
+                     this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
           // we retry a page at a time so the length cannot exceed 4KB
           DeleteArgs( status, response, hostList );
           pgReadHandler->HandleResponseWithHosts( new XRootDStatus( stError, errDataError ), 0, 0 );
@@ -282,8 +282,8 @@ namespace
         if( crcval != pginf->GetCksums().front() )
         {
           Log *log = DefaultEnv::GetLog();
-          log->Info( FileMsg, "[%p@%s] Failed to recover page #%llu.",
-                      this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
+          log->Info( FileMsg, "[%p@%s] Failed to recover page #%zu.",
+                     this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
           DeleteArgs( status, response, hostList );
           pgReadHandler->HandleResponseWithHosts( new XRootDStatus( stError, errDataError ), 0, 0 );
           delete this;
@@ -291,8 +291,8 @@ namespace
         }
 
         Log *log = DefaultEnv::GetLog();
-        log->Info( FileMsg, "[%p@%s] Successfully recovered page #%llu.",
-                    this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
+        log->Info( FileMsg, "[%p@%s] Successfully recovered page #%zu.",
+                   this, pgReadHandler->stateHandler->pFileUrl->GetObfuscatedURL().c_str(), pgnb );
 
         DeleteArgs( 0, response, hostList );
         pgReadHandler->UpdateCksum( pgnb, crcval );
@@ -2459,7 +2459,7 @@ namespace XrdCl
                pFileUrl->GetObfuscatedURL().c_str(), pDataServer->GetHostId().c_str(),
                status->ToStr().c_str() );
 
-    log->Dump(FileMsg, "[%p@%s] Items in the fly %llu, queued for recovery %llu",
+    log->Dump(FileMsg, "[%p@%s] Items in the fly %zu, queued for recovery %zu",
               this, pFileUrl->GetObfuscatedURL().c_str(), pInTheFly.size(), pToBeRecovered.size() );
 
     MonitorClose( status );

--- a/src/XrdCl/XrdClFileStateHandler.cc
+++ b/src/XrdCl/XrdClFileStateHandler.cc
@@ -1415,21 +1415,21 @@ namespace XrdCl
                   if( inf->NeedRetry() ) // so we failed in the end
                   {
                     DefaultEnv::GetLog()->Warning( FileMsg, "[%p@%s] Failed retransmitting corrupted "
-                                                   "page: pgoff=%llu, pglen=%du, pgdigest=%du", self.get(),
-                                                   self->pFileUrl->GetObfuscatedURL().c_str(), pgoff, pglen, pgdigest );
+                                                   "page: pgoff=%llu, pglen=%u, pgdigest=%u", self.get(),
+                                                   self->pFileUrl->GetObfuscatedURL().c_str(), (unsigned long long) pgoff, pglen, pgdigest );
                     pgwrt->SetStatus( new XRootDStatus( stError, errDataError, 0,
                                       "Failed to retransmit corrupted page" ) );
                   }
                   else
                     DefaultEnv::GetLog()->Info( FileMsg, "[%p@%s] Succesfuly retransmitted corrupted "
-                                                "page: pgoff=%llu, pglen=%du, pgdigest=%du", self.get(),
-                                                self->pFileUrl->GetObfuscatedURL().c_str(), pgoff, pglen, pgdigest );
+                                                "page: pgoff=%llu, pglen=%u, pgdigest=%u", self.get(),
+                                                self->pFileUrl->GetObfuscatedURL().c_str(), (unsigned long long) pgoff, pglen, pgdigest );
                 } );
             auto st = PgWriteRetry( self, pgoff, pglen, pgbuf, pgdigest, h, timeout );
             if( !st.IsOK() ) pgwrt->SetStatus( new XRootDStatus( st ) );
             DefaultEnv::GetLog()->Info( FileMsg, "[%p@%s] Retransmitting corrupted page: "
-                                        "pgoff=%llu, pglen=%du, pgdigest=%du", self.get(),
-                                        self->pFileUrl->GetObfuscatedURL().c_str(), pgoff, pglen, pgdigest );
+                                        "pgoff=%llu, pglen=%u, pgdigest=%u", self.get(),
+                                        self->pFileUrl->GetObfuscatedURL().c_str(), (unsigned long long) pgoff, pglen, pgdigest );
           }
         } );
 
@@ -2420,9 +2420,9 @@ namespace XrdCl
       }
 
       log->Debug( FileMsg, "[%p@%s] successfully opened at %s, handle: %#x, "
-                  "session id: %ld", this, pFileUrl->GetObfuscatedURL().c_str(),
+                  "session id: %llu", this, pFileUrl->GetObfuscatedURL().c_str(),
                   pDataServer->GetHostId().c_str(), *((uint32_t*)pFileHandle),
-                  pSessionId );
+                  (unsigned long long) pSessionId );
 
       //------------------------------------------------------------------------
       // Inform the monitoring about opening success

--- a/src/XrdCl/XrdClFileSystem.cc
+++ b/src/XrdCl/XrdClFileSystem.cc
@@ -75,7 +75,7 @@ namespace
         std::ostringstream data;
         data << ssp.st_dev << " " << ssp.st_size << " " << flags << " "
             << ssp.st_mtime;
-        log->Debug( FileMsg, data.str().c_str() );
+        log->Debug( FileMsg, "%s", data.str().c_str() );
 
         StatInfo *statInfo = new StatInfo();
         if( !statInfo->ParseServerResponse( data.str().c_str() ) )
@@ -641,7 +641,7 @@ namespace
               XRootDStatus st = pCtx->fs->DirList( child, flags, handler, timeout );
               if( !st.IsOK() )
               {
-                log->Error( FileMsg, "Recursive directory list operation for %s failed: ",
+                log->Error( FileMsg, "Recursive directory list operation for %s failed: %s",
                             child.c_str(), st.ToString().c_str() );
                 pCtx->UpdateStatus( st );
                 continue;

--- a/src/XrdCl/XrdClJobManager.cc
+++ b/src/XrdCl/XrdClJobManager.cc
@@ -83,7 +83,7 @@ namespace XrdCl
       }
     }
     pRunning = true;
-    log->Debug( JobMgrMsg, "Job manager started, %llu workers", pWorkers.size() );
+    log->Debug( JobMgrMsg, "Job manager started, %zu workers", pWorkers.size() );
     return true;
   }
 

--- a/src/XrdCl/XrdClLocalFileHandler.cc
+++ b/src/XrdCl/XrdClLocalFileHandler.cc
@@ -298,7 +298,7 @@ namespace XrdCl
     std::ostringstream data;
     data << ssp.st_dev << " " << ssp.st_size << " " << ssp.st_mode << " "
         << ssp.st_mtime;
-    log->Debug( FileMsg, data.str().c_str() );
+    log->Debug( FileMsg, "%s", data.str().c_str() );
 
     StatInfo *statInfo = new StatInfo();
     if( !statInfo->ParseServerResponse( data.str().c_str() ) )

--- a/src/XrdCl/XrdClLog.hh
+++ b/src/XrdCl/XrdClLog.hh
@@ -135,27 +135,47 @@ namespace XrdCl
       //------------------------------------------------------------------------
       //! Report an error
       //------------------------------------------------------------------------
-      void Error( uint64_t topic, const char *format, ... );
+      void Error( uint64_t topic, const char *format, ... )
+#if defined(__GNUC__)
+        __attribute__ ((__format__ (__printf__, 3, 4)))
+#endif
+        ;
 
       //------------------------------------------------------------------------
       //! Report a warning
       //------------------------------------------------------------------------
-      void Warning( uint64_t topic, const char *format, ... );
+      void Warning( uint64_t topic, const char *format, ... )
+#if defined(__GNUC__)
+        __attribute__ ((__format__ (__printf__, 3, 4)))
+#endif
+        ;
 
       //------------------------------------------------------------------------
       //! Print an info
       //------------------------------------------------------------------------
-      void Info( uint64_t topic, const char *format, ... );
+      void Info( uint64_t topic, const char *format, ... )
+#if defined(__GNUC__)
+        __attribute__ ((__format__ (__printf__, 3, 4)))
+#endif
+        ;
 
       //------------------------------------------------------------------------
       //! Print a debug message
       //------------------------------------------------------------------------
-      void Debug( uint64_t topic, const char *format, ... );
+      void Debug( uint64_t topic, const char *format, ... )
+#if defined(__GNUC__)
+        __attribute__ ((__format__ (__printf__, 3, 4)))
+#endif
+        ;
 
       //------------------------------------------------------------------------
       //! Print a dump message
       //------------------------------------------------------------------------
-      void Dump( uint64_t topic, const char *format, ... );
+      void Dump( uint64_t topic, const char *format, ... )
+#if defined(__GNUC__)
+        __attribute__ ((__format__ (__printf__, 3, 4)))
+#endif
+        ;
 
       //------------------------------------------------------------------------
       //! Always print the message

--- a/src/XrdCl/XrdClPollerBuiltIn.cc
+++ b/src/XrdCl/XrdClPollerBuiltIn.cc
@@ -142,7 +142,7 @@ namespace XrdCl
       XrdSys::IOEvents::Poller* poller = IOEvents::Poller::Create( errNum, &errMsg );
       if( !poller )
       {
-        log->Error( PollerMsg, "Unable to create the internal poller object: ",
+        log->Error( PollerMsg, "Unable to create the internal poller object: "
                                "%s (%s)", XrdSysE2T( errno ), errMsg );
         return false;
       }
@@ -170,7 +170,7 @@ namespace XrdCl
                                                helper->readTimeout, &errMsg );
         if( !status )
         {
-          log->Error( PollerMsg, "Unable to enable read notifications ",
+          log->Error( PollerMsg, "Unable to enable read notifications "
                       "while re-starting %s (%s)", XrdSysE2T( errno ), errMsg );
 
           return false;
@@ -183,7 +183,7 @@ namespace XrdCl
                                                helper->writeTimeout, &errMsg );
         if( !status )
         {
-          log->Error( PollerMsg, "Unable to enable write notifications ",
+          log->Error( PollerMsg, "Unable to enable write notifications "
                       "while re-starting %s (%s)", XrdSysE2T( errno ), errMsg );
 
           return false;

--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -598,7 +598,7 @@ namespace XrdCl
       {
         Log *log = DefaultEnv::GetLog();
         log->Warning( PostMasterMsg, "[%s] Removed a leftover msg from the in-queue.",
-                      pStreamName.c_str(), subStream );
+                      pStreamName.c_str() );
       }
     }
     pSubStreams[subStream]->outMsgHelper.Reset();
@@ -745,8 +745,8 @@ namespace XrdCl
     // Check if we still have time to try and do something in the current window
     //--------------------------------------------------------------------------
     time_t elapsed = now-pConnectionInitTime;
-    log->Error( PostMasterMsg, "[%s] elapsed = %ld, pConnectionWindow = %d seconds.",
-                pStreamName.c_str(), elapsed, pConnectionWindow );
+    log->Error( PostMasterMsg, "[%s] elapsed = %lld, pConnectionWindow = %d seconds.",
+                pStreamName.c_str(), (long long) elapsed, pConnectionWindow );
 
     //------------------------------------------------------------------------
     // If we have some IP addresses left we try them
@@ -775,8 +775,8 @@ namespace XrdCl
     else if( elapsed < pConnectionWindow && pConnectionCount < pConnectionRetry
              && !status.IsFatal() )
     {
-      log->Info( PostMasterMsg, "[%s] Attempting reconnection in %ld seconds.",
-                 pStreamName.c_str(), pConnectionWindow-elapsed );
+      log->Info( PostMasterMsg, "[%s] Attempting reconnection in %lld seconds.",
+                 pStreamName.c_str(), (long long) (pConnectionWindow - elapsed) );
 
       Task *task = new ::StreamConnectorTask( *pUrl, pStreamName );
       pTaskManager->RegisterTask( task, pConnectionInitTime+pConnectionWindow );

--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -647,8 +647,8 @@ namespace XrdCl
       //------------------------------------------------------------------------
       if( pSubStreams.size() > 1 )
       {
-        log->Debug( PostMasterMsg, "[%s] Attempting to connect %llu additional streams.",
-                    pStreamName.c_str(), pSubStreams.size()-1 );
+        log->Debug( PostMasterMsg, "[%s] Attempting to connect %zu additional streams.",
+                    pStreamName.c_str(), pSubStreams.size() - 1 );
         for( size_t i = 1; i < pSubStreams.size(); ++i )
         {
           pSubStreams[i]->socket->SetAddress( pSubStreams[0]->socket->GetAddress() );

--- a/src/XrdCl/XrdClUtils.cc
+++ b/src/XrdCl/XrdClUtils.cc
@@ -246,7 +246,7 @@ namespace XrdCl
       addrStr += ", ";
     }
     addrStr.erase( addrStr.length()-2, 2 );
-    log->Debug( type, "[%s] Found %llu address(es): %s",
+    log->Debug( type, "[%s] Found %zu address(es): %s",
                       hostId.c_str(), addresses.size(), addrStr.c_str() );
   }
 

--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -2438,9 +2438,9 @@ namespace XrdCl
 
     Log *log = DefaultEnv::GetLog();
     if( warn )
-      log->Warning( XRootDMsg, sstrm.str().c_str() );
+      log->Warning( XRootDMsg, "%s", sstrm.str().c_str() );
     else
-      log->Debug( XRootDMsg, sstrm.str().c_str() );
+      log->Debug( XRootDMsg, "%s", sstrm.str().c_str() );
   }
   
   // Read data from buffer

--- a/src/XrdCl/XrdClXRootDTransport.cc
+++ b/src/XrdCl/XrdClXRootDTransport.cc
@@ -764,9 +764,9 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     XrdSysMutexHelper scopedLock( info->mutex );
     uint16_t allocatedSIDs = info->sidManager->GetNumberOfAllocatedSIDs();
-    log->Dump( XRootDTransportMsg, "[%s] Stream inactive since %ld seconds, "
+    log->Dump( XRootDTransportMsg, "[%s] Stream inactive since %lld seconds, "
                "TTL: %d, allocated SIDs: %d, open files: %d, bound file objects: %d",
-               info->streamName.c_str(), inactiveTime, ttl, allocatedSIDs,
+               info->streamName.c_str(), (long long) inactiveTime, ttl, allocatedSIDs,
                info->openFiles, info->finstcnt.load( std::memory_order_relaxed ) );
 
     if( info->openFiles != 0 && info->finstcnt.load( std::memory_order_relaxed ) != 0 )
@@ -799,9 +799,9 @@ namespace XrdCl
     const bool anySID =
       info->sidManager->IsAnySIDOldAs( now - streamTimeout );
 
-    log->Dump( XRootDTransportMsg, "[%s] Stream inactive since %ld seconds, "
+    log->Dump( XRootDTransportMsg, "[%s] Stream inactive since %lld seconds, "
                "stream timeout: %d, any SID: %d, wait barrier: %s",
-               info->streamName.c_str(), inactiveTime, streamTimeout,
+               info->streamName.c_str(), (long long) inactiveTime, streamTimeout,
                anySID, Utils::TimeToString(info->waitBarrier).c_str() );
 
     if( inactiveTime < streamTimeout )

--- a/src/XrdCl/XrdClZipArchive.cc
+++ b/src/XrdCl/XrdClZipArchive.cc
@@ -156,8 +156,8 @@ namespace XrdCl
                        [relativeOffset, rdbuff, &cache, &me]( XRootDStatus &st, RSP &rsp )
                        {
                          Log *log = DefaultEnv::GetLog();
-                         log->Dump( ZipMsg, "[%p] Read %d bytes of remote data at offset %llu.",
-                                            &me, rsp.GetLength(), rsp.GetOffset() );
+                         log->Dump( ZipMsg, "[%p] Read %u bytes of remote data at offset %llu.",
+                                            &me, rsp.GetLength(), (unsigned long long) rsp.GetOffset() );
                          cache.QueueRsp( st, relativeOffset, std::move( *rdbuff ) );
                        };
         Async( std::move( p ), timeout );
@@ -187,8 +187,8 @@ namespace XrdCl
     Pipeline p = XrdCl::RdWithRsp<RSP>( me.archive, offset, size, usrbuff ) >>
                    [=, &me]( XRootDStatus &st, RSP &r )
                    {
-                     log->Dump( ZipMsg, "[%p] Read %d bytes of remote data at "
-                                        "offset %llu.", &me, r.GetLength(), r.GetOffset() );
+                     log->Dump( ZipMsg, "[%p] Read %u bytes of remote data at "
+                                        "offset %llu.", &me, r.GetLength(), (unsigned long long) r.GetOffset() );
                      if( usrHandler )
                      {
                        XRootDStatus *status = ZipArchive::make_status( st );
@@ -298,7 +298,7 @@ namespace XrdCl
                                  rdbuff = buffer.get();
                                  openstage = HaveEocdBlk;
                                  log->Dump( ZipMsg, "[%p] Opened a ZIP archive, reading "
-                                                    "Central Directory at offset: %llu.", this, *rdoff );
+                                                    "Central Directory at offset: %llu.", this, (unsigned long long) *rdoff );
                                }
                             // read the Central Directory (in several stages if necessary)
                           | XrdCl::Read( archive, rdoff, rdsize, rdbuff ) >>
@@ -327,12 +327,12 @@ namespace XrdCl
                                       log->Dump( ZipMsg, "[%p] EOCD record parsed: %s", this,
                                                          eocd->ToString().c_str() );
                                       if(eocd->cdOffset > archsize || eocd->cdOffset + eocd->cdSize > archsize)
-                                    	  throw bad_data();
+                                        throw bad_data();
                                       }
                                       catch(const bad_data &ex){
-                                    	  XRootDStatus error( stError, errDataError, 0,
-                                    	               "End-of-central-directory signature corrupted." );
-                                    	  Pipeline::Stop( error );
+                                        XRootDStatus error( stError, errDataError, 0,
+                                                            "End-of-central-directory signature corrupted." );
+                                        Pipeline::Stop( error );
                                       }
                                       // Do we have the whole archive?
                                       if( chunk.length == archsize )
@@ -372,7 +372,7 @@ namespace XrdCl
                                       rdbuff    = buffer.get();
                                       openstage = HaveCdRecords;
                                       log->Dump( ZipMsg, "[%p] Reading additional data at offset: %llu.",
-                                                         this, *rdoff );
+                                                         this, (unsigned long long) *rdoff );
                                       Pipeline::Repeat(); break; // the break is really not needed ...
                                     }
 
@@ -391,7 +391,7 @@ namespace XrdCl
                                         rdbuff = buffer.get();
                                         openstage = HaveZip64EocdBlk;
                                         log->Dump( ZipMsg, "[%p] Reading additional data at offset: %llu.",
-                                                           this, *rdoff );
+                                                           this, (unsigned long long) *rdoff );
                                         Pipeline::Repeat();
                                       }
 
@@ -423,7 +423,7 @@ namespace XrdCl
                                       rdbuff    = buffer.get();
                                       openstage = HaveCdRecords;
                                       log->Dump( ZipMsg, "[%p] Reading additional data at offset: %llu.",
-                                                         this, *rdoff );
+                                                         this, (unsigned long long) *rdoff );
                                       Pipeline::Repeat(); break; // the break is really not needed ...
                                     }
 

--- a/src/XrdClHttp/XrdClHttpFilePlugIn.cc
+++ b/src/XrdClHttp/XrdClHttpFilePlugIn.cc
@@ -273,7 +273,7 @@ XRootDStatus HttpFilePlugIn::Read(uint64_t offset, uint32_t size, void *buffer,
   if (avoid_pread_) offset_locker.unlock();
 
   logger_->Debug(kLogXrdClHttp, "Read %d bytes, at offset %llu, from URL: %s",
-                 num_bytes_read, offset, url_.c_str());
+                 num_bytes_read, (unsigned long long) offset, url_.c_str());
 
   auto status = new XRootDStatus();
   auto chunk_info = new ChunkInfo(offset, num_bytes_read, buffer);
@@ -370,7 +370,7 @@ XRootDStatus HttpFilePlugIn::Write(uint64_t offset, uint32_t size,
     filesize += res.first;
 
   logger_->Debug(kLogXrdClHttp, "Wrote %d bytes, at offset %llu, to URL: %s",
-                 res.first, offset, url_.c_str());
+                 res.first, (unsigned long long) offset, url_.c_str());
 
   handler->HandleResponse(new XRootDStatus(), nullptr);
 

--- a/src/XrdEc/XrdEcReader.cc
+++ b/src/XrdEc/XrdEcReader.cc
@@ -980,7 +980,7 @@ namespace XrdEc
 
 										if(!st.IsOK())
 										{
-											log->Dump(XrdCl::XRootDMsg, "EC Vector Read of host %llu failed entirely.", i);
+											log->Dump(XrdCl::XRootDMsg, "EC Vector Read of host %zu failed entirely.", i);
 											MissingVectorRead(currentBlock, blkid, strpid, timeout);
 										}
 										else{
@@ -1002,7 +1002,7 @@ namespace XrdEc
 											uint32_t cksum = objcfg.digest( 0, currentBlock->stripes[strpid].data(), currentBlock->stripes[strpid].size() );
 											if( orgcksum != cksum )
 											{
-												log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Wrong checksum for block %llu stripe %llu.", blkid, strpid);
+												log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Wrong checksum for block %zu stripe %zu.", blkid, strpid);
 												MissingVectorRead(currentBlock, blkid, strpid, timeout);
 												continue;
 											}
@@ -1010,7 +1010,7 @@ namespace XrdEc
 												currentBlock->state[strpid] = block_t::Valid;
 												bool recoverable = currentBlock->error_correction( currentBlock );
 												if(!recoverable)
-													log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't recover block %llu.", blkid);
+													log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Couldn't recover block %zu.", blkid);
 											}
 										}
 									}
@@ -1045,12 +1045,12 @@ namespace XrdEc
 
 				  // put received data into given buffers
 			      if(blockMap.find(blkid) == blockMap.end() || blockMap[blkid] == nullptr){
-			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Missing block %llu.", blkid);
+			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Missing block %zu.", blkid);
 			    	  failed = true;
 			    	  break;
 			      }
 			      if(blockMap[blkid]->state[strpid] != block_t::Valid){
-			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Invalid stripe in block %llu stripe %llu.", blkid, strpid);
+			    	  log->Dump(XrdCl::XRootDMsg, "EC Vector Read: Invalid stripe in block %zu stripe %zu.", blkid, strpid);
 			    	  failed = true;
 			    	  break;
 			      }

--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -573,7 +573,7 @@ Handler::GenerateMacaroonResponse(XrdHttpExtReq &req, const std::string &resourc
     std::vector<char> macaroon_resp; macaroon_resp.resize(size_hint);
     if (macaroon_serialize(mac_with_date, &macaroon_resp[0], size_hint, &mac_err))
     {
-        printf("Returned macaroon_serialize code: %lu\n", (unsigned long)size_hint);
+        printf("Returned macaroon_serialize code: %zu\n", size_hint);
         return req.SendSimpleResp(500, NULL, NULL, "Internal error serializing macaroon", 0);
     }
     macaroon_destroy(mac_with_date);

--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -655,12 +655,12 @@ void Cache::dec_ref_cnt(File* f, bool high_debug)
             char buf[4096];
             int  len = snprintf(buf, 4096, "{\"event\":\"file_close\","
                                  "\"lfn\":\"%s\",\"size\":%lld,\"blk_size\":%d,\"n_blks\":%d,\"n_blks_done\":%d,"
-                                 "\"access_cnt\":%lu,\"attach_t\":%lld,\"detach_t\":%lld,\"remotes\":%s,"
+                                 "\"access_cnt\":%zu,\"attach_t\":%lld,\"detach_t\":%lld,\"remotes\":%s,"
                                  "\"b_hit\":%lld,\"b_miss\":%lld,\"b_bypass\":%lld,"
                                  "\"b_todisk\":%lld,\"b_prefetch\":%lld,\"n_cks_errs\":%d}",
                                  f->GetLocalPath().c_str(), f->GetFileSize(), f->GetBlockSize(),
                                  f->GetNBlocks(), f->GetNDownloadedBlocks(),
-                                 (unsigned long) f->GetAccessCnt(), (long long) as->AttachTime, (long long) as->DetachTime,
+                                 f->GetAccessCnt(), (long long) as->AttachTime, (long long) as->DetachTime,
                                  f->GetRemoteLocations().c_str(),
                                  as->BytesHit, as->BytesMissed, as->BytesBypassed,
                                  st.m_BytesWritten, f->GetPrefetchedBytes(), st.m_NCksumErrors

--- a/tests/XrdCl/XrdClFileTest.cc
+++ b/tests/XrdCl/XrdClFileTest.cc
@@ -643,10 +643,10 @@ void FileTest::VectorWriteTest()
   const uint32_t MB = 1024*1024;
   const uint32_t limit = 10*MB;
 
-  time_t seed = time( 0 );
+  unsigned int seed = (unsigned int) time( 0 );
   srand( seed );
   DefaultEnv::GetLog()->Info( UtilityMsg,
-      "Carrying out the VectorWrite test with seed: %d", seed );
+      "Carrying out the VectorWrite test with seed: %u", seed );
 
   // figure out how many chunks are we going to write/read
   size_t nbChunks = rand() % 100 + 1;


### PR DESCRIPTION
The format for some size_t variables were recently changed from %d to %llu. This fixed a problem on 64 bit architectures, since there size_t is 64 bits wide and %d is the format for a 32 bit type and %llu is the format for a 64 bit type. However, this change introduced a regression on 32 bit architectures where size_t is 32 bits wide.

This change caused some of the tests to fail with a segmentation fault on the Debian armhf architecture:

The following tests FAILED:
	108 - XRootD::noauth::test (Failed)
	111 - XRootD::host::test (Failed)
	114 - XRootD::unix::test (Failed)
	117 - XRootD::sss::test (Failed)
	120 - XRootD::http::test (Failed)

This first commit adds a type cast so that the new format works for all architectures.

It is possible to get warnings from the compilers for bad format strings that don't match the types of the variables by using __atribute__((format)). The second commit adds this attribute to the logging routines in the client library.

The third commit fixes the errors from this type checking produced by the compiler for the master branch.

The fourth commit contains additional fixes for the devel branch relared to the "timeout uses time_t" change. This commit should no go to mastar untill that change does.

The first three commits should go to master.