### PR TITLE
[Seckrb5] Avoid null pointer dereference

### DIFF
--- a/src/XrdSeckrb5/XrdSecProtocolkrb5.cc
+++ b/src/XrdSeckrb5/XrdSecProtocolkrb5.cc
@@ -510,7 +510,9 @@ int XrdSecProtocolkrb5::Authenticate(XrdSecCredentials *cred,
           {char* cpName;
            int ec;
            isCP = true;
-           if ((ec = krb5_unparse_name(krb_context,
+           if (!Ticket || !Ticket->enc_part2)
+               cPrincipal = "[principal not available]";
+           else if ((ec = krb5_unparse_name(krb_context,
                           (krb5_const_principal)Ticket->enc_part2->client,
                           (char **)&cpName)))
               {char mBuff[1024];


### PR DESCRIPTION
Fixes the following potential crash:
```sh    
    Core was generated by `/usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-krb5.cfg -k'.
    Program terminated with signal SIGSEGV, Segmentation fault.
    *0  0x00007f16f2cc52e2 in XrdSecProtocolkrb5::Authenticate (this=0x7f16d8000b90, parms=0x7f16f0423418, error=0x7f16f0423440)
        at xrootd-5.7.2/src/XrdSeckrb5/XrdSecProtocolkrb5.cc:514
    514                              (krb5_const_principal)Ticket->enc_part2->client,
    [Current thread is 1 (Thread 0x7f16f04246c0 (LWP 2274325))]
    (gdb) bt
     0  0x00007f16f2cc52e2 in XrdSecProtocolkrb5::Authenticate (this=0x7f16d8000b90, parms=0x7f16f0423418, error=0x7f16f0423440)
        at xrootd-5.7.2/src/XrdSeckrb5/XrdSecProtocolkrb5.cc:514
     1  0x00007f16f35d092f in XrdXrootdProtocol::do_Auth (this=this@entry=0x7f16e4005a90)
        at xrootd-5.7.2/src/XrdXrootd/XrdXrootdXeq.cc:201
     2  0x00007f16f35be10b in XrdXrootdProtocol::Process2 (this=this@entry=0x7f16e4005a90)
        at xrootd-5.7.2/src/XrdXrootd/XrdXrootdProtocol.cc:521
     3  0x00007f16f35be66a in XrdXrootdProtocol::Process (this=0x7f16e4005a90, lp=<optimized out>)
        at xrootd-5.7.2/src/XrdXrootd/XrdXrootdProtocol.cc:430
     4  0x00007f16f34f3b26 in XrdLinkXeq::DoIt (this=0x7f16e400b8a0)
        at xrootd-5.7.2/src/Xrd/XrdLinkXeq.cc:304
     5  0x00007f16f34f75d5 in XrdScheduler::Run (this=0x5592d8b49120 <XrdGlobal::Sched>)
        at xrootd-5.7.2/src/Xrd/XrdScheduler.cc:406
     6  0x00007f16f34f7656 in XrdStartWorking (carg=<optimized out>)
        at xrootd-5.7.2/src/Xrd/XrdScheduler.cc:89
     7  0x00007f16f34816bf in XrdSysThread_Xeq (myargs=0x7f16e0000b70)
        at xrootd-5.7.2/src/XrdSys/XrdSysPthread.cc:86
     8  0x00007f16f2ebe395 in start_thread (arg=<optimized out>)
        at pthread_create.c:448
     9  0x00007f16f2f2785c in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
    (gdb) list
    509           if (rc)
    510              {char* cpName;
    511               int ec;
    512               isCP = true;
    513               if ((ec = krb5_unparse_name(krb_context,
    514                              (krb5_const_principal)Ticket->enc_part2->client,
    515                              (char **)&cpName)))
    516                  {char mBuff[1024];
    517                   snprintf(mBuff, sizeof(mBuff),
    518                           "[principal unparse failed; %s]", krb_etxt(ec));
    (gdb) p Ticket
    $1 = (krb5_ticket *) 0x0
```