### PR TITLE
[XrdHttp] Allow static headers to be specified for browsers

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -52,6 +52,7 @@
 
 #include <openssl/ssl.h>
 
+#include <unordered_map>
 #include <vector>
 
 #include "XrdHttpReq.hh"
@@ -213,6 +214,7 @@ private:
   static int xlistredir(XrdOucStream &Config);
   static int xselfhttps2http(XrdOucStream &Config);
   static int xembeddedstatic(XrdOucStream &Config);
+  static int xstaticheader(XrdOucStream &Config);
   static int xstaticredir(XrdOucStream &Config);
   static int xstaticpreload(XrdOucStream &Config);
   static int xgmap(XrdOucStream &Config);
@@ -450,5 +452,12 @@ protected:
 
   /// If set to true, the HTTP TPC transfers will forward the credentials to redirected hosts
   static bool tpcForwardCreds;
+
+  /// The static headers to always return; map is from verb to a list of (header, val) pairs.
+  static std::unordered_map<std::string, std::vector<std::pair<std::string, std::string>>> m_staticheader_map;
+
+  /// The static string version of m_staticheader_map.  After config parsing is done, this is
+  /// computed and we won't need to reference m_staticheader_map in the response path.
+  static std::unordered_map<std::string, std::string> m_staticheaders;
 };
 #endif

--- a/tests/XRootD/http.cfg
+++ b/tests/XRootD/http.cfg
@@ -18,4 +18,10 @@ http.exthandler xrdtpc libXrdHttpTPC.so
 http.exthandler xrdmacaroons libXrdMacaroons.so
 macaroons.secretkey $pwd/macaroons-secret
 
+# Verify static headers are appropriately appended to responses
+http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
+http.staticheader -verb=GET Foo Bar
+http.staticheader -verb=GET Foo Baz
+http.staticheader Test 1
+
 continue $src/common.cfg


### PR DESCRIPTION
(This patch is more of a RFI -- I think all the infrastructure is in place that I can add a unit test before marking it as not a draft)

In Pelican, we want to allow users from browsers to be able to access XRootD servers (including through redirections).  However, to do this, we need to add a few extra headers to all `GET` and `OPTIONS` requests to permit redirections across sites (we hit various CORS safeguards that are reasonable for a generic webapp -- but needed for a data federation).

The existing plugin mechanism isn't sufficient because we don't want to _replace_ the XRootD handling of the requests (such as a `GET`) but rather augment it with a few static headers.

This PR adds a new configuration option, `http.staticheader`, that permits such a header to be set.  The config option has the following form:

```
http.staticheader [-verb=[GET|HEAD|...]]* header [value]
```

Here's a few examples:

```
http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
http.staticheader -verb=GET Foo Bar
http.staticheader -verb=GET Foo Baz
http.staticheader Test 1
```

- If the `-verb` is omitted then the header is set for all requests
- If the value is omitted, then the prior static header settings are unset.  Otherwise, they are additive (same header specified multiple times will cause multiple values to be sent; this is perfectly fine in HTTP-land).

So, for the example configuration above, here's the response for a simple `GET` request:

```
< HTTP/1.1 403 Forbidden
< Connection: Close
< Server: XrootD/v5.7.1-85-g42eab06b3
< Test: 1
< Foo: Bar
< Foo: Baz
< Content-Length: 36
```
