### PR TITLE
[Pfc] Fix FD leak when reading file-size from cinfo file in Cache::DetermineFullFileSize()

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -944,13 +944,21 @@ long long Cache::DetermineFullFileSize(const std::string &cinfo_fname)
 
    XrdOssDF *infoFile = m_oss->newFile(m_configuration.m_username.c_str());
    XrdOucEnv env;
+   long long ret;
    int res = infoFile->Open(cinfo_fname.c_str(), O_RDONLY, 0600, env);
-   if (res < 0)
-      return res;
-   Info info(m_trace, 0);
-   if ( ! info.Read(infoFile, cinfo_fname.c_str()))
-      return -EBADF;
-   return info.GetFileSize();
+   if (res < 0) {
+      ret = res;
+   } else {
+      Info info(m_trace, 0);
+      if ( ! info.Read(infoFile, cinfo_fname.c_str())) {
+         ret = -EBADF;
+      } else {
+         ret = info.GetFileSize();
+      }
+      infoFile->Close();
+   }
+   delete infoFile;
+   return ret;
 }
 
 //______________________________________________________________________________


### PR DESCRIPTION
Also fixes leak of XrdOssDF object on the heap.

Note: this code-path is only taken if file-size can not be determined from the xattrs (a new feature, written when file is first created in the cace) so this expected to happen:
- during transition to this new version where old files do not have the information yet;
- when a FS that does not support xattrs is used.

Fixes #2392