### PR TITLE
Correct forward declaration of XrdSfsFSctl

### DIFF
--- a/src/XrdOfs/XrdOfsFSctl_PI.hh
+++ b/src/XrdOfs/XrdOfsFSctl_PI.hh
@@ -41,7 +41,7 @@ class XrdOucErrInfo;
 class XrdSecEntity;
 class XrdSfsFile;
 class XrdSfsFileSystem;
-class XrdSfsFSctl;
+struct XrdSfsFSctl;
 class XrdSysError;
   
 /******************************************************************************/


### PR DESCRIPTION
Withouth this correction, `-Wall -Werror` builds on Mac fail when importing the headers with the following message:

```
/xrootd/build/release_dir/include/xrootd/XrdSfs/XrdSfsInterface.hh:161:1: error: 'XrdSfsFSctl' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
struct XrdSfsFSctl //!< SFS_FSCTL_PLUGIN/PLUGIO/PLUGXC parms
^
/xrootd/build/release_dir/include/xrootd/XrdOfs/XrdOfsFSctl_PI.hh:44:1: note: did you mean struct here?
```

I think aligning the actual declaration and the forward declaration is a reasonable thing to do here.