### PR TITLE
MacOS stress test

### DIFF
--- a/src/Xrd/XrdPollPoll.icc
+++ b/src/Xrd/XrdPollPoll.icc
@@ -34,6 +34,8 @@
 #include "Xrd/XrdPollPoll.hh"
 #include "Xrd/XrdScheduler.hh"
 
+#include <vector>
+
 /******************************************************************************/
 /*                             n e w P o l l e r                              */
 /******************************************************************************/
@@ -274,7 +276,15 @@ void XrdPollPoll::Start(XrdSysSemaphore *syncsem, int &retcode)
 
 // Now do the main poll loop
 //
-   do {do {numpolled = poll(PollTab, PollTNum, -1);}
+   std::vector<struct pollfd> PollTabCopy;
+   do {// Duplicate the polling table so we don't need to hold the PollMutex
+       // while we are sleeping in the poll()
+       PollMutex.Lock();
+       PollTabCopy.resize(PollTNum);
+       memcpy(PollTabCopy.data(), PollTab, sizeof(struct pollfd) * PollTNum);
+       PollMutex.UnLock();
+
+       do {numpolled = poll(PollTabCopy.data(), PollTabCopy.size(), -1);}
           while(numpolled < 0 && (errno == EAGAIN || errno == EINTR));
 
        // Check if we had a polling error
@@ -286,16 +296,25 @@ void XrdPollPoll::Start(XrdSysSemaphore *syncsem, int &retcode)
           }
        numEvents += numpolled;
 
+       // Note this thread is the only one that writes directly to the poll
+       // table (everything else is a read).  Hence, it's OK to assume that
+       // the table after the poll() is unchanged and we can write back the
+       // revents field.
+       PollMutex.Lock();
+       for (size_t idx=0; idx<PollTabCopy.size(); idx++)
+           PollTab[idx].revents = PollTabCopy[idx].revents;
+
        // Check out base poll table entry, we can do this without a lock
        //
        if (PollTab[0].revents & pollOK)
-          {doRequests(numpolled); 
+          {PollMutex.UnLock();
+           doRequests(numpolled);
            if (--numpolled <= 0) continue;
+           PollMutex.Lock();
           }
 
        // Checkout which links must be dispatched (do this locked)
        //
-       PollMutex.Lock();
        plp = 0; nlp = PollQ; jfirst = jlast = 0; num2sched = 0;
        while ((pInfo = nlp) && numpolled > 0)
              {if ((pollevents = pInfo->PollEnt->revents))
@@ -333,26 +352,26 @@ void XrdPollPoll::Start(XrdSysSemaphore *syncsem, int &retcode)
 /******************************************************************************/
 /*                              d o D e t a c h                               */
 /******************************************************************************/
-
+// Detach a given offset in the poll table, `pti`, from the PollTab.
+//
+// This method must be called with the PollMutex held.
 void XrdPollPoll::doDetach(int pti)
 {
    int lastent;
 
 // Get some starting values
 //
-   PollMutex.Lock();
    if ((lastent = PollTNum-1) < 0)
       {Log.Emsg("Poll","Underflow during detach"); abort();}
 
    if (pti == lastent)
       do {PollTNum--;} while(PollTNum && PollTab[PollTNum-1].fd == -1);
-  PollMutex.UnLock();
 }
 
 /******************************************************************************/
 /*                            d o R e q u e s t s                             */
 /******************************************************************************/
-
+// This must be called with the PollMutex unlocked
 void XrdPollPoll::doRequests(int maxreq)
 {
    const char *act;
@@ -367,17 +386,23 @@ void XrdPollPoll::doRequests(int maxreq)
 // Now process all poll table manipulation requests
 //
    while(num2do-- && getRequest())
-        {     if (ReqBuff.req == PipeData::Post)
+        {XrdSysMutexHelper PollGuard(PollMutex);
+              if (ReqBuff.req == PipeData::Post)
                  {ReqBuff.Parms.theSem->Post();
                   continue;
                  }
               pti = ReqBuff.Parms.Arg.ent;
               if ((ptfd = abs(PollTab[pti].fd)) != ReqBuff.Parms.Arg.fd)
-                 {LogEvent(ReqBuff.req, PollTab[pti].fd, ReqBuff.Parms.Arg.fd);
+                 {auto fd = PollTab[pti].fd;
+                  PollGuard.UnLock();
+                  LogEvent(ReqBuff.req, fd, ReqBuff.Parms.Arg.fd);
                   continue;
                  }
               if (!(piP = XrdLinkCtl::fd2PollInfo(ptfd)))
-                 {LogEvent(ReqBuff.req, -1, ptfd); continue;}
+                 {PollGuard.UnLock();
+                  LogEvent(ReqBuff.req, -1, ptfd);
+                  continue;
+                 }
               if (ReqBuff.req == PipeData::EnFD)
                  {PollTab[pti].events = POLLIN | POLLRDNORM;
                   PollTab[pti].fd     = ptfd;
@@ -395,9 +420,11 @@ void XrdPollPoll::doRequests(int maxreq)
                   act = " detached fd ";
                   piP->isEnabled = false;
                  }
-         else {Log.Emsg("Poll", "Received an invalid poll pipe request");
+         else {PollGuard.UnLock();
+               Log.Emsg("Poll", "Received an invalid poll pipe request");
                continue;
               }
+         PollGuard.UnLock();
          TRACE(POLL, "Poller " <<PID <<act <<ReqBuff.Parms.Arg.fd
                      <<" entry " <<pti <<" now at " <<PollTNum);
         }
@@ -464,7 +491,7 @@ void XrdPollPoll::LogEvent(int req, int pollfd, int cmdfd)
 /******************************************************************************/
 /*                               R e c o v e r                                */
 /******************************************************************************/
-  
+// This must be called with PollMutex locked.
 void XrdPollPoll::Recover(int numleft)
 {
    int i;
@@ -486,7 +513,7 @@ void XrdPollPoll::Recover(int numleft)
 /******************************************************************************/
 /*                               R e s t a r t                                */
 /******************************************************************************/
-  
+// This must be called with the PollMutex unlocked
 void XrdPollPoll::Restart(int ecode)
 {
    XrdPollInfo *pInfo;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,3 +28,4 @@ endif()
 
 add_subdirectory( XRootD )
 add_subdirectory( cluster )
+add_subdirectory( stress )

--- a/tests/XRootD/http.cfg
+++ b/tests/XRootD/http.cfg
@@ -7,7 +7,7 @@ set src = $SOURCE_DIR
 xrootd.trace all
 
 xrootd.seclib libXrdSec.so
-xrd.protocol XrdHttp:8094 libXrdHttp.so
+xrd.protocol XrdHttp:$port libXrdHttp.so
 
 http.desthttps false
 http.selfhttps2http false

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -23,7 +23,7 @@ function test_http() {
 	assert xrdfs "${HOST}" mkdir -p "${TMPDIR}"
 
 	# from now on, we use HTTP
-	export HOST=http://localhost:8094
+	export HOST="http://localhost:${XRD_PORT}"
 
 	# create local files with random contents using OpenSSL
 

--- a/tests/XRootD/test.sh
+++ b/tests/XRootD/test.sh
@@ -132,6 +132,14 @@ function setup() {
 		teardown "${NAME}"
 		error "failed to start XRootD server"
 	fi
+
+	# Prepare a test environment file -- can be used by other unit tests that
+	# utilize this fixture but don't inherit the shell environment from run()
+	XRD_PORT="$(cconfig -x xrootd -c "${CONF}" 2>&1 | grep xrd.port | tr -cd '0-9')"
+	HOST="root://${HOSTNAME:-localhost}:${XRD_PORT}/"
+	cat > "${LOCAL_DIR}/test_config.sh" << EOF
+HOST=$HOST
+EOF
 }
 
 function run() {

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -1,0 +1,32 @@
+
+# Curl is necessary for this test
+if( NOT CURL_FOUND )
+  return()
+endif()
+
+# If XRootD::http fixture is not available, we
+# cannot run the HTTP stress test.
+if( NOT ENABLE_HTTP_TESTS )
+  return()
+endif()
+
+include(GoogleTest)
+
+add_executable( xrdhttp-stress-tests
+  curl_stress.cc
+)
+
+target_link_libraries( xrdhttp-stress-tests
+  GTest::GTest GTest::Main CURL::libcurl
+)
+
+gtest_add_tests( TARGET xrdhttp-stress-tests
+  TEST_LIST xrdHttpStressTests
+)
+
+set_tests_properties( ${xrdHttpStressTests}
+  PROPERTIES
+    FIXTURES_REQUIRED XRootD::http
+  ENVIRONMENT "TEST_CONFIG=${CMAKE_BINARY_DIR}/tests/XRootD/http/data/test_config.sh"
+)
+

--- a/tests/stress/curl_stress.cc
+++ b/tests/stress/curl_stress.cc
@@ -1,0 +1,169 @@
+
+#include <curl/curl.h>
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <string>
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+namespace {
+
+std::string g_http_url;
+std::string g_hello_world = "Hello, world!\n";
+
+} // namespace
+
+class HttpStressTest : public testing::TestWithParam<std::tuple<int, std::string>> {
+public:
+  ~HttpStressTest() {}
+  void SetUp() override {
+    ParseEnv();
+  
+    auto [concurrency, prefix] = GetParam();
+
+    m_multi_handle.reset(curl_multi_init());
+    ASSERT_TRUE(m_multi_handle) << "Failed to allocate a curl multi-handle";
+
+    m_offsets.resize(concurrency);
+    CreateCurlUploadHandles(g_http_url + prefix + std::to_string(concurrency));
+  }
+
+  void TearDown() override {
+    if (m_multi_handle) {
+      for (auto &handle : m_handles) {
+        curl_multi_remove_handle(m_multi_handle.get(), handle.get());
+      }
+    }
+    m_multi_handle.reset();
+    m_offsets.clear();
+    m_handles.clear();
+  }
+
+protected:
+  void Execute();
+
+private:
+  void ExecuteUploads();
+  int CreateCurlUploadHandles(const std::string &url_prefix);
+  void ParseEnv();
+
+  std::unique_ptr<CURLM, decltype(curl_multi_cleanup)*> m_multi_handle{nullptr, &curl_multi_cleanup};
+  std::vector<off_t> m_offsets;
+  std::vector<std::unique_ptr<CURL, decltype(curl_easy_cleanup)*>> m_handles;
+};
+
+size_t hello_read_cb(char *buffer, size_t size, size_t nitems, void *offset_ptr) {
+  off_t offset = *(off_t *)(offset_ptr);
+  if (offset > 0) {
+    return 0;
+  }
+  if (size*nitems < g_hello_world.size()) {
+    return -1;
+  }
+  memcpy(buffer, g_hello_world.data(), g_hello_world.size());
+  return g_hello_world.size();
+}
+
+size_t null_write_cb(char * /*buffer*/, size_t size, size_t nitems, void * /*data*/) {
+  return size * nitems;
+}
+
+void HttpStressTest::Execute() {
+    for (int idx=0; idx<20; idx++) {
+      ASSERT_NO_FATAL_FAILURE(ExecuteUploads());
+    }
+}
+
+int HttpStressTest::CreateCurlUploadHandles(const std::string &url_prefix) {
+  for (size_t idx=0; idx<m_offsets.size(); idx++) {
+    m_handles.emplace_back(curl_easy_init(), &curl_easy_cleanup);
+    auto &handle = m_handles.back();
+    auto url_final = url_prefix + "/test" + std::to_string(idx);
+    curl_easy_setopt(handle.get(), CURLOPT_URL, url_final.c_str());
+    curl_easy_setopt(handle.get(), CURLOPT_UPLOAD, 1);
+    if (idx != 2) curl_easy_setopt(handle.get(), CURLOPT_FORBID_REUSE, 1L);
+    curl_easy_setopt(handle.get(), CURLOPT_INFILESIZE_LARGE, (curl_off_t)g_hello_world.size());
+    curl_easy_setopt(handle.get(), CURLOPT_READFUNCTION, hello_read_cb);
+    curl_easy_setopt(handle.get(), CURLOPT_WRITEFUNCTION, null_write_cb);
+    curl_easy_setopt(handle.get(), CURLOPT_FAILONERROR, 1);
+    curl_easy_setopt(handle.get(), CURLOPT_TIMEOUT, 10L);
+    m_offsets[idx] = 0;
+    curl_easy_setopt(handle.get(), CURLOPT_READDATA, m_offsets.data() + idx);
+  }
+  return 0;
+}
+
+void HttpStressTest::ExecuteUploads() {
+  size_t idx = 0;
+  for (auto &handle : m_handles) {
+    auto rc = curl_multi_add_handle(m_multi_handle.get(), handle.get());
+    ASSERT_EQ(rc, CURLM_OK) << "Failed to add curl handle to multi-handle: " << curl_multi_strerror(rc);
+    m_offsets[idx++] = 0;
+  }
+
+  int still_running;
+  do {
+    auto rc = curl_multi_perform(m_multi_handle.get(), &still_running);
+    ASSERT_EQ(rc, CURLM_OK) << "Failed to perform curl multi-handle: " << curl_multi_strerror(rc);
+
+    ASSERT_EQ(rc = curl_multi_wait(m_multi_handle.get(), NULL, 0, 1000, NULL), CURLM_OK) << "Unable to wait on curl multi-handle: " << curl_multi_strerror(rc);
+
+    struct CURLMsg *msg;
+    do {
+      int msgq = 0;
+      msg = curl_multi_info_read(m_multi_handle.get(), &msgq);
+      if (msg && (msg->msg == CURLMSG_DONE)) {
+        CURL *handle = msg->easy_handle;
+        curl_multi_remove_handle(m_multi_handle.get(), handle);
+
+        CURLcode res = msg->data.result;
+        ASSERT_EQ(res, CURLE_OK) << "Failure when uploading: " << curl_easy_strerror(res);
+      }
+    } while (msg);
+  } while (still_running);
+}
+
+void HttpStressTest::ParseEnv() {
+  auto fname = getenv("TEST_CONFIG");
+  ASSERT_NE(fname, nullptr) << "TEST_CONFIG environment variable is missing; was the test run invoked by ctest?";
+	std::ifstream fh(fname);
+  ASSERT_TRUE(fh.is_open()) << "Failed to open env file " << fname << ": " << strerror(errno);
+	std::string line;
+	while (std::getline(fh, line)) {
+		auto idx = line.find("=");
+		if (idx == std::string::npos) {
+			continue;
+		}
+		auto key = line.substr(0, idx);
+		auto val = line.substr(idx + 1);
+		if (key != "HOST") {
+      continue;
+    }
+    if (val.substr(0, 7) == "root://") {
+      g_http_url = "http://" + val.substr(7);
+    } else {
+      g_http_url = val;
+    }
+	}
+
+  ASSERT_FALSE(g_http_url.empty());
+}
+
+TEST_P(HttpStressTest, Upload) {
+  Execute();
+}
+
+// INSTANTIATE_TEST_CASE_P was renamed to INSTANTIATE_TEST_SUITE_P after GTest 1.8.0.
+// Currently, AlmaLinux 8 is the only platform that has a sufficiently old version
+// of GTest that we need to use this ifdef to switch between the two.
+#ifdef INSTANTIATE_TEST_SUITE_P
+INSTANTIATE_TEST_SUITE_P(
+#else
+INSTANTIATE_TEST_CASE_P(
+#endif
+  StressTests, HttpStressTest,
+  testing::Combine(testing::Values(1, 10, 20), testing::Values("/stress_upload"))
+);


### PR DESCRIPTION
This implements a simple HTTP-based stress test that, on my laptop, fails 100% of the time.  All it does is try an increasing number of concurrent HTTP uploads.

By "stress tests", it tends to fail at 10 concurrent transfers _provided_ this line is set:

```
    if (idx != 2) curl_easy_setopt(handle.get(), CURLOPT_FORBID_REUSE, 1L);
```

If, instead, that line is:

```
    curl_easy_setopt(handle.get(), CURLOPT_FORBID_REUSE, 1L);
```

then I've never gotten the stress test to fail, even with more than 100 concurrent transfers.  Note -- `CURLOPT_FORBID_REUSE`, when set, causes a new TCP socket to be created for each transfer.  By turning it off, there's multiple requests on a single TCP socket.

I believe this is due to the fact that HTTP is such a simple protocol the poller only fires once per socket _unless_ there is socket reuse -- at which point we trigger the race condition mentioned in https://github.com/xrootd/xrootd/issues/2212.

Hopefully the GitHub runner will trigger the failure just as reliably as my laptop!