### PR TITLE
Fix compilation errors with GCC 15

### DIFF
--- a/src/Xrd/XrdLinkCtl.hh
+++ b/src/Xrd/XrdLinkCtl.hh
@@ -202,7 +202,7 @@ private:
 static XrdSysMutex   LTMutex;    // For the LinkTab only LTMutex->IOMutex allowed
 static XrdLinkCtl  **LinkTab;
 static char         *LinkBat;
-static unsigned int  LinkAlloc;
+static const unsigned int LinkAlloc;
 static int           LTLast;
 static int           maxFD;
 static const char   *TraceID;

--- a/src/XrdSut/XrdSutPFile.cc
+++ b/src/XrdSut/XrdSutPFile.cc
@@ -1520,7 +1520,8 @@ kXR_int32 XrdSutPFile::ReadInd(kXR_int32 ofs, XrdSutPFEntInd &ind)
       ind.name = 0;
    }
    if (lnam) {
-      ind.name = new char[lnam+1];
+      if (lnam > 0)
+         ind.name = new char[lnam+1];
       if (ind.name) {
          if ((nr = read(fFd,ind.name,lnam)) != lnam)
             return Err(kPFErrRead,"ReadInd",(const char *)&fFd);


### PR DESCRIPTION
```
In file included from /usr/include/features.h:524,
                 from /usr/include/c++/15/x86_64-redhat-linux/bits/os_defines.h:39,
                 from /usr/include/c++/15/x86_64-redhat-linux/bits/c++config.h:2622,
                 from /usr/include/c++/15/cstdio:46,
                 from /builddir/build/BUILD/xrootd-5.7.2-build/xrootd-5.7.2/src/XrdSut/XrdSutPFile.cc:29:
In function ‘read’,
    inlined from ‘XrdSutPFile::ReadInd(int, XrdSutPFEntInd&)’ at /builddir/build/BUILD/xrootd-5.7.2-build/xrootd-5.7.2/src/XrdSut/XrdSutPFile.cc:1525:24:
/usr/include/bits/unistd.h:32:10: error: ‘*read’ specified size 18446744073709551614 exceeds maximum object size 9223372036854775807 [-Werror=stringop-overflow=]
   32 |   return __glibc_fortify (read, __nbytes, sizeof (char),
      |          ^~~~~~~~~~~~~~~
/usr/include/bits/unistd-decl.h: In member function ‘XrdSutPFile::ReadInd(int, XrdSutPFEntInd&)’:
/usr/include/bits/unistd-decl.h:29:16: note: in a call to function ‘*read’ declared with attribute ‘access (write_only, 2, 3)’
   29 | extern ssize_t __REDIRECT_FORTIFY (__read_alias, (int __fd, void *__buf,
      |                ^~~~~~~~~~~~~~~~~~
```

```
/builddir/build/BUILD/xrootd-5.7.2-build/xrootd-5.7.2/src/Xrd/XrdLinkCtl.cc: In function ‘Alloc’:
/builddir/build/BUILD/xrootd-5.7.2-build/xrootd-5.7.2/src/Xrd/XrdLinkCtl.cc:130:59: error: argument 1 value ‘4294967295’ exceeds maximum object size 2147483647 [-Werror=alloc-size-larger-than=]
  130 |        XrdLinkCtl **blp, *nlp = new XrdLinkCtl[LinkAlloc]();
      |                                                           ^
/usr/include/c++/15/new:140:26: note: in a call to allocation function ‘operator new []’ declared here
  140 | _GLIBCXX_NODISCARD void* operator new[](std::size_t)
      |                          ^
```
