### PR TITLE
[XrdOfs] Export configured FSctl plugin to global configuration

### DIFF
--- a/src/XrdOfs/XrdOfsConfig.cc
+++ b/src/XrdOfs/XrdOfsConfig.cc
@@ -299,7 +299,9 @@ int XrdOfs::Configure(XrdSysError &Eroute, XrdOucEnv *EnvInfo) {
 // the cache-specific FSctl() operation. We check if a plugin was provided.
 //
    if (ossFeatures & XRDOSS_HASCACH)
-      FSctl_PC = (XrdOfsFSctl_PI*)EnvInfo->GetPtr("XrdFSCtl_PC*");
+      {FSctl_PC = (XrdOfsFSctl_PI*)EnvInfo->GetPtr("XrdFSCtl_PC*");
+       if (xrdEnv && FSctl_PC) xrdEnv->PutPtr("XrdFSCtl_PC*", FSctl_PC);
+      }
 
 // Configure third party copy phase 2, but only if we are not a manager.
 //


### PR DESCRIPTION
The FSctl plugin is necessary to invoke filesystem-level operations on the PFC.  However, unlike the `XrdOss` and `XrdAccAuthorize` plugins, it is only exported in the xrootd protocol environment, not the process-wide environment.

This provides symmetry between the FSctl and the other plugins. It joins other parts of the PFC available via the process-wide export.

I also investigated invoking the plugin indirectly through some other layer (such as the xrootd protocol bridge) but, unfortunately, the use case for needing to invoke the plugin is a `XrdHttpExtHandler`; the handler framework does not provide access to the protocol bridge.

Fixes #2404