### PR TITLE
[XrdPfc] Check for a null pointer dereference

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1014,7 +1014,13 @@ int Cache::ConsiderCached(const char *curl)
       auto it = m_active.find(f_name);
       if (it != m_active.end()) {
          file = it->second;
-         inc_ref_cnt(file, false, false);
+         // If the file-open is in progress, `file` is a nullptr
+         // so we cannot increase the reference count.  For now,
+         // simply treat it as if the file open doesn't exist instead
+         // of trying to wait and see if it succeeds.
+         if (file) {
+            inc_ref_cnt(file, false, false);
+         }
       }
    }
    if (file) {
@@ -1123,7 +1129,12 @@ int Cache::Stat(const char *curl, struct stat &sbuff)
       auto it = m_active.find(f_name);
       if (it != m_active.end()) {
          file = it->second;
-         inc_ref_cnt(file, false, false);
+         // If `file` is nullptr, the file-open is in progress; instead
+         // of waiting for the file-open to finish, simply treat it as if
+         // the file-open doesn't exist.
+         if (file) {
+            inc_ref_cnt(file, false, false);
+         }
       }
    }
    if (file) {


### PR DESCRIPTION
When looking up the map of active files, the returned value is a a `nullptr` if the file-open is ongoing.  Check for this case and only try to use the file object if it is non-null.

Without this check, the XrdPfc module will trigger a segfault when trying to increase the reference count for a null object.

The places affected by the nullptr already have appropriate fallback code in place if the filename isn't on the active list at all -- we now use that code instead of crashing.