### PR TITLE
[XrdHttp] Add trailing slash to directories in listing

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1936,14 +1936,12 @@ XrdHttpReq::PostProcessListing(bool final_) {
 
           free(estr);
         }
-
-        char *estr = escapeXML(e.path.c_str());
-
-        p += e.path + "\">";
-        p += e.path;
-
-        free(estr);
-
+        std::unique_ptr<char, decltype(&free)> estr(escapeXML(e.path.c_str()), &free);
+        p += estr.get();
+        if (e.flags & kXR_isDir) p += "/";
+        p += "\">";
+        p += estr.get();
+        if (e.flags & kXR_isDir) p += "/";
         p += "</a></td></tr>";
 
         stringresp += p;

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -38,6 +38,7 @@ function test_http() {
 	for i in $FILES; do
 		assert davix-put "${TMPDIR}/${i}.ref" "${HOST}/${TMPDIR}/${i}.ref"
 	done
+	assert davix-put "${TMPDIR}/${i}.ref" "${HOST}/${TMPDIR}/testlistings/01.ref"
 
 	# list uploaded files, then download them to check for corruption
 
@@ -148,4 +149,10 @@ function test_http() {
   receivedDigest=$(grep -i "Digest" "$outputFilePath")
   assert_eq "$expectedDigest" "$receivedDigest" "HEAD request test failed (digest not supported)"
 	wait
+
+  ## Generated HTML has appropriate trailing slashes for directories
+  HTTP_CODE=$(curl --output "$outputFilePath" -v -L --write-out '%{http_code}' "${HOST}/${TMPDIR}")
+  assert_eq 200 "$HTTP_CODE"
+  HTTP_CONTENTS=$(curl -v -L "${HOST}/${TMPDIR}" | tr '"' '\n' | tr '<' '\n' | tr '>' '\n' | grep testlistings/ | wc -l | tr -d ' ')
+  assert_eq 2 "$HTTP_CONTENTS"
 }


### PR DESCRIPTION
Apache, when generating a HTML listing of a local directory, will suffix directory names with a trailing slash.  This PR tweaks the XRootD directory listing to do the same and adds a corresponding integration test.

Beyond matching common practice, the HTTP fsspec plugin in the Python ecosystem uses the trailing slash as a heuristic to indicate a directory.  With this change, Python users should be able to recursively list directories in XRootD.  While not strictly required, this makes a significant improvement for the lives of Python users.