### PR TITLE
[XrdHttp] Quote the resource when handling a redirect

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,7 @@ jobs:
           bash \
           cmake \
           ceph-dev \
+          curl \
           curl-dev \
           fuse-dev \
           fuse3-dev \

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -4,6 +4,7 @@ RUN apk add \
 	bash \
 	cmake \
 	ceph-dev \
+	curl \
 	curl-dev \
 	fuse-dev \
 	fuse3-dev \

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -580,7 +580,7 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
     redirdest += buf;
   }
 
-  redirdest += resource.c_str();
+  redirdest += quote(resource.c_str());
   
   // Here we put back the opaque info, if any
   if (vardata) {

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -427,10 +427,14 @@ char *quote(const char *str) {
         strcpy(r + j, "%3A");
         j += 3;
         break;
-      case '/':
-        strcpy(r + j, "%2F");
-        j += 3;
-        break;
+      // case '/':
+      //   strcpy(r + j, "%2F");
+      //   j += 3;
+      //   break;
+      case '#':
+         strcpy(r + j, "%23");
+         j += 3;
+         break;
       case '\n':
         strcpy(r + j, "%0A");
         j += 3;

--- a/tests/cluster/man1.cfg
+++ b/tests/cluster/man1.cfg
@@ -7,4 +7,8 @@ all.manager localhost:20941
 xrd.port 10941 if exec xrootd
 xrd.port 20941 if exec cmsd
 
+if exec xrootd
+xrd.protocol XrdHttp:10941 libXrdHttp.so
+fi
+
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/man2.cfg
+++ b/tests/cluster/man2.cfg
@@ -7,4 +7,8 @@ all.manager localhost:20942
 xrd.port 10942 if exec xrootd
 xrd.port 20942 if exec cmsd
 
+if exec xrootd
+xrd.protocol XrdHttp:10942 libXrdHttp.so
+fi
+
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/metaman.cfg
+++ b/tests/cluster/metaman.cfg
@@ -6,4 +6,8 @@ all.manager meta localhost:20940
 xrd.port 10940 if exec xrootd
 xrd.port 20940 if exec cmsd
 
+if exec xrootd
+xrd.protocol XrdHttp:10940 libXrdHttp.so
+fi
+
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/srv1.cfg
+++ b/tests/cluster/srv1.cfg
@@ -2,6 +2,11 @@ set name = srv1
 
 all.role server
 all.manager localhost:20941
+
 xrd.port 10943
+
+if exec xrootd
+xrd.protocol XrdHttp:10943 libXrdHttp.so
+fi
 
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/srv2.cfg
+++ b/tests/cluster/srv2.cfg
@@ -2,6 +2,11 @@ set name = srv2
 
 all.role server
 all.manager localhost:20941
+
 xrd.port 10944
+
+if exec xrootd
+xrd.protocol XrdHttp:10944 libXrdHttp.so
+fi
 
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/srv3.cfg
+++ b/tests/cluster/srv3.cfg
@@ -2,6 +2,11 @@ set name = srv3
 
 all.role server
 all.manager localhost:20942
+
 xrd.port 10945
+
+if exec xrootd
+xrd.protocol XrdHttp:10945 libXrdHttp.so
+fi
 
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/srv4.cfg
+++ b/tests/cluster/srv4.cfg
@@ -2,6 +2,11 @@ set name = srv4
 
 all.role server
 all.manager localhost:20942
+
 xrd.port 10946
+
+if exec xrootd
+xrd.protocol XrdHttp:10946 libXrdHttp.so
+fi
 
 continue @CMAKE_CURRENT_BINARY_DIR@/common.cfg

--- a/tests/cluster/test.sh
+++ b/tests/cluster/test.sh
@@ -126,8 +126,8 @@ for host in "${!hosts[@]}"; do
        count=0
 
        for suffix in "${HTTP_SUFFIX[@]}"; do
-           ${CURL} -v -L ${hosts_http[$host]}/${RMTDATADIR}/${host}${suffix} -o ${LCLDATADIR}/${host}.dat_http${count}
-           count=$((count + 1))
+               ${CURL} -v -L ${hosts_http[$host]}/${RMTDATADIR}/${host}${suffix} -o ${LCLDATADIR}/${host}.dat_http${count}
+               count=$((count + 1))
        done
 done
 
@@ -197,9 +197,9 @@ for host in "${!hosts[@]}"; do
        count=0
 
        for suffix in "${HTTP_SUFFIX[@]}"; do
-           ${XRDFS} ${HOST_METAMAN} rm "${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[$suffix]}" &
-           rm ${LCLDATADIR}/${host}.dat_http${count} &
-           count=$((count + 1))
+               ${XRDFS} ${HOST_METAMAN} rm "${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[$suffix]}" &
+               rm ${LCLDATADIR}/${host}.dat_http${count} &
+               count=$((count + 1))
        done
 done
 

--- a/tests/cluster/test.sh
+++ b/tests/cluster/test.sh
@@ -12,6 +12,7 @@ fi
 : ${XRDCP:=$(command -v xrdcp)}
 : ${XRDFS:=$(command -v xrdfs)}
 : ${OPENSSL:=$(command -v openssl)}
+: ${CURL:=$(command -v curl)}
 : ${HOST_METAMAN:=root://localhost:10940}
 : ${HOST_MAN1:=root://localhost:10941}
 : ${HOST_MAN2:=root://localhost:10942}
@@ -20,8 +21,16 @@ fi
 : ${HOST_SRV3:=root://localhost:10945}
 : ${HOST_SRV4:=root://localhost:10946}
 
+: ${HOST_HTTP_METAMAN:=${HOST_METAMAN/root/http}}
+: ${HOST_HTTP_MAN1:=${HOST_MAN1/root/http}}
+: ${HOST_HTTP_MAN2:=${HOST_MAN2/root/http}}
+: ${HOST_HTTP_SRV1:=${HOST_SRV1/root/http}}
+: ${HOST_HTTP_SRV2:=${HOST_SRV2/root/http}}
+: ${HOST_HTTP_SRV3:=${HOST_SRV3/root/http}}
+: ${HOST_HTTP_SRV4:=${HOST_SRV4/root/http}}
+
 # checking for command presence
-for PROG in ${ADLER32} ${CRC32C} ${XRDCP} ${XRDFS} ${OPENSSL}; do
+for PROG in ${ADLER32} ${CRC32C} ${XRDCP} ${XRDFS} ${OPENSSL} ${CURL}; do
        if [[ ! -x "${PROG}" ]]; then
                echo 1>&2 "$(basename $0): error: '${PROG}': command not found"
                exit 1
@@ -69,6 +78,15 @@ hosts["srv2"]="${HOST_SRV2}"
 hosts["srv3"]="${HOST_SRV3}"
 hosts["srv4"]="${HOST_SRV4}"
 
+declare -A hosts_http
+hosts_http["metaman"]="${HOST_HTTP_METAMAN}"
+hosts_http["man1"]="${HOST_HTTP_MAN1}"
+hosts_http["man2"]="${HOST_HTTP_MAN2}"
+hosts_http["srv1"]="${HOST_HTTP_SRV1}"
+hosts_http["srv2"]="${HOST_HTTP_SRV2}"
+hosts_http["srv3"]="${HOST_HTTP_SRV3}"
+hosts_http["srv4"]="${HOST_HTTP_SRV4}"
+
 cleanup() {
        echo "Error occured. Cleaning up..."
        for host in "${!hosts[@]}"; do
@@ -85,9 +103,16 @@ for host in "${!hosts[@]}"; do
 done
 
 # upload local files to the servers in parallel
+HTTP_SUFFIX=(".ref_http" ".ref_%23_http")
+declare -A MAP_HTTP_XRD_SUFFIX=( [".ref_http"]=".ref_http" [".ref_%23_http"]=".ref_#_http" )
 
 for host in "${!hosts[@]}"; do
        ${XRDCP} ${LCLDATADIR}/${host}.ref ${hosts[$host]}/${RMTDATADIR}/${host}.ref
+
+       for suffix in "${HTTP_SUFFIX[@]}"; do
+              ${CURL} -v -L ${hosts_http[$host]}/${RMTDATADIR}/${host}${suffix} -T ${LCLDATADIR}/${host}.ref
+       done
+
 done
 
 # list uploaded files, then download them to check for corruption
@@ -98,36 +123,84 @@ done
 
 for host in "${!hosts[@]}"; do
        ${XRDCP} ${hosts[$host]}/${RMTDATADIR}/${host}.ref ${LCLDATADIR}/${host}.dat
+       count=0
+
+       for suffix in "${HTTP_SUFFIX[@]}"; do
+           ${CURL} -v -L ${hosts_http[$host]}/${RMTDATADIR}/${host}${suffix} -o ${LCLDATADIR}/${host}.dat_http${count}
+           count=$((count + 1))
+       done
 done
 
 # check that all checksums for downloaded files match
 
 for host in "${!hosts[@]}"; do
+       # check the CRC32 checksums
        REF32C=$(${CRC32C} < ${LCLDATADIR}/${host}.ref | cut -d' '  -f1)
        NEW32C=$(${CRC32C} < ${LCLDATADIR}/${host}.dat | cut -d' '  -f1)
        SRV32C=$(${XRDFS} ${hosts[$host]} query checksum ${RMTDATADIR}/${host}.ref?cks.type=crc32c | cut -d' ' -f2)
 
+       if [[ "${NEW32C}" != "${REF32C}" || "${SRV32C}" != "${REF32C}" ]]; then
+               echo "${host}:  crc32c: reference: ${REF32C}, server: ${SRV32C}, downloaded: ${REF32C}"
+               echo 1>&2 "$(basename $0): error: crc32 checksum check failed for file: ${host}.dat"
+               exit 1
+       fi
+
+       # check the HTTP files
+       count=0
+
+       for suffix in "${HTTP_SUFFIX[@]}"; do
+               HTTP_SRV32C=$(${XRDFS} ${hosts[$host]} query checksum ${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[${suffix}]}?cks.type=crc32c | cut -d' ' -f2)
+               HTTP_NEW32C=$(${CRC32C} < ${LCLDATADIR}/${host}.dat_http${count} | cut -d' '  -f1)
+
+               if [[ "${HTTP_NEW32C}" != "${REF32C}" || "${HTTP_SRV32C}" != "${REF32C}" ]]; then
+                       echo "${host}:  crc32c: reference: ${REF32C}, server: ${HTTP_SRV32C}, downloaded: ${HTTP_NEW32C}"
+                       echo 1>&2 "$(basename $0): error: crc32 checksum check failed for file: ${host}${HTTP_SUFFIX[$count]}"
+                       exit 1
+               fi
+
+               count=$((count + 1))
+       done
+
+       # check the ADLER32 checksums
        REFA32=$(${ADLER32} < ${LCLDATADIR}/${host}.ref | cut -d' '  -f1)
        NEWA32=$(${ADLER32} < ${LCLDATADIR}/${host}.dat | cut -d' '  -f1)
        SRVA32=$(${XRDFS} ${hosts[$host]} query checksum ${RMTDATADIR}/${host}.ref?cks.type=adler32 | cut -d' ' -f2)
 
        if [[ "${NEWA32}" != "${REFA32}" || "${SRVA32}" != "${REFA32}" ]]; then
-               echo "${host}:  crc32c: reference: ${REF32C}, server: ${SRV32C}, downloaded: ${REF32C}"
                echo "${host}: adler32: reference: ${NEWA32}, server: ${SRVA32}, downloaded: ${NEWA32}"
                echo 1>&2 "$(basename $0): error: adler32 checksum check failed for file: ${host}.dat"
-               exit 1r
-       fi
-       if [[ "${NEW32C}" != "${REF32C}" || "${SRV32C}" != "${REF32C}" ]]; then
-               echo "${host}:  crc32c: reference: ${REF32C}, server: ${SRV32C}, downloaded: ${REF32C}"
-               echo "${host}: adler32: reference: ${NEWA32}, server: ${SRVA32}, downloaded: ${NEWA32}"
-               echo 1>&2 "$(basename $0): error: crc32 checksum check failed for file: ${host}.dat"
                exit 1
        fi
+
+       # check the HTTP files
+       count=0
+
+       for suffix in "${HTTP_SUFFIX[@]}"; do
+               HTTP_SRVA32=$(${XRDFS} ${hosts[$host]} query checksum ${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[${suffix}]}?cks.type=adler32 | cut -d' ' -f2)
+               HTTP_NEWA32=$(${ADLER32} < ${LCLDATADIR}/${host}.dat_http${count} | cut -d' '  -f1)
+
+               if [[ "${HTTP_NEWA32}" != "${REFA32}" || "${HTTP_SRVA32}" != "${REFA32}" ]]; then
+                       echo "${host}:  adler32: reference: ${REFA32}, server: ${HTTP_SRVA32}, downloaded: ${HTTP_NEWA32}"
+                       echo 1>&2 "$(basename $0): error: adler32 checksum check failed for file: ${host}${HTTP_SUFFIX[$count]}"
+                       exit 1
+               fi
+
+               count=$((count + 1))
+
+       done
 done
+
 
 for host in "${!hosts[@]}"; do
        ${XRDFS} ${HOST_METAMAN} rm ${RMTDATADIR}/${host}.ref &
        rm ${LCLDATADIR}/${host}.dat &
+       count=0
+
+       for suffix in "${HTTP_SUFFIX[@]}"; do
+           ${XRDFS} ${HOST_METAMAN} rm "${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[$suffix]}" &
+           rm ${LCLDATADIR}/${host}.dat_http${count} &
+           count=$((count + 1))
+       done
 done
 
 wait


### PR DESCRIPTION
The resource string is unquoted when the request is handled but in case of a redirect the resource should be quoted again otherwise the client will be redirected with a different path than the initial one.