### PR TITLE
[Docs] Update installation instructions to use consistent build directory path

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -142,9 +142,9 @@ For the anxious user, assuming the repository is cloned into the `xrootd`
 directory under the current working directory, the basic workflow is
 
 ```sh
-cmake -S xrootd -B xrootd_build
-cmake --build xrootd_build --parallel
-cmake --install xrootd_build
+cmake -S xrootd -B xrootd/build
+cmake --build xrootd/build --parallel
+cmake --install xrootd/build
 ```
 
 If you'd like to install somewhere other than the default of `/usr/local`,


### PR DESCRIPTION
Having the build directory path as `xroot/build` in `INSTALL.md` keeps it consistent with next steps described in `TESTING.md`.

https://github.com/xrootd/xrootd/blob/df5006ca1725979cc2e992d34b936d336e1c63ca/docs/TESTING.md?plain=1#L28 