### PR TITLE
Fixes for XrdPosix on Apple 

### DIFF
--- a/src/XrdPosix/XrdPosixLinkage.cc
+++ b/src/XrdPosix/XrdPosixLinkage.cc
@@ -45,26 +45,28 @@
 #endif
 
 #include <cerrno>
+#ifdef __linux__
 #include <cstdio>
+#endif
 
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdPosix/XrdPosixLinkage.hh"
- 
+
 /******************************************************************************/
 /*                   G l o b a l   D e c l a r a t i o n s                    */
 /******************************************************************************/
-  
+
 XrdPosixLinkage Xunix;
- 
+
 /******************************************************************************/
 /*                          M a c r o   L o a d e r                           */
 /******************************************************************************/
-  
+
 #define LOOKUP_UNIX(symb) symb = (Retv_ ## symb (*)(Args_ ## symb)) \
                                  dlsym(RTLD_NEXT, Symb_ ## symb); \
                           if (!symb) {symb = Xrd_U_ ## symb; \
                                       Missing(Symb_ ## symb);}
- 
+
 /******************************************************************************/
 /*          U n r e s o l v e d   R e f e r e n c e   L i n k a g e           */
 /******************************************************************************/
@@ -75,15 +77,15 @@ XrdPosixLinkage Xunix;
       Retv_Acl         Xrd_U_Acl(Args_Acl)
                          {return (Retv_Acl)Xunix.Load_Error("acl");}
 #endif
-      Retv_Chdir       Xrd_U_Chdir(Args_Chdir) 
+      Retv_Chdir       Xrd_U_Chdir(Args_Chdir)
                          {return (Retv_Chdir)Xunix.Load_Error("chdir");}
-      Retv_Close       Xrd_U_Close(Args_Close) 
+      Retv_Close       Xrd_U_Close(Args_Close)
                          {return (Retv_Close)Xunix.Load_Error("close");}
-      Retv_Closedir    Xrd_U_Closedir(Args_Closedir) 
+      Retv_Closedir    Xrd_U_Closedir(Args_Closedir)
                          {return (Retv_Closedir)Xunix.Load_Error("closedir");}
       Retv_Fclose      Xrd_U_Fclose(Args_Fclose)
                          {return (Retv_Fclose)Xunix.Load_Error("fclose");}
-      Retv_Fcntl       Xrd_U_Fcntl(Args_Fcntl) 
+      Retv_Fcntl       Xrd_U_Fcntl(Args_Fcntl)
                          {Xunix.Load_Error("fcntl"); return (Retv_Fcntl)0;}
       Retv_Fcntl64     Xrd_U_Fcntl64(Args_Fcntl64)
                          {Xunix.Load_Error("fcntl"); return (Retv_Fcntl64)0;}
@@ -91,7 +93,7 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Fdatasync)Xunix.Load_Error("fdatasync");}
       Retv_Fflush      Xrd_U_Fflush(Args_Fflush)
                          {return (Retv_Fflush)Xunix.Load_Error("fflush");}
-      Retv_Fopen       Xrd_U_Fopen(Args_Fopen) 
+      Retv_Fopen       Xrd_U_Fopen(Args_Fopen)
                          {Xunix.Load_Error("fopen"); return (Retv_Fopen)0;}
       Retv_Fopen64     Xrd_U_Fopen64(Args_Fopen64)
                          {Xunix.Load_Error("fopen"); return (Retv_Fopen64)0;}
@@ -103,11 +105,11 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Fseeko)Xunix.Load_Error("fseeko");}
       Retv_Fseeko64    Xrd_U_Fseeko64(Args_Fseeko64)
                          {return (Retv_Fseeko64)Xunix.Load_Error("fseeko64");}
-      Retv_Fstat       Xrd_U_Fstat(Args_Fstat) 
+      Retv_Fstat       Xrd_U_Fstat(Args_Fstat)
                          {return (Retv_Fstat)Xunix.Load_Error("fstat");}
       Retv_Fstat64     Xrd_U_Fstat64(Args_Fstat64)
                          {return (Retv_Fstat64)Xunix.Load_Error("fstat64");}
-      Retv_Fsync       Xrd_U_Fsync(Args_Fsync) 
+      Retv_Fsync       Xrd_U_Fsync(Args_Fsync)
                          {return (Retv_Fsync)Xunix.Load_Error("fsync");}
       Retv_Ftell       Xrd_U_Ftell(Args_Ftell)
                          {return (Retv_Ftell)Xunix.Load_Error("ftell");}
@@ -129,7 +131,7 @@ XrdPosixLinkage Xunix;
       Retv_Lgetxattr   Xrd_U_Lgetxattr(Args_Lgetxattr)
                          {return (Retv_Lgetxattr)Xunix.Load_Error("lgetxattr");}
 #endif
-      Retv_Lseek       Xrd_U_Lseek(Args_Lseek) 
+      Retv_Lseek       Xrd_U_Lseek(Args_Lseek)
                          {return (Retv_Lseek)Xunix.Load_Error("lseek");}
       Retv_Lseek64     Xrd_U_Lseek64(Args_Lseek64)
                          {return (Retv_Lseek64)Xunix.Load_Error("lseek");}
@@ -137,13 +139,13 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Lstat)Xunix.Load_Error("lstat");}
       Retv_Lstat64     Xrd_U_Lstat64(Args_Lstat64)
                          {return (Retv_Lstat64)Xunix.Load_Error("lstat");}
-      Retv_Mkdir       Xrd_U_Mkdir(Args_Mkdir) 
+      Retv_Mkdir       Xrd_U_Mkdir(Args_Mkdir)
                          {return (Retv_Mkdir)Xunix.Load_Error("mkdir");}
-      Retv_Open        Xrd_U_Open(Args_Open) 
+      Retv_Open        Xrd_U_Open(Args_Open)
                          {return (Retv_Open)Xunix.Load_Error("open");}
       Retv_Open64      Xrd_U_Open64(Args_Open64)
                          {return (Retv_Open64)Xunix.Load_Error("open");}
-      Retv_Opendir     Xrd_U_Opendir(Args_Opendir) 
+      Retv_Opendir     Xrd_U_Opendir(Args_Opendir)
                          {Xunix.Load_Error("opendir"); return (Retv_Opendir)0;}
       Retv_Pathconf    Xrd_U_Pathconf(Args_Pathconf)
                          {return (Retv_Pathconf)Xunix.Load_Error("pathconf");}
@@ -151,31 +153,31 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Pread)Xunix.Load_Error("pread");}
       Retv_Pread64     Xrd_U_Pread64(Args_Pread64)
                          {return (Retv_Pread64)Xunix.Load_Error("pread");}
-      Retv_Pwrite      Xrd_U_Pwrite(Args_Pwrite) 
+      Retv_Pwrite      Xrd_U_Pwrite(Args_Pwrite)
                          {return (Retv_Pwrite)Xunix.Load_Error("pwrite");}
       Retv_Pwrite64    Xrd_U_Pwrite64(Args_Pwrite64)
                          {return (Retv_Pwrite64)Xunix.Load_Error("pwrite");}
-      Retv_Read        Xrd_U_Read(Args_Read) 
+      Retv_Read        Xrd_U_Read(Args_Read)
                          {return (Retv_Read)Xunix.Load_Error("read");}
-      Retv_Readv       Xrd_U_Readv(Args_Readv) 
+      Retv_Readv       Xrd_U_Readv(Args_Readv)
                          {return (Retv_Readv)Xunix.Load_Error("readv");}
-      Retv_Readdir     Xrd_U_Readdir(Args_Readdir) 
+      Retv_Readdir     Xrd_U_Readdir(Args_Readdir)
                          {Xunix.Load_Error("readdir"); return (Retv_Readdir)0;}
       Retv_Readdir64   Xrd_U_Readdir64(Args_Readdir64)
                          {Xunix.Load_Error("readdir64");return (Retv_Readdir64)0;}
-      Retv_Readdir_r   Xrd_U_Readdir_r(Args_Readdir_r) 
+      Retv_Readdir_r   Xrd_U_Readdir_r(Args_Readdir_r)
                          {return (Retv_Readdir_r)Xunix.Load_Error("readdir_r", ELIBACC);}
       Retv_Readdir64_r Xrd_U_Readdir64_r(Args_Readdir64_r)
                          {return (Retv_Readdir64_r)Xunix.Load_Error("readdir64_r", ELIBACC);}
       Retv_Rename      Xrd_U_Rename(Args_Rename)
                          {return (Retv_Rename)Xunix.Load_Error("rename");}
-      Retv_Rewinddir   Xrd_U_Rewinddir(Args_Rewinddir) 
+      Retv_Rewinddir   Xrd_U_Rewinddir(Args_Rewinddir)
                          {       Xunix.Load_Error("rewinddir"); abort();}
-      Retv_Rmdir       Xrd_U_Rmdir(Args_Rmdir) 
+      Retv_Rmdir       Xrd_U_Rmdir(Args_Rmdir)
                          {return (Retv_Rmdir)Xunix.Load_Error("rmdir");}
-      Retv_Seekdir     Xrd_U_Seekdir(Args_Seekdir) 
+      Retv_Seekdir     Xrd_U_Seekdir(Args_Seekdir)
                          {       Xunix.Load_Error("seekdir"); abort();}
-      Retv_Stat        Xrd_U_Stat(Args_Stat) 
+      Retv_Stat        Xrd_U_Stat(Args_Stat)
                          {return (Retv_Stat)Xunix.Load_Error("stat");}
       Retv_Stat64      Xrd_U_Stat64(Args_Stat64)
                          {return (Retv_Stat64)Xunix.Load_Error("stat");}
@@ -187,23 +189,23 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Statvfs)Xunix.Load_Error("statvfs");}
       Retv_Statvfs64   Xrd_U_Statvfs64(Args_Statvfs64)
                          {return (Retv_Statvfs64)Xunix.Load_Error("statvfs64");}
-      Retv_Telldir     Xrd_U_Telldir(Args_Telldir) 
+      Retv_Telldir     Xrd_U_Telldir(Args_Telldir)
                          {return (Retv_Telldir)Xunix.Load_Error("telldir");}
       Retv_Truncate    Xrd_U_Truncate(Args_Truncate)
                          {return (Retv_Truncate)Xunix.Load_Error("truncate");}
       Retv_Truncate64  Xrd_U_Truncate64(Args_Truncate64)
                          {return (Retv_Truncate64)Xunix.Load_Error("truncate64");}
-      Retv_Unlink      Xrd_U_Unlink(Args_Unlink) 
+      Retv_Unlink      Xrd_U_Unlink(Args_Unlink)
                          {return (Retv_Unlink)Xunix.Load_Error("unlink");}
-      Retv_Write       Xrd_U_Write(Args_Write) 
+      Retv_Write       Xrd_U_Write(Args_Write)
                          {return (Retv_Write)Xunix.Load_Error("write");}
-      Retv_Writev      Xrd_U_Writev(Args_Writev) 
+      Retv_Writev      Xrd_U_Writev(Args_Writev)
                          {return (Retv_Writev)Xunix.Load_Error("writev");}
-  
+
 /******************************************************************************/
 /*           X r d P o s i x L i n k a g e   C o n s t r u c t o r            */
 /******************************************************************************/
-  
+
 int XrdPosixLinkage::Resolve()
 {
   LOOKUP_UNIX(Access)
@@ -281,7 +283,7 @@ int XrdPosixLinkage::Resolve()
 /******************************************************************************/
 /*           X r d P o s i x L i n k a g e : : L o a d _ E r r o r            */
 /******************************************************************************/
-  
+
 int XrdPosixLinkage::Load_Error(const char *epname, int retv)
 {
     if (*Write != &Xrd_U_Write && *Writev != &Xrd_U_Writev)
@@ -293,25 +295,30 @@ int XrdPosixLinkage::Load_Error(const char *epname, int retv)
 /******************************************************************************/
 /*                               M i s s i n g                                */
 /******************************************************************************/
-  
+
 void XrdPosixLinkage::Missing(const char *epname)
 {
   struct Missing
   {struct Missing *Next;
     const char     *What;
-    
+
     Missing(Missing *Prev, const char *That)
       : Next(Prev), What(That) {}
     ~Missing() {}
   };
-  
+
   static Missing *epList = 0;
-  
+
   if (epname) epList = new Missing(epList, epname);
   else {
     Missing *np = epList;
     while(np){
-      printf( "PosixPreload: Unable to resolve Unix '%s()\n", np->What);
+#ifdef __linux__
+      fprintf(stderr, "PosixPreload: Unable to resolve Unix '%s()\n", np->What);
+#else
+      std::cerr << "PosixPreload: Unable to resolve Unix '"
+		<<np->What <<"()'" <<std::endl;
+#endif
       np = np->Next;
     }
   }

--- a/src/XrdPosix/XrdPosixLinkage.cc
+++ b/src/XrdPosix/XrdPosixLinkage.cc
@@ -70,8 +70,10 @@ XrdPosixLinkage Xunix;
 
       Retv_Access      Xrd_U_Access(Args_Access)
                          {return (Retv_Access)Xunix.Load_Error("access");}
+#ifndef __APPLE__
       Retv_Acl         Xrd_U_Acl(Args_Acl)
                          {return (Retv_Acl)Xunix.Load_Error("acl");}
+#endif
       Retv_Chdir       Xrd_U_Chdir(Args_Chdir) 
                          {return (Retv_Chdir)Xunix.Load_Error("chdir");}
       Retv_Close       Xrd_U_Close(Args_Close) 
@@ -122,8 +124,10 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Fgetxattr)Xunix.Load_Error("fgetxattr");}
       Retv_Getxattr    Xrd_U_Getxattr(Args_Getxattr)
                          {return (Retv_Getxattr)Xunix.Load_Error("getxattr");}
+#ifndef __APPLE__
       Retv_Lgetxattr   Xrd_U_Lgetxattr(Args_Lgetxattr)
                          {return (Retv_Lgetxattr)Xunix.Load_Error("lgetxattr");}
+#endif
       Retv_Lseek       Xrd_U_Lseek(Args_Lseek) 
                          {return (Retv_Lseek)Xunix.Load_Error("lseek");}
       Retv_Lseek64     Xrd_U_Lseek64(Args_Lseek64)
@@ -202,7 +206,9 @@ XrdPosixLinkage Xunix;
 int XrdPosixLinkage::Resolve()
 {
   LOOKUP_UNIX(Access)
+#ifndef __APPLE__
   LOOKUP_UNIX(Acl)
+#endif
   LOOKUP_UNIX(Chdir)
   LOOKUP_UNIX(Close)
   LOOKUP_UNIX(Closedir)
@@ -228,7 +234,9 @@ int XrdPosixLinkage::Resolve()
   LOOKUP_UNIX(Fwrite)
   LOOKUP_UNIX(Fgetxattr)
   LOOKUP_UNIX(Getxattr)
+#ifndef __APPLE__
   LOOKUP_UNIX(Lgetxattr)
+#endif
   LOOKUP_UNIX(Lseek)
   LOOKUP_UNIX(Lseek64)
   LOOKUP_UNIX(Lstat)

--- a/src/XrdPosix/XrdPosixLinkage.cc
+++ b/src/XrdPosix/XrdPosixLinkage.cc
@@ -45,9 +45,7 @@
 #endif
 
 #include <cerrno>
-#ifdef __linux__
 #include <cstdio>
-#endif
 
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdPosix/XrdPosixLinkage.hh"
@@ -313,12 +311,7 @@ void XrdPosixLinkage::Missing(const char *epname)
   else {
     Missing *np = epList;
     while(np){
-#ifdef __linux__
       fprintf(stderr, "PosixPreload: Unable to resolve Unix '%s()\n", np->What);
-#else
-      std::cerr << "PosixPreload: Unable to resolve Unix '"
-		<<np->What <<"()'" <<std::endl;
-#endif
       np = np->Next;
     }
   }

--- a/src/XrdPosix/XrdPosixLinkage.hh
+++ b/src/XrdPosix/XrdPosixLinkage.hh
@@ -81,9 +81,15 @@
 #define Retv_Fcntl   int
 #define Args_Fcntl   int, int, ...
 
+#ifdef __APPLE__
+#define Symb_Fcntl64 UNIX_PFX "fcntl"
+#define Retv_Fcntl64 int
+#define Args_Fcntl64 int, int, ...
+#else
 #define Symb_Fcntl64 UNIX_PFX "fcntl64"
 #define Retv_Fcntl64 int
 #define Args_Fcntl64 int, int, ...
+#endif
 
 #define Symb_Fdatasync UNIX_PFX "fdatasync"
 #define Retv_Fdatasync int
@@ -97,9 +103,15 @@
 #define Retv_Fopen FILE *
 #define Args_Fopen const char *, const char *
 
+#ifdef __APPLE__
+#define Symb_Fopen64 UNIX_PFX "fopen"
+#define Retv_Fopen64 FILE *
+#define Args_Fopen64 const char *, const char *
+#else
 #define Symb_Fopen64 UNIX_PFX "fopen64"
 #define Retv_Fopen64 FILE *
 #define Args_Fopen64 const char *, const char *
+#endif
 
 #define Symb_Fread UNIX_PFX "fread"
 #define Retv_Fread size_t
@@ -113,9 +125,15 @@
 #define Retv_Fseeko int
 #define Args_Fseeko FILE *, off_t, int
 
+#ifdef __APPLE__
+#define Symb_Fseeko64 UNIX_PFX "fseeko"
+#define Retv_Fseeko64 int
+#define Args_Fseeko64 FILE *, off64_t, int
+#else
 #define Symb_Fseeko64 UNIX_PFX "fseeko64"
 #define Retv_Fseeko64 int
 #define Args_Fseeko64 FILE *, off64_t, int
+#endif
 
 #if defined(__linux__) and defined(_STAT_VER)
 #define Symb_Fstat UNIX_PFX "__fxstat"
@@ -132,9 +150,15 @@
 #define Retv_Fstat64 int
 #define Args_Fstat64 int, int, struct stat64 *
 #else
+#ifdef __APPLE__
 #define Symb_Fstat64 UNIX_PFX "fstat64"
 #define Retv_Fstat64 int
 #define Args_Fstat64 int, struct stat64 *
+#else
+#define Symb_Fstat64 UNIX_PFX "fstat64"
+#define Retv_Fstat64 int
+#define Args_Fstat64 int, struct stat64 *
+#endif
 #endif
 
 #define Symb_Fsync UNIX_PFX "fsync"
@@ -149,17 +173,29 @@
 #define Retv_Ftello off_t
 #define Args_Ftello FILE *
 
+#ifdef __APPLE__
+#define Symb_Ftello64 UNIX_PFX "ftello"
+#define Retv_Ftello64 off64_t
+#define Args_Ftello64 FILE *
+#else
 #define Symb_Ftello64 UNIX_PFX "ftello64"
 #define Retv_Ftello64 off64_t
 #define Args_Ftello64 FILE *
+#endif
 
 #define Symb_Ftruncate UNIX_PFX "ftruncate"
 #define Retv_Ftruncate int
 #define Args_Ftruncate int, off_t
 
+#ifdef __APPLE__
+#define Symb_Ftruncate64 UNIX_PFX "ftruncate"
+#define Retv_Ftruncate64 int
+#define Args_Ftruncate64 int, off64_t
+#else
 #define Symb_Ftruncate64 UNIX_PFX "ftruncate64"
 #define Retv_Ftruncate64 int
 #define Args_Ftruncate64 int, off64_t
+#endif
 
 #define Symb_Fwrite UNIX_PFX "fwrite"
 #define Retv_Fwrite int
@@ -181,9 +217,15 @@
 #define Retv_Lseek off_t
 #define Args_Lseek int, off_t, int
 
+#ifdef __APPLE__
+#define Symb_Lseek64 UNIX_PFX "lseek"
+#define Retv_Lseek64 off64_t
+#define Args_Lseek64 int, off64_t, int
+#else
 #define Symb_Lseek64 UNIX_PFX "lseek64"
 #define Retv_Lseek64 off64_t
 #define Args_Lseek64 int, off64_t, int
+#endif
 
 #if defined(__linux__) and defined(_STAT_VER)
 #define Symb_Lstat UNIX_PFX "__lxstat"
@@ -200,9 +242,15 @@
 #define Retv_Lstat64 int
 #define Args_Lstat64 int, const char *, struct stat64 *
 #else
+#ifdef __APPLE__
+#define Symb_Lstat64 UNIX_PFX "lstat"
+#define Retv_Lstat64 int
+#define Args_Lstat64 const char *, struct stat64 *
+#else
 #define Symb_Lstat64 UNIX_PFX "lstat64"
 #define Retv_Lstat64 int
 #define Args_Lstat64 const char *, struct stat64 *
+#endif
 #endif
 
 #define Symb_Mkdir UNIX_PFX "mkdir"
@@ -213,9 +261,15 @@
 #define Retv_Open int
 #define Args_Open const char *, int, ...
 
+#ifdef __APPLE__
+#define Symb_Open64 UNIX_PFX "open"
+#define Retv_Open64 int
+#define Args_Open64 const char *, int, ...
+#else
 #define Symb_Open64 UNIX_PFX "open64"
 #define Retv_Open64 int
 #define Args_Open64 const char *, int, ...
+#endif
 
 #define Symb_Opendir UNIX_PFX "opendir"
 #define Retv_Opendir DIR *
@@ -229,17 +283,29 @@
 #define Retv_Pread ssize_t
 #define Args_Pread int, void *, size_t, off_t
   
+#ifdef __APPLE__
+#define Symb_Pread64 UNIX_PFX "pread"
+#define Retv_Pread64 ssize_t
+#define Args_Pread64 int, void *, size_t, off64_t
+#else
 #define Symb_Pread64 UNIX_PFX "pread64"
 #define Retv_Pread64 ssize_t
 #define Args_Pread64 int, void *, size_t, off64_t
+#endif
 
 #define Symb_Pwrite UNIX_PFX "pwrite"
 #define Retv_Pwrite ssize_t
 #define Args_Pwrite int, const void *, size_t, off_t
 
+#ifdef __APPLE__
+#define Symb_Pwrite64 UNIX_PFX "pwrite"
+#define Retv_Pwrite64 ssize_t
+#define Args_Pwrite64 int, const void *, size_t, off64_t
+#else
 #define Symb_Pwrite64 UNIX_PFX "pwrite64"
 #define Retv_Pwrite64 ssize_t
 #define Args_Pwrite64 int, const void *, size_t, off64_t
+#endif
 
 #define Symb_Read UNIX_PFX "read"
 #define Retv_Read ssize_t
@@ -253,17 +319,29 @@
 #define Retv_Readdir struct dirent *
 #define Args_Readdir DIR *
 
+#ifdef __APPLE__
+#define Symb_Readdir64 UNIX_PFX "readdir"
+#define Retv_Readdir64 struct dirent64 *
+#define Args_Readdir64 DIR *
+#else
 #define Symb_Readdir64 UNIX_PFX "readdir64"
 #define Retv_Readdir64 struct dirent64 *
 #define Args_Readdir64 DIR *
+#endif
 
 #define Symb_Readdir_r UNIX_PFX "readdir_r"
 #define Retv_Readdir_r int
 #define Args_Readdir_r DIR *, struct dirent *, struct dirent **
 
+#ifdef __APPLE__
+#define Symb_Readdir64_r UNIX_PFX "readdir_r"
+#define Retv_Readdir64_r int
+#define Args_Readdir64_r DIR *, struct dirent64 *, struct dirent64 **
+#else
 #define Symb_Readdir64_r UNIX_PFX "readdir64_r"
 #define Retv_Readdir64_r int
 #define Args_Readdir64_r DIR *, struct dirent64 *, struct dirent64 **
+#endif
 
 #define Symb_Rename UNIX_PFX "rename"
 #define Retv_Rename int
@@ -296,26 +374,44 @@
 #define Retv_Stat64 int
 #define Args_Stat64 int, const char *, struct stat64 *
 #else
+#ifdef __APPLE__
+#define Symb_Stat64 UNIX_PFX "stat"
+#define Retv_Stat64 int
+#define Args_Stat64 const char *, struct stat64 *
+#else
 #define Symb_Stat64 UNIX_PFX "stat64"
 #define Retv_Stat64 int
 #define Args_Stat64 const char *, struct stat64 *
+#endif
 #endif
 
 #define Symb_Statfs    UNIX_PFX "statfs"
 #define Retv_Statfs    int
 #define Args_Statfs    const char *, struct statfs *
 
+#ifdef __APPLE__
+#define Symb_Statfs64  UNIX_PFX "statfs"
+#define Retv_Statfs64  int
+#define Args_Statfs64  const char *, struct statfs64 *
+#else
 #define Symb_Statfs64  UNIX_PFX "statfs64"
 #define Retv_Statfs64  int
 #define Args_Statfs64  const char *, struct statfs64 *
+#endif
 
 #define Symb_Statvfs UNIX_PFX "statvfs"
 #define Retv_Statvfs int
 #define Args_Statvfs const char *, struct statvfs *
 
+#ifdef __APPLE__
+#define Symb_Statvfs64 UNIX_PFX "statvfs"
+#define Retv_Statvfs64 int
+#define Args_Statvfs64 const char *, struct statvfs64 *
+#else
 #define Symb_Statvfs64 UNIX_PFX "statvfs64"
 #define Retv_Statvfs64 int
 #define Args_Statvfs64 const char *, struct statvfs64 *
+#endif
 
 #define Symb_Telldir UNIX_PFX "telldir"
 #define Retv_Telldir long
@@ -325,9 +421,15 @@
 #define Retv_Truncate int
 #define Args_Truncate const char *, off_t
 
+#ifdef __APPLE__
+#define Symb_Truncate64 UNIX_PFX "truncate"
+#define Retv_Truncate64 int
+#define Args_Truncate64 const char *, off64_t
+#else
 #define Symb_Truncate64 UNIX_PFX "truncate64"
 #define Retv_Truncate64 int
 #define Args_Truncate64 const char *, off64_t
+#endif
 
 #define Symb_Unlink UNIX_PFX "unlink"
 #define Retv_Unlink int

--- a/src/XrdPosix/XrdPosixLinkage.hh
+++ b/src/XrdPosix/XrdPosixLinkage.hh
@@ -151,7 +151,7 @@
 #define Args_Fstat64 int, int, struct stat64 *
 #else
 #ifdef __APPLE__
-#define Symb_Fstat64 UNIX_PFX "fstat64"
+#define Symb_Fstat64 UNIX_PFX "fstat"
 #define Retv_Fstat64 int
 #define Args_Fstat64 int, struct stat64 *
 #else
@@ -321,7 +321,7 @@
 
 #ifdef __APPLE__
 #define Symb_Readdir64 UNIX_PFX "readdir"
-#define Retv_Readdir64 struct dirent64 *
+#define Retv_Readdir64 struct dirent *
 #define Args_Readdir64 DIR *
 #else
 #define Symb_Readdir64 UNIX_PFX "readdir64"

--- a/src/XrdPosix/XrdPosixPreload.cc
+++ b/src/XrdPosix/XrdPosixPreload.cc
@@ -32,6 +32,10 @@
 #undef _FORTIFY_SOURCE
 #endif
 
+#if defined(__APPLE__)
+#define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
 #include <sys/types.h>
 #include <cstdarg>
 #include <unistd.h>


### PR DESCRIPTION
When trying to use XrdPosix on Apple, the code is not able to find system calls like open64. This patch assumes that Apple is always 64bit and maps these functions to the "regular" system calls. Using  XRDPOSIX_REPORT=1 reports two more missing functions, namely acl() and Lgetxattr() which cannot be found. These are disabled by this patch when running on this platform. With this fix in xrootd, the next version of CERNLIB can be xrootd enabled as well on Apple.
