### PR TITLE
[XrdSciTokens] Accept `access_token` CGI parameter

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcUtils.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcUtils.cc
@@ -43,6 +43,9 @@ std::string XrdHttpTpcUtils::prepareOpenURL(const std::string & reqResource, std
           reqHeaders["Authorization"] = token.substr(6);
           has_authz_header = true;
         }
+      } else if (!strncmp(token.c_str(), "access_token=", 13) && !has_authz_header) {
+        reqHeaders["Authorization"] = token.substr(13);
+        has_authz_header = true;
       } else {
         opaque << "&" << token;
       }

--- a/src/XrdMacaroons/XrdMacaroonsAuthz.cc
+++ b/src/XrdMacaroons/XrdMacaroonsAuthz.cc
@@ -173,7 +173,8 @@ Authz::Access(const XrdSecEntity *Entity, const char *path,
     }
 
     const char *authz = env ? env->Get("authz") : nullptr;
-    if (authz && !strncmp(authz, "Bearer%20", 9))
+    if ((authz && !strncmp(authz, "Bearer%20", 9)) ||
+        (!authz && (authz = env ? env->Get("access_token") : nullptr) && !strncmp(authz, "Bearer%20", 9)))
     {
         authz += 9;
     }

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -1535,7 +1535,7 @@ std::string obfuscateAuth(const std::string& input)
 {
   static const regex_t auth_regex = []() {
     constexpr char re[] =
-      "(authz=|(transferheader)?(www-|proxy-)?auth(orization|enticate)[[:space:]]*:[[:space:]]*)"
+      "(access_token=|authz=|(transferheader)?(www-|proxy-)?auth(orization|enticate)[[:space:]]*:[[:space:]]*)"
       "(Bearer([[:space:]]|%20)?(token([[:space:]]|%20)?)?)?";
 
     regex_t regex;

--- a/tests/XrdOucTests/CMakeLists.txt
+++ b/tests/XrdOucTests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(xrdoucutils-unit-tests XrdOucUtilsTests.cc)
+add_executable(xrdoucutils-unit-tests XrdOucUtilsTests.cc XrdOucEnvTests.cc)
 
 target_link_libraries(xrdoucutils-unit-tests XrdUtils GTest::GTest GTest::Main)
 

--- a/tests/XrdOucTests/XrdOucEnvTests.cc
+++ b/tests/XrdOucTests/XrdOucEnvTests.cc
@@ -1,0 +1,28 @@
+
+#include "XrdOuc/XrdOucEnv.hh"
+
+#include <gtest/gtest.h>
+
+static const std::pair<std::string, std::string> env_tests[] = {
+    {"foo=bar", "&foo=bar"},
+    {"authz=bar", "&"},
+    {"authz=bar&foo=1", "&foo=1"},
+    {"&authz=bar&authz=1", "&"},
+    {"authz=bar&authz=1", "&"},
+    {"&authz=bar", "&"},
+    {"&access_token=bar", "&"},
+    {"foo=1&authz=bar", "&foo=1"},
+    {"foo=1&authz=foo&access_token=bar", "&foo=1"},
+    {"authz=foo&access_token=bar", "&"},
+    {"authz=foo&foo=bar", "&foo=bar"},
+    {"authz=foo&foo=bar&access_token=3", "&foo=bar"},
+    {"authz=1&access_token=2&authz=3&access_token=4", "&"},
+};
+
+TEST(XrdOucEnv, EnvTidy) {
+    for (const auto &env_str : env_tests) {
+        int envlen;
+        XrdOucEnv env(env_str.first.c_str(), env_str.first.size());
+        ASSERT_STREQ(env_str.second.c_str(), env.EnvTidy(envlen)) << "Testing tidy of " << env_str.first;
+    }
+}

--- a/tests/XrdOucTests/XrdOucUtilsTests.cc
+++ b/tests/XrdOucTests/XrdOucUtilsTests.cc
@@ -99,13 +99,16 @@ static const std::string plain_urls[] = {
 
 static const std::string authz_strings[] = {
   "authz=REDACTED",
+  "access_token=REDACTED",
   " authz=REDACTED ",
   " 'authz=REDACTED' ",
   " \"authz=REDACTED\" ",
   "authz=REDACTED&scitag.flow=144&test=abcd",
+  "access_token=REDACTED&scitag.flow=144&test=abcd",
   "scitag.flow=144&authz=REDACTED&test=abcd",
   "scitag.flow=144&test=abcd&authz=REDACTED",
   "authz=REDACTED&test=test2&authz=REDACTED",
+  "authz=REDACTED&test=test2&access_token=REDACTED",
   "authz=REDACTED&test=test2&authz=REDACTED&authz=REDACTED&test=test2&authz=REDACTED",
   "/path/test.txt?scitag.flow=44&authz=REDACTED done close.",
   "/path/test.txt?authz=REDACTED&scitag.flow=44 done close.",


### PR DESCRIPTION
On reading the definition of the `Bearer` Authentication scheme in RFC 6750, I stumbled upon Section 2.3 ("URI Query Parameter") which specifies the query parameter name that should be used when embedding the token in the URL; it should be `access_token`.

This commit continues to accept `authz` (too much historical baggage to break) but adds in `access_token` alongside it.

This commit includes unit test coverage for the new parameter name, including tests for `XrdOucEnv::TidyEnv` and fixes bugs for `TidyEnv` in the case the tidying resulted in the empty string.

This is the first step of splitting up #2397 into smaller, easier-to-review chunks.  Note the change to `src/XrdSciTokens/XrdSciTokensAccess.cc` is primarily whitespace shifts; it's easier to see the semantic differences from `git diff -w`.