### PR TITLE
[Xrootd] Fix gstream configuration processing.

### DIFF
--- a/src/XrdXrootd/XrdXrootdConfigMon.cc
+++ b/src/XrdXrootd/XrdXrootdConfigMon.cc
@@ -104,7 +104,7 @@ bool XrdXrootdProtocol::ConfigGStream(XrdOucEnv &myEnv, XrdOucEnv *urEnv)
    XrdXrootdGStream *gs;
    static const int numgs=sizeof(gsObj)/sizeof(struct XrdXrootdGSReal::GSParms);
    char vbuff[64];
-   bool aOK, gXrd[numgs] = {false, false, true, false, true};
+   bool aOK, gXrd[numgs] = {false, false, false, true, false, true};
 
 // For each enabled monitoring provider, allocate a g-stream and put
 // its address in our environment.


### PR DESCRIPTION
This part was missing from commit 3ad5ad5584bb63c76110b8a1073e46dc13e99b3e in #2279. This caused the wrong index of `gXrd` to apply to everything after the new `oss` entry.
In particular, 'pfc' monitor driver was placed in the wrong environment and could not be retrieved in the `Pfc` code, causing pfc gstream to stop working.
