### PR TITLE
[XrdHttp] Fix HTTP protocol errors on failure

### DIFF
--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -145,7 +145,7 @@ private:
 
   // If requested by the client, sends any I/O errors that occur during the transfer
   // into a footer.
-  void sendFooterError(const std::string &);
+  int sendFooterError(const std::string &);
 
   // Set the age header from the file modification time
   void addAgeHeader(std::string & headers);
@@ -166,7 +166,7 @@ private:
 
 public:
   XrdHttpReq(XrdHttpProtocol *protinstance, const XrdHttpReadRangeHandler::Configuration &rcfg) :
-      readRangeHandler(rcfg), keepalive(true) {
+      readRangeHandler(rcfg), closeAfterError(false), keepalive(true) {
 
     prot = protinstance;
     length = 0;
@@ -207,6 +207,9 @@ public:
   void appendOpaque(XrdOucString &s, XrdSecEntity *secent, char *hash, time_t tnow);
 
   void addCgi(const std::string & key, const std::string & value);
+
+  // Set the transfer status header, if requested by the client
+  void setTransferStatusHeader(std::string &header);
 
   // Return the current user agent; if none has been specified, returns an empty string
   const std::string &userAgent() const {return m_user_agent;}
@@ -256,6 +259,10 @@ public:
   /// Tracking the next ranges of data to read during GET
   XrdHttpReadRangeHandler   readRangeHandler;
   bool                      readClosing;
+
+  // Indication that there was a read error and the next
+  // request processing state should cleanly close the file.
+  bool                      closeAfterError;
 
   bool keepalive;
   long long length;  // Total size from client for PUT; total length of response TO client for GET.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT ENABLE_SERVER_TESTS)
   return()
 endif()
 
+add_subdirectory( XrdOssTests )
 add_subdirectory( XRootD )
 add_subdirectory( cluster )
 add_subdirectory( stress )

--- a/tests/XRootD/common.cfg
+++ b/tests/XRootD/common.cfg
@@ -9,6 +9,7 @@ oss.localroot $basedir/$name/xrootd
 
 ofs.chkpnt enable
 ofs.ckslib zcrc32 libXrdCksCalczcrc32.so
+ofs.osslib ++ $basedir/../../lib/libXrdOssTests.so
 xrootd.chksum adler32 crc32c zcrc32 chkcgi
 
 xrd.maxfd strict 1k

--- a/tests/XRootD/test.sh
+++ b/tests/XRootD/test.sh
@@ -15,6 +15,12 @@ function assert_eq() {
   [[ "$1" == "$2" ]] || error "$3: expected $1 but received $2"
 }
 
+# Ensure two returned values are not equal to each other
+# $1 is expected_value $2 is received value $3 is the error message
+function assert_ne() {
+  [[ "$1" != "$2" ]] || error "$3: expected $1 to not be equal to $2"
+}
+
 function assert_failure() {
 	echo "$@"; "$@" && error "command \"$*\" did not fail";
 }

--- a/tests/XrdOssTests/CMakeLists.txt
+++ b/tests/XrdOssTests/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+#
+# The XrdOssTests is a wrapper OSS that injects specific behaviors
+# (typically, errors) into the filesystem for the purpose of allowing
+# the testing of failures
+#
+
+add_library( XrdOssTests MODULE xrdoss_tests.cc )
+target_link_libraries( XrdOssTests XrdServer )
+
+set_target_properties( XrdOssTests PROPERTIES OUTPUT_NAME "XrdOssTests-${PLUGIN_VERSION}" SUFFIX ".so" )
+

--- a/tests/XrdOssTests/xrdoss_tests.cc
+++ b/tests/XrdOssTests/xrdoss_tests.cc
@@ -1,0 +1,71 @@
+
+//
+// An OSS meant for unit tests.
+//
+
+#include "XrdOss/XrdOssWrapper.hh"
+#include "XrdVersion.hh"
+
+#include <memory>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+class File final : public XrdOssWrapDF {
+  public:
+    File(std::unique_ptr<XrdOssDF> wrapDF)
+        : XrdOssWrapDF(*wrapDF), m_wrapped(std::move(wrapDF)) {}
+
+    virtual ~File() {}
+
+    int Open(const char *path, int Oflag, mode_t Mode, XrdOucEnv &env) override {
+        std::string path_str(path);
+        auto const pos = path_str.find_last_of('/');
+        const auto leaf = path_str.substr(pos + 1);
+        m_fail = leaf == "fail_read.txt";
+        return wrapDF.Open(path, Oflag, Mode, env);
+    }
+
+    ssize_t Read(void *buffer, off_t offset, size_t size) override {
+        if (m_fail && offset > 0) return -EIO;
+        return wrapDF.Read(buffer, offset, size);
+    }
+
+    int getFD() override {return -1;}
+
+  private:
+    bool m_fail{false};
+    std::unique_ptr<XrdOssDF> m_wrapped;
+};
+
+class FileSystem final : public XrdOssWrapper {
+  public:
+    FileSystem(XrdOss *oss, XrdSysLogger *log, XrdOucEnv *envP)
+        : XrdOssWrapper(*oss), m_oss(oss) {}
+
+    virtual ~FileSystem() {}
+
+    XrdOssDF *newFile(const char *user = 0) override {
+        std::unique_ptr<XrdOssDF> wrapped(wrapPI.newFile(user));
+        return new File(std::move(wrapped));
+    }
+
+  private:
+    std::unique_ptr<XrdOss> m_oss;
+};
+
+} // namespace
+
+extern "C" {
+
+XrdOss *XrdOssAddStorageSystem2(XrdOss *curr_oss, XrdSysLogger *logger,
+                                const char *config_fn, const char *parms,
+                                XrdOucEnv *envP) {
+    return new FileSystem(curr_oss, logger, envP);
+}
+
+XrdVERSIONINFO(XrdOssAddStorageSystem2, slowfs);
+
+} // extern "C"
+


### PR DESCRIPTION
When using `X-Transfer-Status`, there were three subtle HTTP protocol
errors:
- The trailer contained a `\n` which is not a permitted character. This caused clients to view the last CRLF as leftover data on
  an idle TCP channel.
- A trailer was sent but no `Trailer` header was sent in the response.
- When the server said that the connection would be kept alive but an error occurred, it closed the TCP connection unexpectedly on the client.  The server now keeps the TCP connection open if keepalive is enabled, provided the HTTP response was sent cleanly.

To prevent regressions, this adds the first unit test that injects read failures mid-transfer.