### PR TITLE
[XrdTpc] Modernize libcurl linkage

### DIFF
--- a/src/XrdTpc.cmake
+++ b/src/XrdTpc.cmake
@@ -50,9 +50,7 @@ if( BUILD_TPC )
     XrdHttpUtils
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${CURL_LIBRARIES} )
-
-  target_include_directories( ${LIB_XRD_TPC} PRIVATE ${CURL_INCLUDE_DIRS} )
+    CURL::libcurl )
 
   if( MacOSX )
     set( TPC_LINK_FLAGS, "-Wl" )


### PR DESCRIPTION
Small improvement I noticed for XrdTpc while cleaning up other sources:

We define a minimum CMake version such that we're guaranteed to have the `CURL::libcurl` target; use that to match CMake's current philosophy.