### PR TITLE
[Pfc] Fix usage of saveptr in strtok_r used by PathTokenizer

### DIFF
--- a/src/XrdPfc/XrdPfcCommand.cc
+++ b/src/XrdPfc/XrdPfcCommand.cc
@@ -66,7 +66,7 @@ void Cache::ExecuteCommandUrl(const std::string& command_url)
    token = cp.get_token_as_string();
 
    auto get_opt = [](SplitParser &sp) -> char {
-      char *t = sp.get_token();
+      const char *t = sp.get_token();
       if (t)
          return (t[0] == '-' && t[1] != 0) ? t[1] : 0;
       else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,8 @@ add_subdirectory( XrdSsiTests )
 
 add_subdirectory(XrdTpcTests)
 
+add_subdirectory(XrdPfcTests)
+
 if( BUILD_SCITOKENS )
   add_subdirectory( scitokens )
 endif()

--- a/tests/XrdPfcTests/CMakeLists.txt
+++ b/tests/XrdPfcTests/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(xrdpfc-unit-tests XrdPfcTests.cc)
+
+target_link_libraries(xrdpfc-unit-tests GTest::GTest GTest::Main)
+target_include_directories(xrdpfc-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+
+gtest_discover_tests(xrdpfc-unit-tests)

--- a/tests/XrdPfcTests/XrdPfcTests.cc
+++ b/tests/XrdPfcTests/XrdPfcTests.cc
@@ -1,0 +1,19 @@
+
+#include "XrdPfc/XrdPfcPathParseTools.hh"
+
+#include <gtest/gtest.h>
+
+using namespace XrdPfc;
+
+TEST(XrdPfcTests, PathTokenizer)
+{
+    PathTokenizer("/pelican/hello_world.txt", 0, true);
+    PathTokenizer("/pelican/hello_world.txt", -1, true);
+    PathTokenizer("/pelican/hello_world.txt", 1, true);
+    PathTokenizer("/pelican/hello_world.txt", 2, true);
+
+    PathTokenizer("/pelican/hello_world.txt", 0, false);
+    PathTokenizer("/pelican/hello_world.txt", -1, false);
+    PathTokenizer("/pelican/hello_world.txt", 1, false);
+    PathTokenizer("/pelican/hello_world.txt", 2, false);
+}

--- a/tests/XrdPfcTests/XrdPfcTests.cc
+++ b/tests/XrdPfcTests/XrdPfcTests.cc
@@ -1,19 +1,85 @@
-
 #include "XrdPfc/XrdPfcPathParseTools.hh"
 
 #include <gtest/gtest.h>
 
+class PathParseToolTest : public ::testing::Test {
+protected:
+    std::vector<std::string> dirs { "vultures", "nest", "quite", "high", "in", "a",
+                                    "directory", "tree" };
+    std::string file { "an_egg.gzip" };
+    std::string path { "" };
+
+    const int n_dirs = dirs.size();
+
+    void clear_path() { path = ""; }
+    std::string get_lfn() { return path + "/" + file; }
+};
+
 using namespace XrdPfc;
 
-TEST(XrdPfcTests, PathTokenizer)
+TEST_F(PathParseToolTest, SplitParser)
 {
-    PathTokenizer("/pelican/hello_world.txt", 0, true);
-    PathTokenizer("/pelican/hello_world.txt", -1, true);
-    PathTokenizer("/pelican/hello_world.txt", 1, true);
-    PathTokenizer("/pelican/hello_world.txt", 2, true);
+    for (int i = 0; i < n_dirs; ++i)
+    {
+        path += "/" + dirs[i];
+        SplitParser sp(get_lfn(), "/");
+        int n_tokens = i + 2;
+        EXPECT_EQ(sp.pre_count_n_tokens(), n_tokens);
+        for (int it = 0; it < i + 1; ++it)
+        {
+            EXPECT_EQ(sp.get_token_as_string(), dirs[it]);
+        }
+        EXPECT_EQ(std::string(sp.get_reminder()), file);
+    }
+}
 
-    PathTokenizer("/pelican/hello_world.txt", 0, false);
-    PathTokenizer("/pelican/hello_world.txt", -1, false);
-    PathTokenizer("/pelican/hello_world.txt", 1, false);
-    PathTokenizer("/pelican/hello_world.txt", 2, false);
+TEST_F(PathParseToolTest, PathTokenizer)
+{
+    int  max_depth;
+    bool parse_as_lfn;
+
+    parse_as_lfn = true;
+    {
+        // Separate test for files in root directory.
+        max_depth = 1024;
+        PathTokenizer pt(get_lfn(), max_depth, parse_as_lfn);
+        ASSERT_EQ(pt.m_n_dirs, 0);
+        ASSERT_EQ(std::string(pt.m_reminder), file);
+    }
+    for (int i = 0; i < n_dirs; ++i)
+    {
+        path += "/" + dirs[i];
+        {
+            max_depth = 1024;
+            PathTokenizer pt(get_lfn(), max_depth, parse_as_lfn);
+            ASSERT_EQ(pt.m_n_dirs, i + 1);
+            ASSERT_EQ(std::string(pt.m_reminder), file);
+        }
+        {
+            max_depth = 0;
+            PathTokenizer pt(get_lfn(), max_depth, parse_as_lfn);
+            ASSERT_EQ(pt.m_n_dirs, 0);
+            ASSERT_EQ(std::string(pt.m_reminder), get_lfn());
+        }
+    }
+    clear_path();
+
+    parse_as_lfn = false;
+    for (int i = 0; i < n_dirs; ++i)
+    {
+        path += "/" + dirs[i];
+        {
+            max_depth = 1024;
+            PathTokenizer pt(get_lfn(), max_depth, parse_as_lfn);
+            ASSERT_EQ(pt.m_n_dirs, i + 2);
+            ASSERT_EQ(std::string(pt.m_reminder), std::string(""));
+        }
+        {
+            max_depth = 0;
+            PathTokenizer pt(get_lfn(), max_depth, parse_as_lfn);
+            ASSERT_EQ(pt.m_n_dirs, 0);
+            ASSERT_EQ(std::string(pt.m_reminder), get_lfn());
+        }
+    }
+    clear_path();
 }


### PR DESCRIPTION
Implement the equivalent of strtok_r with reproducible beahavior across architectures. Previous implementation relied on undocumented behavior of the Linux implementation and was causing SEGVs on mac-OS.

This addresses #2450.

This PR also includes a prototype implementation of XrdPfcTests by @bbockelm and extends it to cover more use-cases, thus superseding the now closed #2451.
