### PR TITLE
[XrdPss] Fix proxy when using tokens and crc32c

### DIFF
--- a/src/XrdPss/XrdPssCks.cc
+++ b/src/XrdPss/XrdPssCks.cc
@@ -170,7 +170,7 @@ int XrdPssCks::Init(const char *ConfigFN, const char *DfltCalc)
 // See if we need to set the default calculation
 //
    if (DfltCalc)
-      {for (i = 0; i < csLast; i++) if (!strcmp(csTab[i].Name, DfltCalc)) break;
+      {for (i = 0; i <= csLast; i++) if (!strcmp(csTab[i].Name, DfltCalc)) break;
        if (i >= csMax)
           {eDest->Emsg("Config", DfltCalc, "cannot be made the default; "
                                            "not supported.");

--- a/src/XrdPss/XrdPssCks.cc
+++ b/src/XrdPss/XrdPssCks.cc
@@ -85,7 +85,8 @@ XrdPssCks::XrdPssCks(XrdSysError *erP) : XrdCks(erP)
    csTab[0].Len =  4; strcpy(csTab[0].Name, "adler32");
    csTab[1].Len =  4; strcpy(csTab[1].Name, "crc32");
    csTab[2].Len = 16; strcpy(csTab[2].Name, "md5");
-   csLast = 2;
+   csTab[3].Len =  4; strcpy(csTab[3].Name, "crc32c");
+   csLast = 3;
 }
 
 /******************************************************************************/

--- a/src/XrdPss/XrdPssCks.cc
+++ b/src/XrdPss/XrdPssCks.cc
@@ -122,7 +122,7 @@ int XrdPssCks::Get(const char *Pfn, XrdCksData &Cks)
 
 // Construct the correct url info
 //
-   XrdPssUrlInfo uInfo(Cks.envP, Pfn, cgiBuff, false);
+   XrdPssUrlInfo uInfo(Cks.envP, Pfn, cgiBuff, true);
    uInfo.setID();
 
 // Direct the path to the origin

--- a/src/XrdPss/XrdPssCks.hh
+++ b/src/XrdPss/XrdPssCks.hh
@@ -78,7 +78,7 @@ struct csInfo
 
 csInfo *Find(const char *Name);
 
-static const int csMax = 4;
+static const int csMax = 8;
 csInfo           csTab[csMax];
 int              csLast;
 };


### PR DESCRIPTION
When debugging the proxy with crc32c enabled and using token auth, I hit two issues fixed by this PR:
1.  `crc32c` is not in the hardcoded list of known algorithms.  Probably due to the fact `crc32c` support is newer than the PSS checksum support?
2. XrdPss drops the authorization token when it creates the forwarded request.  Unlike other calls to construct a URL, it disabled the appending of the environment CGI.
   - A side-effect of this was it also dropped the `cks.type` parameter for non-xrootd URLs (e.g., `https://` or `pelican://`) because `cks.type` was only explicitly forwarded for xroot-protocol-based origins.

On the upside, with this, I'm able to get checksums to pass-through from the cache to a Pelican-based origin!