### PR TITLE
Fix builds where xrootd is embedded CMake dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ configure_file(src/XrdVersion.hh.in src/XrdVersion.hh)
 # Build in subdirectories
 #-------------------------------------------------------------------------------
 
-include_directories(BEFORE ${CMAKE_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/src)
+include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR}/src)
 
 include(CTest)
 

--- a/src/XrdCl/CMakeLists.txt
+++ b/src/XrdCl/CMakeLists.txt
@@ -25,10 +25,10 @@ set( XrdClPipelineSources
 #-------------------------------------------------------------------------------
 if( BUILD_XRDEC )
   set( XrdEcSources
-       ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcRedundancyProvider.cc
-       ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcUtilities.cc
-       ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcStrmWriter.cc
-       ${CMAKE_SOURCE_DIR}/src/XrdEc/XrdEcReader.cc
+       ../XrdEc/XrdEcRedundancyProvider.cc
+       ../XrdEc/XrdEcUtilities.cc
+       ../XrdEc/XrdEcStrmWriter.cc
+       ../XrdEc/XrdEcReader.cc
        XrdClEcHandler.cc
   )
   add_compile_definitions( WITH_XRDEC )

--- a/src/XrdMacaroons.cmake
+++ b/src/XrdMacaroons.cmake
@@ -36,7 +36,7 @@ if( BUILD_MACAROONS )
   if( APPLE )
     SET( MACAROONS_LINK_FLAGS "-Wl")
   else()
-    SET( MACAROONS_LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/XrdMacaroons/export-lib-symbols" )
+    SET( MACAROONS_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/XrdMacaroons/export-lib-symbols" )
   endif()
 
   set_target_properties(

--- a/src/XrdPlugins.cmake
+++ b/src/XrdPlugins.cmake
@@ -147,7 +147,7 @@ add_library(
 if( APPLE )
   SET( OSSSTATS_LINK_FLAGS "-Wl")
 else()
-  SET( OSSSTATS_LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/XrdOssStats/export-lib-symbols" )
+  SET( OSSSTATS_LINK_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/XrdOssStats/export-lib-symbols" )
 endif()
 
 target_link_libraries(

--- a/src/XrdTpc.cmake
+++ b/src/XrdTpc.cmake
@@ -55,7 +55,7 @@ if( BUILD_TPC )
   if( APPLE )
     set( TPC_LINK_FLAGS, "-Wl" )
   else()
-    set( TPC_LINK_FLAGS, "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/XrdTpc/export-lib-symbols" )
+    set( TPC_LINK_FLAGS, "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/XrdTpc/export-lib-symbols" )
   endif()
 
   set_target_properties(

--- a/src/XrdVoms.cmake
+++ b/src/XrdVoms.cmake
@@ -10,10 +10,10 @@ set( LIB_XRD_HTTP_VOMS        XrdHttpVOMS-${PLUGIN_VERSION} )
 add_library(
    ${LIB_XRD_VOMS}
    MODULE
-   ${CMAKE_SOURCE_DIR}/src/XrdVoms/XrdVomsFun.cc
-   ${CMAKE_SOURCE_DIR}/src/XrdVoms/XrdVomsMapfile.cc
-   ${CMAKE_SOURCE_DIR}/src/XrdVoms/XrdVomsgsi.cc
-   ${CMAKE_SOURCE_DIR}/src/XrdVoms/XrdVomsHttp.cc )
+   XrdVoms/XrdVomsFun.cc
+   XrdVoms/XrdVomsMapfile.cc
+   XrdVoms/XrdVomsgsi.cc
+   XrdVoms/XrdVomsHttp.cc )
 
 target_link_libraries(
    ${LIB_XRD_VOMS}

--- a/tests/XrdHttpTests/CMakeLists.txt
+++ b/tests/XrdHttpTests/CMakeLists.txt
@@ -5,6 +5,6 @@ endif()
 add_executable(xrdhttp-unit-tests XrdHttpTests.cc)
 
 target_link_libraries(xrdhttp-unit-tests XrdHttpUtils GTest::GTest GTest::Main)
-target_include_directories(xrdhttp-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(xrdhttp-unit-tests PRIVATE ../../src)
 
 gtest_discover_tests(xrdhttp-unit-tests)

--- a/tests/XrdOucTests/CMakeLists.txt
+++ b/tests/XrdOucTests/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(xrdoucutils-unit-tests XrdOucUtilsTests.cc)
 
 target_link_libraries(xrdoucutils-unit-tests XrdUtils GTest::GTest GTest::Main)
-target_include_directories(xrdoucutils-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(xrdoucutils-unit-tests PRIVATE ../../src)
 
 gtest_discover_tests(xrdoucutils-unit-tests)

--- a/tests/XrdPfcTests/CMakeLists.txt
+++ b/tests/XrdPfcTests/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_executable(xrdpfc-unit-tests XrdPfcTests.cc)
 
 target_link_libraries(xrdpfc-unit-tests GTest::GTest GTest::Main)
-target_include_directories(xrdpfc-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(xrdpfc-unit-tests PRIVATE ../../src)
 
 gtest_discover_tests(xrdpfc-unit-tests)

--- a/tests/XrdTpcTests/CMakeLists.txt
+++ b/tests/XrdTpcTests/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_executable(xrdtpc-unit-tests XrdTpcTests.cc)
 
 add_library(XrdTpcUtils
-        ${CMAKE_SOURCE_DIR}/src/XrdTpc/XrdTpcUtils.cc)
+        ../../src/XrdTpc/XrdTpcUtils.cc)
 
 target_link_libraries(xrdtpc-unit-tests XrdTpcUtils GTest::GTest GTest::Main)
-target_include_directories(xrdtpc-unit-tests PRIVATE ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(xrdtpc-unit-tests PRIVATE ../../src)
 
 gtest_discover_tests(xrdtpc-unit-tests)


### PR DESCRIPTION
When doing builds of XRootD that are embedded in other projects, `${CMAKE_SOURCE_DIR}` refers to the top-level build directory (which is not the xrootd source code but the parent project).  Remove use of `${CMAKE_SOURCE_DIR}` where not needed and switch to `${CMAKE_CURRENT_SOURCE_DIR}` (the absolute path to the directory where the current cmake file resides) for things like build flags.