### PR TITLE
[XrdTpc] Force use of `Expect: 100-continue` header

### DIFF
--- a/src/XrdTpc/XrdTpcState.cc
+++ b/src/XrdTpc/XrdTpcState.cc
@@ -33,6 +33,7 @@ void State::Move(State &other)
     m_start_offset = other.m_start_offset;
     m_status_code = other.m_status_code;
     m_content_length = other.m_content_length;
+    m_push_length = other.m_push_length;
     m_stream = other.m_stream;
     m_curl = other.m_curl;
     m_headers = other.m_headers;
@@ -66,6 +67,7 @@ bool State::InstallHandlers(CURL *curl) {
             curl_easy_setopt(curl, CURLOPT_READDATA, this);
             struct stat buf;
             if (SFS_OK == m_stream->Stat(&buf)) {
+                m_push_length = buf.st_size;
                 curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, buf.st_size);
             }
         } else {
@@ -90,9 +92,13 @@ bool State::InstallHandlers(CURL *curl) {
 }
 
 /**
- * Handle the 'Copy-Headers' feature
+ * Setup any headers necessary for the GET/PUT operation
+ *
+ * Currently includes:
+ * - Handle the 'Copy-Headers' feature
+ * - Adding `Expect: 100-continue` to get around a libcurl bug on uploads.
  */
-void State::CopyHeaders(XrdHttpExtReq &req) {
+void State::SetupHeaders(XrdHttpExtReq &req) {
     struct curl_slist *list = NULL;
     for (std::map<std::string, std::string>::const_iterator hdr_iter = req.headers.begin();
          hdr_iter != req.headers.end();
@@ -109,6 +115,17 @@ void State::CopyHeaders(XrdHttpExtReq &req) {
             m_headers_copy.emplace_back(ss.str());
         }
     }
+
+    if (m_is_transfer_state && m_push && m_push_length > 0) {
+        // On libcurl 8.5.0 - 8.9.1, we've observed bugs causing failures whenever
+        // `Expect: 100-continue` is not used.  Older versions of libcurl unconditionally
+        // set `Expect` whenever PUT is used (likely an older bug).  To workaround the issue,
+        // we force `Expect` to be set, triggering the older libcurl behavior.
+        // See: https://github.com/xrootd/xrootd/issues/2470
+        // See: https://github.com/curl/curl/issues/17004
+        list = curl_slist_append(list, "Expect: 100-continue");
+    }
+
     if (list != NULL) {
         curl_easy_setopt(m_curl, CURLOPT_HTTPHEADER, list);
         m_headers = list;
@@ -119,6 +136,7 @@ void State::ResetAfterRequest() {
     m_offset = 0;
     m_status_code = -1;
     m_content_length = -1;
+    m_push_length = -1;
     m_recv_all_headers = false;
     m_recv_status_line = false;
 }

--- a/src/XrdTpc/XrdTpcState.hh
+++ b/src/XrdTpc/XrdTpcState.hh
@@ -49,6 +49,7 @@ public:
       m_status_code(-1),
       m_error_code(0),
       m_content_length(-1),
+      m_push_length(-1),
       m_stream(NULL),
       m_curl(curl),
       m_headers(NULL),
@@ -70,6 +71,7 @@ public:
       m_status_code(-1),
       m_error_code(0),
       m_content_length(-1),
+      m_push_length(-1),
       m_stream(&stream),
       m_curl(curl),
       m_headers(NULL),
@@ -83,7 +85,7 @@ public:
 
     void SetTransferParameters(off_t offset, size_t size);
 
-    void CopyHeaders(XrdHttpExtReq &req);
+    void SetupHeaders(XrdHttpExtReq &req);
 
     off_t BytesTransferred() const {return m_offset;}
 
@@ -165,6 +167,7 @@ private:
     int m_status_code;  // status code from HTTP response.
     int m_error_code; // error code from underlying stream operations.
     off_t m_content_length;  // value of Content-Length header, if we received one.
+    off_t m_push_length; // For push transfers, the size of the file on our server.
     Stream *m_stream;  // stream corresponding to this transfer.
     CURL *m_curl;  // libcurl handle
     struct curl_slist *m_headers; // any headers we set as part of the libcurl request.

--- a/src/XrdTpc/XrdTpcTPC.cc
+++ b/src/XrdTpc/XrdTpcTPC.cc
@@ -468,7 +468,7 @@ int TPCHandler::GetContentLengthTPCPull(CURL *curl, XrdHttpExtReq &req, uint64_t
     State state(curl,req.tpcForwardCreds);
     //Don't forget to copy the headers of the client's request before doing the HEAD call. Otherwise, if there is a need for authentication,
     //it will fail
-    state.CopyHeaders(req);
+    state.SetupHeaders(req);
     int result;
     //In case we cannot get the content length, we return the error to the client
     if ((result = DetermineXferSize(curl, req, state, success, rec)) || !success) {
@@ -857,7 +857,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
 
     Stream stream(std::move(fh), 0, 0, m_log);
     State state(0, stream, curl, true, req.tpcForwardCreds);
-    state.CopyHeaders(req);
+    state.SetupHeaders(req);
 
     return RunCurlWithUpdates(curl, req, state, rec);
 }
@@ -1009,7 +1009,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     }
     Stream stream(std::move(fh), streams * m_pipelining_multiplier, streams > 1 ? m_block_size : m_small_block_size, m_log);
     State state(0, stream, curl, false, req.tpcForwardCreds);
-    state.CopyHeaders(req);
+    state.SetupHeaders(req);
     state.SetContentLength(sourceFileContentLength);
 
     if (streams > 1) {


### PR DESCRIPTION
On older versions of libcurl (at least 7.x), PUTs unconditionally triggered the use of `Expect: 100-continue`.

We've observed that newer versions of libcurl no longer force this behavior -- but also have bugs when it's not present!  Upstream issue is reported at https://github.com/curl/curl/issues/17004.

Pragmatically, until libcurl is fixed -- and we can assume the fix is deployed everywhere -- we will need to go back to the older behavior as seen on AlmaLinux 9 and similar.

Credit to @dynamic-entropy for uncovering the issue, narrowing it down, and coming up with the approach for the fix.  I just added some comments :)

Fixes: https://github.com/xrootd/xrootd/issues/2470