### PR TITLE
[XrdPfc] Add simple integration test for the PFC

### DIFF
--- a/tests/XRootD/CMakeLists.txt
+++ b/tests/XRootD/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-list(APPEND XROOTD_CONFIGS noauth host unix sss)
+list(APPEND XROOTD_CONFIGS noauth host unix sss cache)
 
 if(ENABLE_FUSE_TESTS)
   list(APPEND XROOTD_CONFIGS fuse)
@@ -15,6 +15,10 @@ if(BUILD_SCITOKENS AND HAVE_SCITOKEN_CONFIG_SET_STR)
   list(APPEND XROOTD_CONFIGS scitokens)
   list(APPEND scitokens_FIXTURES SciTokens)
 endif()
+
+# The cache test requires the XRootD::host fixture to be running to
+# act as an origin
+list(APPEND cache_FIXTURES XRootD::host)
 
 foreach(CONFIG ${XROOTD_CONFIGS})
   add_test(NAME XRootD::${CONFIG}::setup

--- a/tests/XRootD/cache.cfg
+++ b/tests/XRootD/cache.cfg
@@ -1,0 +1,24 @@
+set name = cache
+set port = 7096
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+xrootd.trace all
+pfc.trace info
+
+xrootd.seclib libXrdSec.so
+xrd.protocol XrdHttp:$port libXrdHttp.so
+
+http.desthttps false
+http.selfhttps2http false
+
+xrootd.chksum max 2 md5 adler32 crc32 crc32c
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+
+pss.setopt DebugLevel 4
+pss.origin localhost:5094
+
+continue $src/common.cfg

--- a/tests/XRootD/cache.sh
+++ b/tests/XRootD/cache.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+export XrdSecPROTOCOL=host
+
+function setup_cache() {
+	require_commands diff
+}
+
+function test_cache() {
+	echo
+	echo "client: XRootD $(xrdcp --version 2>&1)"
+	echo "server: XRootD $(xrdfs "${HOST}" query config version 2>&1)"
+	echo
+
+	ORIGIN_HOST="root://localhost:5094"
+
+	assert xrdcp -f "${SOURCE_DIR}"/host.cfg "${ORIGIN_HOST}//host.cfg"
+	assert xrdcp -f "${ORIGIN_HOST}"//host.cfg host.origin.cfg
+	assert diff -u "${SOURCE_DIR}"/host.cfg host.origin.cfg
+
+	assert xrdcp -f "${HOST}"//host.cfg host.cache.cfg
+	assert diff -u "${SOURCE_DIR}"/host.cfg host.cache.cfg
+}


### PR DESCRIPTION
This adds a simple integration test that downloads a file from a XCache server through another fixture as an origin, then verifies the file is unchanged.

@amadio - the approach is as what we discussed earlier today ... added explicit dependency between fixtures but did not rework how the CMakeLists.txt is working.