### PR TITLE
[XrdPfc] fix cmake install rule

### DIFF
--- a/src/XrdPfc.cmake
+++ b/src/XrdPfc.cmake
@@ -115,7 +115,7 @@ install(
     ${CMAKE_CURRENT_SOURCE_DIR}/XrdPfc/XrdPfcFile.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/XrdPfc/XrdPfcTypes.hh
     ${CMAKE_CURRENT_SOURCE_DIR}/XrdPfc/XrdPfcInfo.hh
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/xrootd/XrdPfc
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/xrootd/XrdPfc
 )
 
 install(


### PR DESCRIPTION
~~Follow recommendation from https://cmake.org/cmake/help/latest/command/install.html and make the destination path relative.~~

Use `CMAKE_INSTALL_INCLUDEDIR` instead of hardcoded `include/` suffix.

Context: [updating XRootD from 5.7.1 to 5.8.0 on nixpkgs](https://github.com/NixOS/nixpkgs/pull/397667).

[This patch](https://github.com/xrootd/xrootd/pull/2436/files#diff-7b25d5f1cdc3ff8d39ffeb84e4285b93dcdce7bb4ed29217eed6d2702b26994dR107-R120) is causing our build to fail when installing the package:
```
Moving /nix/store/3zw12avd4c3h07a0rpl35jvqhv0gfx6l-xrootd-5.8.0-bin/bin/xrootd-config to /nix/store/6vnmipw8p1hc6cmkrsq9v1ay7j6iycq2-xrootd-5.8.0-dev/bin/xrootd-config
Running phase: fixupPhase
@nix { "action": "setPhase", "phase": "fixupPhase" }
Moving /nix/store/jbh4667k5zm74h9wv8y1j11x89cv6pnd-xrootd-5.8.0/include to /nix/store/6vnmipw8p1hc6cmkrsq9v1ay7j6iycq2-xrootd-5.8.0-dev/include
mv: cannot overwrite '/nix/store/6vnmipw8p1hc6cmkrsq9v1ay7j6iycq2-xrootd-5.8.0-dev/include/xrootd': Directory not empty
```

This PR fixes this issue by ~~following [CMake's recommendation to use relative paths in `install`'s `DESTINATION`s](https://cmake.org/cmake/help/latest/command/install.html#id3).~~ substituting `${CMAKE_INSTALL_PREFIX}/include` with `${CMAKE_INSTALL_INCLUDEDIR}` in `DESTINATION`.
