### PR TITLE
[XrdPosix] Map operation timeouts to ETIME

### DIFF
--- a/src/XrdPosix/XrdPosixMap.cc
+++ b/src/XrdPosix/XrdPosixMap.cc
@@ -110,7 +110,7 @@ int XrdPosixMap::mapCode(int rc)
         case XrdCl::errLoginFailed:          return ECONNABORTED; // Cl:203
         case XrdCl::errAuthFailed:           return EAUTH;        // Cl:204
         case XrdCl::errQueryNotSupported:    return ENOTSUP;      // Cl:205
-        case XrdCl::errOperationExpired:     return ESTALE;       // Cl:206
+        case XrdCl::errOperationExpired:     return ETIME;        // Cl:206
         case XrdCl::errOperationInterrupted: return EINTR;        // Cl:207
         case XrdCl::errNoMoreFreeSIDs:       return ENOSR;        // Cl:301
         case XrdCl::errInvalidRedirectURL:   return ESPIPE;       // Cl:302


### PR DESCRIPTION
Elsewhere, we use ETIME to indicate a server timeout (particularly, XRootD uses it for "504 Gateway Timeout").  Many users have found it confusing that timeouts result in "stale NFS file handle". Beyond giving the correct HTTP status code, this will cause the following message to be provided:

```
sTREAM ioctl timeout
```

It's not the greatest -- and the capitalization is strange -- but at least it includes the word "timeout".  For the xroot protocol, one receives 3035, `kXR_TimerExpired`.