### PR TITLE
[XrdThrottle] Fix Throttle bug causing incorrect HTTP response

### DIFF
--- a/src/XrdThrottle/XrdThrottle.hh
+++ b/src/XrdThrottle/XrdThrottle.hh
@@ -25,7 +25,7 @@ typedef std::auto_ptr<XrdSfsFile> unique_sfs_ptr;
 
 class FileSystem;
 
-class File : public XrdSfsFile {
+class File final : public XrdSfsFile {
 
 friend class FileSystem;
 
@@ -36,85 +36,85 @@ public:
               XrdSfsFileOpenMode   openMode,
               mode_t               createMode,
         const XrdSecEntity        *client,
-        const char                *opaque = 0);
+        const char                *opaque = 0) override;
 
    virtual int
-   close();
+   close() override;
 
    virtual int
-   checkpoint(cpAct act, struct iov *range=0, int n=0);
+   checkpoint(cpAct act, struct iov *range=0, int n=0) override;
 
    using XrdSfsFile::fctl;
    virtual int
    fctl(const int               cmd,
         const char             *args,
-              XrdOucErrInfo    &out_error);
+              XrdOucErrInfo    &out_error) override;
 
    virtual const char *
-   FName();
+   FName() override;
 
    virtual int
-   getMmap(void **Addr, off_t &Size);
+   getMmap(void **Addr, off_t &Size) override;
 
    virtual XrdSfsXferSize
    pgRead(XrdSfsFileOffset   offset,
           char              *buffer,
           XrdSfsXferSize     rdlen,
           uint32_t          *csvec,
-          uint64_t           opts=0);
+          uint64_t           opts=0) override;
 
    virtual XrdSfsXferSize
-   pgRead(XrdSfsAio *aioparm, uint64_t opts=0);
+   pgRead(XrdSfsAio *aioparm, uint64_t opts=0) override;
 
    virtual XrdSfsXferSize
    pgWrite(XrdSfsFileOffset   offset,
            char              *buffer,
            XrdSfsXferSize     rdlen,
            uint32_t          *csvec,
-           uint64_t           opts=0);
+           uint64_t           opts=0) override;
 
    virtual XrdSfsXferSize
-   pgWrite(XrdSfsAio *aioparm, uint64_t opts=0);
+   pgWrite(XrdSfsAio *aioparm, uint64_t opts=0) override;
 
    virtual int
    read(XrdSfsFileOffset   fileOffset,   // Preread only
-        XrdSfsXferSize     amount);
+        XrdSfsXferSize     amount) override;
 
    virtual XrdSfsXferSize
    read(XrdSfsFileOffset   fileOffset,
         char              *buffer,
-        XrdSfsXferSize     buffer_size);
+        XrdSfsXferSize     buffer_size) override;
 
    virtual int
-   read(XrdSfsAio *aioparm);
+   read(XrdSfsAio *aioparm) override;
 
    virtual XrdSfsXferSize
    write(XrdSfsFileOffset   fileOffset,
          const char        *buffer,
-         XrdSfsXferSize     buffer_size);
+         XrdSfsXferSize     buffer_size) override;
 
    virtual int
-   write(XrdSfsAio *aioparm);
+   write(XrdSfsAio *aioparm) override;
 
    virtual int
-   sync();
+   sync() override;
 
    virtual int
-   sync(XrdSfsAio *aiop);
+   sync(XrdSfsAio *aiop) override;
 
    virtual int
-   stat(struct stat *buf);
+   stat(struct stat *buf) override;
 
    virtual int
-   truncate(XrdSfsFileOffset   fileOffset);
+   truncate(XrdSfsFileOffset   fileOffset) override;
 
    virtual int
-   getCXinfo(char cxtype[4], int &cxrsz);
+   getCXinfo(char cxtype[4], int &cxrsz) override;
 
    virtual int
    SendData(XrdSfsDio         *sfDio,
             XrdSfsFileOffset   offset,
-            XrdSfsXferSize     size);
+            XrdSfsXferSize     size) override;
 
 private:
    File(const char *, unique_sfs_ptr, XrdThrottleManager &, XrdSysError &);
@@ -132,7 +132,7 @@ private:
    XrdSysError &m_eroute;
 };
 
-class FileSystem : public XrdSfsFileSystem
+class FileSystem final : public XrdSfsFileSystem
 {
 
 friend XrdSfsFileSystem * XrdSfsGetFileSystem_Internal(XrdSfsFileSystem *, XrdSysLogger *, const char *, XrdOucEnv *);
@@ -140,10 +140,10 @@ friend XrdSfsFileSystem * XrdSfsGetFileSystem_Internal(XrdSfsFileSystem *, XrdSy
 public:
 
    virtual XrdSfsDirectory *
-   newDir(char *user=0, int monid=0);
+   newDir(char *user=0, int monid=0) override;
 
    virtual XrdSfsFile *
-   newFile(char *user=0, int monid=0);
+   newFile(char *user=0, int monid=0) override;
 
    virtual int
    chksum(      csFunc         Func,
@@ -151,84 +151,80 @@ public:
           const char          *path,
                 XrdOucErrInfo &eInfo,
           const XrdSecEntity  *client = 0,
-          const char          *opaque = 0);
+          const char          *opaque = 0) override;
 
    virtual int
    chmod(const char             *Name,
                XrdSfsMode        Mode,
                XrdOucErrInfo    &out_error,
          const XrdSecEntity     *client,
-         const char             *opaque = 0);
+         const char             *opaque = 0) override;
 
    virtual void
-   Connect(const XrdSecEntity     *client = 0);
+   Connect(const XrdSecEntity     *client = 0) override;
 
    virtual void
-   Disc(const XrdSecEntity   *client = 0);
+   Disc(const XrdSecEntity   *client = 0) override;
 
    virtual void
-   EnvInfo(XrdOucEnv *envP);
+   EnvInfo(XrdOucEnv *envP) override;
 
    virtual int
    exists(const char                *fileName,
                 XrdSfsFileExistence &exists_flag,
                 XrdOucErrInfo       &out_error,
           const XrdSecEntity        *client,
-          const char                *opaque = 0);
+          const char                *opaque = 0) override;
 
    virtual int
    FAttr(      XrdSfsFACtl      *faReq,
                XrdOucErrInfo    &eInfo,
-         const XrdSecEntity     *client = 0);
-
-
-   virtual uint64_t
-   Features();
+         const XrdSecEntity     *client = 0) override;
 
    virtual int
    fsctl(const int               cmd,
          const char             *args,
                XrdOucErrInfo    &out_error,
-         const XrdSecEntity     *client);
+         const XrdSecEntity     *client) override;
 
    virtual int
-   getChkPSize();
+   getChkPSize() override;
 
    virtual int
-   getStats(char *buff, int blen);
+   getStats(char *buff, int blen) override;
 
    virtual const char *
-   getVersion();
+   getVersion() override;
 
    virtual int
    gpFile(      gpfFunc          &gpAct,
                 XrdSfsGPFile     &gpReq,
                 XrdOucErrInfo    &eInfo,
-          const XrdSecEntity     *client = 0);
+          const XrdSecEntity     *client = 0) override;
 
    virtual int
    mkdir(const char             *dirName,
                XrdSfsMode        Mode,
                XrdOucErrInfo    &out_error,
          const XrdSecEntity     *client,
-         const char             *opaque = 0);
+         const char             *opaque = 0) override;
 
    virtual int
    prepare(      XrdSfsPrep       &pargs,
                  XrdOucErrInfo    &out_error,
-           const XrdSecEntity     *client = 0);
+           const XrdSecEntity     *client = 0) override;
 
    virtual int
    rem(const char             *path,
              XrdOucErrInfo    &out_error,
        const XrdSecEntity     *client,
-       const char             *info = 0);
+       const char             *info = 0) override;
 
    virtual int
    remdir(const char             *dirName,
                 XrdOucErrInfo    &out_error,
           const XrdSecEntity     *client,
-          const char             *info = 0);
+          const char             *info = 0) override;
 
    virtual int
    rename(const char             *oldFileName,
@@ -236,31 +232,28 @@ public:
                 XrdOucErrInfo    &out_error,
           const XrdSecEntity     *client,
           const char             *infoO = 0,
-          const char             *infoN = 0);
+          const char             *infoN = 0) override;
 
    virtual int
    stat(const char             *Name,
               struct stat      *buf,
               XrdOucErrInfo    &out_error,
         const XrdSecEntity     *client,
-        const char             *opaque = 0);
+        const char             *opaque = 0) override;
 
    virtual int
    stat(const char             *Name,
               mode_t           &mode,
               XrdOucErrInfo    &out_error,
         const XrdSecEntity     *client,
-        const char             *opaque = 0);
+        const char             *opaque = 0) override;
 
    virtual int
    truncate(const char             *Name,
                   XrdSfsFileOffset fileOffset,
                   XrdOucErrInfo    &out_error,
             const XrdSecEntity     *client = 0,
-            const char             *opaque = 0);
-
-   virtual int
-   Configure(XrdSysError &, XrdSfsFileSystem *native_fs, XrdOucEnv *envP);
+            const char             *opaque = 0) override;
 
 private:
    static void
@@ -269,6 +262,9 @@ private:
                     XrdSysLogger     *lp,
               const char             *config_file,
                     XrdOucEnv        *envP);
+
+   int
+   Configure(XrdSysError &, XrdSfsFileSystem *native_fs, XrdOucEnv *envP);
 
    FileSystem();
 

--- a/src/XrdThrottle/XrdThrottleFileSystem.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystem.cc
@@ -91,12 +91,6 @@ FileSystem::FAttr(      XrdSfsFACtl      *faReq,
    return m_sfs_ptr->FAttr(faReq, eInfo, client);
 }
 
-uint64_t
-FileSystem::Features()
-{
-   return m_sfs_ptr->Features();
-}
-
 int
 FileSystem::fsctl(const int               cmd,
                   const char             *args,

--- a/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
@@ -184,7 +184,10 @@ FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs, XrdOucEnv 
        m_throttle.SetMonitor(gstream);
    }
 
-
+   // The Feature function is not a virtual but implemented by the base class to
+   // look at a protected member.  Thus, to forward the call, we need to copy
+   // from the underlying filesystem
+   FeatureSet = m_sfs_ptr->Features();
    return 0;
 }
 


### PR DESCRIPTION
XrdHttp relies on a flag set by XrdXrootd indicating that the file being stat'd is cached. In turn, the stat flag is only set if the SFS layer claims to have the "cache" feature.

It turns out that the XrdThrottle class treated the `Features()` function as if it was an overrided virtual when instead it was a non-virtual method in the base class with the following implementation:

```
uint64_t       Features() {return FeatureSet;}
```

where `FeatureSet` is a protected member.

So, the features reported when the throttle is installed are just some defaults, not the actual features of the object it wraps.

The impact of the bug is the `Age` header is never set for caches with the throttle installed.  It was picked up by the Pelican integration tests when an upgrade to v5.8.0 was attempted.

The fix for the bug sets the `FeatureSet` member inside the Throttle object based on the value returned by the object it wraps.  To prevent future recurrences where a virtual function looks like it is overriding when it does not, I also added the proper annotations to the throttle header file.

I would suggest considering making the `Features()` function virtual in R6.