### PR TITLE
Fix broken file access mode detection

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -1069,7 +1069,7 @@ int Cache::Prepare(const char *curl, int oflags, mode_t mode)
    std::string i_name = f_name + Info::s_infoExtension;
 
    // Do not allow write access.
-   if (oflags & (O_WRONLY | O_RDWR | O_APPEND | O_CREAT))
+   if ((oflags & O_ACCMODE) != O_RDONLY)
    {
       TRACE(Warning, "Prepare write access requested on file " << f_name << ". Denying access.");
       return -EROFS;


### PR DESCRIPTION
The access mode values for files are not the same for all platforms. The detection of a read only request here assumes that O_RDONLY is 0, which is not mandated by the POSIX standaed.

Linux:
```
  #define O_ACCMODE       00000003
  #define O_RDONLY        00000000
  #define O_WRONLY        00000001
  #define O_RDWR          00000002
```
But this is also allowed:
```
  #define O_RDONLY	0x0001	/* Open read-only.  */
  #define O_WRONLY	0x0002	/* Open write-only.  */
  #define O_RDWR	(O_RDONLY|O_WRONLY) /* Open for reading and writing. */
  #define O_ACCMODE	O_RDWR	/* Mask for file access modes.  */
```
And on systems using this option the detection of a read only request as implemented here is is broken and the cache test fails.

This commit fixes the detection so that it is done in the intended way that works everywhere.

Compare:

https://github.com/xrootd/xrootd/blob/fde6e456f133e0a1ef35c4b8b7ab296a3c53c2ee/src/XrdCeph/XrdCephPosix.cc#L683

https://github.com/xrootd/xrootd/blob/fde6e456f133e0a1ef35c4b8b7ab296a3c53c2ee/src/XrdOssCsi/XrdOssCsiFile.cc#L315

Log of failing test:
[cachelog.txt](https://github.com/user-attachments/files/20230464/cachelog.txt)
