### PR TITLE
Fix race conditions around use of `ecMsg`

### DIFF
--- a/src/XrdFfs/XrdFfsMisc.cc
+++ b/src/XrdFfs/XrdFfsMisc.cc
@@ -77,7 +77,7 @@ char XrdFfsMisc_get_current_url(const char *oldurl, char *newurl)
     }
 
     XrdOucECMsg   ecMsg;
-    XrdPosixAdmin adm(oldurl,ecMsg);
+    XrdPosixAdmin adm(oldurl,ecMsg,nullptr);
     if (adm.isOK() && adm.Stat())
     {
 // We might have been redirected to a destination server. Better 
@@ -103,7 +103,7 @@ char* XrdFfsMisc_getNameByAddr(char* ipaddr)
 int XrdFfsMisc_get_all_urls_real(const char *oldurl, char **newurls, const int nnodes)
 {
     XrdOucECMsg   ecMsg;
-    XrdPosixAdmin adm(oldurl,ecMsg);
+    XrdPosixAdmin adm(oldurl,ecMsg,nullptr);
     XrdCl::URL *uVec;
     int i, rval = 0;
 

--- a/src/XrdPosix/XrdPosixDir.hh
+++ b/src/XrdPosix/XrdPosixDir.hh
@@ -52,7 +52,7 @@ class XrdPosixDir : public XrdPosixObject
 {
 public:
                    XrdPosixDir(const char *path)
-                              : DAdmin(path,ecMsg), myDirVec(0), myDirEnt(0),
+                              : DAdmin(path,ecMsg, &ecMutex), myDirVec(0), myDirEnt(0),
                                 myBuf(nullptr), nxtEnt(0), numEnt(0), eNum(0)
                               {}
 

--- a/src/XrdPosix/XrdPosixFileRH.cc
+++ b/src/XrdPosix/XrdPosixFileRH.cc
@@ -112,7 +112,9 @@ void XrdPosixFileRH::HandleResponse(XrdCl::XRootDStatus *status,
 // Determine ending status. Note: error indicated as result set to -errno.
 //
         if (!(status->IsOK()))
-           result = XrdPosixMap::Result(*status, theFile->ecMsg, false);
+           {std::unique_lock lock(theFile->ecMutex);
+            result = XrdPosixMap::Result(*status, theFile->ecMsg, false);
+           }
    else if (typeIO == nonIO) result = 0;
    else if (typeIO == isRead)
            {XrdCl::ChunkInfo *cInfo = 0;

--- a/src/XrdPosix/XrdPosixObject.cc
+++ b/src/XrdPosix/XrdPosixObject.cc
@@ -199,6 +199,12 @@ do{if (fd >= lastFD || fd < baseFD)
    return (XrdPosixFile *)0;
 }
 
+XrdOucECMsg
+XrdPosixObject::getECMsg() const {
+    std::unique_lock lock(ecMutex);
+    return ecMsg;
+}
+
 /******************************************************************************/
 /*                                  I n i t                                   */
 /******************************************************************************/

--- a/src/XrdPosix/XrdPosixPrepIO.cc
+++ b/src/XrdPosix/XrdPosixPrepIO.cc
@@ -102,7 +102,11 @@ bool XrdPosixPrepIO::Init(XrdOucCacheIOCB *iocbP)
 // Make sure all went well. If so, do a Stat() call on the underlying file
 //
    if (Status.IsOK()) fileP->Stat(Status);
-      else {openRC = XrdPosixMap::Result(Status, fileP->ecMsg, false);
+      else {
+            {
+               std::unique_lock lock(fileP->ecMutex);
+               openRC = XrdPosixMap::Result(Status, fileP->ecMsg, false);
+            }
             if (DEBUGON && errno != ENOENT && errno != ELOOP)
                {std::string eTxt = Status.ToString();
                 DEBUG(eTxt<<" deferred open "<< obfuscateAuth(fileP->Origin()));


### PR DESCRIPTION
There is one `ecMsg` object per file while there can be an arbitrary number of outstanding operations per file (and hence, multiple threads writing to the object's memory location concurrently).  We've observed crashes caused by two simultaneous overwrites leading to a double-delete of the underlying object.

This commit takes a fairly simple approach: wrap all read and writes of `ecMsg` with a new mutex to prevent race conditions.

@abh3 - this is one approach for fixing https://github.com/xrootd/xrootd/issues/2517.  I don't find it particularly elegant - it steps on a lot of code in a lot of places - but I wanted to get something out to the ops team as there were hundreds of segfaults across the infrastructure by the end of the day.