### PR TITLE
Overhaul the throttle plugin

### DIFF
--- a/src/XrdThrottle/CMakeLists.txt
+++ b/src/XrdThrottle/CMakeLists.txt
@@ -2,10 +2,12 @@ set(XrdThrottle XrdThrottle-${PLUGIN_VERSION})
 
 add_library(${XrdThrottle} MODULE
   ${PROJECT_SOURCE_DIR}/src/XrdOfs/XrdOfsFS.cc
+  XrdThrottleConfig.cc XrdThrottleConfig.hh
   XrdThrottle.hh           XrdThrottleTrace.hh
   XrdThrottleFileSystem.cc
   XrdThrottleFileSystemConfig.cc
   XrdThrottleFile.cc
+  XrdOssThrottleFile.cc
   XrdThrottleManager.cc    XrdThrottleManager.hh
 )
 

--- a/src/XrdThrottle/XrdOssThrottleFile.cc
+++ b/src/XrdThrottle/XrdOssThrottleFile.cc
@@ -1,0 +1,251 @@
+/******************************************************************************/
+/*                                                                            */
+/* (c) 2025 by the Morgridge Institute for Research                           */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdOuc/XrdOucEnv.hh"
+#include <XrdOuc/XrdOucGatherConf.hh>
+#include "XrdOss/XrdOss.hh"
+#include "XrdOss/XrdOssWrapper.hh"
+#include "XrdSfs/XrdSfsAio.hh"
+#include "XrdSys/XrdSysLogger.hh"
+#include "XrdThrottle/XrdThrottleConfig.hh"
+#include "XrdThrottle/XrdThrottleManager.hh"
+#include "XrdThrottle/XrdThrottleTrace.hh"
+#include "XrdVersion.hh"
+
+#include <functional>
+
+namespace {
+
+class File final : public XrdOssWrapDF {
+public:
+    File(std::unique_ptr<XrdOssDF> wrapDF, XrdThrottleManager &throttle, XrdSysError *lP, XrdOucTrace *tP)
+        : XrdOssWrapDF(*wrapDF), m_log(lP), m_throttle(throttle), m_trace(tP), m_wrapped(std::move(wrapDF)) {}
+
+virtual ~File() {}
+
+virtual int Open(const char *path, int Oflag, mode_t Mode,
+    XrdOucEnv &env) override {
+
+    std::tie(m_user, m_uid) = m_throttle.GetUserInfo(env.secEnv());
+
+    std::string open_error_message;
+    if (!m_throttle.OpenFile(m_user, open_error_message)) {
+        TRACE(DEBUG, open_error_message);
+        return -EMFILE;
+    }
+
+    auto rval = wrapDF.Open(path, Oflag, Mode, env);
+
+    if (rval < 0) {
+        m_throttle.CloseFile(m_user);
+    }
+
+    return rval;
+}
+
+virtual int Close(long long *retsz) override {
+   m_throttle.CloseFile(m_user);
+   return wrapDF.Close(retsz);
+}
+
+virtual int getFD() override {return -1;}
+
+virtual off_t getMmap(void **addr) override {*addr = 0; return 0;}
+
+virtual ssize_t pgRead (void* buffer, off_t offset, size_t rdlen,
+    uint32_t* csvec, uint64_t opts) override {
+
+    return DoThrottle(rdlen, 1,
+        static_cast<ssize_t (XrdOssDF::*)(void*, off_t, size_t, uint32_t*, uint64_t)>(&XrdOssDF::pgRead),
+        buffer, offset, rdlen, csvec, opts);
+}
+
+virtual int pgRead(XrdSfsAio *aioparm, uint64_t opts) override
+{  // We disable all AIO-based reads.
+   aioparm->Result = pgRead((char *)aioparm->sfsAio.aio_buf,
+                                    aioparm->sfsAio.aio_offset,          
+                                    aioparm->sfsAio.aio_nbytes,
+                                    aioparm->cksVec, opts);
+   aioparm->doneRead();
+   return 0;
+}
+
+virtual ssize_t pgWrite(void* buffer, off_t offset, size_t wrlen,
+    uint32_t* csvec, uint64_t opts) override {
+
+    return DoThrottle(wrlen, 1,
+        static_cast<ssize_t (XrdOssDF::*)(void*, off_t, size_t, uint32_t*, uint64_t)>(&XrdOssDF::pgWrite),
+        buffer, offset, wrlen, csvec, opts);
+}
+
+virtual int pgWrite(XrdSfsAio *aioparm, uint64_t opts) override
+{  // We disable all AIO-based writes.
+   aioparm->Result = this->pgWrite((char *)aioparm->sfsAio.aio_buf,
+                                           aioparm->sfsAio.aio_offset, 
+                                           aioparm->sfsAio.aio_nbytes,
+                                           aioparm->cksVec, opts);
+   aioparm->doneWrite();
+   return 0;
+}
+
+virtual ssize_t Read(off_t offset, size_t size) override {
+    return DoThrottle(size, 1,
+        static_cast<ssize_t (XrdOssDF::*)(off_t, size_t)>(&XrdOssDF::Read),
+        offset, size);
+}
+virtual ssize_t Read(void* buffer, off_t offset, size_t size) override {
+    return DoThrottle(size, 1,
+        static_cast<ssize_t (XrdOssDF::*)(void*, off_t, size_t)>(&XrdOssDF::Read),
+        buffer, offset, size);
+}
+
+virtual int Read(XrdSfsAio *aiop) override {
+    aiop->Result = this->Read((char *)aiop->sfsAio.aio_buf,
+                                   aiop->sfsAio.aio_offset,
+                                   aiop->sfsAio.aio_nbytes);
+    aiop->doneRead();
+    return 0;
+}
+
+virtual ssize_t ReadV(XrdOucIOVec *readV, int rdvcnt) override {
+    off_t sum = 0;
+    for (int i = 0; i < rdvcnt; ++i) {
+        sum += readV[i].size;
+    }
+    return DoThrottle(sum, rdvcnt, &XrdOssDF::ReadV, readV, rdvcnt);
+}
+
+
+virtual ssize_t Write(const void* buffer, off_t offset, size_t size) override {
+    return DoThrottle(size, 1,
+        static_cast<ssize_t (XrdOssDF::*)(const void*, off_t, size_t)>(&XrdOssDF::Write),
+        buffer, offset, size);
+}
+
+virtual int Write(XrdSfsAio *aiop) override {
+    aiop->Result = this->Write((char *)aiop->sfsAio.aio_buf,
+                                    aiop->sfsAio.aio_offset,
+                                    aiop->sfsAio.aio_nbytes);
+    aiop->doneWrite();
+    return 0;
+}
+
+private:
+
+    template <class Fn, class... Args>
+    int DoThrottle(size_t rdlen, size_t ops, Fn &&fn, Args &&... args) {
+        m_throttle.Apply(rdlen, ops, m_uid);
+        bool ok = true;
+        XrdThrottleTimer timer = m_throttle.StartIOTimer(m_uid, ok);
+        if (!ok) {
+            TRACE(DEBUG, "Throttling in progress");
+            return -EMFILE;
+        }
+        return std::invoke(fn, wrapDF, std::forward<Args>(args)...);
+    }
+
+    XrdSysError *m_log{nullptr};
+    XrdThrottleManager &m_throttle;
+    XrdOucTrace *m_trace{nullptr};
+    std::unique_ptr<XrdOssDF> m_wrapped;
+    std::string m_user;
+    uint16_t m_uid;
+
+    static constexpr char TraceID[] = "XrdThrottleFile";
+};
+
+class FileSystem final : public XrdOssWrapper {
+public:
+    FileSystem(XrdOss *oss, XrdSysLogger *log, XrdOucEnv *envP)
+        : XrdOssWrapper(*oss),
+          m_env(envP),
+          m_oss(oss),
+          m_log(new XrdSysError(log)),
+          m_trace(new XrdOucTrace(m_log.get())),
+          m_throttle(m_log.get(), m_trace.get())
+    {
+
+        m_throttle.Init();
+        if (envP)
+        {
+            auto gstream = reinterpret_cast<XrdXrootdGStream*>(envP->GetPtr("Throttle.gStream*"));
+            m_log->Say("Config", "Throttle g-stream has", gstream ? "" : " NOT", " been configured via xrootd.mongstream directive");
+            m_throttle.SetMonitor(gstream);
+        }
+    }
+
+    int Configure(const std::string &config_filename) {
+        XrdThrottle::Configuration config(*m_log, m_env);
+        if (config.Configure(config_filename)) {
+            m_log->Emsg("Config", "Unable to load configuration file", config_filename.c_str());
+            return 1;
+        }
+        m_throttle.FromConfig(config);
+        return 0;
+    }
+
+    virtual ~FileSystem() {}
+
+    virtual XrdOssDF *newFile(const char *user = 0) override {
+        std::unique_ptr<XrdOssDF> wrapped(wrapPI.newFile(user));
+        return new File(std::move(wrapped), m_throttle, m_log.get(), m_trace.get());
+    }
+
+private:
+    XrdOucEnv *m_env{nullptr};
+    std::unique_ptr<XrdOss> m_oss;
+    std::unique_ptr<XrdSysError> m_log{nullptr};
+    std::unique_ptr<XrdOucTrace> m_trace{nullptr};
+    XrdThrottleManager m_throttle;
+};
+
+} // namespace
+
+extern "C" {
+
+XrdOss *XrdOssAddStorageSystem2(XrdOss *curr_oss, XrdSysLogger *logger,
+                                const char *config_fn, const char *parms,
+                                XrdOucEnv *envP) {
+    std::unique_ptr<FileSystem> fs(new FileSystem(curr_oss, logger, envP));
+    if (fs->Configure(config_fn)) {
+        XrdSysError(logger, "XrdThrottle").Say("Config", "Unable to load configuration file", config_fn);
+        return nullptr;
+    }
+    // Note the throttle is set up as an OSS.
+    // This will prevent the throttle from being layered on top of the OFS; to keep backward
+    // compatibility with old configurations, we do not cause the server to fail.
+    //
+    // Originally, XrdThrottle was used as an OFS because the loadshed code required the ability
+    // to redirect the client to a different server.  This is rarely (never?) used in practice.
+    // By putting the throttle in the OSS, we benefit from the fact the OFS has first run the
+    // authorization code and has made a user name available for fairshare of the throttle.
+    envP->PutInt("XrdOssThrottle", 1);
+    return fs.release();
+}
+
+XrdVERSIONINFO(XrdOssAddStorageSystem2, throttle);
+    
+} // extern "C"
+

--- a/src/XrdThrottle/XrdThrottle.hh
+++ b/src/XrdThrottle/XrdThrottle.hh
@@ -286,6 +286,9 @@ private:
    int
    xmaxconn(XrdOucStream &Config);
 
+   int
+   xmaxwait(XrdOucStream &Config);
+
    static FileSystem  *m_instance;
    XrdSysError         m_eroute;
    XrdOucTrace         m_trace;

--- a/src/XrdThrottle/XrdThrottle.hh
+++ b/src/XrdThrottle/XrdThrottle.hh
@@ -271,24 +271,6 @@ private:
    virtual
   ~FileSystem();
 
-   int
-   xthrottle(XrdOucStream &Config);
-
-   int
-   xloadshed(XrdOucStream &Config);
-
-   int
-   xtrace(XrdOucStream &Config);
-
-   int
-   xmaxopen(XrdOucStream &Config);
-
-   int
-   xmaxconn(XrdOucStream &Config);
-
-   int
-   xmaxwait(XrdOucStream &Config);
-
    static FileSystem  *m_instance;
    XrdSysError         m_eroute;
    XrdOucTrace         m_trace;

--- a/src/XrdThrottle/XrdThrottleConfig.cc
+++ b/src/XrdThrottle/XrdThrottleConfig.cc
@@ -1,0 +1,351 @@
+/******************************************************************************/
+/*                                                                            */
+/* (c) 2025 by the Morgridge Institute for Research                           */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdOuc/XrdOuca2x.hh"
+#include "XrdOuc/XrdOucEnv.hh"
+#include "XrdOuc/XrdOucStream.hh"
+#include "XrdSys/XrdSysError.hh"
+#include "XrdThrottle/XrdThrottleConfig.hh"
+#include "XrdThrottle/XrdThrottleTrace.hh"
+
+#include <cstring>
+#include <string>
+#include <fcntl.h>
+
+using namespace XrdThrottle;
+
+#define TS_Xeq(key, func) NoGo = (strcmp(key, var) == 0) ? func(Config) : 0
+int
+Configuration::Configure(const std::string &config_file)
+{
+    XrdOucEnv myEnv;
+    XrdOucStream Config(&m_log, getenv("XRDINSTANCE"), &myEnv, "(Throttle Config)> ");
+    int cfgFD;
+    if (config_file.empty()) {
+        m_log.Say("No filename specified.");
+        return 1;
+    }
+    if ((cfgFD = open(config_file.c_str(), O_RDONLY)) < 0) {
+        m_log.Emsg("Config", errno, "Unable to open configuration file", config_file.c_str());
+        return 1;
+    }
+    Config.Attach(cfgFD);
+    static const char *cvec[] = { "*** throttle (ofs) plugin config:", 0 };
+    Config.Capture(cvec);
+
+    char *var, *val;
+    int NoGo = 0;
+    while( (var = Config.GetMyFirstWord()) )
+    {
+        if (!strcmp("throttle.fslib", var)) {
+            val = Config.GetWord();
+            if (!val || !val[0]) {m_log.Emsg("Config", "fslib not specified."); continue;}
+            m_fslib = val;
+        }
+        TS_Xeq("throttle.max_open_files", xmaxopen);
+        TS_Xeq("throttle.max_active_connections", xmaxconn);
+        TS_Xeq("throttle.throttle", xthrottle);
+        TS_Xeq("throttle.loadshed", xloadshed);
+        TS_Xeq("throttle.max_wait_time", xmaxwait);
+        TS_Xeq("throttle.trace", xtrace);
+        if (NoGo)
+        {
+            m_log.Emsg("Config", "Throttle configuration failed.");
+            return 1;
+        }
+    }
+    return 0;
+}
+
+/******************************************************************************/
+/*                            x m a x o p e n                                 */
+/******************************************************************************/
+
+/* Function: xmaxopen
+
+   Purpose:  Parse the directive: throttle.max_open_files <limit>
+
+             <limit>   maximum number of open file handles for a unique entity.
+
+  Output: 0 upon success or !0 upon failure.
+*/
+int
+Configuration::xmaxopen(XrdOucStream &Config)
+{
+    auto val = Config.GetWord();
+    if (!val || val[0] == '\0')
+       {m_log.Emsg("Config", "Max open files not specified!  Example usage: throttle.max_open_files 16000");}
+    long long max_open = -1;
+    if (XrdOuca2x::a2sz(m_log, "max open files value", val, &max_open, 1)) return 1;
+
+    m_max_open = max_open;
+    return 0;
+}
+
+
+/******************************************************************************/
+/*                            x m a x c o n n                                 */
+/******************************************************************************/
+
+/* Function: xmaxconn
+
+   Purpose:  Parse the directive: throttle.max_active_connections <limit>
+
+             <limit>   maximum number of connections with at least one open file for a given entity
+
+  Output: 0 upon success or !0 upon failure.
+*/
+int
+Configuration::xmaxconn(XrdOucStream &Config)
+{
+    auto val = Config.GetWord();
+    if (!val || val[0] == '\0')
+       {m_log.Emsg("Config", "Max active connections not specified!  Example usage: throttle.max_active_connections 4000");}
+    long long max_conn = -1;
+    if (XrdOuca2x::a2sz(m_log, "max active connections value", val, &max_conn, 1)) return 1;
+
+    m_max_conn = max_conn;
+    return 0;
+}
+
+/******************************************************************************/
+/*                            x m a x w a i t                                 */
+/******************************************************************************/
+
+/* Function: xmaxwait
+
+   Purpose:  Parse the directive: throttle.max_wait_time <limit>
+
+             <limit>   maximum wait time, in seconds, before an operation should fail
+
+   If the directive is not provided, the default is 30 seconds.
+
+  Output: 0 upon success or !0 upon failure.
+*/
+int
+Configuration::xmaxwait(XrdOucStream &Config)
+{
+    auto val = Config.GetWord();
+    if (!val || val[0] == '\0')
+       {m_log.Emsg("Config", "Max waiting time not specified (must be in seconds)!  Example usage: throttle.max_wait_time 20");}
+    long long max_wait = -1;
+    if (XrdOuca2x::a2sz(m_log, "max waiting time value", val, &max_wait, 1)) return 1;
+
+    return 0;
+}
+
+/******************************************************************************/
+/*                            x t h r o t t l e                               */
+/******************************************************************************/
+
+/* Function: xthrottle
+
+   Purpose:  To parse the directive: throttle [data <drate>] [iops <irate>] [concurrency <climit>] [interval <rint>]
+
+             <drate>    maximum bytes per second through the server.
+             <irate>    maximum IOPS per second through the server.
+             <climit>   maximum number of concurrent IO connections.
+             <rint>     minimum interval in milliseconds between throttle re-computing.
+
+   Output: 0 upon success or !0 upon failure.
+*/
+int
+Configuration::xthrottle(XrdOucStream &Config)
+{
+    long long drate = -1, irate = -1, rint = 1000, climit = -1;
+    char *val;
+
+    while ((val = Config.GetWord()))
+    {
+       if (strcmp("data", val) == 0)
+       {
+          if (!(val = Config.GetWord()))
+             {m_log.Emsg("Config", "data throttle limit not specified."); return 1;}
+          if (XrdOuca2x::a2sz(m_log,"data throttle value",val,&drate,1)) return 1;
+       }
+       else if (strcmp("iops", val) == 0)
+       {
+          if (!(val = Config.GetWord()))
+             {m_log.Emsg("Config", "IOPS throttle limit not specified."); return 1;}
+          if (XrdOuca2x::a2sz(m_log,"IOPS throttle value",val,&irate,1)) return 1;
+       }
+       else if (strcmp("rint", val) == 0)
+       {
+          if (!(val = Config.GetWord()))
+             {m_log.Emsg("Config", "recompute interval not specified (in ms)."); return 1;}
+          if (XrdOuca2x::a2sp(m_log,"recompute interval value (in ms)",val,&rint,10)) return 1;
+       }
+       else if (strcmp("concurrency", val) == 0)
+       {
+          if (!(val = Config.GetWord()))
+             {m_log.Emsg("Config", "Concurrency limit not specified."); return 1;}
+          if (XrdOuca2x::a2sz(m_log,"Concurrency limit value",val,&climit,1)) return 1;
+       }
+       else
+       {
+          m_log.Emsg("Config", "Warning - unknown throttle option specified", val, ".");
+       }
+    }
+
+    m_throttle_data_rate = drate;
+    m_throttle_iops_rate = irate;
+    m_throttle_concurrency_limit = climit;
+    m_throttle_recompute_interval_ms = rint;
+
+    return 0;
+}
+
+/******************************************************************************/
+/*                            x l o a d s h e d                               */
+/******************************************************************************/
+
+/* Function: xloadshed
+
+   Purpose:  To parse the directive: loadshed host <hostname> [port <port>] [frequency <freq>]
+
+             <hostname> hostname of server to shed load to.  Required
+             <port>     port of server to shed load to.  Defaults to 1094
+             <freq>     A value from 1 to 100 specifying how often to shed load
+                        (1 = 1% chance; 100 = 100% chance; defaults to 10).
+
+   Output: 0 upon success or !0 upon failure.
+*/
+int Configuration::xloadshed(XrdOucStream &Config)
+{
+    long long port = 0, freq = 0;
+    char *val;
+    std::string hostname;
+
+    while ((val = Config.GetWord()))
+    {
+       if (strcmp("host", val) == 0)
+       {
+          if (!(val = Config.GetWord()))
+             {m_log.Emsg("Config", "loadshed hostname not specified."); return 1;}
+          hostname = val;
+       }
+       else if (strcmp("port", val) == 0)
+       {
+          if (!(val = Config.GetWord()))
+             {m_log.Emsg("Config", "Port number not specified."); return 1;}
+          if (XrdOuca2x::a2sz(m_log,"Port number",val,&port,1, 65536)) return 1;
+       }
+       else if (strcmp("frequency", val) == 0)
+       {
+           if (!(val = Config.GetWord()))
+              {m_log.Emsg("Config", "Loadshed frequency not specified."); return 1;}
+           if (XrdOuca2x::a2sz(m_log,"Loadshed frequency",val,&freq,1,100)) return 1;
+       }
+       else
+       {
+           m_log.Emsg("Config", "Warning - unknown loadshed option specified", val, ".");
+       }
+    }
+
+    if (hostname.empty())
+    {
+        m_log.Emsg("Config", "must specify hostname for loadshed parameter.");
+        return 1;
+    }
+
+    m_loadshed_freq = freq;
+    m_loadshed_hostname = hostname;
+    m_loadshed_port = port;
+
+    return 0;
+}
+
+/******************************************************************************/
+/*                                x t r a c e                                 */
+/******************************************************************************/
+
+/* Function: xtrace
+
+   Purpose:  To parse the directive: trace <events>
+
+             <events> the blank separated list of events to trace. Trace
+                      directives are cummalative.
+
+   Output: 0 upon success or 1 upon failure.
+*/
+
+int Configuration::xtrace(XrdOucStream &Config)
+{
+   char *val;
+   static const struct traceopts {const char *opname; int opval;} tropts[] =
+   {
+      {"all",       TRACE_ALL},
+      {"off",       TRACE_NONE},
+      {"none",      TRACE_NONE},
+      {"debug",     TRACE_DEBUG},
+      {"iops",      TRACE_IOPS},
+      {"bandwidth", TRACE_BANDWIDTH},
+      {"ioload",    TRACE_IOLOAD},
+      {"files",     TRACE_FILES},
+      {"connections",TRACE_CONNS},
+   };
+   int i, neg, trval = 0, numopts = sizeof(tropts)/sizeof(struct traceopts);
+
+   if (!(val = Config.GetWord()))
+   {
+      m_log.Emsg("Config", "trace option not specified");
+      return 1;
+   }
+   while (val)
+   {
+      if (!strcmp(val, "off"))
+      {
+         trval = 0;
+      }
+      else
+      {
+         if ((neg = (val[0] == '-' && val[1])))
+         {
+            val++;
+         }
+         for (i = 0; i < numopts; i++)
+         {
+            if (!strcmp(val, tropts[i].opname))
+            {
+               if (neg)
+               {
+                  if (tropts[i].opval) trval &= ~tropts[i].opval;
+                  else trval = TRACE_ALL;
+               }
+               else if (tropts[i].opval) trval |= tropts[i].opval;
+               else trval = TRACE_NONE;
+               break;
+            }
+         }
+         if (i >= numopts)
+         {
+            m_log.Say("Config warning: ignoring invalid trace option '", val, "'.");
+         }
+      }
+      val = Config.GetWord();
+   }
+   m_trace_levels = trval;
+   return 0;
+}

--- a/src/XrdThrottle/XrdThrottleConfig.hh
+++ b/src/XrdThrottle/XrdThrottleConfig.hh
@@ -1,0 +1,125 @@
+/******************************************************************************/
+/*                                                                            */
+/* (c) 2025 by the Morgridge Institute for Research                           */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#ifndef XrdThrottle_Config_hh
+#define XrdThrottle_Config_hh
+
+#include <string>
+
+class XrdOucEnv;
+class XrdOucStream;
+class XrdSysError;
+
+namespace XrdThrottle {
+
+class Configuration {
+public:
+    Configuration(XrdSysError & log, XrdOucEnv *env)
+    : m_env(env), m_log(log)
+    {}
+
+    // Generate the XrdThrottle configuration from the given file name.
+    //
+    // Returns 0 on success, or a non-zero error code on failure.
+    int Configure(const std::string &config_file);
+
+    // Get the configuration for the fslib to use.
+    // The default is "libXrdOfs.so".
+    const std::string &GetFileSystemLibrary() const { return m_fslib; }
+
+    // Get the configuration for the loadshed hostname.
+    // If not set, the default is empty.
+    const std::string &GetLoadshedHost() const { return m_loadshed_hostname; }
+
+    // Get the configuration for the loadshed port.
+    // Valid values are 1 to 65535.
+    // If not set, the default is 0.
+    long long GetLoadshedPort() const { return m_loadshed_port; }
+
+    // Get the configuration for the loadshed frequency.
+    // Valid values are 1 to 100.
+    // If not set, the default is 0.
+    long long GetLoadshedFreq() const { return m_loadshed_freq; }
+
+    // Get the configuration for th maximum number of open files.
+    // If -1, no limit is set.
+    long long GetMaxOpen() const { return m_max_open; }
+
+    // Get the configuration for the maximum number of active connections.
+    // If -1, no limit is set.
+    long long GetMaxConn() const { return m_max_conn; }
+
+    // Get the configuration for the maximum wait time before a request is
+    // failed with EMFILE.
+    // If not set, the default is 30 seconds.
+    long long GetMaxWait() const { return m_max_wait; }
+
+    // Get the configuration for the throttle concurrency limit.
+    // If -1, no limit is set.
+    long long GetThrottleConcurrency() const { return m_throttle_concurrency_limit; }
+
+    // Get the configuration for the maximum number of bytes per second.
+    // If -1, no limit is set.
+    long long GetThrottleDataRate() const { return m_throttle_data_rate; }
+
+    // Get the configuration for the maximum number of IOPS per second.
+    // If -1, no limit is set.
+    long long GetThrottleIOPSRate() const { return m_throttle_iops_rate; }
+
+    // Get the configuration for the recompute interval, in milliseconds.
+    // If not set, the default is 1000 ms.
+    long long GetThrottleRecomputeIntervalMS() const { return m_throttle_recompute_interval_ms; }
+
+    // Get the configuration for the trace levels.
+    // If not set, the default is 0.
+    int GetTraceLevels() const { return m_trace_levels; }
+
+private:
+    int xloadshed(XrdOucStream &Config);
+    int xmaxopen(XrdOucStream &Config);
+    int xmaxconn(XrdOucStream &Config);
+    int xmaxwait(XrdOucStream &Config);
+    int xthrottle(XrdOucStream &Config);
+    int xtrace(XrdOucStream &Config);
+
+    XrdOucEnv *m_env{nullptr};
+    std::string m_fslib{"libXrdOfs.so"};
+    XrdSysError &m_log;
+    std::string m_loadshed_hostname;
+    long long m_loadshed_freq{0};
+    long long m_loadshed_port{0};
+    long long m_max_conn{-1};
+    long long m_max_open{-1};
+    long long m_max_wait{30};
+    long long m_throttle_concurrency_limit{-1};
+    long long m_throttle_data_rate{-1};
+    long long m_throttle_iops_rate{-1};
+    long long m_throttle_recompute_interval_ms{1000};
+    int m_trace_levels{0};
+};
+
+} // namespace XrdThrottle
+
+#endif // XrdThrottle_Config_hh

--- a/src/XrdThrottle/XrdThrottleFile.cc
+++ b/src/XrdThrottle/XrdThrottleFile.cc
@@ -58,16 +58,7 @@ File::open(const char                *fileName,
            const XrdSecEntity        *client,
            const char                *opaque)
 {
-   // Try various potential "names" associated with the request, from the most
-   // specific to most generic.
-   if (client->eaAPI && client->eaAPI->Get("token.subject", m_user)) {
-       if (client->vorg) m_user = std::string(client->vorg) + ":" + m_user;
-   } else if (client->eaAPI) {
-       std::string user;
-       if (client->eaAPI->Get("request.name", user) && !user.empty()) m_user = user;
-   }
-   if (m_user.empty()) {m_user = client->name ? client->name : "nobody";}
-   m_uid = XrdThrottleManager::GetUid(m_user.c_str());
+   std::tie(m_user, m_uid) = m_throttle.GetUserInfo(client);
    m_throttle.PrepLoadShed(opaque, m_loadshed);
    std::string open_error_message;
    if (!m_throttle.OpenFile(m_user, open_error_message)) {

--- a/src/XrdThrottle/XrdThrottleFile.cc
+++ b/src/XrdThrottle/XrdThrottleFile.cc
@@ -20,7 +20,13 @@ using namespace XrdThrottle;
 #define DO_THROTTLE(amount) \
 DO_LOADSHED \
 m_throttle.Apply(amount, 1, m_uid); \
-XrdThrottleTimer xtimer = m_throttle.StartIOTimer();
+bool ok; \
+auto xtimer = m_throttle.StartIOTimer(m_uid, ok); \
+if (!ok) { \
+   error.setErrInfo(EMFILE, "I/O limit exceeded and wait time hit"); \
+   return SFS_ERROR; \
+}
+
 
 File::File(const char                     *user,
                  unique_sfs_ptr            sfs,

--- a/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
@@ -163,6 +163,7 @@ FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs, XrdOucEnv 
       TS_Xeq("throttle.max_active_connections", xmaxconn);
       TS_Xeq("throttle.throttle", xthrottle);
       TS_Xeq("throttle.loadshed", xloadshed);
+      TS_Xeq("throttle.max_wait_time", xmaxwait);
       TS_Xeq("throttle.trace", xtrace);
       if (NoGo)
       {
@@ -234,7 +235,7 @@ FileSystem::xmaxconn(XrdOucStream &Config)
 {
     auto val = Config.GetWord();
     if (!val || val[0] == '\0')
-       {m_eroute.Emsg("Config", "Max active cconnections not specified!  Example usage: throttle.max_active_connections 4000");}
+       {m_eroute.Emsg("Config", "Max active connections not specified!  Example usage: throttle.max_active_connections 4000");}
     long long max_conn = -1;
     if (XrdOuca2x::a2sz(m_eroute, "max active connections value", val, &max_conn, 1)) return 1;
 
@@ -242,6 +243,32 @@ FileSystem::xmaxconn(XrdOucStream &Config)
     return 0;
 }
 
+/******************************************************************************/
+/*                            x m a x w a i t                                 */
+/******************************************************************************/
+
+/* Function: xmaxwait
+
+   Purpose:  Parse the directive: throttle.max_wait_time <limit>
+
+             <limit>   maximum wait time, in seconds, before an operation should fail
+
+   If the directive is not provided, the default is 30 seconds.
+
+  Output: 0 upon success or !0 upon failure.
+*/
+int
+FileSystem::xmaxwait(XrdOucStream &Config)
+{
+    auto val = Config.GetWord();
+    if (!val || val[0] == '\0')
+       {m_eroute.Emsg("Config", "Max waiting time not specified (must be in seconds)!  Example usage: throttle.max_wait_time 20");}
+    long long max_wait = -1;
+    if (XrdOuca2x::a2sz(m_eroute, "max waiting time value", val, &max_wait, 1)) return 1;
+
+    m_throttle.SetMaxWait(max_wait);
+    return 0;
+}
 
 /******************************************************************************/
 /*                            x t h r o t t l e                               */

--- a/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
+++ b/src/XrdThrottle/XrdThrottleFileSystemConfig.cc
@@ -2,11 +2,13 @@
 #include <fcntl.h>
 
 #include "XrdSys/XrdSysPlugin.hh"
+#include "XrdSys/XrdSysLogger.hh"
 #include "XrdOuc/XrdOuca2x.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOuc/XrdOucStream.hh"
 
 #include "XrdThrottle/XrdThrottle.hh"
+#include "XrdThrottle/XrdThrottleConfig.hh"
 #include "XrdThrottle/XrdThrottleTrace.hh"
 
 using namespace XrdThrottle;
@@ -59,6 +61,13 @@ XrdSfsGetFileSystem_Internal(XrdSfsFileSystem *native_fs,
                             XrdOucEnv        *envP)
 {
    FileSystem* fs = NULL;
+   if (envP && envP->GetInt("XrdOssThrottle") == 1) {
+      XrdSysError eDest(lp, "XrdOssThrottle");
+      eDest.Emsg("Config", "XrdOssThrottle is loaded; not stacking XrdThrottle on OFS.  "
+         "This is a warning for backward compatability; this configuration may generate an "
+         "error in the future.");
+      return native_fs;
+   }
    FileSystem::Initialize(fs, native_fs, lp, configfn, envP);
    return fs;
 }
@@ -130,53 +139,22 @@ FileSystem::Initialize(FileSystem      *&fs,
 int
 FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs, XrdOucEnv *envP)
 {
-   XrdOucEnv myEnv;
-   XrdOucStream Config(&m_eroute, getenv("XRDINSTANCE"), &myEnv, "(Throttle Config)> ");
-   int cfgFD;
-   if (m_config_file.length() == 0)
+   XrdThrottle::Configuration Config(log, envP);
+   if (Config.Configure(m_config_file))
    {
-      log.Say("No filename specified.");
+      log.Emsg("Config", "Unable to load configuration file", m_config_file.c_str());
       return 1;
    }
-   if ((cfgFD = open(m_config_file.c_str(), O_RDONLY)) < 0)
-   {
-      log.Emsg("Config", errno, "Unable to open configuration file", m_config_file.c_str());
-      return 1;
-   }
-   Config.Attach(cfgFD);
-   static const char *cvec[] = { "*** throttle (ofs) plugin config:", 0 };
-   Config.Capture(cvec);
 
-   std::string fslib = OFS_NAME;
-
-   char *var, *val;
-   int NoGo = 0;
-   while( (var = Config.GetMyFirstWord()) )
-   {
-      if (strcmp("throttle.fslib", var) == 0)
-      {
-         val = Config.GetWord();
-         if (!val || !val[0]) {log.Emsg("Config", "fslib not specified."); continue;}
-         fslib = val;
-      }
-      TS_Xeq("throttle.max_open_files", xmaxopen);
-      TS_Xeq("throttle.max_active_connections", xmaxconn);
-      TS_Xeq("throttle.throttle", xthrottle);
-      TS_Xeq("throttle.loadshed", xloadshed);
-      TS_Xeq("throttle.max_wait_time", xmaxwait);
-      TS_Xeq("throttle.trace", xtrace);
-      if (NoGo)
-      {
-         log.Emsg("Config", "Throttle configuration failed.");
-      }
-   }
+   m_throttle.FromConfig(Config);
+   m_trace.What = Config.GetTraceLevels();
 
    // Load the filesystem object.
-   m_sfs_ptr = native_fs ? native_fs : LoadFS(fslib, m_eroute, m_config_file);
+   m_sfs_ptr = native_fs ? native_fs : LoadFS(Config.GetFileSystemLibrary(), m_eroute, m_config_file);
    if (!m_sfs_ptr) return 1;
 
    // Overwrite the environment variable saying that throttling is the fslib.
-   XrdOucEnv::Export("XRDOFSLIB", fslib.c_str());
+   XrdOucEnv::Export("XRDOFSLIB", Config.GetFileSystemLibrary().c_str());
 
    if (envP)
    {
@@ -191,269 +169,3 @@ FileSystem::Configure(XrdSysError & log, XrdSfsFileSystem *native_fs, XrdOucEnv 
    FeatureSet = m_sfs_ptr->Features();
    return 0;
 }
-
-/******************************************************************************/
-/*                            x m a x o p e n                                 */
-/******************************************************************************/
-
-/* Function: xmaxopen
-
-   Purpose:  Parse the directive: throttle.max_open_files <limit>
-
-             <limit>   maximum number of open file handles for a unique entity.
-
-  Output: 0 upon success or !0 upon failure.
-*/
-int
-FileSystem::xmaxopen(XrdOucStream &Config)
-{
-    auto val = Config.GetWord();
-    if (!val || val[0] == '\0')
-       {m_eroute.Emsg("Config", "Max open files not specified!  Example usage: throttle.max_open_files 16000");}
-    long long max_open = -1;
-    if (XrdOuca2x::a2sz(m_eroute, "max open files value", val, &max_open, 1)) return 1;
-
-    m_throttle.SetMaxOpen(max_open);
-    return 0;
-}
-
-
-/******************************************************************************/
-/*                            x m a x c o n n                                 */
-/******************************************************************************/
-
-/* Function: xmaxconn
-
-   Purpose:  Parse the directive: throttle.max_active_connections <limit>
-
-             <limit>   maximum number of connections with at least one open file for a given entity
-
-  Output: 0 upon success or !0 upon failure.
-*/
-int
-FileSystem::xmaxconn(XrdOucStream &Config)
-{
-    auto val = Config.GetWord();
-    if (!val || val[0] == '\0')
-       {m_eroute.Emsg("Config", "Max active connections not specified!  Example usage: throttle.max_active_connections 4000");}
-    long long max_conn = -1;
-    if (XrdOuca2x::a2sz(m_eroute, "max active connections value", val, &max_conn, 1)) return 1;
-
-    m_throttle.SetMaxConns(max_conn);
-    return 0;
-}
-
-/******************************************************************************/
-/*                            x m a x w a i t                                 */
-/******************************************************************************/
-
-/* Function: xmaxwait
-
-   Purpose:  Parse the directive: throttle.max_wait_time <limit>
-
-             <limit>   maximum wait time, in seconds, before an operation should fail
-
-   If the directive is not provided, the default is 30 seconds.
-
-  Output: 0 upon success or !0 upon failure.
-*/
-int
-FileSystem::xmaxwait(XrdOucStream &Config)
-{
-    auto val = Config.GetWord();
-    if (!val || val[0] == '\0')
-       {m_eroute.Emsg("Config", "Max waiting time not specified (must be in seconds)!  Example usage: throttle.max_wait_time 20");}
-    long long max_wait = -1;
-    if (XrdOuca2x::a2sz(m_eroute, "max waiting time value", val, &max_wait, 1)) return 1;
-
-    m_throttle.SetMaxWait(max_wait);
-    return 0;
-}
-
-/******************************************************************************/
-/*                            x t h r o t t l e                               */
-/******************************************************************************/
-
-/* Function: xthrottle
-
-   Purpose:  To parse the directive: throttle [data <drate>] [iops <irate>] [concurrency <climit>] [interval <rint>]
-
-             <drate>    maximum bytes per second through the server.
-             <irate>    maximum IOPS per second through the server.
-             <climit>   maximum number of concurrent IO connections.
-             <rint>     minimum interval in milliseconds between throttle re-computing.
-
-   Output: 0 upon success or !0 upon failure.
-*/
-int
-FileSystem::xthrottle(XrdOucStream &Config)
-{
-    long long drate = -1, irate = -1, rint = 1000, climit = -1;
-    char *val;
-
-    while ((val = Config.GetWord()))
-    {
-       if (strcmp("data", val) == 0)
-       {
-          if (!(val = Config.GetWord()))
-             {m_eroute.Emsg("Config", "data throttle limit not specified."); return 1;}
-          if (XrdOuca2x::a2sz(m_eroute,"data throttle value",val,&drate,1)) return 1;
-       }
-       else if (strcmp("iops", val) == 0)
-       {
-          if (!(val = Config.GetWord()))
-             {m_eroute.Emsg("Config", "IOPS throttle limit not specified."); return 1;}
-          if (XrdOuca2x::a2sz(m_eroute,"IOPS throttle value",val,&irate,1)) return 1;
-       }
-       else if (strcmp("rint", val) == 0)
-       {
-          if (!(val = Config.GetWord()))
-             {m_eroute.Emsg("Config", "recompute interval not specified."); return 1;}
-          if (XrdOuca2x::a2sp(m_eroute,"recompute interval value",val,&rint,10)) return 1;
-       }
-       else if (strcmp("concurrency", val) == 0)
-       {
-          if (!(val = Config.GetWord()))
-             {m_eroute.Emsg("Config", "Concurrency limit not specified."); return 1;}
-          if (XrdOuca2x::a2sz(m_eroute,"Concurrency limit value",val,&climit,1)) return 1;
-       }
-       else
-       {
-          m_eroute.Emsg("Config", "Warning - unknown throttle option specified", val, ".");
-       }
-    }
-
-    m_throttle.SetThrottles(drate, irate, climit, static_cast<float>(rint)/1000.0);
-    return 0;
-}
-
-/******************************************************************************/
-/*                            x l o a d s h e d                               */
-/******************************************************************************/
-
-/* Function: xloadshed
-
-   Purpose:  To parse the directive: loadshed host <hostname> [port <port>] [frequency <freq>]
-
-             <hostname> hostname of server to shed load to.  Required
-             <port>     port of server to shed load to.  Defaults to 1094
-             <freq>     A value from 1 to 100 specifying how often to shed load
-                        (1 = 1% chance; 100 = 100% chance; defaults to 10).
-
-   Output: 0 upon success or !0 upon failure.
-*/
-int FileSystem::xloadshed(XrdOucStream &Config)
-{
-    long long port = 0, freq = 0;
-    char *val;
-    std::string hostname;
-
-    while ((val = Config.GetWord()))
-    {
-       if (strcmp("host", val) == 0)
-       {
-          if (!(val = Config.GetWord()))
-             {m_eroute.Emsg("Config", "loadshed hostname not specified."); return 1;}
-          hostname = val;
-       }
-       else if (strcmp("port", val) == 0)
-       {
-          if (!(val = Config.GetWord()))
-             {m_eroute.Emsg("Config", "Port number not specified."); return 1;}
-          if (XrdOuca2x::a2sz(m_eroute,"Port number",val,&port,1, 65536)) return 1;
-       }
-       else if (strcmp("frequency", val) == 0)
-       {
-           if (!(val = Config.GetWord()))
-              {m_eroute.Emsg("Config", "Loadshed frequency not specified."); return 1;}
-           if (XrdOuca2x::a2sz(m_eroute,"Loadshed frequency",val,&freq,1,100)) return 1;
-       }
-       else
-       {
-           m_eroute.Emsg("Config", "Warning - unknown loadshed option specified", val, ".");
-       }
-    }
-
-    if (hostname.empty())
-    {
-        m_eroute.Emsg("Config", "must specify hostname for loadshed parameter.");
-        return 1;
-    }
-
-    m_throttle.SetLoadShed(hostname, port, freq);
-    return 0;
-}
-
-/******************************************************************************/
-/*                                x t r a c e                                 */
-/******************************************************************************/
-
-/* Function: xtrace
-
-   Purpose:  To parse the directive: trace <events>
-
-             <events> the blank separated list of events to trace. Trace
-                      directives are cummalative.
-
-   Output: 0 upon success or 1 upon failure.
-*/
-
-int FileSystem::xtrace(XrdOucStream &Config)
-{
-   char *val;
-   static const struct traceopts {const char *opname; int opval;} tropts[] =
-   {
-      {"all",       TRACE_ALL},
-      {"off",       TRACE_NONE},
-      {"none",      TRACE_NONE},
-      {"debug",     TRACE_DEBUG},
-      {"iops",      TRACE_IOPS},
-      {"bandwidth", TRACE_BANDWIDTH},
-      {"ioload",    TRACE_IOLOAD},
-      {"files",     TRACE_FILES},
-      {"connections",TRACE_CONNS},
-   };
-   int i, neg, trval = 0, numopts = sizeof(tropts)/sizeof(struct traceopts);
-
-   if (!(val = Config.GetWord()))
-   {
-      m_eroute.Emsg("Config", "trace option not specified");
-      return 1;
-   }
-   while (val)
-   {
-      if (!strcmp(val, "off"))
-      {
-         trval = 0;
-      }
-      else
-      {
-         if ((neg = (val[0] == '-' && val[1])))
-         {
-            val++;
-         }
-         for (i = 0; i < numopts; i++)
-         {
-            if (!strcmp(val, tropts[i].opname))
-            {
-               if (neg)
-               {
-                  if (tropts[i].opval) trval &= ~tropts[i].opval;
-                  else trval = TRACE_ALL;
-               }
-               else if (tropts[i].opval) trval |= tropts[i].opval;
-               else trval = TRACE_NONE;
-               break;
-            }
-         }
-         if (i >= numopts)
-         {
-            m_eroute.Say("Config warning: ignoring invalid trace option '", val, "'.");
-         }
-      }
-      val = Config.GetWord();
-   }
-   m_trace.What = trval;
-   return 0;
-}
-

--- a/src/XrdThrottle/XrdThrottleManager.hh
+++ b/src/XrdThrottle/XrdThrottleManager.hh
@@ -46,6 +46,10 @@ class XrdOucTrace;
 class XrdThrottleTimer;
 class XrdXrootdGStream;
 
+namespace XrdThrottle {
+   class Configuration;
+}
+
 class XrdThrottleManager
 {
 
@@ -59,6 +63,8 @@ bool        OpenFile(const std::string &entity, std::string &open_error_message)
 bool        CloseFile(const std::string &entity);
 
 void        Apply(int reqsize, int reqops, int uid);
+
+void        FromConfig(XrdThrottle::Configuration &config);
 
 bool        IsThrottling() {return (m_ops_per_second > 0) || (m_bytes_per_second > 0);}
 


### PR DESCRIPTION
This is an extensive reworking of the throttle plugin containing the following changes:
- Overhaul the concurrency throttle to be "multiuser-aware".  Each user's (as identified from the `XrdSecEntity`) load is tracked separately.  When a new I/O operation can be started, the user's likelihood of being woken up is proportional to how close they are to their fairshare average.
- Users who are under their fairshare are not delayed by the throttle.  This provides a smooth experience to a user even when a server is overloaded by another user.
- The plugin can be loaded as an OSS; this is required to get user information for fairshare calculation (as the user name is extracted by the OFS when authorizing using tokens).  When run in OSS mode, the "loadshed" functionality (redirecting users to a fixed other server when under load) is disabled as redirection can only be done at the OFS layer.  The lack of the "loadshed" is probably OK: it's unclear if it is used anywhere in production.
- "I/O load" is tracked via exponential moving average, with a window of 10s.  The "fairshare" target is the admin-provided concurrency limit divided by the number of active users.
- Prevent potential starvation / long delay due to unfair wakeup ordering.  Oldest operation for a given user is woken up first.
- Operations that have been sleeping for more than a fixed timeout value (30s) return an error instead of performing the I/O.  This aims to avoid performing I/O for a client that left a long time ago.
- Remove use of heavy-duty atomics where possible and replace with relaxed atomics.

This branch has been running in the OSDF for approximately a month, meaning it's delivered about 30PB of data across a few dozen endpoints.  The experience has generally been positive; no crashes observed and a significant decrease in errors from servers under load.  Previously, when a cache was heavily loaded, it would start spewing errors for all clients as the wait time due to the request backlog was observed to be up to 30 minutes!