### PR TITLE
Make HTTP's maximum open delay configurable

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -226,7 +226,8 @@ private:
   static int xtlsreuse(XrdOucStream &Config);
   static int xauth(XrdOucStream &Config);
   static int xtlsclientauth(XrdOucStream &Config);
-  
+  static int xmaxdelay(XrdOucStream &Config);
+
   static bool isRequiredXtractor; // If true treat secxtractor errors as fatal
   static XrdHttpSecXtractor *secxtractor;
   
@@ -426,6 +427,10 @@ protected:
   
   // Url to redirect to in the case a /static is requested
   static char *staticredir;
+
+  // Maximum amount of time an operation on the bridge can be
+  // delayed
+  static int m_maxdelay;
 
   // Hash that keeps preloaded files
   struct StaticPreloadInfo {


### PR DESCRIPTION
By default, the bridge will retry operations internally until the maximum delay is hit and then return an error.  By default, the maximum delay is 3600 seconds; this is well beyond the timeouts of a typical HTTP client.

This makes the delay configurable for HTTP with the following:

```
http.maxdelay <seconds>
```

as in

```
http.maxdelay 10
```

It also tunes down the default delay to 30s.

Note: the response time can still be greater than 30s; this just limits how long the bridge will process "wait" responses for.