### PR TITLE
Avoid reference beyond end of table

### DIFF
--- a/src/XrdOuc/XrdOucTable.hh
+++ b/src/XrdOuc/XrdOucTable.hh
@@ -137,7 +137,9 @@ T  *Remove(int Tnum)
            Table[Tnum].Fnum = avlnum;
            avlnum = Tnum;
            if (Tnum == (curnum-1))
-              while(curnum && Table[curnum].Item == 0) curnum--;
+              {if (curnum == maxnum) curnum--;
+               while(curnum && Table[curnum].Item == 0) curnum--;
+              }
            return temp;
           }
 


### PR DESCRIPTION
Previously, when the last entry in the table was deleted, there was a check of the `N+1` entry.  This could potentially cause a segfault if the end of the table is the end of a page.

A segfault was triggered when running under ASAN with a high concurrency of jobs requesting checksums.

Fixes #2534