### PR TITLE
[XrdHttp] Added header utils class for header parsing

### DIFF
--- a/src/XrdHttp/CMakeLists.txt
+++ b/src/XrdHttp/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(XrdHttpUtils SHARED
                              XrdHttpStatic.hh
                              XrdHttpTrace.hh
   XrdHttpUtils.cc            XrdHttpUtils.hh
+  XrdHttpHeaderUtils.cc      XrdHttpHeaderUtils.hh
 )
 
 set_target_properties(XrdHttpUtils

--- a/src/XrdHttp/XrdHttpHeaderUtils.cc
+++ b/src/XrdHttp/XrdHttpHeaderUtils.cc
@@ -1,0 +1,59 @@
+//------------------------------------------------------------------------------
+// This file is part of XrdHTTP: A pragmatic implementation of the
+// HTTP/WebDAV protocol for the Xrootd framework
+//
+// Copyright (c) 2025 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <ccaffy@cern.ch>
+// File Date: Jun 2025
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+#include "XrdHttpHeaderUtils.hh"
+#include "XrdOuc/XrdOucTUtils.hh"
+#include "XrdOuc/XrdOucUtils.hh"
+
+#include <vector>
+#include <algorithm>
+
+
+void XrdHttpHeaderUtils::parseReprDigest(const std::string &header, std::map<std::string, std::string> &output) {
+  // Expected format per entry: <cksumType>=:<digestValue>:
+  std::vector<std::string> digestNameValuePairs;
+  XrdOucTUtils::splitString(digestNameValuePairs, header, ",");
+
+  for (const auto &digestNameValue : digestNameValuePairs) {
+    std::string_view digestNameValueSV {digestNameValue};
+    auto equalPos = digestNameValueSV.find('=');
+    if (equalPos == std::string::npos || equalPos >= digestNameValueSV.size() - 1)
+      continue;
+
+    std::string_view cksumTypeSV = digestNameValueSV.substr(0, equalPos);
+    XrdOucUtils::trim(cksumTypeSV);
+    if (cksumTypeSV.empty())
+      continue;
+
+    std::string_view cksumValueInSV = digestNameValueSV.substr(equalPos + 1);
+    size_t beginCksumPos = cksumValueInSV.find(':');
+    size_t endCksumPos = cksumValueInSV.rfind(':');
+
+    // Check that the string starts with ':' and contains two distinct colons
+    if (beginCksumPos == 0 && endCksumPos > beginCksumPos + 1 && endCksumPos < cksumValueInSV.size()) {
+      std::string_view cksumValue = cksumValueInSV.substr(beginCksumPos + 1, endCksumPos - beginCksumPos - 1);
+      XrdOucUtils::trim(cksumValue);
+      if (!cksumValue.empty())
+        output[std::string(cksumTypeSV)] = cksumValue;
+    }
+    // Malformed entries are silently ignored
+  }
+}

--- a/src/XrdHttp/XrdHttpHeaderUtils.hh
+++ b/src/XrdHttp/XrdHttpHeaderUtils.hh
@@ -1,0 +1,36 @@
+//------------------------------------------------------------------------------
+// This file is part of XrdHTTP: A pragmatic implementation of the
+// HTTP/WebDAV protocol for the Xrootd framework
+//
+// Copyright (c) 2025 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <ccaffy@cern.ch>
+// File Date: Jun 2025
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#ifndef XROOTD_XRDHTTPHEADERUTILS_HH
+#define XROOTD_XRDHTTPHEADERUTILS_HH
+
+#include <map>
+#include <string>
+
+class XrdHttpHeaderUtils {
+public:
+  static void parseReprDigest(const std::string & header, std::map<std::string,std::string> & output);
+
+};
+
+
+#endif //XROOTD_XRDHTTPHEADERUTILS_HH

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -1449,6 +1449,16 @@ void XrdOucUtils::trim(std::string &str) {
         str.resize (str.size () - 1);
 }
 
+void XrdOucUtils::trim(std::string_view & sv) {
+  const auto toTrim = [](char c) { return !isgraph(c); };
+  size_t start = 0;
+  size_t end = sv.size();
+
+  while (start < end && toTrim(sv[start])) ++start;
+  while (end > start && toTrim(sv[end - 1])) --end;
+
+  sv = sv.substr(start, end - start);
+}
 /**
  * Returns a boolean indicating whether 'c' is a valid token character or not.
  * See https://datatracker.ietf.org/doc/html/rfc6750#section-2.1 for details.

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -137,6 +137,8 @@ static int getModificationTime(const char * path, time_t & modificationTime);
 
 static void trim(std::string & str);
 
+static void trim(std::string_view & sv);
+
     XrdOucUtils() {}
     ~XrdOucUtils() {}
 

--- a/tests/XrdHttpTests/XrdHttpTests.cc
+++ b/tests/XrdHttpTests/XrdHttpTests.cc
@@ -4,6 +4,7 @@
 #include "XrdHttp/XrdHttpProtocol.hh"
 #include "XrdHttp/XrdHttpChecksumHandler.hh"
 #include "XrdHttp/XrdHttpReadRangeHandler.hh"
+#include "XrdHttp/XrdHttpHeaderUtils.hh"
 #include <exception>
 #include <gtest/gtest.h>
 #include <string>
@@ -605,5 +606,26 @@ static inline const std::pair<std::string,std::string> decodedEncodedOpaque [] {
 TEST(XrdHttpTests,encodeOpaqueTest) {
   for(auto [decoded,encoded]: decodedEncodedOpaque) {
     ASSERT_EQ(encoded,encode_opaque(decoded));
+  }
+}
+
+static inline const std::pair<std::string, std::map<std::string,std::string>> reprDigest[] {
+  {"", {}},
+  {"adler=:test:",{{"adler","test"}}},
+  {"adler=:RXJyb3IK=:",{{"adler","RXJyb3IK="}}},
+  {"adler=:test:, sha256=:sha256value:",{{"adler","test"},{"sha256","sha256value"}}},
+  {"adler=",{}},
+  {"adler=,sha256=:sha256value:",{{"sha256","sha256value"}}},
+  {"azerty",{}},
+  {"adler=:abc:def:",{{"adler","abc:def"}}},
+  {"adler=::abc:",{{"adler",":abc"}}},
+  {"=::value:",{}}
+};
+
+TEST(XrdHttpTests, parseReprDigest) {
+  for(const auto & [input, expectedMap]: reprDigest) {
+    std::map<std::string,std::string> output;
+    XrdHttpHeaderUtils::parseReprDigest(input,output);
+    ASSERT_EQ(expectedMap, output);
   }
 }


### PR DESCRIPTION
This makes header parsing located in one place in addition to allow unit testing for header parsing.
As an example, the Repr-Digest header parsing has been implemented.

This is a preparation for future header parsing refactoring and new header parsing addition (https://github.com/xrootd/xrootd/issues/2541). It would be nice to have it in master so that I can refer to this code on my future developments.