### PR TITLE
2541 cors plugin implementation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,6 +109,7 @@ if( NOT XRDCL_ONLY )
 
   add_subdirectory( XrdMacaroons )
   add_subdirectory( XrdVoms )
+  add_subdirectory( XrdHttpCors )
   add_subdirectory( XrdCeph )
   add_subdirectory( XrdSciTokens )
 endif()

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -49,6 +49,7 @@
 #include "XrdHttpChecksumHandler.hh"
 #include "XrdHttpReadRangeHandler.hh"
 #include "XrdNet/XrdNetPMark.hh"
+#include "XrdHttpCors/XrdHttpCors.hh"
 
 #include <openssl/ssl.h>
 
@@ -206,6 +207,7 @@ private:
   static int xsslcert(XrdOucStream &Config);
   static int xsslkey(XrdOucStream &Config);
   static int xsecxtractor(XrdOucStream &Config);
+  static int xcors(XrdOucStream &Config);
   static int xexthandler(XrdOucStream & Config, std::vector<extHInfo> &hiVec);
   static int xsslcadir(XrdOucStream &Config);
   static int xsslcipherfilter(XrdOucStream &Config);
@@ -256,6 +258,7 @@ private:
                             const char *configFN, const char *libParms,
                             XrdOucEnv *myEnv, const char *instName);
 
+  static int LoadCorsHandler(XrdSysError *eDest, const char * libname);
   // Determines whether one of the loaded ExtHandlers are interested in
   // handling a given request.
   //
@@ -376,7 +379,9 @@ protected:
   /// This also can process HTTP/DAV stuff
   XrdHttpReq CurrentReq;
 
+  static std::string xrdcorsLibPath;
 
+  static XrdHttpCors * xrdcors;
   //
   // Processing configuration values
   //

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -57,6 +57,7 @@
 #include "XrdOuc/XrdOucTUtils.hh"
 #include "XrdOuc/XrdOucUtils.hh"
 #include "XrdOuc/XrdOucPrivateUtils.hh"
+#include "XrdHttp/XrdHttpHeaderUtils.hh"
 
 #include "XrdHttpUtils.hh"
 
@@ -206,6 +207,9 @@ int XrdHttpReq::parseLine(char *line, int len) {
     } else if (!strcasecmp(key, "user-agent")) {
       m_user_agent = val;
       trim(m_user_agent);
+    } else if (!strcasecmp(key,"origin")) {
+      m_origin = val;
+      trim(m_origin);
     } else {
       // Some headers need to be translated into "local" cgi info.
       auto it = std::find_if(prot->hdr2cgimap.begin(), prot->hdr2cgimap.end(),[key](const auto & item) {
@@ -2844,6 +2848,7 @@ void XrdHttpReq::reset() {
 
   m_resource_with_digest = "";
   m_user_agent = "";
+  m_origin = "";
 
   headerok = false;
   keepalive = true;

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -357,6 +357,8 @@ public:
 
   int mScitag;
 
+  std::string m_origin;
+
 
 
 

--- a/src/XrdHttpCors/CMakeLists.txt
+++ b/src/XrdHttpCors/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(XrdHttpCors       XrdHttpCors-${PLUGIN_VERSION})
+
+add_library(${XrdHttpCors} MODULE XrdHttpCorsHandler.cc)
+target_link_libraries(${XrdHttpCors} XrdUtils )
+
+install(TARGETS ${XrdHttpCors} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/XrdHttpCors/README.md
+++ b/src/XrdHttpCors/README.md
@@ -1,0 +1,51 @@
+# CORS Plugin
+
+Provides HTTP CORS (Cross Origin Resource Sharing) functionality.
+For now, the plugin only supports Access-Allow-Control-Origin headers.
+
+## Configuration
+
+Enable the CORS plugin via the XRootD server configuration file:
+```
+http.cors libXrdHttpCors.so
+```
+
+## Trusted origins
+
+### Add multiple trusted origins
+
+In the XRootD server configuration file, add trusted origins like the following:
+
+```
+cors.origin https://myhttpserver1.cern.ch
+cors.origin https://myhttpserver2.cern.ch
+```
+
+One can also merge the two lines into a single one:
+
+```
+cors.origin https://myhttpserver1.cern.ch https://myhttpserver2.cern.ch
+```
+
+### Processing expectation
+
+Any HTTP request towards an XRootD HTTP server with CORS configured will receive an 'Access-Allow-Control-Origin: <trusted_origin>' header in all the server replies, provided the `Origin` header matches
+one of the trusted origin.
+
+Example:
+
+```
+> PUT /tmp/file.txt HTTP/1.1
+> Host: xrootd.server.ch:1096
+> User-Agent: curl/7.76.1
+> Accept: */*
+> Origin: https://myhttpserver1.cern.ch
+> Content-Length: 5242880
+> Expect: 100-continue
+> 
+
+< HTTP/1.1 100 Continue
+< Connection: Close
+< Server: XrootD/v5.7.1-22-g82a3fc0e8
+< Access-Control-Allow-Origin: https://myhttpserver1.cern.ch
+```

--- a/src/XrdHttpCors/XrdHttpCors.hh
+++ b/src/XrdHttpCors/XrdHttpCors.hh
@@ -1,0 +1,75 @@
+//------------------------------------------------------------------------------
+// This file is part of the XRootD framework
+//
+// Copyright (c) 2025 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <cedric.caffy@cern.ch>
+// File Date: Jun 2025
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#ifndef __XRD_HTTP_CORS_HEADERS__
+#define __XRD_HTTP_CORS_HEADERS__
+
+#include <map>
+#include <string>
+#include <string_view>
+#include <optional>
+
+
+class XrdOucEnv;
+class XrdOucErrInfo;
+class XrdSysError;
+
+/**
+ * Base class for CORS plugin implementation
+ */
+class XrdHttpCors {
+public:
+  /**
+   * Configure the CORS plugin
+   * @param configFN the server configuration file path
+   * @param errP the pointer to the error object
+   * @return 0 if the configuration is successful, 1 otherwise
+   */
+  virtual int Configure(const char * configFN, XrdSysError *errP) = 0;
+  /**
+   * Add trusted origins to the CORS plugin
+   * @param origin the trusted origin to add
+   */
+  virtual void addAllowedOrigin(const std::string & origin) = 0;
+  /**
+   * Returns the fully formed Access-Control-Allow-Origin header.
+   * If the origin passed in parameter matches one of the previously added origins, it will return
+   * "Access-Control-Allow-Origin: matchedOrigin".
+   * If the origin passed in parameter does not match any of the previously added origins, then std::nullopt will
+   * be returned
+   * @param origin
+   * @return either the fully formed Access-Control-Allow-Origin header or nullopt if the origin does not match any added origin
+   */
+  virtual std::optional<std::string>  getCORSAllowOriginHeader(const std::string & origin) = 0;
+};
+
+typedef XrdHttpCors *(*XrdHttpCorsget_t)(XrdSysError *eDest,
+                                             const char  *confg,
+                                             XrdOucEnv   *envP
+);
+
+// Define arguments to get the Cors handler here
+#define XrdHttpCorsGetHandlerArgs
+
+extern "C" XrdHttpCors* XrdHttpCorsGetHandler(XrdHttpCorsGetHandlerArgs);
+
+#endif
+

--- a/src/XrdHttpCors/XrdHttpCorsHandler.cc
+++ b/src/XrdHttpCors/XrdHttpCorsHandler.cc
@@ -1,0 +1,72 @@
+//------------------------------------------------------------------------------
+// This file is part of the XRootD framework
+//
+// Copyright (c) 2025 by European Organization for Nuclear Research (CERN)
+// Author: Cedric Caffy <cedric.caffy@cern.ch>
+// File Date: Jun 2025
+//------------------------------------------------------------------------------
+// XRootD is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// XRootD is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+//------------------------------------------------------------------------------
+
+#include "XrdHttpCorsHandler.hh"
+#include "XrdOuc/XrdOucGatherConf.hh"
+#include "XrdVersion.hh"
+#include "XrdOuc/XrdOucUtils.hh"
+
+extern "C"
+{
+XrdHttpCors *XrdHttpCorsGetHandler(XrdHttpCorsGetHandlerArgs) {
+  return new XrdHttpCorsHandler();
+}
+}
+
+/**
+ * Configure the CORS handler
+ * @param configFN the configuration file name
+ * @param errP the error pointer allowing to log potential errors
+ * @return 0 if successful, 1 otherwise
+ */
+int XrdHttpCorsHandler::Configure(const char *configFN, XrdSysError *errP) {
+  // Get the cors.origin parameters which can be either space-delimited or a repetition of cors.origin
+  XrdOucGatherConf gconf("cors.origin",errP);
+  if(gconf.Gather(configFN,XrdOucGatherConf::only_body) < 0){
+    return 1;
+  }
+  if(gconf.GetLine()) {
+    while(char * val = gconf.GetToken()) {
+      // No need to check for correctness
+      addAllowedOrigin(val);
+    }
+  }
+  return 0;
+}
+
+std::optional<std::string> XrdHttpCorsHandler::getCORSAllowOriginHeader(const std::string & origin) {
+  auto originItor = m_origins.find(origin);
+  if(originItor != m_origins.end()) {
+    return "Access-Control-Allow-Origin: " + origin;
+  }
+  // We did not find any allowed origin, return nullopt
+  return std::nullopt;
+}
+
+void XrdHttpCorsHandler::addAllowedOrigin(const std::string & origin) {
+  std::string_view origin_sv(origin);
+  XrdOucUtils::trim(origin_sv);
+  if(!origin_sv.empty()) {
+    m_origins.emplace(origin_sv);
+  }
+}
+
+XrdVERSIONINFO(XrdHttpCorsget,XrdHttpCorsHandler);

--- a/src/XrdHttpCors/XrdHttpCorsHandler.hh
+++ b/src/XrdHttpCors/XrdHttpCorsHandler.hh
@@ -1,9 +1,8 @@
 //------------------------------------------------------------------------------
-// This file is part of XrdHTTP: A pragmatic implementation of the
-// HTTP/WebDAV protocol for the Xrootd framework
+// This file is part of the XRootD framework
 //
 // Copyright (c) 2025 by European Organization for Nuclear Research (CERN)
-// Author: Cedric Caffy <ccaffy@cern.ch>
+// Author: Cedric Caffy <cedric.caffy@cern.ch>
 // File Date: Jun 2025
 //------------------------------------------------------------------------------
 // XRootD is free software: you can redistribute it and/or modify
@@ -20,16 +19,24 @@
 // along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
 //------------------------------------------------------------------------------
 
-#ifndef XROOTD_XRDHTTPHEADERUTILS_HH
-#define XROOTD_XRDHTTPHEADERUTILS_HH
+#ifndef __XROOTD_XRDHTTPCORSHANDLER_HH__
+#define __XROOTD_XRDHTTPCORSHANDLER_HH__
 
-#include <map>
-#include <string>
+#include "XrdHttpCors/XrdHttpCors.hh"
+#include <unordered_set>
 
-class XrdHttpHeaderUtils {
+/**
+ * Basic CORS plugin implementation
+ */
+class XrdHttpCorsHandler : public XrdHttpCors {
 public:
-  static void parseReprDigest(const std::string & header, std::map<std::string,std::string> & output);
+  XrdHttpCorsHandler() = default;
+  void addAllowedOrigin(const std::string & origin) override;
+  int Configure(const char * configFN, XrdSysError *errP) override;
+  std::optional<std::string> getCORSAllowOriginHeader(const std::string & origin) override;
+private:
+  std::unordered_set<std::string> m_origins;
 };
 
 
-#endif //XROOTD_XRDHTTPHEADERUTILS_HH
+#endif //__XROOTD_XRDHTTPCORSHANDLER_HH__

--- a/src/XrdVersionPlugin.hh
+++ b/src/XrdVersionPlugin.hh
@@ -183,6 +183,7 @@
          "libXrdCryptossl.so",       \
          "libXrdHttp.so",            \
          "libXrdHttpTPC.so",         \
+         "libXrdHttpCors.so",         \
          "libXrdMacaroons.so",       \
          "libXrdN2No2p.so",          \
          "libXrdOssSIgpfsT.so",      \

--- a/tests/XRootD/http.cfg
+++ b/tests/XRootD/http.cfg
@@ -24,4 +24,7 @@ http.staticheader -verb=GET Foo Bar
 http.staticheader -verb=GET Foo Baz
 http.staticheader Test 1
 
+http.cors libXrdHttpCors.so
+cors.origin https://webserver.bli.bla.blo
+
 continue $src/common.cfg

--- a/tests/XrdHttpTests/CMakeLists.txt
+++ b/tests/XrdHttpTests/CMakeLists.txt
@@ -2,9 +2,10 @@ if(NOT BUILD_HTTP)
     return()
 endif()
 
-add_executable(xrdhttp-unit-tests XrdHttpTests.cc)
+add_executable(xrdhttp-unit-tests XrdHttpTests.cc
+        ${PROJECT_SOURCE_DIR}/src/XrdHttpCors/XrdHttpCorsHandler.cc)
 
-target_link_libraries(xrdhttp-unit-tests XrdHttpUtils GTest::GTest GTest::Main)
+target_link_libraries(xrdhttp-unit-tests XrdHttpUtils GTest::GTest GTest::Main XrdUtils)
 
 gtest_discover_tests(xrdhttp-unit-tests
   PROPERTIES DISCOVERY_TIMEOUT 10)

--- a/tests/XrdHttpTests/XrdHttpTests.cc
+++ b/tests/XrdHttpTests/XrdHttpTests.cc
@@ -5,6 +5,7 @@
 #include "XrdHttp/XrdHttpChecksumHandler.hh"
 #include "XrdHttp/XrdHttpReadRangeHandler.hh"
 #include "XrdHttp/XrdHttpHeaderUtils.hh"
+#include "XrdHttpCors/XrdHttpCorsHandler.hh"
 #include <exception>
 #include <gtest/gtest.h>
 #include <string>
@@ -628,4 +629,25 @@ TEST(XrdHttpTests, parseReprDigest) {
     XrdHttpHeaderUtils::parseReprDigest(input,output);
     ASSERT_EQ(expectedMap, output);
   }
+}
+
+TEST(XrdHttpTests, getCORSAllowOriginHeader) {
+  std::unordered_set<std::string> allowedOrigins = {
+    "https://helloworld.cern.ch",
+    "https://anotherorigins.cern.ch"
+  };
+  XrdHttpCorsHandler corsHandler;
+  for(const auto & allowedOrigin: allowedOrigins) {
+    corsHandler.addAllowedOrigin(allowedOrigin);
+  }
+  ASSERT_EQ(std::nullopt,corsHandler.getCORSAllowOriginHeader("test"));
+  ASSERT_EQ(std::nullopt,corsHandler.getCORSAllowOriginHeader(""));
+  for(const auto & allowedOrigin: allowedOrigins) {
+    std::string expected {"Access-Control-Allow-Origin: " + allowedOrigin};
+    ASSERT_EQ(expected,corsHandler.getCORSAllowOriginHeader(allowedOrigin));
+  }
+  corsHandler.addAllowedOrigin("");
+  corsHandler.addAllowedOrigin(" ");
+  ASSERT_EQ(std::nullopt,corsHandler.getCORSAllowOriginHeader(""));
+  ASSERT_EQ(std::nullopt,corsHandler.getCORSAllowOriginHeader(" "));
 }

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -614,6 +614,7 @@ fi
 %{_libdir}/libXrdFileCache-5.so
 %{_libdir}/libXrdHttp-5.so
 %{_libdir}/libXrdHttpTPC-5.so
+%{_libdir}/libXrdHttpCors-5.so
 %{_libdir}/libXrdMacaroons-5.so
 %{_libdir}/libXrdN2No2p-5.so
 %{_libdir}/libXrdOfsPrepGPI-5.so


### PR DESCRIPTION
This is draft and not properly tested. Despite having unit tests, I plan to add system test as well!

Please have a look so I can get early feedback and correct things once I'm back.

Thanks,
Cheers,
Cedric

This is the config file:
```
  http.cors libXrdCors.so
  cors.origin https://test.cern.ch
# AND ONE CAN PUT EVERYTHING IN ONE LINE IF NEEDED
  cors.origin https://test2.cern.ch https://test.ch
```

This is the effect on a PUT request:

```
> PUT /tmp/fic.txt_dest? HTTP/1.1
> Host: xrootd.cern.ch:1096
> User-Agent: curl/7.76.1
> Accept: */*
> Repr-Digest: adler=:RXJyb3IK=:, sha256=:test:
> Origin: https://test.cern.ch
> Content-Length: 5242880
> Expect: 100-continue
> 

< HTTP/1.1 100 Continue
< Connection: Close
< Server: XrootD/v5.7.1-22-g82a3fc0e8
< Access-Control-Allow-Origin: https://test.cern.ch

```