### PR TITLE
Fix memory leak detected by Address sanitizer

### DIFF
--- a/src/XrdApps/XrdAppsCconfig.cc
+++ b/src/XrdApps/XrdAppsCconfig.cc
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
 //
    Name = XrdOucUtils::InstName(Name);
    sprintf(buff,"%s %s@%s", Xeq, Name, Host);
-   Config = new XrdOucStream(&Say, strdup(buff), &myEnv, "");
+   Config = new XrdOucStream(&Say, buff, &myEnv, "");
    Config->Attach(cfgFD);
 
 // We will capture the resulting config file for later
@@ -225,7 +225,5 @@ int main(int argc, char *argv[])
 //
    if (oFile && !retc) retc = cfOut(oFile, theConfig);
 
-// Should never get here
-//
    exit(retc);
 }


### PR DESCRIPTION
- buff is duplicated into XrdOucStream and never freed

```
130: ==77706==ERROR: LeakSanitizer: detected memory leaks 130:
130: Direct leak of 25 byte(s) in 1 object(s) allocated from:
130:     #0 0xffff866de3e0 in strdup (/lib64/libasan.so.8+0xde3e0) (BuildId: 8a06fba3c3703d6d4fc1517732173e023d50b811)
130:     #1 0x40258c in main /xrootd/src/XrdApps/XrdAppsCconfig.cc:189
130:     #2 0xffff85c560d8 in __libc_start_call_main (/lib64/libc.so.6+0x260d8) (BuildId: 6b190cb37e36bb79643c3b0727477dee387d4cf8)
130:     #3 0xffff85c561b8 in __libc_start_main_alias_1 (/lib64/libc.so.6+0x261b8) (BuildId: 6b190cb37e36bb79643c3b0727477dee387d4cf8)
130:     #4 0x402d6c in _start (/home/xrootd/build/bin/cconfig+0x402d6c) (BuildId: abdf333ad86ac01dbfaab35089b0f2ca46c00ff1)
```