### PR TITLE
Fix memory leak in scitokens test reported by address sanitizer

### DIFF
--- a/tests/scitokens/XrdScitokensCreateJwks.cc
+++ b/tests/scitokens/XrdScitokensCreateJwks.cc
@@ -128,6 +128,7 @@ bool readPubkey(const std::string &fname, std::string &x, std::string &y) {
         return false;
     }
 
+	OPENSSL_free(buf);
     OSSL_PARAM_free(params);
 #else
     std::unique_ptr<EC_KEY, decltype(&EC_KEY_free)> pkey(


### PR DESCRIPTION
OSSL_PARAM_get_octet_string() retrieves an OCTET string from the parameter pointed to by p. The OCTETs are either stored into *val with a length limit of max_len or, in the case when *val is NULL, memory is allocated and max_len is ignored. *used_len is populated with the number of OCTETs stored. If val is NULL then the OCTETS are not stored, but *used_len is still populated. If memory is allocated by this function, it must be freed by the caller.

```
110: ==71089==ERROR: LeakSanitizer: detected memory leaks
110:
110: Direct leak of 65 byte(s) in 1 object(s) allocated from:
110:     #0 0xffff940e3fa0 in malloc (/lib64/libasan.so.8+0xe3fa0) (BuildId: 8a06fba3c3703d6d4fc1517732173e023d50b811)
110:     #1 0xffff93b70cc8 in CRYPTO_malloc (/lib64/libcrypto.so.3+0x170cc8) (BuildId: 33e0997b4260371d5963783548a106ff6f0d6fc2)
110:     #2 0xffff93b734d0 in get_string_internal (/lib64/libcrypto.so.3+0x1734d0) (BuildId: 33e0997b4260371d5963783548a106ff6f0d6fc2)
110:     #3 0xffff93b73544 in OSSL_PARAM_get_octet_string (/lib64/libcrypto.so.3+0x173544) (BuildId: 33e0997b4260371d5963783548a106ff6f0d6fc2)
110:     #4 0x403268 in readPubkey(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) /xrootd/tests/scitokens/XrdScitokensCreateJwks.cc:116
110:     #5 0x401f8c in main /xrootd/tests/scitokens/XrdScitokensCreateJwks.cc:180
110:     #6 0xffff934560d8 in __libc_start_call_main (/lib64/libc.so.6+0x260d8) (BuildId: 6b190cb37e36bb79643c3b0727477dee387d4cf8)
110:     #7 0xffff934561b8 in __libc_start_main_alias_1 (/lib64/libc.so.6+0x261b8) (BuildId: 6b190cb37e36bb79643c3b0727477dee387d4cf8)
110:     #8 0x4022ec in _start (/home/xrootd/build/bin/xrdscitokens-create-jwks+0x4022ec) (BuildId: 59427405cd76ed61fc5a88686a7466e1ec3ecc68)
110:
```