### PR TITLE
Couple of Csi bug fixes

### DIFF
--- a/src/XrdOssCsi/XrdOssCsi.cc
+++ b/src/XrdOssCsi/XrdOssCsi.cc
@@ -39,6 +39,7 @@
 
 #include <string>
 #include <memory>
+#include <functional>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -188,7 +189,9 @@ int XrdOssCsi::Rename(const char *oldname, const char *newname,
 
    // take in consistent order
    XrdSysMutexHelper lck(NULL), lck2(NULL);
-   if (newpmi > pmi)
+   // using the pointer here to get a total order, which is not
+   // guaranteed for operator<() so use std::less
+   if (std::less{}(pmi,newpmi))
    {
      lck.Lock(&newpmi->mtx);
      lck2.Lock(&pmi->mtx);


### PR DESCRIPTION
Hi,

These are two bug fixs for OssCsi: (as two commits),

(1) Use std::less when comparing two pointers (in this situation the total ordering of pointers is used to give a locking order)
(2) When using nofill option do not cause tag files to potentially be sparse as a side effect.

The first does not appear to cause any problem, using operator<() or std::less produced similar code in the builds I tried. But I believe it's not correct according to the standard. (Actually was previusly using operator<() of a std::shared_ptr, which, may be defined. But commit adds comment as well, to point out ordering issue)

The second may have been seen to cause a rare problem in some old development tests (on rh7) I was reviewing. 