### PR TITLE
[XrdHttp] Set the sequential I/O flag for simple HTTP requests

### DIFF
--- a/src/XrdHttp/XrdHttpReadRangeHandler.cc
+++ b/src/XrdHttp/XrdHttpReadRangeHandler.cc
@@ -97,6 +97,14 @@ bool XrdHttpReadRangeHandler::isFullFile()
 }
 
 //------------------------------------------------------------------------------
+//! return the maximum number of ranges that may be requested
+//------------------------------------------------------------------------------
+size_t XrdHttpReadRangeHandler::getMaxRanges() const
+{
+  return rawUserRanges_.empty() ? 1 : rawUserRanges_.size();
+}
+
+//------------------------------------------------------------------------------
 //! indicates a single range (implied whole file, or single range) or empty file
 //------------------------------------------------------------------------------
 bool XrdHttpReadRangeHandler::isSingleRange()

--- a/src/XrdHttp/XrdHttpReadRangeHandler.hh
+++ b/src/XrdHttp/XrdHttpReadRangeHandler.hh
@@ -143,6 +143,17 @@ public:
   const Error&  getError() const;
 
   /**
+   * Return the maximum number of expected ranges for the request.
+   * Used to determine whether a vector range request may be used at open time.
+   * At that time, `isSingleRange()` cannot be invoked because it internally
+   * resolves the correct ranges which requires the file size to be set (which
+   * only occurs after file-open).
+   * The use case is to determine whether we should set the sequential I/O flag
+   * at open time.
+   */
+  size_t getMaxRanges() const;
+
+  /**
    * Indicates no valid Range header was given and thus the implication is that
    * whole file is required. A range or ranges may be given that cover the whole
    * file but that situation is not detected.

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -1137,7 +1137,7 @@ int XrdHttpReq::ProcessHTTPReq() {
           l = resourceplusopaque.length() + 1;
           xrdreq.open.dlen = htonl(l);
           xrdreq.open.mode = 0;
-          xrdreq.open.options = htons(kXR_retstat | kXR_open_read);
+          xrdreq.open.options = htons(kXR_retstat | kXR_open_read | ((readRangeHandler.getMaxRanges() <= 1) ? kXR_seqio : 0));
 
           if (!prot->Bridge->Run((char *) &xrdreq, (char *) resourceplusopaque.c_str(), l)) {
             prot->SendSimpleResp(404, NULL, NULL, (char *) "Could not run request.", 0, false);


### PR DESCRIPTION
From the HTTP headers, we know exactly whether there will be any non-sequential requests (i.e., vector reads).  If there aren't, provide the hint to the filesystem that we will be doing exclusively sequential reads.

In the original issue (https://github.com/xrootd/xrootd/issues/2155), properly setting this flag resulted in a (frankly shocking!) ~2x improvement in throughput for a shared filesystem.  In the original issue, the plumbing was done at the XRootD layer; this simply pushes through to the HTTP protocol.