### PR TITLE
When using a `pkcs11:`-style URL, load via the engine API

### DIFF
--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -2415,7 +2415,7 @@ int XrdConfig::xtls(XrdSysError *eDest, XrdOucStream &Config)
 
     if (!(val = Config.GetWord())) return 0;
 
-    if (*val == '/')
+    if (*val == '/' || !strncmp(val, "pkcs11:", 7))
        {tlsKey = strdup(val);
         if (!(val = Config.GetWord())) return 0;
        }


### PR DESCRIPTION
With this, the following works:

```
xrd.tls /home/foo/.config/certificates/tls.crt \
       pkcs11:token=test-token;object=priv_key;type=public?pin-value=1234
```

Likely isn't the final version of this PR but I wanted to share the concept with other.

With this patch - plus the right OpenSSL configuration - you can make it so the xrootd server does not have the ability to read its own TLS key.  That means it's impossible for xrootd to inadvertently serve it's private key, for example.