### PR TITLE
[XrdOuc] Fix memory leak

### DIFF
--- a/src/XrdOuc/XrdOucGatherConf.cc
+++ b/src/XrdOuc/XrdOucGatherConf.cc
@@ -110,6 +110,8 @@ XrdOucGatherConf::~XrdOucGatherConf()
         }
 
    if (gcP->gBuff)     free(gcP->gBuff);
+
+   delete gcP;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
Constructor unconditionally allocates the `gcP` pointer; destructor must free the space.

Leak detected via dependant plugin built with ASAN.