### PR TITLE
Add StartSimpleResp and SendData to External header API

### DIFF
--- a/src/XrdHttp/XrdHttpExtHandler.cc
+++ b/src/XrdHttp/XrdHttpExtHandler.cc
@@ -27,25 +27,25 @@
 #include "XrdHttpProtocol.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 
-/// Sends a basic response. If the length is < 0 then it is calculated internally
-int XrdHttpExtReq::SendSimpleResp(int code, const char* desc, const char* header_to_add, const char* body, long long int bodylen)
+int XrdHttpExtReq::SendSimpleResp(int code, const char* desc, const char* header_to_add, const char* body, long long bodylen)
 {
   if (!prot) return -1;
 
-  // @FIXME
-  // - need this to circumvent missing API calls and keep ABI compatibility
-  // - when large files are returned we cannot return them in a single buffer
-  // @TODO: for XRootD 5.0 this two hidden calls should just be added to the external handler API and the code here can be removed
-
-  if ( code == 0 ) {
-    return prot->StartSimpleResp(200, desc, header_to_add, bodylen, true);
-  }
-
-  if ( code == 1 ) {
-    return prot->SendData(body, bodylen);
-  }
-
   return prot->SendSimpleResp(code, desc, header_to_add, body, bodylen, true);
+}
+
+int XrdHttpExtReq::StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen, bool keepalive)
+{
+  if (!prot) return -1;
+
+  return prot->StartSimpleResp(200, desc, header_to_add, bodylen, true);
+}
+
+int XrdHttpExtReq::SendData(const char *body, int bodylen)
+{
+  if (!prot) return -1;
+
+  return prot->SendData(body, bodylen);
 }
 
 int XrdHttpExtReq::StartChunkedResp(int code, const char *desc, const char *header_to_add)

--- a/src/XrdHttp/XrdHttpExtHandler.hh
+++ b/src/XrdHttp/XrdHttpExtHandler.hh
@@ -75,6 +75,12 @@ public:
   /// Sends a basic response. If the length is < 0 then it is calculated internally
   int SendSimpleResp(int code, const char *desc, const char *header_to_add, const char *body, long long bodylen);
 
+  // Start response to the client; often followed by data in multiple chunks
+  int StartSimpleResp(int code, const char *desc, const char *header_to_add, long long bodylen, bool keepalive);
+
+  // Send generic data to the client
+  int SendData(const char *body, int bodylen);
+
   /// Starts a chunked response; body of request is sent over multiple parts using the SendChunkResp
   //  API.
   int StartChunkedResp(int code, const char *desc, const char *header_to_add);


### PR DESCRIPTION
For XRootd 6 - Breaks ABI but cleans up the code as previously envisioned for XRootD 5