### PR TITLE
[XrdHttpTpc] Correctly map linux error codes to HTTP error codes

### DIFF
--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -37,6 +37,7 @@
  */
 
 
+#include "XrdHttpUtils.hh"
 
 #include <cstring>
 #include <openssl/hmac.h>
@@ -496,5 +497,161 @@ char *escapeXML(const char *str) {
   return r;
 }
 
+int mapErrNoToHttp(int errNo) {
 
+  switch (errNo) {
 
+    case EACCES:
+    case EROFS:
+      return HTTP_FORBIDDEN;
+
+    case EPERM:
+      return HTTP_UNAUTHORIZED;
+
+    case ENOENT:
+      return HTTP_NOT_FOUND;
+
+    case EEXIST:
+    case ENOTEMPTY:
+      return HTTP_CONFLICT;
+
+    case ENOTDIR:
+    case EISDIR:
+    case EXDEV:
+      return HTTP_UNPROCESSABLE_ENTITY;
+
+    case ENAMETOOLONG:
+      return HTTP_URI_TOO_LONG;
+
+    case ELOOP:
+      return HTTP_LOOP_DETECTED;
+
+    case ENOSPC:
+    case EDQUOT:
+      return HTTP_INSUFFICIENT_STORAGE;
+
+    case EFBIG:
+      return HTTP_PAYLOAD_TOO_LARGE;
+
+    case EINVAL:
+    case EBADF:
+    case EFAULT:
+    case ENXIO:
+    case ESPIPE:
+    case ENODEV:
+    case EOVERFLOW:
+      return HTTP_BAD_REQUEST;
+
+    case ENOTSUP: // EOPNOTSUPP
+      return HTTP_NOT_IMPLEMENTED;
+
+    case EBUSY:
+    case EAGAIN:
+    case EINTR:
+    case ENOMEM:
+    case EMFILE:
+    case ENFILE:
+    case ETXTBSY:
+      return HTTP_SERVICE_UNAVAILABLE;
+
+    case ETIMEDOUT:
+      return HTTP_GATEWAY_TIMEOUT;
+
+    case ECONNREFUSED:
+    case ECONNRESET:
+    case ENETDOWN:
+    case ENETUNREACH:
+    case EHOSTUNREACH:
+    case EPIPE:
+      return HTTP_BAD_GATEWAY;
+
+    default:
+      return HTTP_INTERNAL_SERVER_ERROR;
+  }
+}
+
+std::string httpStatusToString(int status) {
+  switch (status) {
+    // 1xx Informational
+    case 100: return "Continue";
+    case 101: return "Switching Protocols";
+    case 102: return "Processing";
+    case 103: return "Early Hints";
+
+    // 2xx Success
+    case 200: return "OK";
+    case 201: return "Created";
+    case 202: return "Accepted";
+    case 203: return "Non-Authoritative Information";
+    case 204: return "No Content";
+    case 205: return "Reset Content";
+    case 206: return "Partial Content";
+    case 207: return "Multi-Status";
+    case 208: return "Already Reported";
+    case 226: return "IM Used";
+
+    // 3xx Redirection
+    case 300: return "Multiple Choices";
+    case 301: return "Moved Permanently";
+    case 302: return "Found";
+    case 303: return "See Other";
+    case 304: return "Not Modified";
+    case 305: return "Use Proxy";
+    case 307: return "Temporary Redirect";
+    case 308: return "Permanent Redirect";
+
+    // 4xx Client Errors
+    case 400: return "Bad Request";
+    case 401: return "Unauthorized";
+    case 402: return "Payment Required";
+    case 403: return "Forbidden";
+    case 404: return "Not Found";
+    case 405: return "Method Not Allowed";
+    case 406: return "Not Acceptable";
+    case 407: return "Proxy Authentication Required";
+    case 408: return "Request Timeout";
+    case 409: return "Conflict";
+    case 410: return "Gone";
+    case 411: return "Length Required";
+    case 412: return "Precondition Failed";
+    case 413: return "Payload Too Large";
+    case 414: return "URI Too Long";
+    case 415: return "Unsupported Media Type";
+    case 416: return "Range Not Satisfiable";
+    case 417: return "Expectation Failed";
+    case 418: return "I'm a teapot";
+    case 421: return "Misdirected Request";
+    case 422: return "Unprocessable Entity";
+    case 423: return "Locked";
+    case 424: return "Failed Dependency";
+    case 425: return "Too Early";
+    case 426: return "Upgrade Required";
+    case 428: return "Precondition Required";
+    case 429: return "Too Many Requests";
+    case 431: return "Request Header Fields Too Large";
+    case 451: return "Unavailable For Legal Reasons";
+
+    // 5xx Server Errors
+    case 500: return "Internal Server Error";
+    case 501: return "Not Implemented";
+    case 502: return "Bad Gateway";
+    case 503: return "Service Unavailable";
+    case 504: return "Gateway Timeout";
+    case 505: return "HTTP Version Not Supported";
+    case 506: return "Variant Also Negotiates";
+    case 507: return "Insufficient Storage";
+    case 508: return "Loop Detected";
+    case 510: return "Not Extended";
+    case 511: return "Network Authentication Required";
+
+    default:
+      switch (status) {
+        case 100 ... 199: return "Informational";
+        case 200 ... 299: return "Success";
+        case 300 ... 399: return "Redirection";
+        case 400 ... 499: return "Client Error";
+        case 500 ... 599: return "Server Error";
+        default: return "Unknown";
+      }
+  }
+}

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -48,6 +48,78 @@
 #ifndef XRDHTTPUTILS_HH
 #define	XRDHTTPUTILS_HH
 
+enum : int {
+  HTTP_CONTINUE                        = 100,
+  HTTP_SWITCHING_PROTOCOLS             = 101,
+  HTTP_PROCESSING                      = 102,
+  HTTP_EARLY_HINTS                     = 103,
+
+  // 2xx Success
+  HTTP_OK                              = 200,
+  HTTP_CREATED                         = 201,
+  HTTP_ACCEPTED                        = 202,
+  HTTP_NON_AUTHORITATIVE_INFORMATION   = 203,
+  HTTP_NO_CONTENT                      = 204,
+  HTTP_RESET_CONTENT                   = 205,
+  HTTP_PARTIAL_CONTENT                 = 206,
+  HTTP_MULTI_STATUS                    = 207,
+  HTTP_ALREADY_REPORTED                = 208,
+  HTTP_IM_USED                         = 226,
+
+  // 3xx Redirection
+  HTTP_MULTIPLE_CHOICES                = 300,
+  HTTP_MOVED_PERMANENTLY               = 301,
+  HTTP_FOUND                           = 302,
+  HTTP_SEE_OTHER                       = 303,
+  HTTP_NOT_MODIFIED                    = 304,
+  HTTP_USE_PROXY                       = 305,
+  HTTP_TEMPORARY_REDIRECT              = 307,
+  HTTP_PERMANENT_REDIRECT              = 308,
+
+  // 4xx Client Errors
+  HTTP_BAD_REQUEST                     = 400,
+  HTTP_UNAUTHORIZED                    = 401,
+  HTTP_PAYMENT_REQUIRED                = 402,
+  HTTP_FORBIDDEN                       = 403,
+  HTTP_NOT_FOUND                       = 404,
+  HTTP_METHOD_NOT_ALLOWED              = 405,
+  HTTP_NOT_ACCEPTABLE                  = 406,
+  HTTP_PROXY_AUTHENTICATION_REQUIRED   = 407,
+  HTTP_REQUEST_TIMEOUT                 = 408,
+  HTTP_CONFLICT                        = 409,
+  HTTP_GONE                            = 410,
+  HTTP_LENGTH_REQUIRED                 = 411,
+  HTTP_PRECONDITION_FAILED             = 412,
+  HTTP_PAYLOAD_TOO_LARGE               = 413,
+  HTTP_URI_TOO_LONG                    = 414,
+  HTTP_UNSUPPORTED_MEDIA_TYPE          = 415,
+  HTTP_RANGE_NOT_SATISFIABLE           = 416,
+  HTTP_EXPECTATION_FAILED              = 417,
+  HTTP_IM_A_TEAPOT                     = 418, // RFC 2324
+  HTTP_MISDIRECTED_REQUEST             = 421,
+  HTTP_UNPROCESSABLE_ENTITY            = 422,
+  HTTP_LOCKED                          = 423,
+  HTTP_FAILED_DEPENDENCY               = 424,
+  HTTP_TOO_EARLY                       = 425,
+  HTTP_UPGRADE_REQUIRED                = 426,
+  HTTP_PRECONDITION_REQUIRED           = 428,
+  HTTP_TOO_MANY_REQUESTS               = 429,
+  HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE = 431,
+  HTTP_UNAVAILABLE_FOR_LEGAL_REASONS   = 451,
+
+  // 5xx Server Errors
+  HTTP_INTERNAL_SERVER_ERROR           = 500,
+  HTTP_NOT_IMPLEMENTED                 = 501,
+  HTTP_BAD_GATEWAY                     = 502,
+  HTTP_SERVICE_UNAVAILABLE             = 503,
+  HTTP_GATEWAY_TIMEOUT                 = 504,
+  HTTP_HTTP_VERSION_NOT_SUPPORTED      = 505,
+  HTTP_VARIANT_ALSO_NEGOTIATES         = 506,
+  HTTP_INSUFFICIENT_STORAGE            = 507,
+  HTTP_LOOP_DETECTED                   = 508,
+  HTTP_NOT_EXTENDED                    = 510,
+  HTTP_NETWORK_AUTHENTICATION_REQUIRED = 511,
+};
 
 // GetHost from URL
 // Parse an URL and extract the host name and port
@@ -170,9 +242,12 @@ inline std::string encode_opaque(const std::string & opaque) {
 // Escape a string and return a new one
 char *escapeXML(const char *str);
 
+int mapErrNoToHttp(int err);
+
+std::string httpStatusToString(int status);
+
 typedef std::vector<XrdOucIOVec2> XrdHttpIOList;
 
 
- 
-#endif	/* XRDHTTPUTILS_HH */
 
+#endif	/* XRDHTTPUTILS_HH */

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -11,6 +11,7 @@
 #include "XrdXrootd/XrdXrootdTpcMon.hh"
 #include "XrdOuc/XrdOucTUtils.hh"
 #include "XrdHttpTpc/XrdHttpTpcUtils.hh"
+#include "XrdHttp/XrdHttpUtils.hh"
 
 #include <curl/curl.h>
 
@@ -22,7 +23,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <thread>
-#include <iostream> // Delete later!!!
 
 #include "XrdHttpTpcState.hh"
 #include "XrdHttpTpcStream.hh"
@@ -837,9 +837,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
         const char *msg = fh->error.getErrText(code);
         if (msg == NULL) ss << "Failed to open local resource";
         else ss << msg;
-        rec.status = 400;
-        if (code == EACCES) rec.status = 401;
-        else if (code == EEXIST) rec.status = 412;
+        rec.status = mapErrNoToHttp(code);
         logTransferEvent(LogMask::Error, rec, "OPEN_FAIL", msg);
         int resp_result = req.SendSimpleResp(rec.status, NULL, NULL, generateClientErr(ss, rec).c_str(), 0);
         fh->close();
@@ -991,9 +989,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         const char *msg = fh->error.getErrText(code);
         if ((msg == NULL) || (*msg == '\0')) ss << "Failed to open local resource";
         else ss << msg;
-        rec.status = 400;
-        if (code == EACCES) rec.status = 401;
-        else if (code == EEXIST) rec.status = 412;
+        rec.status = mapErrNoToHttp(code);
         logTransferEvent(LogMask::Error, rec, "OPEN_FAIL", ss.str());
         int resp_result = req.SendSimpleResp(rec.status, NULL, NULL,
                                              generateClientErr(ss, rec).c_str(), 0);


### PR DESCRIPTION
Fix #2591 

We had two oppurtunities to map linux error codes to their HTTP counterparts

This PR provides an enum of= list of HTTP error codes defined in the RFC. The use if "Named" enum error is preferred for readability over numbers for e.g. `HTTP_INSUFFICIENT_STORAGE` over `http_507`.

This PR also makes and attempt to map error codes defined in asm-generic/errno-base.h to their HTTP counterparts.

Looking forward we also need a mapping between XrdError and HTTP status codes - this is being done as part of the WebDAV error improvement project. 

