### PR TITLE
[Pfc] Implement URL CGI parameters for setting block-size and max number of blocks for prefetching on per file basis

### DIFF
--- a/src/XrdPfc/XrdPfc.cc
+++ b/src/XrdPfc/XrdPfc.cc
@@ -107,7 +107,7 @@ XrdOucCache *XrdOucGetCache(XrdSysLogger *logger,
          XrdSysThread::Run(&tid, ProcessWriteTaskThread, 0, 0, "XrdPfc WriteTasks ");
       }
 
-      if (instance.RefConfiguration().m_prefetch_max_blocks > 0)
+      if (instance.is_prefetch_enabled())
       {
          XrdSysThread::Run(&tid, PrefetchThread, 0, 0, "XrdPfc Prefetch ");
       }
@@ -444,7 +444,7 @@ File* Cache::GetFile(const std::string& path, IO* io, long long off, long long f
 
    if (filesize >= 0)
    {
-      file = File::FileOpen(path, off, filesize);
+      file = File::FileOpen(path, off, filesize, io->GetInput());
    }
 
    {

--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -105,12 +105,19 @@ struct Configuration
    int       m_dirStatsMaxDepth;        //!< maximum depth for statistics write out
    int       m_dirStatsStoreDepth;      //!< depth to which statistics should be collected
 
-   long long m_bufferSize;              //!< prefetch buffer size, default 1MB
+   long long m_bufferSize;              //!< cache block size, default 128 kB
    long long m_RamAbsAvailable;         //!< available from configuration
    int       m_RamKeepStdBlocks;        //!< number of standard-sized blocks kept after release
    int       m_wqueue_blocks;           //!< maximum number of blocks written per write-queue loop
    int       m_wqueue_threads;          //!< number of threads writing blocks to disk
-   int       m_prefetch_max_blocks;     //!< maximum number of blocks to prefetch per file
+   int       m_prefetch_max_blocks;     //!< default maximum number of blocks to prefetch per file
+
+   long long m_cgi_min_bufferSize = 0;          //!< min buffer size allowed in pfc.blocksize
+   long long m_cgi_max_bufferSize = 0;          //!< max buffer size allowed in pfc.blocksize
+   int       m_cgi_min_prefetch_max_blocks = 0; //!< min prefetch block count allowed in pfc.prefetch
+   int       m_cgi_max_prefetch_max_blocks = 0; //!< max prefetch block count allowed in pfc.prefetch
+   bool      m_cgi_blocksize_allowed = false;   //!< allow cgi setting of blocksize
+   bool      m_cgi_prefetch_allowed  = false;   //!< allow cgi setting of prefetch
 
    long long m_hdfsbsize;               //!< used with m_hdfsmode, default 128MB
    long long m_flushCnt;                //!< nuber of unsynced blcoks on disk before flush is called
@@ -121,6 +128,11 @@ struct Configuration
 
    long long m_onlyIfCachedMinSize;     //!< minumum size of downloaded file, used by only-if-cached CGI option
    double    m_onlyIfCachedMinFrac;     //!< minimum fraction of downloaded file, used by only-if-cached CGI option
+
+   static constexpr long long s_min_bufferSize = 4 * 1024;
+   static constexpr long long s_max_bufferSize = 512 * 1024 * 1024;
+
+   static constexpr int s_max_prefetch_max_blocks = 4096;
 };
 
 //------------------------------------------------------------------------------
@@ -279,8 +291,8 @@ public:
 
    void FileSyncDone(File*, bool high_debug);
 
-   XrdSysError* GetLog()   { return &m_log;  }
-   XrdSysTrace* GetTrace() { return m_trace; }
+   XrdSysError* GetLog()   const { return &m_log;  }
+   XrdSysTrace* GetTrace() const { return m_trace; }
 
    ResourceMonitor& RefResMon() { return *m_res_mon; }
    XrdXrootdGStream* GetGStream() { return m_gstream; }
@@ -288,6 +300,11 @@ public:
    void ExecuteCommandUrl(const std::string& command_url);
 
    static XrdScheduler *schedP;
+
+   bool blocksize_str2value(const char *from, const char *str, long long &val, long long min, long long max) const;
+   bool prefetch_str2value(const char *from, const char *str, int &val, int min, int max) const;
+
+   bool is_prefetch_enabled() const { return m_prefetch_enabled; }
 
 private:
    bool ConfigParameters(std::string, XrdOucStream&, TmpConfiguration &tmpc);
@@ -298,12 +315,12 @@ private:
    bool xtrace(XrdOucStream &);
    bool test_oss_basics_and_features();
 
-   bool cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name);
+   bool cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name) const;
 
    static Cache     *m_instance;        //!< this object
 
    XrdOucEnv        *m_env;             //!< environment passed in at creation
-   XrdSysError       m_log;             //!< XrdPfc namespace logger
+   mutable XrdSysError m_log;           //!< XrdPfc namespace logger
    XrdSysTrace      *m_trace;
    const char       *m_traceID;
 

--- a/src/XrdPfc/XrdPfcConfiguration.cc
+++ b/src/XrdPfc/XrdPfcConfiguration.cc
@@ -64,7 +64,7 @@ Configuration::Configuration() :
 {}
 
 
-bool Cache::cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name)
+bool Cache::cfg2bytes(const std::string &str, long long &store, long long totalSpace, const char *name) const
 {
    char errStr[1024];
    snprintf(errStr, 1024, "ConfigParameters() Error parsing parameter %s", name);
@@ -97,6 +97,30 @@ bool Cache::cfg2bytes(const std::string &str, long long &store, long long totalS
      m_log.Emsg(errStr, "");
      return false;
    }
+
+   return true;
+}
+
+bool Cache::blocksize_str2value(const char *from, const char *str,
+                                long long &val, long long min, long long max) const
+{
+   if (XrdOuca2x::a2sz(m_log, "Error parsing block-size", str, &val, min, max))
+      return false;
+
+   if (val & 0xFFF) {
+      val &= ~0x0FFF;
+      val +=  0x1000;
+      m_log.Emsg(from, "blocksize must be a multiple of 4 kB. Rounded up.");
+   }
+
+   return true;
+}
+
+bool Cache::prefetch_str2value(const char *from, const char *str,
+                               int &val, int min, int max) const
+{
+   if (XrdOuca2x::a2i(m_log, "Error parsing prefetch block count", str, &val, min, max))
+      return false;
 
    return true;
 }
@@ -441,6 +465,8 @@ bool Cache::Config(const char *config_filename, const char *parameters)
 
    TmpConfiguration tmpc;
 
+   Configuration &CFG = m_configuration;
+
    // Adjust default parameters for client/serverless caching
    if (m_isClient)
    {
@@ -625,7 +651,6 @@ bool Cache::Config(const char *config_filename, const char *parameters)
 
    if (aOK)
    {
-      int  loff = 0;
 //                         000    001            010
       const char *csc[] = {"off", "cache nonet", "nocache net notls",
 //                         011
@@ -634,16 +659,28 @@ bool Cache::Config(const char *config_filename, const char *parameters)
                            "off", "cache nonet", "nocache net tls",
 //                         111
                            "cache net tls"};
-      char buff[8192], uvk[32];
+      char uvk[32];
       if (m_configuration.m_cs_UVKeep < 0)
          strcpy(uvk, "lru");
       else
          sprintf(uvk, "%lld", (long long) m_configuration.m_cs_UVKeep);
-      float rg = (m_configuration.m_RamAbsAvailable) / float(1024*1024*1024);
+      float ram_gb = (m_configuration.m_RamAbsAvailable) / float(1024*1024*1024);
+
+      char urlcgi_blks[64] = "ignore", urlcgi_npref[32] = "ignore";
+      if (CFG.m_cgi_blocksize_allowed)
+         snprintf(urlcgi_blks, sizeof(urlcgi_blks), "%lldk %lldk",
+                  CFG.m_cgi_min_bufferSize >> 10, CFG.m_cgi_max_bufferSize >> 10);
+      if (CFG.m_cgi_prefetch_allowed)
+         snprintf(urlcgi_npref, sizeof(urlcgi_npref), "%d %d",
+                  CFG.m_cgi_min_prefetch_max_blocks, CFG.m_cgi_max_prefetch_max_blocks);
+
+      char buff[8192];
+      int  loff = 0;
       loff = snprintf(buff, sizeof(buff), "Config effective %s pfc configuration:\n"
                       "       pfc.cschk %s uvkeep %s\n"
-                      "       pfc.blocksize %lld\n"
+                      "       pfc.blocksize %lldk\n"
                       "       pfc.prefetch %d\n"
+                      "       pfc.urlcgi blocksize %s prefetch %s\n"
                       "       pfc.ram %.fg\n"
                       "       pfc.writequeue %d %d\n"
                       "       # Total available disk: %lld\n"
@@ -656,9 +693,10 @@ bool Cache::Config(const char *config_filename, const char *parameters)
                       "       pfc.onlyIfCachedMinFrac %.2f\n",
                       config_filename,
                       csc[int(m_configuration.m_cs_Chk)], uvk,
-                      m_configuration.m_bufferSize,
+                      m_configuration.m_bufferSize >> 10,
                       m_configuration.m_prefetch_max_blocks,
-                      rg,
+                      urlcgi_blks, urlcgi_npref,
+                      ram_gb,
                       m_configuration.m_wqueue_blocks, m_configuration.m_wqueue_threads,
                       sP.Total,
                       m_configuration.m_diskUsageLWM, m_configuration.m_diskUsageHWM,
@@ -708,8 +746,8 @@ bool Cache::Config(const char *config_filename, const char *parameters)
    }
 
    // Derived settings
-   m_prefetch_enabled   = m_configuration.m_prefetch_max_blocks > 0;
-   Info::s_maxNumAccess = m_configuration.m_accHistorySize;
+   m_prefetch_enabled   = CFG.m_prefetch_max_blocks > 0 || CFG.m_cgi_max_prefetch_max_blocks > 0;
+   Info::s_maxNumAccess = CFG.m_accHistorySize;
 
    m_gstream = (XrdXrootdGStream*) m_env->GetPtr("pfc.gStream*");
 
@@ -761,7 +799,8 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
 
    ConfWordGetter cwg(config);
 
-   XrdSysError err(0, "");
+   Configuration &CFG = m_configuration;
+
    if ( part == "user" )
    {
       m_configuration.m_username = cwg.GetWord();
@@ -928,18 +967,9 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
    }
    else if ( part == "blocksize" )
    {
-      long long minBSize =   4 * 1024;
-      long long maxBSize = 512 * 1024 * 1024;
-      if (XrdOuca2x::a2sz(m_log, "Error reading block-size", cwg.GetWord(), &m_configuration.m_bufferSize, minBSize, maxBSize))
-      {
+      if ( ! blocksize_str2value("Config", cwg.GetWord(), CFG.m_bufferSize,
+                                 CFG.s_min_bufferSize, CFG.s_max_bufferSize))
          return false;
-      }
-      if (m_configuration.m_bufferSize & 0xFFF)
-      {
-         m_configuration.m_bufferSize &= ~0x0FFF;
-         m_configuration.m_bufferSize +=  0x1000;
-         m_log.Emsg("Config", "pfc.blocksize must be a multiple of 4 kB. Rounded up.");
-      }
    }
    else if ( part == "prefetch" || part == "nramprefetch" )
    {
@@ -948,11 +978,66 @@ bool Cache::ConfigParameters(std::string part, XrdOucStream& config, TmpConfigur
          m_log.Emsg("Config", "pfc.nramprefetch is deprecated, please use pfc.prefetch instead. Replacing the directive internally.");
       }
 
-      if (XrdOuca2x::a2i(m_log, "Error setting prefetch block count", cwg.GetWord(), &m_configuration.m_prefetch_max_blocks, 0, 128))
-      {
+      if ( ! prefetch_str2value("Config", cwg.GetWord(), CFG.m_prefetch_max_blocks,
+                                0, CFG.s_max_prefetch_max_blocks))
          return false;
-      }
-
+   }
+   else if ( part == "urlcgi" )
+   {
+      //  pfc.urlcgi [blocksize {ignore | min max}] [prefetch {ignore | min max}]
+      const char *p = 0;
+      while ((p = cwg.GetWord()) && cwg.HasLast())
+      {
+         if (strcmp(p, "blocksize") == 0)
+         {
+            std::string bmin = cwg.GetWord();
+            if (bmin == "ignore")
+               continue;
+            std::string bmax = cwg.GetWord();
+            if ( ! cwg.HasLast()) {
+               m_log.Emsg("Config", "Error: pfc.urlcgi blocksize parameter requires two arguments.");
+               return false;
+            }
+            if ( ! blocksize_str2value("Config::urlcgi", bmin.c_str(), CFG.m_cgi_min_bufferSize,
+                                       CFG.s_min_bufferSize, CFG.s_max_bufferSize))
+               return false;
+            if ( ! blocksize_str2value("Config::urlcgi", bmax.c_str(), CFG.m_cgi_max_bufferSize,
+                                       CFG.s_min_bufferSize, CFG.s_max_bufferSize))
+               return false;
+            if (CFG.m_cgi_min_bufferSize > CFG.m_cgi_max_bufferSize) {
+               m_log.Emsg("Config", "Error: pfc.urlcgi blocksize second argument must be larger or equal to the first one.");
+               return false;
+            }
+            CFG.m_cgi_blocksize_allowed = true;
+         }
+         else if (strcmp(p, "prefetch") == 0)
+         {
+            std::string bmin = cwg.GetWord();
+            if (bmin == "ignore")
+               continue;
+            std::string bmax = cwg.GetWord();
+            if ( ! cwg.HasLast()) {
+               m_log.Emsg("Config", "Error: pfc.urlcgi blocksize parameter requires two arguments.");
+               return false;
+            }
+            if ( ! prefetch_str2value("Config::urlcgi", bmin.c_str(), CFG.m_cgi_min_prefetch_max_blocks,
+                                       0, CFG.s_max_prefetch_max_blocks))
+               return false;
+            if ( ! prefetch_str2value("Config::urlcgi", bmax.c_str(), CFG.m_cgi_max_prefetch_max_blocks,
+                                      0, CFG.s_max_prefetch_max_blocks))
+               return false;
+            if (CFG.m_cgi_min_prefetch_max_blocks > CFG.m_cgi_max_prefetch_max_blocks) {
+               m_log.Emsg("Config", "Error: pfc.urlcgi prefetch second argument must be larger or equal to the first one.");
+               return false;
+            }
+            CFG.m_cgi_prefetch_allowed = true;
+         }
+         else
+         {
+            m_log.Emsg("Config", "Error: urlcgi stanza contains unknown directive '", p, "'");
+            return false;
+         }
+      } // while get next pfc.urlcgi word
    }
    else if ( part == "nramread" )
    {

--- a/src/XrdPfc/XrdPfcFile.hh
+++ b/src/XrdPfc/XrdPfcFile.hh
@@ -208,7 +208,7 @@ public:
    // Constructor, destructor, Open() and Close() are private.
 
    //! Static constructor that also does Open. Returns null ptr if Open fails.
-   static File* FileOpen(const std::string &path, long long offset, long long fileSize);
+   static File* FileOpen(const std::string &path, long long offset, long long fileSize, XrdOucCacheIO* inputIO);
 
    //! Handle removal of a block from Cache's write queue.
    void BlockRemovedFromWriteQ(Block*);
@@ -261,8 +261,8 @@ public:
 
    const std::string& GetLocalPath() const { return m_filename; }
 
-   XrdSysError* GetLog();
-   XrdSysTrace* GetTrace();
+   XrdSysError* GetLog() const;
+   XrdSysTrace* GetTrace() const;
 
    long long GetFileSize() const { return m_file_size; }
 
@@ -301,7 +301,8 @@ private:
    void Close();
 
    //! Open file handle for data file and info file on local disk.
-   bool Open();
+   bool Open(XrdOucCacheIO* inputIO);
+   void parse_pfc_url_args(XrdOucCacheIO* inputIO, long long &pfc_blocksize, int &pfc_prefetch) const;
 
    static const char *m_traceID;
 
@@ -364,6 +365,7 @@ private:
    enum PrefetchState_e { kOff=-1, kOn, kHold, kStopped, kComplete };
 
    PrefetchState_e m_prefetch_state;
+   int             m_prefetch_max_blocks_in_flight;
 
    long long m_prefetch_bytes;
    int   m_prefetch_read_cnt;

--- a/src/XrdPfc/XrdPfcResourceMonitor.cc
+++ b/src/XrdPfc/XrdPfcResourceMonitor.cc
@@ -378,7 +378,7 @@ void ResourceMonitor::heart_beat()
       if (next_event > start)
       {
          unsigned int t_sleep = next_event - start;
-         TRACE(Debug, tpfx << "sleeping for " << t_sleep << " seconds until the next beat.");
+         TRACE(Dump, tpfx << "sleeping for " << t_sleep << " seconds until the next beat.");
          sleep(t_sleep);
       }
 
@@ -398,7 +398,7 @@ void ResourceMonitor::heart_beat()
       // Always process the queues.
       int n_processed = process_queues();
       next_queue_proc_time = queue_swap_time + s_queue_proc_interval;
-      TRACE(Debug, tpfx << "process_queues -- n_records=" << n_processed);
+      TRACE(Dump, tpfx << "process_queues -- n_records=" << n_processed);
 
       // Always update basic info on m_fs_state (space, usage, file_usage).
       update_vs_and_file_usage_info();


### PR DESCRIPTION
In the context of WLCG Analysis Facilities it became clear that people want to experiment with different settings for block-size and prefetching. This PR adds the ability to configure ranges of acceptable values for those two parameters and then pass them to the cache via opaque url cgi parameters `pfc.blocksize` and `pfc.prefetch`.

### Configuration
```
pfc.urlcgi [blocksize {ignore | min max}] [prefetch {ignore | min max}]
```
E.g.:
```
pfc.urlcgi blocksize 4k 512k prefetch 0 100
```

### Example usage:
```
xrdcp -f 'root://xcache.site.org//store/user/matevz/xrdmon-far/xmfar-2019-01.root?pfc.blocksize=32k&pfc.prefetch=60' /dev/null
```