### PR TITLE
[Pfc] Cleanup processing and storage of pfc.dirstats configuration parameters

### DIFF
--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -67,7 +67,7 @@ struct Configuration
    bool are_file_usage_limits_set()    const { return m_fileUsageMax > 0; }
    bool is_age_based_purge_in_effect() const { return m_purgeColdFilesAge > 0 ; }
    bool is_uvkeep_purge_in_effect()    const { return m_cs_UVKeep >= 0; }
-   bool is_dir_stat_reporting_on()     const { return m_dirStatsMaxDepth >= 0 || ! m_dirStatsDirs.empty() || ! m_dirStatsDirGlobs.empty(); }
+   bool is_dir_stat_reporting_on()     const { return m_dirStatsStoreDepth >= 0 || ! m_dirStatsDirs.empty() || ! m_dirStatsDirGlobs.empty(); }
    bool is_purge_plugin_set_up()       const { return false; }
 
    CkSumCheck_e get_cs_Chk() const { return (CkSumCheck_e) m_cs_Chk; }
@@ -102,8 +102,7 @@ struct Configuration
    std::set<std::string> m_dirStatsDirs;     //!< directories for which stat reporting was requested
    std::set<std::string> m_dirStatsDirGlobs; //!< directory globs for which stat reporting was requested
    int       m_dirStatsInterval;        //!< time between resource monitor statistics dump in seconds
-   int       m_dirStatsMaxDepth;        //!< maximum depth for statistics write out
-   int       m_dirStatsStoreDepth;      //!< depth to which statistics should be collected
+   int       m_dirStatsStoreDepth;      //!< maximum depth for statistics write out
 
    long long m_bufferSize;              //!< cache block size, default 128 kB
    long long m_RamAbsAvailable;         //!< available from configuration


### PR DESCRIPTION
There was some confusion in usage of an obsolete configuration parameter `m_dirStatsMaxDepth` vs. `m_dirStatsStoreDepth`. This PR removes the obsolete parameter and improves the config file parsing by automatically rounding down the `pfc.dirstats interval` value to the nearest acceptable one.

The following is updated documentation that will go into the 5.9 docs.

### pfc.dirstats

Resource Monitor provides detailed and accurate snapshots of state and usage of existing directories. It allows optimization of per-directory statistics information collection and storage, and reduces the number of required cache namespace traversals. It can periodically export the state into a JSON file (/pfc-stats/DirStats.json) for viewing the current state and for further processing or aggregation. Similar information, collected in parallel, also serves as input to the purge process.
```
pfc.dirstats [maxdepth <report-depth>] [interval {60|120|300|600|900|1200|1800|3600}]
```
* `maxdepth`: report directory depth, 0 -- 16. 0 means report for root dir only.
* `interval`: reporting interval. It is automatically rounded down to the closest allowed value (and noted in the log). The reason for this restriction is to make it easier to coalesce reports over larger time periods. One can use the 'm' notation to specify minutes instead of seconds, e.g., 5m.

Example:
```
pfc.dirstats maxdepth 8 interval 5m
```
Defaults:
```
pfc.dirstats maxdepth 1 interval 900
```