### PR TITLE
[Pfc] Return error code for set cache evict if the file does not exist.

### DIFF
--- a/src/XrdPfc/XrdPfcFSctl.cc
+++ b/src/XrdPfc/XrdPfcFSctl.cc
@@ -113,8 +113,11 @@ int XrdPfcFSctl::FSctl(const int               cmd,
        ec = myCache.UnlinkFile(path, *xeq != 'f');
        switch(ec)
              {case       0: if (hProc) hProc->Hide(path.c_str());
-                            [[fallthrough]];
-              case -ENOENT: rc = SFS_OK;
+                            rc = SFS_OK;
+                            break;
+              case -ENOENT: ec = ENOENT;
+                            rc = SFS_ERROR;
+                            msg = "file does not exist";
                             break;
               case  -EBUSY: ec = ENOTTY;
                             rc = SFS_ERROR;


### PR DESCRIPTION
_set cache evict_ returned success code when the file does not exist in the cache. This returns the proper error code and message.