### PR TITLE
Use checked out HEAD reference for PRs

### DIFF
--- a/.github/workflows/ABI.yml
+++ b/.github/workflows/ABI.yml
@@ -47,6 +47,12 @@ jobs:
     - name: Install XRootD build dependencies
       run: mk-build-deps --install --remove -s sudo debian/control <<< yes
 
+    - name: Configure XRootD (Head Reference)
+      run: cmake -S . -B build/new -DCMAKE_INSTALL_PREFIX=install/new
+
+    - name: Build and Install XRootD (Head Reference)
+      run: cmake --build build/new --parallel --target install
+
     - name: Checkout Base Reference of XRootD to Compare ABI
       run: git checkout -f ${GITHUB_BASE_REF:-$(git rev-list --tags --max-count=1)}
 
@@ -55,15 +61,6 @@ jobs:
 
     - name: Build and Install XRootD (Base Reference)
       run: cmake --build build/old --parallel --target install
-
-    - name: Checkout Head Reference of XRootD to Compare ABI
-      run: git checkout -f ${GITHUB_HEAD_REF:-${GITHUB_SHA}}
-
-    - name: Configure XRootD (Head Reference)
-      run: cmake -S . -B build/new -DCMAKE_INSTALL_PREFIX=install/new
-
-    - name: Build and Install XRootD (Head Reference)
-      run: cmake --build build/new --parallel --target install
 
     - name: Check ABI Compatibility between Base and Head References
       run: |


### PR DESCRIPTION
As can be seen in the below job for a Test PR - the CI loses track of the `HEAD` related to the PR for the ABI job.
https://github.com/xrootd/xrootd/actions/runs/18978259360/job/54203708690

<img width="824" height="370" alt="Screenshot From 2025-10-31 17-31-40" src="https://github.com/user-attachments/assets/04179af3-3793-4998-af8f-56fb763e9d36" />


This PR reorders the build order for new (PR) and old (latest tagged commit) before ABI reports are compared.
