### PR TITLE
Revert "[Cl] Avoid poller callbacks blocking each other". To fix #2629

### DIFF
--- a/src/XrdCl/XrdClChannel.cc
+++ b/src/XrdCl/XrdClChannel.cc
@@ -87,7 +87,7 @@ namespace XrdCl
                     TaskManager      *taskManager,
                     JobManager       *jobManager,
                     const URL        &prefurl ):
-    pUrl( std::make_shared<URL>( url.GetHostId() ) ),
+    pUrl( url.GetHostId() ),
     pPoller( poller ),
     pTransport( transport ),
     pTaskManager( taskManager ),
@@ -104,13 +104,13 @@ namespace XrdCl
     log->Debug( PostMasterMsg, "Creating new channel to: %s",
                                 url.GetChannelId().c_str() );
 
-    pUrl->SetParams( url.GetParams() );
-    pUrl->SetProtocol( url.GetProtocol() );
+    pUrl.SetParams( url.GetParams() );
+    pUrl.SetProtocol( url.GetProtocol() );
 
     //--------------------------------------------------------------------------
     // Create the stream
     //--------------------------------------------------------------------------
-    pStream = new Stream( pUrl, prefurl );
+    pStream = new Stream( &pUrl, prefurl );
     pStream->SetTransport( transport );
     pStream->SetPoller( poller );
     pStream->SetIncomingQueue( &pIncoming );
@@ -122,7 +122,7 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     // Register the task generating timeout events
     //--------------------------------------------------------------------------
-    pTickGenerator = new TickGeneratorTask( this, pUrl->GetChannelId() );
+    pTickGenerator = new TickGeneratorTask( this, pUrl.GetChannelId() );
     pTaskManager->RegisterTask( pTickGenerator, ::time(0)+timeoutResolution );
   }
 

--- a/src/XrdCl/XrdClChannel.hh
+++ b/src/XrdCl/XrdClChannel.hh
@@ -74,7 +74,7 @@ namespace XrdCl
       //------------------------------------------------------------------------
       const URL &GetURL() const
       {
-        return *pUrl;
+        return pUrl;
       }
 
       //------------------------------------------------------------------------
@@ -158,7 +158,7 @@ namespace XrdCl
 
     private:
 
-      std::shared_ptr<URL>   pUrl;
+      URL                    pUrl;
       Poller                *pPoller;
       TransportHandler      *pTransport;
       TaskManager           *pTaskManager;

--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -93,7 +93,7 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   // Constructor
   //----------------------------------------------------------------------------
-  Stream::Stream( std::shared_ptr<URL> url, const URL &prefer ):
+  Stream::Stream( const URL *url, const URL &prefer ):
     pUrl( url ),
     pPrefer( prefer ),
     pTransport( 0 ),
@@ -107,10 +107,6 @@ namespace XrdCl
     pConnectionInitTime( 0 ),
     pAddressType( Utils::IPAll ),
     pSessionId( 0 ),
-    pTTLDiscJob( nullptr ),
-    pSubsWaitingClose( 0 ),
-    pDiscCV( 0 ),
-    pDiscAllCnt( 0 ),
     pBytesSent( 0 ),
     pBytesReceived( 0 )
   {
@@ -366,18 +362,6 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   void Stream::Disconnect( bool /*force*/ )
   {
-    //--------------------------------------------------------------------------
-    // See comment about deadlocks in ForceError() method. We don't expect
-    // to be called from a callback thread.
-    //--------------------------------------------------------------------------
-    XrdSysCondVarHelper discLock( pDiscCV );
-    while ( pDiscAllCnt )
-    {
-      pDiscCV.Wait();
-    }
-    ++pDiscAllCnt;
-    discLock.UnLock();
-
     XrdSysMutexHelper scopedLock( pMutex );
     SubStreamList::iterator it;
     for( it = pSubStreams.begin(); it != pSubStreams.end(); ++it )
@@ -385,12 +369,6 @@ namespace XrdCl
       (*it)->socket->Close();
       (*it)->status = Socket::Disconnected;
     }
-    pSubsWaitingClose = 0;
-
-    scopedLock.UnLock();
-    discLock.Lock( &pDiscCV );
-    --pDiscAllCnt;
-    pDiscCV.Signal();
   }
 
   //----------------------------------------------------------------------------
@@ -645,38 +623,6 @@ namespace XrdCl
   void Stream::OnConnect( uint16_t subStream )
   {
     XrdSysMutexHelper scopedLock( pMutex );
-    if( subStream == 0 )
-    {
-      int nsubconn = 0;
-      if( pSubStreams.size() > 1 )
-      {
-        for( size_t i = 1; i < pSubStreams.size(); ++i )
-          if( pSubStreams[i]->status != Socket::Disconnected ) nsubconn++;
-      }
-      if( nsubconn )
-      {
-        pSubsWaitingClose = nsubconn;
-        pSubStreams[0]->socket->DisableUplink();
-        return;
-      }
-      else
-        pSubStreams[0]->socket->EnableUplink();
-    }
-    else
-    {
-      if( pSubsWaitingClose > 0 )
-      {
-        pSubStreams[subStream]->socket->Close();
-        pSubStreams[subStream]->status = Socket::Disconnected;
-        if( --pSubsWaitingClose == 0 )
-        {
-          scopedLock.UnLock();
-          OnConnect( 0 );
-        }
-        return;
-      }
-    }
-
     pSubStreams[subStream]->status = Socket::Connected;
 
     std::string ipstack( pSubStreams[0]->socket->GetIpStack() );
@@ -723,11 +669,7 @@ namespace XrdCl
           if( !st.IsOK() )
           {
             pSubStreams[0]->outQueue->GrabItems( *pSubStreams[i]->outQueue );
-            // mark as disconnected. We don't try to actively Close here as
-            // we're in a poller callback thread and the i'th substream here
-            // may be hadled by a different poller callback thread, raising
-            // the possibility of deadlock.
-            pSubStreams[i]->status = Socket::Disconnected;
+            pSubStreams[i]->socket->Close();
           }
           else
           {
@@ -801,19 +743,7 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     if( subStream > 0 )
     {
-      const Socket::SocketStatus oldstate = pSubStreams[subStream]->status;
       pSubStreams[subStream]->status = Socket::Disconnected;
-
-      if( pSubsWaitingClose > 0 && oldstate != Socket::Disconnected )
-      {
-        if( --pSubsWaitingClose == 0 )
-        {
-          scopedLock.UnLock();
-          OnConnect( 0 );
-        }
-        return;
-      }
-
       pSubStreams[0]->outQueue->GrabItems( *pSubStreams[subStream]->outQueue );
       if( pSubStreams[0]->status == Socket::Connected )
       {
@@ -897,21 +827,8 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   void Stream::OnError( uint16_t subStream, XRootDStatus status )
   {
-    //--------------------------------------------------------------------------
-    // See comment about deadlocks in ForceError() method. We expect to be
-    // called form a callback thread. However we take care to only potentially
-    // disconnect the socket for our own subStream. We require no ongoing
-    // disconnect of all substreams and ensure that remains true throughout
-    // our execution by releasing discLock only after acquiring pMutex.
-    //--------------------------------------------------------------------------
-
-    XrdSysCondVarHelper discLock( pDiscCV );
-    if( pDiscAllCnt ) return;
-
     XrdSysMutexHelper scopedLock( pMutex );
-    discLock.UnLock();
     Log *log = DefaultEnv::GetLog();
-    const Socket::SocketStatus oldstate = pSubStreams[subStream]->status;
     pSubStreams[subStream]->socket->Close();
     pSubStreams[subStream]->status = Socket::Disconnected;
 
@@ -949,46 +866,20 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     if( subStream > 0 )
     {
-      if( pSubsWaitingClose > 0 && oldstate != Socket::Disconnected )
-      {
-        if( --pSubsWaitingClose == 0 )
-        {
-          scopedLock.UnLock();
-          OnConnect( 0 );
-        }
+      if( pSubStreams[subStream]->outQueue->IsEmpty() )
         return;
-      }
 
       if( pSubStreams[0]->status != Socket::Disconnected )
       {
-        pSubStreams[subStream]->socket->SetAddress( pSubStreams[0]->socket->GetAddress() );
-        XRootDStatus st = pSubStreams[subStream]->socket->Connect( pConnectionWindow );
-        if( !st.IsOK() )
+        pSubStreams[0]->outQueue->GrabItems( *pSubStreams[subStream]->outQueue );
+        if( pSubStreams[0]->status == Socket::Connected )
         {
-          pSubStreams[subStream]->socket->Close();
-          if( pSubStreams[subStream]->outQueue->IsEmpty() )
-            return;
-          pSubStreams[0]->outQueue->GrabItems( *pSubStreams[subStream]->outQueue );
-          if( pSubStreams[0]->status == Socket::Connected )
-          {
-            XRootDStatus st = pSubStreams[0]->socket->EnableUplink();
-            if( !st.IsOK() )
-              OnFatalError( 0, st, scopedLock );
-            return;
-          }
-          if( pSubStreams[0]->status == Socket::Connecting )
-            return;
-        }
-        else
-        {
-          pSubStreams[subStream]->status = Socket::Connecting;
+          XRootDStatus st = pSubStreams[0]->socket->EnableUplink();
+          if( !st.IsOK() )
+            OnFatalError( 0, st, scopedLock );
           return;
         }
-        OnFatalError( subStream, status, scopedLock );
-        return;
       }
-      if( pSubStreams[subStream]->outQueue->IsEmpty() )
-        return;
       OnFatalError( subStream, status, scopedLock );
       return;
     }
@@ -1041,30 +932,6 @@ namespace XrdCl
   //------------------------------------------------------------------------
   void Stream::ForceError( XRootDStatus status, bool hush )
   {
-    //----------------------------------------------------------------------
-    // We can be called in two ways: first is by by a non-poller thread,
-    // with errOperationInterrupted as error as part of ForceDisconnect. In
-    // which case the Stream will be destoryed shortly after we return. The
-    // second way is call by a poller thread with another type of error.
-    // Further, when we call socket handler Close() for a socket handled a
-    // callback running we wait for that to complete (unless it is
-    // ourselves). This raises the possibility of a deadlock. We avoid this
-    // by returning quickly if we detect we're in a callback thread and
-    // there's already a disconnect affecting multiple streams in progress.
-    //----------------------------------------------------------------------
-    XrdSysCondVarHelper discLock( pDiscCV );
-    if( pDiscAllCnt &&
-      !( status.IsError() && status.code == errOperationInterrupted ) )
-    {
-      return;
-    }
-    while( pDiscAllCnt )
-    {
-      pDiscCV.Wait();
-    }
-    ++pDiscAllCnt;
-    discLock.UnLock();
-
     XrdSysMutexHelper scopedLock( pMutex );
     Log    *log = DefaultEnv::GetLog();
     for( size_t substream = 0; substream < pSubStreams.size(); ++substream )
@@ -1103,7 +970,6 @@ namespace XrdCl
     }
 
     pConnectionCount = 0;
-    pSubsWaitingClose = 0;
 
     //------------------------------------------------------------------------
     // We're done here, unlock the stream mutex to avoid deadlocks and
@@ -1122,10 +988,6 @@ namespace XrdCl
 
     pIncomingQueue->ReportStreamEvent( MsgHandler::Broken, status );
     pChannelEvHandlers.ReportEvent( ChannelEventHandler::StreamBroken, status );
-
-    discLock.Lock( &pDiscCV );
-    --pDiscAllCnt;
-    pDiscCV.Signal();
   }
 
   //----------------------------------------------------------------------------
@@ -1191,22 +1053,7 @@ namespace XrdCl
     // We only take the main stream into account
     //--------------------------------------------------------------------------
     if( substream != 0 )
-    {
-      if( pSubsWaitingClose )
-      {
-        XrdSysMutexHelper scopedLock( pMutex );
-        if( !pSubsWaitingClose ) return true;
-        if( pSubStreams[substream]->status == Socket::Disconnected ) return true;
-        pSubStreams[substream]->socket->Close();
-        pSubStreams[substream]->status = Socket::Disconnected;
-        if( --pSubsWaitingClose == 0 )
-        {
-          scopedLock.UnLock();
-          OnConnect( 0 );
-        }
-      }
       return true;
-    }
 
     //--------------------------------------------------------------------------
     // Check if there is no outgoing messages and if the stream TTL is elapesed.
@@ -1237,21 +1084,18 @@ namespace XrdCl
       {
         log->Debug( PostMasterMsg, "[%s] Stream TTL elapsed, disconnecting...",
                     pStreamName.c_str() );
+        scopedLock.UnLock();
         //----------------------------------------------------------------------
         // Important note!
         //
-        // This job destroys the Stream object itself, the underlying
+        // This destroys the Stream object itself, the underlined
         // AsyncSocketHandler object (that called this method) and the Channel
         // object that aggregates this Stream.
         //
         // Additionally &(*pUrl) is used by ForceDisconnect to check if we are
         // in a Channel that was previously collapsed in a redirect.
         //----------------------------------------------------------------------
-        if( !pTTLDiscJob )
-        {
-          pTTLDiscJob = new ForceDisconnectJob( pUrl );
-          pJobManager->QueueJob( pTTLDiscJob );
-        }
+        DefaultEnv::GetPostMaster()->ForceDisconnect( *pUrl );
         return false;
       }
     }


### PR DESCRIPTION
This reverts commit a85f1fd7d4056ce061b247c670a4460573bad420, in order to fix regression reported in #2629.

While investigating issue #2629 (in 5.9.0) by running more tests, I saw the following deadlock, appears to be the cause of #2629. This would be a regression with respect to 5.8.4.

```
Thread 62 (Thread 0x7f5e2efde640 (LWP 3261741) "xrootd"):
#0  0x00007f5e468868ba in __futex_abstimed_wait_common () from target:/lib64/libc.so.6
#1  0x00007f5e46891d68 in __new_sem_wait_slow64.constprop.0 () from target:/lib64/libc.so.6
#2  0x00007f5e46f5648e in XrdSys::IOEvents::Poller::SendCmd(XrdSys::IOEvents::Poller::PipeData&) () from target:/lib64/libXrdUtils.so.3
#3  0x00007f5e46f5655e in XrdSys::IOEvents::PollE::Exclude(XrdSys::IOEvents::Channel*, bool&, bool) () from target:/lib64/libXrdUtils.so.3
#4  0x00007f5e46f55590 in XrdSys::IOEvents::Channel::Delete() () from target:/lib64/libXrdUtils.so.3
#5  0x00007f5e4410e948 in XrdCl::PollerBuiltIn::RemoveSocket(XrdCl::Socket*) () from target:/lib64/libXrdCl.so.3
#6  0x00007f5e44194694 in XrdCl::AsyncSocketHandler::Close() () from target:/lib64/libXrdCl.so.3
#7  0x00007f5e44115ced in XrdCl::Stream::ForceError(XrdCl::XRootDStatus, bool) () from target:/lib64/libXrdCl.so.3
#8  0x00007f5e441105b4 in XrdCl::Channel::ForceDisconnect(bool) () from target:/lib64/libXrdCl.so.3
#9  0x00007f5e4411206f in XrdCl::PostMaster::ForceDisconnect(XrdCl::URL const&, bool) () from target:/lib64/libXrdCl.so.3
#10 0x00007f5e44113775 in XrdCl::Stream::ForceDisconnectJob::Run(void*) () from target:/lib64/libXrdCl.so.3
#11 0x00007f5e4419dbbd in XrdCl::JobManager::RunJobs() () from target:/lib64/libXrdCl.so.3
#12 0x00007f5e4419dc0d in RunRunnerThread () from target:/lib64/libXrdCl.so.3
#13 0x00007f5e46889d22 in start_thread () from target:/lib64/libc.so.6
#14 0x00007f5e4690ed40 in clone3 () from target:/lib64/libc.so.6
```

and

```
Thread 32 (Thread 0x7f5e3b5fc640 (LWP 3261711) "xrootd"):
#0  0x00007f5e46886839 in __futex_abstimed_wait_common () from target:/lib64/libc.so.6
#1  0x00007f5e4688f84b in pthread_rwlock_rdlock@GLIBC_2.2.5 () from target:/lib64/libc.so.6
#2  0x00007f5e44111a17 in XrdCl::PostMaster::Send(XrdCl::URL const&, XrdCl::Message*, XrdCl::MsgHandler*, bool, long) () from target:/lib64/libXrdCl.so.3
#3  0x00007f5e44140a60 in XrdCl::XRootDMsgHandler::RetryAtServer(XrdCl::URL const&, XrdCl::RedirectEntry::Type) () from target:/lib64/libXrdCl.so.3
#4  0x00007f5e4413f509 in XrdCl::XRootDMsgHandler::HandleError(XrdCl::XRootDStatus) () from target:/lib64/libXrdCl.so.3
#5  0x00007f5e4413f786 in XrdCl::XRootDMsgHandler::OnStreamEvent(XrdCl::MsgHandler::StreamEvent, XrdCl::XRootDStatus) () from target:/lib64/libXrdCl.so.3
#6  0x00007f5e44125aee in XrdCl::InQueue::ReportStreamEvent(XrdCl::MsgHandler::StreamEvent, XrdCl::XRootDStatus) () from target:/lib64/libXrdCl.so.3
#7  0x00007f5e4411ad84 in XrdCl::Stream::OnError(unsigned short, XrdCl::XRootDStatus) () from target:/lib64/libXrdCl.so.3
#8  0x00007f5e4411b4c3 in XrdCl::Stream::OnReadTimeout(unsigned short) () from target:/lib64/libXrdCl.so.3
#9  0x00007f5e441a2b9b in XrdCl::AsyncSocketHandler::Event(unsigned char, XrdCl::Socket*) () from target:/lib64/libXrdCl.so.3
#10 0x00007f5e4410f3aa in (anonymous namespace)::SocketCallBack::Event(XrdSys::IOEvents::Channel*, void*, int) () from target:/lib64/libXrdCl.so.3
#11 0x00007f5e46f570dc in XrdSys::IOEvents::Poller::CbkXeq(XrdSys::IOEvents::Channel*, int, int, char const*) () from target:/lib64/libXrdUtils.so.3
#12 0x00007f5e46f576b6 in XrdSys::IOEvents::Poller::CbkTMO() () from target:/lib64/libXrdUtils.so.3
#13 0x00007f5e46f579b5 in XrdSys::IOEvents::Poller::TmoGet() () from target:/lib64/libXrdUtils.so.3
#14 0x00007f5e46f584da in XrdSys::IOEvents::PollE::Begin(XrdSysSemaphore*, int&, char const**) () from target:/lib64/libXrdUtils.so.3
#15 0x00007f5e46f543f1 in XrdSys::IOEvents::BootStrap::Start(void*) () from target:/lib64/libXrdUtils.so.3
#16 0x00007f5e46f65a8c in XrdSysThread_Xeq () from target:/lib64/libXrdUtils.so.3
#17 0x00007f5e46889d22 in start_thread () from target:/lib64/libc.so.6
#18 0x00007f5e4690ed40 in clone3 () from target:/lib64/libc.so.6
```

Same IOEvents::Channel involved between the two threads, but different XrdCl::Stream. (This is a regression because a85f1fd  made a call of ForceDisconnect asynchronous with respect to the IOEvents::Poller callback).

I thought the best way to address the #2629 is to initially revert a85f1fd in the next patch release, altough doing so leaves the original reason for the commit, #2578 unresolved. However that latter bug was only noticed by me and is presumably not curerntly being reported in any production situation. So I propose to make a new fix for #2578 later, and allow for more testing, with that to be included in R6 or a furuter 5.9.x patch release.

#2578 is more likely to be encountered if multiple streams (substreams) are in use by a long lived client process, e.g. in xcache or in an application like EOS fuse client. This situation could arrise, e.g. if xcache was configured with the non-default XRD_TLSNODATA=1, as in many situations root:// origins are being configured to require TLS on the login stream, probably beause of ZTN (and the client would introduce a bound sub-stream to support non-tls data channel).