### PR TITLE
HTTP summary monitoring

### DIFF
--- a/tests/XRootD/http.cfg
+++ b/tests/XRootD/http.cfg
@@ -22,6 +22,8 @@ macaroons.secretkey $pwd/macaroons-secret
 
 xrootd.mongstream http use flush 3s send json 127.0.0.1:8888
 
+xrd.report 127.0.0.1:9999 every 3 json plugins
+
 # Verify static headers are appropriately appended to responses
 http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
 http.staticheader -verb=GET Foo Bar

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -403,4 +403,9 @@ function test_http() {
   run_and_assert_http_and_error_code 200 "" \
     --header "Want-Digest: crc32c" -I "${HOST}/$alphabetFilePath"
 
+  # Uncomment sleep to test monitoring packets - to keep the server running beyond monitoring flush intervals
+  # For HTTP Summary monitoring in another terminal use: socat -u udp-recv:9999 -
+  # For HTTP GStream monitoring use: socat -u udp-recv:8888 -
+  # sleep 5
+
 }


### PR DESCRIPTION
This PR builds on top of HTTP GStream monitoring and provides HTTP Summary monitoring using the new XrdMonRoll interface. 

It provides counters for HTTP Request Verbs and HTTP Response Status codes as defined in the comment. https://github.com/xrootd/xrootd/pull/2604#issuecomment-3479530517

```
1. Total requests received by `HTTP Request verb` type
2. Total response count by `HTTP Status Code` type
```

#2604 is a parent PR, and we discussed that it needs to be reviewed and merged before this.