### PR TITLE
[XrdOuc] Correct is_subdirectory check for dir with trailing /

### DIFF
--- a/src/XrdOuc/XrdOucPrivateUtils.hh
+++ b/src/XrdOuc/XrdOucPrivateUtils.hh
@@ -33,13 +33,13 @@
 static inline bool is_subdirectory(const std::string& dir,
                                    const std::string& subdir)
 {
-    if (subdir.size() < dir.size())
+    if (subdir.size() < dir.size() || dir.empty())
       return false;
 
     if (subdir.compare(0, dir.size(), dir, 0, dir.size()) != 0)
       return false;
 
-    return dir.size() == subdir.size() || subdir[dir.size()] == '/' || dir == "/";
+    return dir.size() == subdir.size() || subdir[dir.size()] == '/' || dir.back() == '/';
 }
 
 /**


### PR DESCRIPTION
The current check fails checks for directories ending with a trailing slash

For e.g.
``` 
subdir = /data/subdir/mydir
dir = /data/subdir/
```

The current code only takes into account paths without a trailing slash: `subdir[dir.size()]` 
This PR adds checks for paths with a trailing slash: `dir[dir.size()-1]` 
The actual code uses string member functions instead of the array indexing shown above.
