### PR TITLE
Python: expose fSetXattrAdler32 in python

### DIFF
--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from .glob_funcs import glob, iglob
 from .filesystem import FileSystem as FileSystem
 from .file import File as File
+from pyxrootd.client import setXAttrAdler32_cpp as setXAttrAdler32
 from .url import URL as URL
 from .copyprocess import CopyProcess as CopyProcess
 from .env import EnvPutString as EnvPutString

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -11,6 +11,7 @@ Python_add_library(client MODULE WITH_SOABI
   PyXRootDFileSystem.hh
   PyXRootDFinalize.hh
   PyXRootDURL.hh
+  PyXRootDAdler32.hh
   Utils.hh
   # sources
   PyXRootDCopyProcess.cc
@@ -19,6 +20,7 @@ Python_add_library(client MODULE WITH_SOABI
   PyXRootDFileSystem.cc
   PyXRootDModule.cc
   PyXRootDURL.cc
+  PyXRootDAdler32.cc
   Utils.cc
 )
 

--- a/python/src/PyXRootDAdler32.cc
+++ b/python/src/PyXRootDAdler32.cc
@@ -1,0 +1,105 @@
+//------------------------------------------------------------------------------
+// Copyright (c) 2025 - Binding for setXAttrAdler32
+//------------------------------------------------------------------------------
+// This file provides a Python wrapper with simplified API for logic equivalent
+// to fSetXattrAdler32(const char* path, int fd, const char* attr, char* value)
+// present in Xrdadler32.cc.
+//
+// Simplified API: setXAttrAdler32(path, checksum)
+//   - Takes only path and checksum string
+//   - Opens file internally with O_RDONLY
+//   - Uses fixed attribute names per original code
+//------------------------------------------------------------------------------
+#include "PyXRootDAdler32.hh"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <cstring>
+#include <cerrno>
+#include <time.h>
+#if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
+  #include <sys/xattr.h>
+#endif
+
+#include "XrdCks/XrdCksXAttr.hh"
+#include "XrdOuc/XrdOucXAttr.hh"
+
+namespace PyXRootD {
+
+// Python exposed function: setXAttrAdler32(path:str, checksum:str)
+// Returns None on success, raises OSError/ValueError on error.
+extern "C" PyObject* setXAttrAdler32_cpp(PyObject* /*self*/, PyObject* args)
+{
+  const char* path = nullptr;
+  const char* value = nullptr;
+
+  if (!PyArg_ParseTuple(args, "ss", &path, &value)) {
+    return nullptr; // Type error automatically set by PyArg_ParseTuple
+  }
+
+  // Basic validation matching original function expectations.
+  if (!value || std::strlen(value) != 8) {
+    PyErr_SetString(PyExc_ValueError, "Checksum value must be exactly 8 hex characters");
+    return nullptr;
+  }
+
+  // Open file read-only (matching xrdadler32 usage pattern)
+  int fd = open(path, O_RDONLY);
+  if (fd < 0) {
+    PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
+    return nullptr;
+  }
+
+  // Stat the file via fd (original code uses fstat on fd only).
+  struct stat st;
+  if (fstat(fd, &st) != 0) {
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
+    return nullptr;
+  }
+
+  // Set up attribute object and populate checksum metadata.
+  XrdOucXAttr<XrdCksXAttr> xCS;
+  if (!xCS.Attr.Cks.Set("adler32") || !xCS.Attr.Cks.Set(value, 8)) {
+    close(fd);
+    PyErr_SetString(PyExc_RuntimeError, "Failed to set checksum name or value (invalid hex?)");
+    return nullptr;
+  }
+
+  xCS.Attr.Cks.fmTime = static_cast<long long>(st.st_mtime);
+  xCS.Attr.Cks.csTime = static_cast<int>(time(nullptr) - st.st_mtime);
+
+  // Write the structured attribute using XrdSysFAttr mechanism via fd.
+  int rc = xCS.Set("", fd);
+  if (rc != 0) {
+    int saved_errno = (rc < 0) ? -rc : errno;
+    close(fd);
+    // xCS.Set returns -errno on failure
+    if (rc < 0) {
+      errno = saved_errno;
+      PyErr_SetFromErrnoWithFilename(PyExc_OSError, path);
+    } else {
+      PyErr_SetString(PyExc_RuntimeError, "Unknown error writing checksum attribute");
+    }
+    return nullptr;
+  }
+
+  // Remove legacy attribute if present (original code did unconditional remove).
+  // Use fixed attribute name per original code
+  const char* legacy_attr = "user.checksum.adler32";
+#if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
+  (void)fremovexattr(fd, legacy_attr); // best-effort, ignore errors
+#elif defined(__solaris__)
+  int attrfd = openat(fd, legacy_attr, O_XATTR|O_RDONLY);
+  if (attrfd >= 0) { unlinkat(attrfd, legacy_attr, 0); close(attrfd); }
+#endif
+
+  close(fd);
+  Py_RETURN_NONE;
+}
+
+} // namespace PyXRootD

--- a/python/src/PyXRootDAdler32.hh
+++ b/python/src/PyXRootDAdler32.hh
@@ -1,0 +1,12 @@
+//------------------------------------------------------------------------------
+// Python binding header for setXAttrAdler32 (simplified API).
+//------------------------------------------------------------------------------
+#ifndef PYXROOTD_ADLER32_HH
+#define PYXROOTD_ADLER32_HH
+#include <Python.h>
+
+namespace PyXRootD {
+  extern "C" PyObject* setXAttrAdler32_cpp(PyObject* self, PyObject* args);
+}
+
+#endif

--- a/python/src/PyXRootDModule.cc
+++ b/python/src/PyXRootDModule.cc
@@ -29,6 +29,7 @@
 #include "PyXRootDURL.hh"
 #include "PyXRootDFinalize.hh"
 #include "PyXRootDEnv.hh"
+#include "PyXRootDAdler32.hh"
 
 namespace PyXRootD
 {
@@ -53,6 +54,7 @@ namespace PyXRootD
       { "EnvGetDefault_cpp",    EnvGetDefault_cpp,    METH_VARARGS, "Get default values from XrdCl environment" },
       { "SetLogLevel_cpp",      SetLogLevel_cpp,      METH_VARARGS, "Set XrdCl log level" },
       { "SetLogMask_cpp",       SetLogMask_cpp,       METH_VARARGS, "Set XrdCl log mask" },
+      { "setXAttrAdler32_cpp",  setXAttrAdler32_cpp,  METH_VARARGS, "Set adler32 checksum extended attribute (path, checksum)." },
       { NULL, NULL, 0, NULL }
     };
 

--- a/python/tests/test_adler32_binding.py
+++ b/python/tests/test_adler32_binding.py
@@ -1,0 +1,34 @@
+# Basic test for setXAttrAdler32 binding
+import os, tempfile
+from XRootD.client import setXAttrAdler32
+
+# Create temp file
+path = None
+try:
+    fd, path = tempfile.mkstemp()
+    # write some data
+    with os.fdopen(fd, 'wb') as f:
+        f.write(b'Testing adler32 binding')
+
+    # Use dummy checksum value of length 8 (not validated for correctness here)
+    chk = '01234567'
+
+    # Call binding with simplified API (only path and checksum)
+    setXAttrAdler32(path, chk)
+    print('Called setXAttrAdler32 successfully on', path)
+
+    # Verify structured attribute existence via listxattr
+    try:
+        import xattr
+        # The structured attribute created via XrdCksXAttr will have name 'user.XrdCks.adler32'
+        xas = xattr.listxattr(path)
+        print('xattrs after call:', xas)
+        if 'user.XrdCks.adler32' in xas:
+            print('PASS: structured checksum attribute present')
+        else:
+            print('WARN: expected user.XrdCks.adler32 not found')
+    except Exception as e:
+        print('xattr verification skipped:', e)
+finally:
+    if path and os.path.exists(path):
+        os.unlink(path)


### PR DESCRIPTION
When running at sites which have mounted writable file system, we simply use posix semantic to "upload" the files produced by jobs. 
But when we want to access these files from outside (other jobs or FTS), we do it via an xrootd server. 
This triggers a checksum computation which is intensive, and we end up ddossing the server.

The idea is to be able, from python, to write the checksum as extended attributes directly from the workernode. 