### PR TITLE
[XrdHttpTpc] Use HTTP 202 Accepted instead of HTTP 201 Created 

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
@@ -283,7 +283,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
     curl_multi_setopt(multi_handle, CURLMOPT_MAX_HOST_CONNECTIONS, streams);
 
     // Start response to client prior to the first call to curl_multi_perform
-    int retval = req.StartChunkedResp(201, "Created", "Content-Type: text/plain");
+    int retval = req.StartChunkedResp(202, NULL, "Content-Type: text/plain");
     if (retval) {
         logTransferEvent(LogMask::Error, rec, "RESPONSE_FAIL",
             "Failed to send the initial response to the TPC client");

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -612,7 +612,7 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
     }
 
     // Start response to client prior to the first call to curl_multi_perform
-    int retval = req.StartChunkedResp(201, "Created", "Content-Type: text/plain");
+    int retval = req.StartChunkedResp(202, NULL, "Content-Type: text/plain");
     if (retval) {
         curl_multi_cleanup(multi_handle);
         logTransferEvent(LogMask::Error, rec, "RESPONSE_FAIL",

--- a/tests/TPCTests/test.sh
+++ b/tests/TPCTests/test.sh
@@ -301,8 +301,8 @@ done
 for src_idx in {0..1}; do
     for dst_idx in {0..1}; do
        perform_tpc "${src_idx}" "${dst_idx}"
-       assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN")" "HTTP TPC pull failed"
-       assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "push" "$BEARER_TOKEN" "$BEARER_TOKEN")" "HTTP TPC push failed"
+       assert_eq "202" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN")" "HTTP TPC pull failed"
+       assert_eq "202" "$(perform_http_tpc "$src_idx" "$dst_idx" "push" "$BEARER_TOKEN" "$BEARER_TOKEN")" "HTTP TPC push failed"
     done
 done
 
@@ -363,8 +363,8 @@ verify_checksum "crc32c" "${LCLDATADIR}/${src}_empty.ref" "${LCLDATADIR}/${src}_
 verify_checksum "adler32" "${LCLDATADIR}/${src}_empty.ref" "${LCLDATADIR}/${src}_empty.dat" "${hosts[$src_idx]}" "${RMTDATADIR}/${src}_empty.ref"
 
 perform_tpc "${src_idx}" "${dst_idx}" "_empty"
-assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN" "_empty")" "HTTP TPC pull failed"
-assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "push" "$BEARER_TOKEN" "$BEARER_TOKEN" "_empty")" "HTTP TPC push failed"
+assert_eq "202" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN" "_empty")" "HTTP TPC pull failed"
+assert_eq "202" "$(perform_http_tpc "$src_idx" "$dst_idx" "push" "$BEARER_TOKEN" "$BEARER_TOKEN" "_empty")" "HTTP TPC push failed"
 
 remote_file="${hosts_http[$dst_idx]}/${RMTDATADIR}/${src}_to_${dst}_empty.ref"
 local_file="${LCLDATADIR}/${src}_to_${dst}_empty.dat"


### PR DESCRIPTION
Fixes #2625 

Note that the description "Created" is replaced with `NULL`, and not "Accepted" since we added a common translation for status codes and string `httpStatusToString` in XrdHttpUtils. 