### PR TITLE
[Tests] Adjust test timeouts

### DIFF
--- a/tests/XRootD/test.sh
+++ b/tests/XRootD/test.sh
@@ -58,8 +58,8 @@ export XRD_LOGLEVEL XRD_LOGFILE
 # Reduce default timeouts to catch errors quickly and prevent the test
 # suite from getting stuck waiting for timeouts while running.
 
-: "${XRD_REQUESTTIMEOUT:=10}"
-: "${XRD_STREAMTIMEOUT:=5}"
+: "${XRD_REQUESTTIMEOUT:=15}"
+: "${XRD_STREAMTIMEOUT:=10}"
 : "${XRD_TIMEOUTRESOLUTION:=1}"
 
 export XRD_REQUESTTIMEOUT XRD_STREAMTIMEOUT XRD_TIMEOUTRESOLUTION


### PR DESCRIPTION
After increasing the timeouts in commit 9f18c52, the tests work most of the time. However, there are still occasional failures due to timeouts.

There are two types of errors:

1. Run: [ERROR] Socket timeout:  (destination)

This is the XRD_STREAMTIMEOUT (currently set to 5 seconds) expiring.

2. Run: [ERROR] Operation expired:  (destination)

This is the XRD_REQUESTTIMEOUT (currently set to 10 seconds) expirin.g

This commit increases the timeouts to 10 and 15 seconds respectively.