### PR TITLE
[XrdCl] Add constructor to InitialisePlugin without opening the file

### DIFF
--- a/src/XrdCl/XrdClFile.hh
+++ b/src/XrdCl/XrdClFile.hh
@@ -54,13 +54,24 @@ namespace XrdCl
 
       //------------------------------------------------------------------------
       //! Constructor
+      //! @param enablePlugIns enable the plug-in mechanism for the object
       //------------------------------------------------------------------------
       File( bool enablePlugIns = true );
 
       //------------------------------------------------------------------------
       //! Constructor
+      //! @param virtRedirect
+      //! @param enablePlugIns
       //------------------------------------------------------------------------
       File( VirtRedirect virtRedirect, bool enablePlugIns = true );
+
+      //------------------------------------------------------------------------
+      //! Constructor
+      //!
+      //! @param url URL for the file to initialise the plugin for
+      //! @param enablePlugIns enable the plug-in mechanism for the object
+      //------------------------------------------------------------------------
+      File( const std::string &url, bool enablePlugIns = true );
 
       //------------------------------------------------------------------------
       //! Destructor
@@ -830,6 +841,14 @@ namespace XrdCl
 
       template <bool HasHndl>
       friend class ChkptWrtVImpl;
+
+      //------------------------------------------------------------------------
+      //! Helper to Initialise Plugin
+      //!
+      //! @param url     url of the file to intialise the plugin for
+      //! @return        status of the operation
+      //------------------------------------------------------------------------
+      void InitPlugin( const std::string &url);
 
       //------------------------------------------------------------------------
       //! Create a checkpoint - async


### PR DESCRIPTION
Fixes: #2512 
This PR adds a constructor to `XrdCl::File`, similar to `XrdCl::Filesystem`, that creates the file object on constructor call as opposed to during the Open call, allowing plugins to set flags, i.e `myfile->SetProperty`. 

Then the xrdcl-curl PR https://github.com/xrootd/xrootd/pull/2567 can be patched with

```patch
diff --git a/src/XrdClS3/XrdClS3DownloadHandler.cc b/src/XrdClS3/XrdClS3DownloadHandler.cc
index 8b5b78aa4..1c9884ff4 100644
--- a/src/XrdClS3/XrdClS3DownloadHandler.cc
+++ b/src/XrdClS3/XrdClS3DownloadHandler.cc
@@ -232,15 +232,7 @@ S3DownloadHandler::CloseHandler::HandleResponse(XrdCl::XRootDStatus *status_raw,
 XrdCl::XRootDStatus
 XrdClS3::DownloadUrl(const std::string &url, XrdClCurl::HeaderCallout *header_callout, XrdCl::ResponseHandler *handler, time_t timeout)
 {
-    std::unique_ptr<XrdCl::File> http_file(new XrdCl::File());
-    // Hack - we need to set a few properties on the file object before the open occurs.
-    // However, the "real" (plugin) file object is not created until the open call.
-    // This forces the plugin object to be created, so we can set the properties and Open later.
-    auto status = http_file->Open(url, XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, time_t(0));
-    if (!status.IsOK()) {
-        return status;
-    }
-
+    std::unique_ptr<XrdCl::File> http_file(new XrdCl::File(url));

     if (header_callout) {
         auto callout_loc = reinterpret_cast<long long>(header_callout);
diff --git a/src/XrdClS3/XrdClS3File.cc b/src/XrdClS3/XrdClS3File.cc
index f760ed7f5..ae2c65296 100644
--- a/src/XrdClS3/XrdClS3File.cc
+++ b/src/XrdClS3/XrdClS3File.cc
@@ -146,14 +146,8 @@ File::GetFileHandle(const std::string &s3_url) {
         return std::make_tuple(XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, "Invalid generated XrdCl URL"), "", nullptr);
     }
     m_url = https_url;
-    std::unique_ptr<XrdCl::File> wrapped_file(new XrdCl::File());
-    // Hack - we need to set a few properties on the file object before the open occurs.
-    // However, the "real" (plugin) file object is not created until the open call.
-    // This forces the plugin object to be created, so we can set the properties and Open later.
-    auto status = wrapped_file->Open(url.GetURL(), XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, time_t(0));
-    if (!status.IsOK()) {
-        return std::make_tuple(status, "", nullptr);
-    }
+
+    std::unique_ptr<XrdCl::File> wrapped_file(new XrdCl::File(url.GetURL()));

     std::stringstream ss;
     ss << std::hex << reinterpret_cast<long long>(&m_header_callout);
```