### PR TITLE
[XrdPfc] Bugfix: possible uninitialized value passing into resource-monitor purge queue

### DIFF
--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -509,7 +509,9 @@ bool File::Open(XrdOucCacheIO *inputIO)
          TRACEF(Warning, tpfx << "Basic sanity checks on data file failed, resetting info file, truncating data file.");
          m_cfi.ResetAllAccessStats();
          m_data_file->Ftruncate(0);
-         Cache::ResMon().register_file_purge(m_filename, data_stat.st_blocks);
+         // data-file might not have existed at entry -- data_stat is then undefined
+         if (data_existed)
+            Cache::ResMon().register_file_purge(m_filename, data_stat.st_blocks);
       }
    }
 
@@ -522,6 +524,7 @@ bool File::Open(XrdOucCacheIO *inputIO)
          initialize_info_file = true;
          m_cfi.ResetAllAccessStats();
          m_data_file->Ftruncate(0);
+         // data-file is known to exist due to checks in the previous if block
          Cache::ResMon().register_file_purge(m_filename, data_stat.st_blocks);
       } else {
          // TODO: If the file is complete, we don't need to reset net cksums.


### PR DESCRIPTION
On File::Open(), when cinfo file existed but the corresponding data-file did not, a callout to ResourceMonitor::register_file_purge() was made with uninitialized struct stat::st_blocks (as stat on the data-file has failed). This then resulted in corrupt reported values for directory usage statistics.

This PR adds a check for data-file existence before the resource-monitor call-out.

This was observed at a cache using a LVM setup after one of the disks holding the data files went bad.
