### PR TITLE
[Sec] Add logging callback for use during XrdSecGetProtocol

### DIFF
--- a/src/XrdCl/XrdClXRootDTransport.cc
+++ b/src/XrdCl/XrdClXRootDTransport.cc
@@ -2678,6 +2678,34 @@ namespace XrdCl
       return XRootDStatus( stFatal, errAuthFailed, 0, "Could not load authentication handler." );
 
     //--------------------------------------------------------------------------
+    // Set up a callback the security layer can use to send us log messages
+    //--------------------------------------------------------------------------
+    XrdSecGetProtLogCallback lcb(
+        [log,hsData]( XrdSecGetProtLogCallback::LogLevel llevel,
+                      const std::string &msg )
+        {
+          switch( llevel )
+          {
+            case XrdSecGetProtLogCallback::LogLevel::DEBUG:
+              log->Debug( XRootDTransportMsg, "[%s] Processing ptoken: %s",
+                          hsData->streamName.c_str(), msg.c_str() );
+              break;
+            case XrdSecGetProtLogCallback::LogLevel::INFO:
+              log->Info( XRootDTransportMsg, "[%s] Processing ptoken: %s",
+                         hsData->streamName.c_str(), msg.c_str() );
+              break;
+            case XrdSecGetProtLogCallback::LogLevel::WARN:
+              log->Warning( XRootDTransportMsg, "[%s] Processing ptoken: %s",
+                            hsData->streamName.c_str(), msg.c_str() );
+              break;
+          case XrdSecGetProtLogCallback::LogLevel::ERROR:
+              log->Error( XRootDTransportMsg, "[%s] Processing ptoken: %s",
+                          hsData->streamName.c_str(), msg.c_str() );
+              break;
+        } } );
+    ei.setErrCB( &lcb );
+
+    //--------------------------------------------------------------------------
     // Retrieve secuid and secgid, if available. These will override the fsuid
     // and fsgid of the current thread reading the credentials to prevent
     // security holes in case this process is running with elevated permissions.

--- a/src/XrdSec/XrdSecClient.cc
+++ b/src/XrdSec/XrdSecClient.cc
@@ -96,12 +96,20 @@ XrdSecProtocol *XrdSecGetProtocol(const char             *hostname,
    const char *noperr = "XrdSec: No authentication protocols are available.";
 
    XrdSecProtocol *protp;
+   std::stringstream ss;
 
 // Perform any required debugging
 //
-   DEBUG("protocol request for host " <<hostname <<" token='"
+   std::string pstr(parms.size > 0 ? parms.buffer : "", parms.size);
+   ss << "protocol request for host " <<hostname <<" token='"
          <<(parms.size > 0 ? std::setw(parms.size) : std::setw(1))
-         <<(parms.size > 0 ? parms.buffer : "") <<"'");
+         << pstr <<"'";
+
+   DEBUG(ss.str());
+
+   XrdSecGetProtLogCallback *lcb = 0;
+   if (einfo) lcb = (XrdSecGetProtLogCallback*)einfo->getErrCB();
+   if (lcb) lcb->logfn(XrdSecGetProtLogCallback::LogLevel::INFO, ss.str());
 
 // Check if the server wants no security.
 //
@@ -112,6 +120,7 @@ XrdSecProtocol *XrdSecGetProtocol(const char             *hostname,
    if (!(protp = PManager.Get(hostname, endPoint, parms, einfo)))
       {if (einfo) einfo->setErrInfo(ENOPROTOOPT, noperr);
          else std::cerr <<noperr <<std::endl;
+       if (lcb) lcb->logfn(XrdSecGetProtLogCallback::LogLevel::INFO, noperr);
       }
 
 // All done

--- a/src/XrdSec/XrdSecInterface.hh
+++ b/src/XrdSec/XrdSecInterface.hh
@@ -36,7 +36,10 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <functional>
+#include <string>
 
+#include "XrdOuc/XrdOucErrInfo.hh"
 #include "XrdSec/XrdSecEntity.hh"
 
 /******************************************************************************/
@@ -484,6 +487,44 @@ typedef XrdSecProtocol *(*XrdSecGetProt_t)(const char *hostname,
                                            XrdNetAddrInfo &endPoint,
                                            XrdSecParameters &sectoken,
                                            XrdOucErrInfo *einfo);
+
+//------------------------------------------------------------------------------
+// XrdSecGetProtLogCallback may be set as a callback in the XrdOucErrInfo object
+// supplied to XrdSecGetProtocol. The supplied logfn will be called to log
+// messages during the attempt to return an appropreate XrdSecProtocol.
+//------------------------------------------------------------------------------
+class XrdSecGetProtLogCallback : public XrdOucEICB
+{
+public:
+
+  enum class LogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+  };
+
+virtual void        Done(int           &Result,   //I/O: Function result
+                         XrdOucErrInfo *eInfo,    // In: Error Info
+                         const char    *Path=0) { }
+
+virtual int         Same(unsigned long long arg1, unsigned long long arg2)
+                         { return 0; }
+
+//------------------------------------------------------------------------------
+//! Constructor
+//!
+//! @fn a std::function to be repeatedly called with informational log messages
+//------------------------------------------------------------------------------
+
+   XrdSecGetProtLogCallback(const std::function<
+                              void(LogLevel, const std::string &)> &fn):
+     logfn(fn) {}
+
+  ~XrdSecGetProtLogCallback() {}
+
+   std::function<void(LogLevel, const std::string &)> logfn;
+};
 
 /*! Example:
 


### PR DESCRIPTION
Hi Andy. Quite a while ago we had talked about adding extra logging or returning extra information from, at least, XrdSecGetProtocol. This wasn't done so far, but I still had this in mind. So I've made this draft to see if there's anything of use here. (As written this doesn't break ABI, so there would be no rush for this for R6).

Here's some sample logging from a client: xrdcp command (with XRD_LOGLEVEL=Dump) with what this initial PR could add:

```
[2026-01-06 15:57:27.214150 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Sending authentication data
[2026-01-06 15:57:27.214379 +0100][Info   ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Processing ptoken: protocol request for host david-dev-al9.cern.ch token='&P=krb5,host/david-dev-al9.cern.ch@CERN.CH&P=gsi,v:10600,c:ssl,ca:5168735f.0|4339b4bc.0&P=unix'
[2026-01-06 15:57:27.214537 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Processing ptoken: Using krb5 protocol, args='host/david-dev-al9.cern.ch@CERN.CH'
[2026-01-06 15:57:27.214551 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Trying to authenticate using krb5
[2026-01-06 15:57:27.214670 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Cannot get credentials for protocol krb5: Seckrb5: No or invalid credentials; No credentials cache found(server=host/david-dev-al9.cern.ch@CERN.CH).
[2026-01-06 15:57:27.214685 +0100][Info   ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Processing ptoken: protocol request for host david-dev-al9.cern.ch token='&P=gsi,v:10600,c:ssl,ca:5168735f.0|4339b4bc.0&P=unix'
[2026-01-06 15:57:27.215047 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Processing ptoken: Using gsi protocol, args='v:10600,c:ssl,ca:5168735f.0|4339b4bc.0'
[2026-01-06 15:57:27.215071 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Trying to authenticate using gsi
[2026-01-06 15:57:27.226760 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Cannot get credentials for protocol gsi: Secgsi: ErrParseBuffer: error getting user proxies: kXGS_init
[2026-01-06 15:57:27.226789 +0100][Info   ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Processing ptoken: protocol request for host david-dev-al9.cern.ch token='&P=unix'
[2026-01-06 15:57:27.226904 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Processing ptoken: Using unix protocol, args=''
[2026-01-06 15:57:27.226928 +0100][Debug  ][XRootDTransport   ] [david-dev-al9.cern.ch:1094.0] Trying to authenticate using unix
```

The 6 lines containing "Processing ptoken" is the extra logging introduced. I'm not sure this is useful or not. What do you think (about the logging, or how to do it)? Thanks.