### PR TITLE
[XrdClCurl] Improve compatibility with non-XRootD WebDAV

### DIFF
--- a/src/XrdClCurl/XrdClCurlOpStat.cc
+++ b/src/XrdClCurl/XrdClCurlOpStat.cc
@@ -38,6 +38,7 @@ CurlStatOp::OptionsDone()
     auto verbs = instance.Get(target.empty() ? m_url : target);
     if (verbs.IsSet(VerbsCache::HttpVerb::kPROPFIND)) {
         curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "PROPFIND");
+        m_headers_list.emplace_back("Depth", "0");
         curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 0L);
         m_is_propfind = true;
     } else {
@@ -63,6 +64,7 @@ CurlStatOp::Redirect(std::string &target)
 
     if (verbs.IsSet(VerbsCache::HttpVerb::kPROPFIND)) {
         curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "PROPFIND");
+        m_headers_list.emplace_back("Depth", "0");
         curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 0L);
         m_is_propfind = true;
     } else {
@@ -83,6 +85,7 @@ CurlStatOp::Setup(CURL *curl, CurlWorker &worker)
     auto verbs = instance.Get(m_url);
     if (verbs.IsSet(VerbsCache::HttpVerb::kPROPFIND)) {
         curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "PROPFIND");
+        m_headers_list.emplace_back("Depth", "0");
         curl_easy_setopt(m_curl.get(), CURLOPT_NOBODY, 0L);
         m_is_propfind = true;
     } else {
@@ -133,6 +136,10 @@ CurlStatOp::ParseProp(TiXmlElement *prop) {
         } else if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
             m_is_dir = child->FirstChildElement("D:collection") != nullptr;
         }
+    }
+    if (m_length < 0 && m_is_dir) {
+        // Don't require length for directories; fake it as zero
+        m_length = 0;
     }
     return {m_length, m_is_dir};
 }


### PR DESCRIPTION
When testing XrdClCurl against `golang.org/x/net/webdav`, I found some modest incompatibilities worth fixing:

- WebDAV may include a trailing slash for subdirectories which broke our filename parsing.
- The size attribute is not mandatory for a collection; in this case, just set it as zero.
- The other WebDAV server defaults to `Depth: 1` if `Depth` is not specified.  This didn't break our parsing but caused excessively large responses to `stat` (as `stat` became a directory listing even though the client ignored the directory listing response).
- The client did not understand redirects to the existing server (that is, a redirect to `/foo` broke; the client didn't understand that it should implicitly do `https://example.com/foo` in such a case).