### PR TITLE
[XrdPfc] Rename `pfc.writemode` to `pfc.writethrough` taking `on`/`off` as values

### DIFF
--- a/src/XrdPfc/XrdPfc.hh
+++ b/src/XrdPfc/XrdPfc.hh
@@ -150,7 +150,6 @@ struct TmpConfiguration
    std::string m_fileUsageNominal;
    std::string m_fileUsageMax;
    std::string m_flushRaw;
-   std::string m_writemodeRaw;
 
    TmpConfiguration() :
       m_diskUsageLWM("0.90"), m_diskUsageHWM("0.95"),


### PR DESCRIPTION
As [discussed](https://github.com/xrootd/xrootd/pull/2472#issuecomment-3574585630) in #2472.