### PR TITLE
[XrdAcc] Add `/etc/xrootd/authdb` as default path for `authdb` file

### DIFF
--- a/src/XrdAcc/XrdAccConfig.cc
+++ b/src/XrdAcc/XrdAccConfig.cc
@@ -105,11 +105,20 @@ XrdAccConfig::XrdAccConfig()
 
 // Initialize path value and databse pointer to nil
 //
-   dbpath        = strdup("/opt/xrd/etc/Authfile");
    Database      = 0;
    Authorization = 0;
    spChar        = 0;
    uriPath       = false;
+
+   const char *dbpath_defaults[] = {
+    "/opt/xrd/etc/Authfile",
+    "/etc/xrootd/authdb"
+   };
+
+   dbpath = nullptr;
+   for (const char *path : dbpath_defaults)
+     if (access(path, R_OK) == 0)
+       dbpath = strdup(path);
 
 // Establish other defaults
 //

--- a/src/XrdAcc/XrdAccConfig.hh
+++ b/src/XrdAcc/XrdAccConfig.hh
@@ -81,7 +81,7 @@ XrdAccGroups  GroupMaster;
 int           AuthRT;
 
               XrdAccConfig();
-             ~XrdAccConfig() {}    // Configuration is never destroyed!
+             ~XrdAccConfig() { free(dbpath); }
 
 private:
 


### PR DESCRIPTION
This will need a matching update in the documentation.

As suggested by @abh3, I'm keeping the current path, and adding the extra path afterwards as an alternative default path.