### PR TITLE
[XrdHttp] Fix typo and omit version info in response header

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -1632,7 +1632,7 @@ int XrdHttpProtocol::StartSimpleResp(int code, const char *desc,
   else
     ss << "Connection: Close" << crlf;
 
-  ss << "Server: XrootD/" << XrdVSTRING << crlf;
+  ss << "Server: XRootD" << crlf;
 
   const auto iter = m_staticheaders.find(CurrentReq.requestverb);
   if (iter != m_staticheaders.end()) {


### PR DESCRIPTION
Remove version information to improve security. Apache, nginx, and other servers also omit their versions for the same reason.



See also:
- https://www.rfc-editor.org/rfc/rfc9110.html#section-10.2.4-5
- https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Headers_Cheat_Sheet.html#recommendation_15