### PR TITLE
[XrdHttp] Fix a null byte buffer overflow when parsing %-encoded strings

### DIFF
--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -448,7 +448,7 @@ char *unquote(char *str) {
 
   for (i = 0; i < l; i++) {
     if (str[i] == '%') {
-      if (i + 3 >= l) {
+      if (i + 3 > l) {
         r[j] = '\0';
         return r;
       }


### PR DESCRIPTION
The unquote function adds 3 to the index without checking whether the new index goes OOB.