### PR TITLE
[XrdHttp] Fix buffer overflow issues when parsing HTTP request lines

### DIFF
--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -641,13 +641,13 @@ int XrdHttpProtocol::Process(XrdLink *lp) // We ignore the argument here
 
       if (CurrentReq.request == CurrentReq.rtUnset) {
         TRACE(DEBUG, " Parsing first line: " << traceLine.c_str());
-        int result = CurrentReq.parseFirstLine((char *)tmpline.c_str(), rc);
+        int result = CurrentReq.parseFirstLine((char *)tmpline.c_str(), tmpline.length());
         if (result < 0) {
           TRACE(DEBUG, " Parsing of first line failed with " << result);
           return -1;
         }
       } else {
-        int result = CurrentReq.parseLine((char *) tmpline.c_str(), rc);
+        int result = CurrentReq.parseLine((char *) tmpline.c_str(), tmpline.length());
         if(result < 0) {
           TRACE(DEBUG, " Parsing of header line failed with " << result)
           SendSimpleResp(400,NULL,NULL,"Malformed header line. Hint: ensure the line finishes with \"\\r\\n\"", 0, false);


### PR DESCRIPTION
Buffgetline returns the total number of bytes read, while the string stops reading on null bytes. Pass the length of the string to subroutines instead of the return value of Buffgetline.