### PR TITLE
[XrdHttpMon] Use XrdMonRoll for http summary monitoring

### DIFF
--- a/tests/XRootD/http.cfg
+++ b/tests/XRootD/http.cfg
@@ -22,6 +22,8 @@ macaroons.secretkey $pwd/macaroons-secret
 
 xrootd.mongstream http use flush 3s send json 127.0.0.1:8888
 
+xrd.report 127.0.0.1:9999 every 3 json plugins
+
 # Verify static headers are appropriately appended to responses
 http.staticheader -verb=OPTIONS Access-Control-Allow-Origin *
 http.staticheader -verb=GET Foo Bar

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -403,4 +403,9 @@ function test_http() {
   run_and_assert_http_and_error_code 200 "" \
     --header "Want-Digest: crc32c" -I "${HOST}/$alphabetFilePath"
 
+  # Uncomment sleep to test monitoring packets - to keep the server running beyond monitoring flush intervals
+  # For HTTP Summary monitoring in another terminal use: socat -u udp-recv:9999 -
+  # For HTTP GStream monitoring use: socat -u udp-recv:8888 -
+  # sleep 5
+
 }


### PR DESCRIPTION
This adds summary monitoring for the HTTP protocol Two types of counters are store: verb counters and status code counters The monitoring is conditionally enabled based on the xrd.report configuration We use uint64_t for counting both verb and status counters. It uses the version 2 XrdMonRoll interface to create a single json for http_plugin with request and response nested objects.

Example output of monitoring packet:
```
"stats_http_plugin": {
  "request": {
    "Unknown": 0,
    "Malformed": 0,
    "GET": 24,
    "HEAD": 11,
    "PUT": 21,
    "OPTIONS": 1,
    "PATCH": 0,
    "DELETE": 10,
    "PROPFIND": 2,
    "MKCOL": 0,
    "MOVE": 0,
    "POST": 0,
    "COPY": 0
  },
  "response": {
    "100": 0,
    "200": 44,
    "201": 17,
    "202": 0,
    "206": 1,
    "207": 2,
    "302": 0,
    "307": 0,
    "400": 0,
    "401": 0,
    "403": 1,
    "404": 1,
    "405": 0,
    "409": 1,
    "416": 0,
    "423": 0,
    "500": 0,
    "502": 0,
    "504": 0,
    "507": 2,
    "OTHERS": 0
  }
}
```