### PR TITLE
[XrdHttpTPC] Allow missing CRL checking if configured via xrd.tlsca

### DIFF
--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -2532,12 +2532,16 @@ int XrdConfig::xtlsca(XrdSysError *eDest, XrdOucStream &Config)
       }
    tlsNoVer = false;
 
-
    do {if (!strcmp(val, "proxies") || !strcmp("noproxies", val))
           {if (*val == 'n') tlsOpts |=  XrdTlsContext::nopxy;
               else          tlsOpts &= ~XrdTlsContext::nopxy;
            continue;
           }
+
+         if (!strcmp(val,"allowmissingcrl")) {
+            tlsOpts |= XrdTlsContext::crlAM;
+            continue;
+         }
 
        if (strlen(val) >= (int)sizeof(kword))
           {eDest->Emsg("Config", "Invalid tlsca parameter -", val);
@@ -2590,8 +2594,7 @@ int XrdConfig::xtlsca(XrdSysError *eDest, XrdOucStream &Config)
                {if (XrdOuca2x::a2i(*eDest,"tlsca verdepth",val,&vd,1,255))
                    return 1;
                 tlsOpts = TLS_SET_VDEPTH(tlsOpts,vd);
-               }
-       else {eDest->Emsg("Config", "invalid tlsca option -",kword); return 1;}
+               } else {eDest->Emsg("Config", "invalid tlsca option -",kword); return 1;}
 
        } while((val = Config.GetWord()));
 

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -406,6 +406,9 @@ protected:
   /// CRL thread refresh interval
   static int crlRefIntervalSec;
 
+  // Allows missing CRL for CA verification
+  static bool allowMissingCRL;
+
   /// Gridmap file location. The same used by XrdSecGsi
   static char *gridmap;// [s] gridmap file [/etc/grid-security/gridmap]
   static bool isRequiredGridmap; // If true treat gridmap errors as fatal

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -34,6 +34,8 @@
  * 
  * 
  */
+#ifndef XRDHTTPUTILS_HH
+#define	XRDHTTPUTILS_HH
 
 #include "XProtocol/XPtypes.hh"
 #include "XProtocol/XProtocol.hh"
@@ -46,9 +48,6 @@
 #include <memory>
 #include <sstream>
 #include <cstdint>
-
-#ifndef XRDHTTPUTILS_HH
-#define	XRDHTTPUTILS_HH
 
 enum : int {
   HTTP_CONTINUE                        = 100,

--- a/src/XrdHttpTpc/CMakeLists.txt
+++ b/src/XrdHttpTpc/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries(${XrdHttpTPC}
     XrdUtils
     XrdHttpUtils
     CURL::libcurl
+    OpenSSL::SSL
+    OpenSSL::Crypto
     ${CMAKE_THREAD_LIBS_INIT}
     ${CMAKE_DL_LIBS}
 )

--- a/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
@@ -24,7 +24,8 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
 
     // test if XrdEC is used
     usingEC = getenv("XRDCL_EC")? true : false;
-
+    // Test if the CRL checking is enabled
+    allowMissingCRL = (bool) myEnv->GetInt("http.allowmissingcrl");
     std::string authLib;
     std::string authLibParms;
     int cfgFD = open(configfn, O_RDONLY, 0);

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.hh
@@ -1,4 +1,5 @@
-
+#ifndef XRD_HTTP_TPC_TPC_HH
+#define XRD_HTTP_TPC_TPC_HH
 #include <memory>
 #include <string>
 #include <vector>
@@ -13,6 +14,7 @@
 #include "XrdHttpTpcPMarkManager.hh"
 
 #include <curl/curl.h>
+#include <openssl/ssl.h>
 
 class XrdOucErrInfo;
 class XrdOucStream;
@@ -61,6 +63,8 @@ private:
                                    struct curl_sockaddr *address);
 
     static int closesocket_callback(void *clientp, curl_socket_t fd);
+    static int ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *clientp);
+    static int verify_callback(int preverify_ok, X509_STORE_CTX* ctx);
 
     struct TPCLogRecord {
 
@@ -183,6 +187,8 @@ private:
 
     bool usingEC; // indicate if XrdEC is used
 
+    static bool allowMissingCRL;
+
     // Time to connect the curl socket to the remote server uses the linux's default value
     // of 60 seconds
     static const long CONNECT_TIMEOUT = 60;
@@ -191,3 +197,4 @@ private:
     std::map<std::string,std::string> hdr2cgimap;
 };
 }
+#endif

--- a/src/XrdTls/XrdTlsContext.hh
+++ b/src/XrdTls/XrdTlsContext.hh
@@ -252,9 +252,13 @@ static const uint64_t rfCRL = 0x0000004000000000; //!< Turn on the CRL refresh t
 static const uint64_t crlON = 0x0000008000000000; //!< Enables crl checking
 static const uint64_t crlFC = 0x000000C000000000; //!< Full crl chain checking
 static const uint64_t crlRF = 0x00000000ffff0000; //!< Mask to isolate crl refresh in min
+static const uint64_t crlAM = 0x0000001000000000; //!< Allow CA validation when CRL is missing (CRL soft-fail)
 static const int      crlRS = 16;                 //!< Bits to shift   vdept
 static const uint64_t artON = 0x0000002000000000; //!< Auto retry Handshake
 static const uint64_t clcOF = 0x0000010000000000; //!< Disable client certificate request
+
+
+static int ctxIndex;
 
        XrdTlsContext(const char *cert=0,  const char *key=0,
                      const char *cadir=0, const char *cafile=0,

--- a/tests/XrdHttpTpc/CMakeLists.txt
+++ b/tests/XrdHttpTpc/CMakeLists.txt
@@ -4,6 +4,14 @@ add_library(XrdHttpTpcUtils
   ${PROJECT_SOURCE_DIR}/src/XrdHttpTpc/XrdHttpTpcUtils.cc
 )
 
-target_link_libraries(xrdhttptpc-unit-tests XrdHttpTpcUtils GTest::GTest GTest::Main)
+target_link_libraries(XrdHttpTpcUtils
+        PRIVATE
+        OpenSSL::SSL
+        OpenSSL::Crypto)
+
+target_link_libraries(xrdhttptpc-unit-tests
+        XrdHttpTpcUtils
+        GTest::GTest
+        GTest::Main)
 
 gtest_discover_tests(xrdhttptpc-unit-tests PROPERTIES DISCOVERY_TIMEOUT 10)


### PR DESCRIPTION
One can deactivate missing CRL checking by setting the flag "allowmissingcrl" in the xrd.tlsca directive

Fixes #2681