### PR TITLE
Fix FDs leaked in constructors when logging to stderr

### DIFF
--- a/src/XrdSys/XrdSysLogger.cc
+++ b/src/XrdSys/XrdSysLogger.cc
@@ -161,8 +161,11 @@ XrdSysLogger::XrdSysLogger(int ErrFD, int dorotate)
 // Establish message routing
 //
    if (ErrFD != STDERR_FILENO) baseFD = ErrFD;
-      else {baseFD = XrdSysFD_Dup(ErrFD);
-            Bind(logFN, 1);
+      else {baseFD = ErrFD;
+            if (logFN)
+               {baseFD = XrdSysFD_Dup(ErrFD);
+                Bind(logFN, 1);
+               }
            }
 }
   


### PR DESCRIPTION
This is ancient code and a relatively minor bug, but it caused us some grief trying to use XRootD in the ADIOS2 project. There are a lot of static instances of XrdSysLogger in the xrootd code base.  If there's not a explicit logging file name set, each of these will dup() stderr and leave the FD open.  This is a relatively minor waste of resources, but it kept ADIOS from running executables linked with Xrootd client libraries from running in testing as a CMake fixture.   (To run in the background forked fixtures need to drop access the parent-process stdin,stdout,stderr, but the lingering dup()s of stderr cause problems.  It was tracking down open FDs that led me to examine XrdSysLogger. Since this happens in static initializers, the problem exists even if XRootdD code isn't actually called.) Our workaround has been to simply call close on the first dozen or so FDs before getting on with the rest of our application.  This was OK in our case because that particular server linked with xrootd-enabled ADIOS but didn't use xrootd features.  However obviously it'd be better to address the problem directly.

I believe that this patch preserves original functionality, keeping baseFD as valid when binding ErrFD to a file, but it avoids calling dup unnecessarily in the non-file case.