### PR TITLE
[XrdCl] Correct protocol check for supported protocols

### DIFF
--- a/src/XrdApps/XrdCpConfig.cc
+++ b/src/XrdApps/XrdCpConfig.cc
@@ -377,10 +377,11 @@ do{while(optind < Argc && Legacy(optind)) {}
      if (dstFile->Protocol != XrdCpFile::isFile
      &&  dstFile->Protocol != XrdCpFile::isStdIO
      &&  dstFile->Protocol != XrdCpFile::isXroot
+     &&  dstFile->Protocol != XrdCpFile::isXroots
      &&  dstFile->Protocol != XrdCpFile::isPelican
      &&  dstFile->Protocol != XrdCpFile::isS3
      &&  dstFile->Protocol != XrdCpFile::isHttp
-     &&  dstFile->Protocol == XrdCpFile::isHttps)
+     &&  dstFile->Protocol != XrdCpFile::isHttps)
         {FMSG(dstFile->ProtName <<"file protocol is not supported.", 22)}
 
 // Resolve this file if it is a local file


### PR DESCRIPTION
Fix typo for check for supported protocols.

```
❯ bin/xrdcp -f /tmp/f01 https://localhost:10940/rootfile
[2026-02-20 13:54:11.435899 +0100][Debug  ][Utility           ] Initializing xrootd client version: v5.9.1-251-g3502f84ab
[2026-02-20 13:54:11.436069 +0100][Debug  ][Utility           ] Unable to process user config file: [ERROR] OS Error: no such file or directory
[2026-02-20 13:54:11.436153 +0100][Info   ][Utility           ] Env: Importing from shell XRD_REQUESTTIMEOUT=5 as requesttimeout
[2026-02-20 13:54:11.436252 +0100][Debug  ][PlugInMgr         ] Initializing plug-in manager...
[2026-02-20 13:54:11.436259 +0100][Debug  ][PlugInMgr         ] No default plug-in, loading plug-in configs...
[2026-02-20 13:54:11.436263 +0100][Debug  ][PlugInMgr         ] Processing plug-in definitions in /etc/xrootd/client.plugins.d...
[2026-02-20 13:54:11.436372 +0100][Debug  ][PlugInMgr         ] Trying to disable plug-in for '*'
[2026-02-20 13:54:11.436419 +0100][Debug  ][PlugInMgr         ] Processing plug-in definitions in /home/rchauhan/.xrootd/client.plugins.d...
[2026-02-20 13:54:11.436463 +0100][Debug  ][PlugInMgr         ] Trying to load a plug-in for 'http://*;https://*;dav://*;davs://*' from 'libXrdClHttp.so'
[2026-02-20 13:54:11.438419 +0100][Debug  ][PlugInMgr         ] Registering a factory for dav from libXrdClHttp.so
[2026-02-20 13:54:11.438432 +0100][Debug  ][PlugInMgr         ] Registering a factory for davs from libXrdClHttp.so
[2026-02-20 13:54:11.438440 +0100][Debug  ][PlugInMgr         ] Registering a factory for http from libXrdClHttp.so
[2026-02-20 13:54:11.438447 +0100][Debug  ][PlugInMgr         ] Registering a factory for https from libXrdClHttp.so
xrdcp: httpsfile protocol is not supported.

```