### PR TITLE
[XrdFrm] Remove local XrdXrootdTrace clashing with global symbol

### DIFF
--- a/src/XrdFrm/XrdFrmAdminMain.cc
+++ b/src/XrdFrm/XrdFrmAdminMain.cc
@@ -93,7 +93,6 @@ using namespace XrdFrm;
 
 // The following is needed to resolve symbols for objects included from xrootd
 //
-       XrdOucTrace       *XrdXrootdTrace;
        XrdSysError        XrdLog(0, "");
        XrdOucTrace        XrdTrace(&Say);
 
@@ -143,10 +142,6 @@ int main(int argc, char *argv[])
    Say.logger(&Logger);
    XrdLog.logger(&Logger);
    if (!Config.Configure(argc, argv, 0)) exit(4);
-
-// Fill out the dummy symbol to avoid crashes
-//
-   XrdXrootdTrace = new XrdOucTrace(&Say);
 
 // We either have a command line or need to enter interactive mode
 //

--- a/src/XrdFrm/XrdFrmPurgMain.cc
+++ b/src/XrdFrm/XrdFrmPurgMain.cc
@@ -109,7 +109,6 @@ using namespace XrdFrm;
 
 // The following is needed to resolve symbols for objects included from xrootd
 //
-       XrdOucTrace       *XrdXrootdTrace;
        XrdSysError        XrdLog(0, "");
        XrdOucTrace        XrdTrace(&Say);
 
@@ -147,10 +146,6 @@ int main(int argc, char *argv[])
    Say.logger(&Logger);
    XrdLog.logger(&Logger);
    if (!Config.Configure(argc, argv, &mainConfig)) exit(4);
-
-// Fill out the dummy symbol to avoid crashes
-//
-   XrdXrootdTrace = new XrdOucTrace(&Say);
 
 // Display configuration (deferred because mum might have been in effect)
 //

--- a/src/XrdFrm/XrdFrmXfrMain.cc
+++ b/src/XrdFrm/XrdFrmXfrMain.cc
@@ -101,7 +101,6 @@ using namespace XrdFrm;
 
 // The following is needed to resolve symbols for objects included from xrootd
 //
-       XrdOucTrace       *XrdXrootdTrace;
        XrdSysError        XrdLog(0, "");
        XrdOucTrace        XrdTrace(&Say);
 
@@ -136,10 +135,6 @@ int main(int argc, char *argv[])
    Say.logger(&Logger);
    XrdLog.logger(&Logger);
    if (!Config.Configure(argc, argv, &mainConfig)) exit(4);
-
-// Fill out the dummy symbol to avoid crashes
-//
-   XrdXrootdTrace = new XrdOucTrace(&Say);
 
 // All done, simply exit based on our persona
 //


### PR DESCRIPTION
Fixes warnings like the one below (ODR violations reported by the address sanitizer):
```
[ 64%] Linking CXX executable ../../bin/frm_admin
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: warning:
  size of symbol `XrdXrootdTrace' changed from 848 in CMakeFiles/frm_purged.dir/XrdFrmPurgMain.cc.o
  (symbol from plugin) to 8 in /tmp/cc6BZkMF.ltrans0.ltrans.o
/usr/lib/gcc/x86_64-pc-linux-gnu/14/../../../../x86_64-pc-linux-gnu/bin/ld: warning:
  NOTE: size discrepancies can cause real problems.  Investigation is advised.
```
This is because `XrdXrootdTrace` is declared as a global symbol in `XrdXrootd/XrdXrootdProtocol.cc` with type `XrdSysTrace` (size 848), and in XrdFrm binaries it's declared as `XrdOucTrace*` (size 8).