### PR TITLE
[Cl] Don't let send notification modify MessageHandler after flagging

### DIFF
--- a/src/XrdCl/XrdClXRootDMsgHandler.cc
+++ b/src/XrdCl/XrdClXRootDMsgHandler.cc
@@ -120,8 +120,6 @@ namespace XrdCl
                  "that it was sent, assuming it was sent ok.",
                  pUrl.GetHostId().c_str(),
                  pRequest->GetObfuscatedDescription().c_str() );
-
-      pMsgInFly = true;
     }
 
     //--------------------------------------------------------------------------
@@ -461,7 +459,7 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     // we have an response for the message so it's not in fly anymore
     //--------------------------------------------------------------------------
-    pMsgInFly = false;
+    pSendingState.fetch_or( kInFlyDone );
 
     //--------------------------------------------------------------------------
     // Reset the aggregated wait (used to omit wait response in case of Metalink
@@ -923,6 +921,16 @@ namespace XrdCl
   {
     Log *log = DefaultEnv::GetLog();
 
+    if( status.IsOK() )
+    {
+      log->Dump( XRootDMsg, "[%s] Got notification that outgoing message %s "
+                 "was sent successfully.", pUrl.GetHostId().c_str(),
+                 message->GetObfuscatedDescription().c_str() );
+    }
+
+    // After setting kSendDone processing of this object may continue in
+    // another thread. Unless we're in an error condition our object may
+    // be modified or even destroyed after this point.
     const int sst = pSendingState.fetch_or( kSendDone );
 
     // ignore if we're already in this state
@@ -941,27 +949,24 @@ namespace XrdCl
 
     if( sst & kFinalResp )
     {
-      log->Dump( XRootDMsg, "[%s] Got late notification that outgoing message %s was "
-                 "sent, already have final response, queuing handler callback.",
-                 pUrl.GetHostId().c_str(), message->GetObfuscatedDescription().c_str() );
+      // late notification and we already have final response for user,
+      // need to queue handler callback.
       HandleRspOrQueue();
       return;
     }
 
     if( sst & kRetryAtSrv )
     {
-      log->Dump( XRootDMsg, "[%s] Got late notification that outgoing message %s was "
-                 "sent, already want to retry at different server.",
-                 pUrl.GetHostId().c_str(), message->GetObfuscatedDescription().c_str() );
+       // late notification and we already received a response and know
+       // we need to retry at differnt server.
        HandleError( RetryAtServer( pRetryAtUrl, pRetryAtEntryType ) );
        return;
     }
 
     if( sst & kSawResp )
     {
-      log->Dump( XRootDMsg, "[%s] Got late notification that message %s has "
-                 "been successfully sent.",
-                 pUrl.GetHostId().c_str(), message->GetObfuscatedDescription().c_str() );
+      // late notification, response processing may be happening in another
+      // thread.
       return;
     }
 
@@ -970,10 +975,9 @@ namespace XrdCl
     //--------------------------------------------------------------------------
     if( status.IsOK() )
     {
-      log->Dump( XRootDMsg, "[%s] Message %s has been successfully sent.",
-                 pUrl.GetHostId().c_str(), message->GetObfuscatedDescription().c_str() );
-
-      pMsgInFly = true;
+      // this is the expcted order, we got the notificaiton but no response
+      // received yet. However another thread is liable to be processing
+      // one or sending a final response and deleting us at any point now.
       return;
     }
 
@@ -1231,7 +1235,7 @@ namespace XrdCl
     if( pSidMgr && finalrsp )
     {
       ClientRequest *req = (ClientRequest *)pRequest->GetBuffer();
-      if( status->IsOK() || !pMsgInFly ||
+      if( status->IsOK() || !IsInFly() ||
           !( status->code == errOperationExpired || status->code == errOperationInterrupted ) )
         pSidMgr->ReleaseSID( req->header.streamid );
     }
@@ -2042,7 +2046,7 @@ namespace XrdCl
     if( status.IsOK() )
       return;
 
-    if( pSidMgr && pMsgInFly && ( 
+    if( pSidMgr && IsInFly() && ( 
         status.code == errOperationExpired ||
         status.code == errOperationInterrupted ) )
     {

--- a/src/XrdCl/XrdClXRootDMsgHandler.hh
+++ b/src/XrdCl/XrdClXRootDMsgHandler.hh
@@ -167,7 +167,6 @@ namespace XrdCl
 
         pAggregatedWaitTime( 0 ),
 
-        pMsgInFly( false ),
         pSendingState( 0 ),
 
         pTimeoutFence( false ),
@@ -454,6 +453,7 @@ namespace XrdCl
       static constexpr int kFinalResp    = 0x0004;
       static constexpr int kSawReadySend = 0x0008;
       static constexpr int kRetryAtSrv   = 0x0010;
+      static constexpr int kInFlyDone    = 0x0020;
 
       //------------------------------------------------------------------------
       //! Recover error
@@ -619,6 +619,17 @@ namespace XrdCl
         return pgcnt;
       }
 
+      //------------------------------------------------------------------------
+      // Used to track whether we need to relase or timeout SID
+      //------------------------------------------------------------------------
+      inline bool IsInFly() const
+      {
+        const int sst = pSendingState;
+        if ( ( sst & ( kSawResp|kSendDone ) ) && !( sst & kInFlyDone ) )
+          return true;
+        return false;
+      }
+
       Message                               *pRequest;
       std::shared_ptr<Message>               pResponse; //< the ownership is shared with MsgReader
       std::vector<std::shared_ptr<Message>>  pPartialResps; //< the ownership is shared with MsgReader
@@ -665,7 +676,6 @@ namespace XrdCl
       std::unique_ptr<RedirectEntry>         pRdirEntry;
       RedirectTraceBack                      pRedirectTraceBack;
 
-      bool                                   pMsgInFly;
       std::atomic<int>                       pSendingState;
 
       //------------------------------------------------------------------------


### PR DESCRIPTION
This is a fix for 1 of the warning/errors that came up during recent effort to clean up thread-sanitizer errors in an experimental branch. This fix concerned more recent code and appears to be be a defect, so I'd say we could fix this one now.