### PR TITLE
[XrdClHttp] Enable libcurl header traces in Debug mode

### DIFF
--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -30,6 +30,7 @@
 #include <XrdCl/XrdClURL.hh>
 #include <XrdCl/XrdClXRootDResponses.hh>
 #include <XrdOuc/XrdOucCRC.hh>
+#include <XrdOuc/XrdOucPrivateUtils.hh>
 #include <XrdSys/XrdSysPageSize.hh>
 #include <XrdVersion.hh>
 
@@ -597,7 +598,8 @@ int DumpHeader(CURL *handle, curl_infotype type, char *data, size_t size, void *
         return 0;
     }
 
-    logger->Debug(kLogXrdClHttp, "%s %s", direction, std::string(data, size).c_str());
+    const std::string redacted = obfuscateAuth(std::string(data, size));
+    logger->Debug(kLogXrdClHttp, "%s %s", direction, redacted.c_str());
     return 0;
 }
 


### PR DESCRIPTION
Allow a user to enable curl header dumps with `XRD_LOGLEVEL=Debug`

Currently, one can only achieve this by recompiling; this PR allows a user to set it with xrd env vars. 
It is especially useful when debugging issues reported by users.

If we should make these header traces available at `Debug` or `Dump` can be discussed. 