### PR TITLE
Use correct format specifier for user connections in monitoring report

### DIFF
--- a/src/XrdXrootd/XrdXrootdMonitor.cc
+++ b/src/XrdXrootd/XrdXrootdMonitor.cc
@@ -337,7 +337,7 @@ void XrdXrootdMonitor::User::Report(int eCode, int aCode)
 {
    char buff[1024];
 
-   snprintf(buff, sizeof(buff), "&Uc=%d&Ec=%d&Ac=%d", ntohl(Did), eCode, aCode);
+   snprintf(buff, sizeof(buff), "&Uc=%u&Ec=%d&Ac=%d", ntohl(Did), eCode, aCode);
 
    XrdXrootdMonitor::Map(XROOTD_MON_MAPUEAC,*this,buff);
 }
@@ -352,7 +352,7 @@ bool XrdXrootdMonitor::User::Report(WhatInfo infoT, const char *info)
 //
    if (infoT != TokenInfo) return false;
 
-   snprintf(buff, sizeof(buff), "&Uc=%d%s%s", ntohl(Did),
+   snprintf(buff, sizeof(buff), "&Uc=%u%s%s", ntohl(Did),
                                 (*info == '&' ? "" : "&"), info);
 
    XrdXrootdMonitor::Map(XROOTD_MON_MAPTOKN,*this,buff);


### PR DESCRIPTION
Caught this from a user-reported error in Pelican: `msg="Pelican failed to handle monitoring packet received from XRootD: Provided ID, -7865, is not a valid uint32"`

It looks like `Did` [is in fact a unsigned](https://github.com/xrootd/xrootd/blob/e1ec1c4bc71c8f2d21483634f683a4070627f802/src/XrdXrootd/XrdXrootdMonitor.hh#L179), but the `snprintf` statements had the wrong format specifier.