### PR TITLE
Fix EMA use for slow transfer classification

### DIFF
--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -485,12 +485,15 @@ CurlOperation::TransferStalled(uint64_t xfer, const std::chrono::steady_clock::t
         m_last_xfer_count = xfer;
         m_last_xfer = now;
     }
-    if (elapsed > m_stall_interval) {
+
+    // If progress is made in this callback do not classify as stalled
+    if (elapsed > m_stall_interval && xfer_diff == 0) {
         if (m_error == OpError::ErrNone) m_error = IsPaused() ? OpError::ErrTransferClientStall : OpError::ErrTransferStall;
         return true;
     }
+
+    // Curl updated us with new timing but the byte count hasn't changed; no need to update the EMA.
     if (xfer_diff == 0) {
-        // Curl updated us with new timing but the byte count hasn't changed; no need to update the EMA.
         return false;
     }
 
@@ -509,7 +512,7 @@ CurlOperation::TransferStalled(uint64_t xfer, const std::chrono::steady_clock::t
     auto recent_rate = static_cast<double>(xfer_diff) / elapsed_seconds;
     auto alpha = 1.0 - exp(-elapsed_seconds / std::chrono::duration<double>(m_stall_interval).count());
     m_ema_rate = (1.0 - alpha) * m_ema_rate + alpha * recent_rate;
-    if (recent_rate < static_cast<double>(m_minimum_rate)) {
+    if (m_ema_rate < static_cast<double>(m_minimum_rate)) {
         if (m_error == OpError::ErrNone) m_error = OpError::ErrTransferSlow;
         return true;
     }


### PR DESCRIPTION
Observed failures for a seemingly healthy transfer when transferring files over the Atlantic.

```
[2026-03-12 17:09:09.290726 +0100][Debug  ][XrdClHttp         ] Closed davs://cmseos.fnal.gov:9000/eos/uscms/store/group/lpclonglived/DisappTrks/WtoLNu-4Jets_TuneCP5_13p6TeV_madgraphMLM-pythia8/TriggerEfficiencySF_WtoLNu4Jets/260312_051402/0000/triggerEfficiency_427.root?xrdclhttp.timeout=9s500ms
[2026-03-12 17:09:09.290756 +0100][Debug  ][File              ] [0x2f1f3bf0@file://localhost/dev/null?oss.asize=18576606526&xrdcl.requuid=4cd93e5f-507e-4827-9c39-b95f414b7995] Close returned from localhost with: [SUCCESS] 
[3.977GB/17.3GB][ 22%][===========>                                      ][44.75MB/s]  
Run: [ERROR] Operation expired: Transfer speed below minimum threshold (read operation at offset 0) (source)
[2026-03-12 17:09:09.290867 +0100][Debug  ][JobMgr            ] Stopping the job manager...
```
