### PR TITLE
[XrdSecztn] Harden token parsing and validation logic

### DIFF
--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -462,23 +462,35 @@ XrdSecCredentials *XrdSecProtocolztn::readToken(XrdOucErrInfo *erp,
 //
    isbad = true;
 
-// Get the size of the file
+// Open the token file and inspect metadata from the open file descriptor.
+// This avoids TOCTOU races between stat/open/read.
 //
-   if (stat(path, &Stat))
+   int open_flags = O_RDONLY;
+#ifdef O_NOFOLLOW
+   open_flags |= O_NOFOLLOW;
+#endif
+   if ((tokFD = open(path, open_flags)) < 0)
       {if (errno != ENOENT) return readFail(erp, path, errno);
        isbad = false;
        return 0;
       }
+   if (fstat(tokFD, &Stat))
+      {int rc = errno;
+       close(tokFD);
+       return readFail(erp, path, rc);
+      }
 
-// Make sure token is not too big
+// Make sure token is not too big and inaccessible by group/other.
 //
-   if (Stat.st_size > maxTSize) return readFail(erp, path, EMSGSIZE);
+   if (Stat.st_size > maxTSize)
+      {close(tokFD);
+       return readFail(erp, path, EMSGSIZE);
+      }
+   if (Stat.st_mode & (S_IRWXG | S_IRWXO))
+      {close(tokFD);
+       return readFail(erp, path, EPERM);
+      }
    buff = (char *)alloca(Stat.st_size+1);
-
-// Open the token file
-//
-   if ((tokFD = open(path, O_RDONLY)) < 0)
-      return readFail(erp, path, errno);
 
 // Read in the token
 //
@@ -499,10 +511,6 @@ XrdSecCredentials *XrdSecProtocolztn::readToken(XrdOucErrInfo *erp,
       {isbad = false;
        return 0;
       }
-
-// Make sure the file is not accessible to anyone but the owner
-//
-   if (Stat.st_mode & (S_IRWXG | S_IRWXO)) return readFail(erp, path, EPERM);
 
 // Return response
 //

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -614,7 +614,7 @@ int XrdSecProtocolztn::Authenticate(XrdSecCredentials *cred,
 
 // Check if this is our protocol
 //
-   if (strcmp(tResp->hdr.id, "ztn"))
+   if (memcmp(tResp->hdr.id, "ztn", 3) || tResp->hdr.id[3] != '\0')
       {char msg[256];
        snprintf(msg, sizeof(msg),
                 "Authentication protocol id mismatch ('ztn' != '%.4s').",
@@ -679,7 +679,9 @@ int XrdSecProtocolztn::Authenticate(XrdSecCredentials *cred,
        if ((Entity.creds = (char *)malloc(Entity.credslen+1)))
          strcpy(Entity.creds, tResp->tkn);
        else
-         Fatal(erp, "'ztn' bad alloc", ENOMEM, false);
+         {Fatal(erp, "'ztn' bad alloc", ENOMEM, false);
+          return -1;
+         }
        if (!Entity.name) Entity.name = strdup("anon");
        return 0;
       }

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -40,6 +40,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <atomic>
 #include <vector>
 
 #ifndef __FreeBSD__
@@ -112,8 +113,8 @@ inline uint64_t monotonic_time() {
 /*                    G l o b a l   S t a t i c   D a t a                     */
 /******************************************************************************/
   
-int expiry = 1;
-bool tokenlib = true;
+std::atomic<int>  expiry{1};
+std::atomic<bool> tokenlib{true};
 }
 
 /******************************************************************************/
@@ -156,7 +157,7 @@ bool getLinkage(XrdOucErrInfo *erp, const char *piName)
   
 namespace
 {
-int MaxTokSize = 4096;
+std::atomic<int> MaxTokSize{4096};
 
 // Option flags
 //
@@ -204,7 +205,7 @@ public:
         XrdSecProtocolztn(const char *hname, XrdNetAddrInfo &endPoint,
                           XrdSciTokensHelper *sthp)
                          : XrdSecProtocol("ztn"), sthP(sthp), tokName(""),
-                           maxTSize(MaxTokSize), cont(false),
+                           maxTSize(MaxTokSize.load()), cont(false),
                            rtGet(false), verJWT(false)
                          {Entity.host = strdup(hname);
                           Entity.name = strdup("anon");
@@ -718,7 +719,7 @@ char  *XrdSecProtocolztnInit(const char     mode,
    if (!parms || !(*parms))
       {char buff[256];
        if (!getLinkage(erp, accPlugin.c_str())) return 0;
-       snprintf(buff, sizeof(buff), "TLS:%" PRIu64 ":%d:", opts, MaxTokSize);
+       snprintf(buff, sizeof(buff), "TLS:%" PRIu64 ":%d:", opts, MaxTokSize.load());
        return strdup(buff);
       }
 
@@ -742,13 +743,14 @@ char  *XrdSecProtocolztnInit(const char     mode,
                      {Fatal(erp, "-maxsz argument missing", EINVAL);
                       return 0;
                      }
-                  MaxTokSize = strtol(val, &endP, 10);
+                  int maxTokSize = strtol(val, &endP, 10);
                   if (*endP == 'k' || *endP == 'K')
-                     {MaxTokSize *= 1024; endP++;}
-                  if (MaxTokSize <= 0 || MaxTokSize > 524288 || *endP)
+                     {maxTokSize *= 1024; endP++;}
+                  if (maxTokSize <= 0 || maxTokSize > 524288 || *endP)
                      {Fatal(erp, "-maxsz argument is invalid", EINVAL);
                       return 0;
                      }
+                  MaxTokSize.store(maxTokSize);
                  }
          else if (!strcmp(val, "-expiry"))
                  {if (!(val = cfg.GetToken()))
@@ -772,7 +774,7 @@ char  *XrdSecProtocolztnInit(const char     mode,
                      {accPlugin = val;
                      }
                      else
-                     {tokenlib = false;
+                     {tokenlib.store(false);
                      }
                  }
 
@@ -787,12 +789,12 @@ char  *XrdSecProtocolztnInit(const char     mode,
 // get the validation object pointer. This will be filled in later but we
 // want to know that it's actually present.
 //
-   if (tokenlib && !getLinkage(erp, accPlugin.c_str())) return 0;
+   if (tokenlib.load() && !getLinkage(erp, accPlugin.c_str())) return 0;
 
 // Assemble the parameter line and return it
 //
    char buff[256];
-   snprintf(buff, sizeof(buff), "TLS:%" PRIu64 ":%d:", opts, MaxTokSize);
+   snprintf(buff, sizeof(buff), "TLS:%" PRIu64 ":%d:", opts, MaxTokSize.load());
    return strdup(buff);
 }
 }
@@ -830,7 +832,7 @@ XrdSecProtocol *XrdSecProtocolztnObject(const char              mode,
       }
 
    XrdSciTokensHelper *sthP= nullptr;
-   if (tokenlib)
+   if (tokenlib.load())
       {
 // In server mode we need to make sure the token plugin was actually
 // loaded and initialized as we need a pointer to the helper.

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -96,20 +96,6 @@ XrdSecCredentials *Fatal(XrdOucErrInfo *erp, const char *eMsg, int rc,
 }
 
 /******************************************************************************/
-/*                        m o n o t o n i c _ t i m e                         */
-/******************************************************************************/
-  
-inline uint64_t monotonic_time() {
-  struct timespec tp;
-#ifdef CLOCK_MONOTONIC_COARSE
-  clock_gettime(CLOCK_MONOTONIC_COARSE, &tp);
-#else
-  clock_gettime(CLOCK_MONOTONIC, &tp);
-#endif
-  return tp.tv_sec + (tp.tv_nsec >= 500000000);
-}
-
-/******************************************************************************/
 /*                    G l o b a l   S t a t i c   D a t a                     */
 /******************************************************************************/
   

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -658,20 +658,21 @@ int XrdSecProtocolztn::Authenticate(XrdSecCredentials *cred,
    long long   eTime;
    bool validated = false;
    if (Entity.name) {free(Entity.name); Entity.name = 0;}
-   if (tokenlib && sthP->Validate(tResp->tkn, msgRC, (expiry ? &eTime : 0), &Entity))
-      {if (expiry)
-          {if (eTime < 0 && expiry > 0)
+   int expiryMode = expiry.load();
+   if (tokenlib.load() && sthP->Validate(tResp->tkn, msgRC, (expiryMode ? &eTime : 0), &Entity))
+      {if (expiryMode)
+          {if (eTime < 0 && expiryMode > 0)
               {Fatal(erp, "'ztn' token expiry missing", EINVAL, false);
                return -1;
               }
-           if ((monotonic_time() - eTime) <= 0)
+           if ((eTime >= 0) && (time(nullptr) >= eTime))
               {Fatal(erp, "'ztn' token expired", EINVAL, false);
                return -1;
               }
 	  }
        validated = true;
       }
-   if (!tokenlib || validated)
+   if (!tokenlib.load() || validated)
       {
        Entity.credslen = strlen(tResp->tkn);
        if (Entity.creds)
@@ -767,9 +768,9 @@ char  *XrdSecProtocolztnInit(const char     mode,
                      {Fatal(erp, "-expiry argument missing", EINVAL);
                       return 0;
                      }
-                       if (strcmp(val, "ignore"))   expiry =  0;
-                  else if (strcmp(val, "optional")) expiry = -1;
-                  else if (strcmp(val, "required")) expiry =  1;
+                       if (!strcmp(val, "ignore"))   expiry.store(0);
+                  else if (!strcmp(val, "optional")) expiry.store(-1);
+                  else if (!strcmp(val, "required")) expiry.store(1);
                   else {Fatal(erp, "-expiry argument invalid", EINVAL);
                         return 0;
                        }


### PR DESCRIPTION
Fix unsafe protocol-id parsing, correct expiry handling and -expiry option parsing, remove token-file TOCTOU by validating metadata on opened FDs, and make global runtime ztn settings thread-safe with atomics.