### PR TITLE
[XrdClHttp] Harden parsing and redirect host handling

### DIFF
--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -90,7 +90,9 @@ bool CurlListdirOp::ParseProp(DavEntry &entry, TiXmlElement *prop)
             }
             try {
                 entry.m_size = std::stoll(size);
-            } catch (std::invalid_argument &e) {
+            } catch (std::invalid_argument &) {
+                return false;
+            } catch (std::out_of_range &) {
                 return false;
             }
         } else if (!strcasecmp(child->Value(), "D:getlastmodified") || !strcasecmp(child->Value(), "lp1:getlastmodified")) {
@@ -181,6 +183,11 @@ CurlListdirOp::Success()
     }
 
     auto elem = doc.RootElement();
+    if (!elem) {
+        m_logger->Error(kLogXrdClHttp, "XML response had no root element");
+        Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded to directory listing with invalid XML");
+        return;
+    }
     if (strcasecmp(elem->Value(), "D:multistatus")) {
         m_logger->Error(kLogXrdClHttp, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
         Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded to directory listing unexpected XML root");

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -131,7 +131,11 @@ CurlStatOp::ParseProp(TiXmlElement *prop) {
         if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
             auto len = child->GetText();
             if (len) {
-                m_length = std::stoll(len);
+                try {
+                    m_length = std::stoll(len);
+                } catch (...) {
+                    return {-1, false};
+                }
             }
         } else if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
             m_is_dir = child->FirstChildElement("D:collection") != nullptr;
@@ -162,6 +166,10 @@ CurlStatOp::GetStatInfo() {
     }
 
     auto elem = doc.RootElement();
+    if (!elem) {
+        m_logger->Error(kLogXrdClHttp, "XML response had no root element");
+        return {-1, false};
+    }
     if (strcasecmp(elem->Value(), "D:multistatus")) {
         m_logger->Error(kLogXrdClHttp, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
         return {-1, false};

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -131,17 +131,57 @@ std::pair<std::string, int> ParseHostPort(const std::string &location) {
     if (pos != std::string::npos) {
         hostport = hostport.substr(0, pos);
     }
-    pos = hostport.find(':');
-    if (pos == std::string::npos) {
+    if (hostport.empty()) {
+        return {"", -1};
+    }
+    if (hostport[0] == '[') {
+        auto close = hostport.find(']');
+        if (close == std::string::npos || close == 1) {
+            return {"", -1};
+        }
+        auto host = hostport.substr(1, close - 1);
+        if (close + 1 == hostport.size()) {
+            return {host, std_port};
+        }
+        if (hostport[close + 1] != ':') {
+            return {"", -1};
+        }
+        int port = -1;
+        try {
+            port = std::stoi(hostport.substr(close + 2));
+        } catch (...) {
+            return {"", -1};
+        }
+        if (port < 1 || port > 65535) {
+            return {"", -1};
+        }
+        return {host, port};
+    }
+
+    auto first_colon = hostport.find(':');
+    if (first_colon == std::string::npos) {
         return {hostport, std_port};
     }
-    int port = std_port;
-    try {
-        port = std::stoi(hostport.substr(pos + 1));
-    } catch (...) {
-        port = std_port;
+    auto last_colon = hostport.rfind(':');
+    if (first_colon != last_colon) {
+        // Unbracketed IPv6 literal; treat as host-only and use default port.
+        return {hostport, std_port};
     }
-    return {hostport.substr(0, pos), port};
+
+    auto host = hostport.substr(0, first_colon);
+    if (host.empty()) {
+        return {"", -1};
+    }
+    int port = -1;
+    try {
+        port = std::stoi(hostport.substr(first_colon + 1));
+    } catch (...) {
+        return {"", -1};
+    }
+    if (port < 1 || port > 65535) {
+        return {"", -1};
+    }
+    return {host, port};
 }
 
 std::string DavToHttp(const std::string &url) {

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -390,19 +390,27 @@ bool HeaderParser::Parse(const std::string &header_line)
             return false;
         }
         auto first_pos = incl_range.substr(0, found);
+        long long first_byte;
         try {
-            m_response_offset = std::stoll(first_pos);
+            first_byte = std::stoll(first_pos);
         } catch (...) {
            return false;
         }
+        if (first_byte < 0) {
+            return false;
+        }
+        m_response_offset = static_cast<uint64_t>(first_byte);
         auto last_pos = incl_range.substr(found + 1);
-        size_t last_byte;
+        long long last_byte;
         try {
            last_byte = std::stoll(last_pos);
         } catch (...) {
            return false;
         }
-        m_content_length = last_byte - m_response_offset + 1;
+        if (last_byte < first_byte) {
+            return false;
+        }
+        m_content_length = last_byte - first_byte + 1;
     }
     else if (header_name == "Location") {
         m_location = header_value;


### PR DESCRIPTION
Prevent remote-triggered crashes by validating XML roots and numeric conversions, harden Content-Range parsing against invalid ranges, and correctly parse IPv6/invalid authorities before connection-callout remapping.