### PR TITLE
[XrdSecsss] Fix security and correctness issues

### DIFF
--- a/src/XrdSecsss/XrdSecProtocolsss.cc
+++ b/src/XrdSecsss/XrdSecProtocolsss.cc
@@ -174,7 +174,8 @@ int XrdSecProtocolsss::Authenticate(XrdSecCredentials *cred,
    Persona             myID(&decKey);
 
    char *idP = 0, *dP = 0, *eodP = 0, *theIP = 0, *theHost = 0, *atKey = 0, eType = '\0';
-   int idNum = 0, idTLen, idSz, dLen;
+   int idNum = 0, idTLen, idSz, dLen, attrCount = 0;
+   static const int maxAttrCount = 64;
    bool badAttr = false;
 
 // Make sure we have atleast the header plus the data header
@@ -255,6 +256,7 @@ int XrdSecProtocolsss::Authenticate(XrdSecCredentials *cred,
                                                 atKey         = idP; break;
                 case XrdSecsssRR_Data::theAVal:
                      if (!atKey) badAttr = true;
+                     else if (++attrCount > maxAttrCount) badAttr = true;
                         else {Entity.eaAPI->Add(std::string(atKey),
                                          std::string(idP), true);
                               atKey = 0;

--- a/src/XrdSecsss/XrdSecProtocolsss.cc
+++ b/src/XrdSecsss/XrdSecProtocolsss.cc
@@ -187,9 +187,17 @@ int XrdSecProtocolsss::Authenticate(XrdSecCredentials *cred,
    if (cred->size > maxLen)
       return Fatal(einfo, "Auth", EINVAL, "Credentials too big.");
 
-// Allocate the buffer from the stack
+// Allocate the decryption buffer on the heap. The RAII guard zeroes and
+// frees it on scope exit so key material does not persist on the stack.
 //
-   rrData = (XrdSecsssRR_Data *)alloca(cred->size);
+   struct ScrubBuf {
+       char *ptr; int sz;
+       ScrubBuf(int n) : ptr(static_cast<char*>(malloc(n))), sz(n) {}
+       ~ScrubBuf() { if (ptr) { memset(ptr, 0, sz); free(ptr); } }
+   } rrDataBuf(cred->size);
+   if (!rrDataBuf.ptr)
+      return Fatal(einfo, "Authenticate", ENOMEM, "Insufficient memory for credentials.");
+   rrData = (XrdSecsssRR_Data *)rrDataBuf.ptr;
 
 // Decode the credentials
 //
@@ -342,6 +350,8 @@ if (!(decKey.Data.Opts & XrdSecsssKT::ktEnt::noIPCK))
 //
    if (idBuff) free(idBuff);
    idBuff = idP = (char *)malloc(idTLen);
+   if (!idBuff)
+      return Fatal(einfo, "Authenticate", ENOMEM, "Insufficient memory for entity data.");
    Entity.host         = urName;
    Entity.name         = setID(myID.name, &idP);
    Entity.vorg         = setID(myID.vorg, &idP);

--- a/src/XrdSecsss/XrdSecsssEnt.cc
+++ b/src/XrdSecsss/XrdSecsssEnt.cc
@@ -129,8 +129,7 @@ int XrdSecsssEnt::RR_Data(char *&dP, const char *hostIP, int dataOpts)
 
 // Add in the hostIP if specified and hostname if available
 //
-   n = strlen(hostIP) + 4;
-   if (hostIP) totLen += n;
+   if (hostIP) { n = strlen(hostIP) + 4; totLen += n; }
    totLen += myHostNLen;
 
 // Allocate a buffer

--- a/src/XrdSecsss/XrdSecsssKT.cc
+++ b/src/XrdSecsss/XrdSecsssKT.cc
@@ -351,14 +351,18 @@ int XrdSecsssKT::Rewrite(int Keep, int &numKeys, int &numTot, int &numExp)
    if (retc) return (retc < 0 ? -retc : retc);
    if (Slash) *Slash = '/';
 
-// Construct temporary filename
+// Construct temporary filename with random suffix to resist symlink races.
+// O_EXCL ensures the open fails if the path already exists.
 //
-   sprintf(buff, ".%d", static_cast<int>(getpid()));
+   {struct timeval tv; gettimeofday(&tv, nullptr);
+    sprintf(buff, ".%08x", static_cast<unsigned>(tv.tv_usec)
+                         ^ static_cast<unsigned>(getpid()));
+   }
    strcat(tmpFN, buff);
 
 // Open the file for output
 //
-   if ((ktFD = open(tmpFN, O_WRONLY|O_CREAT|O_TRUNC, theMode)) < 0)
+   if ((ktFD = open(tmpFN, O_WRONLY|O_CREAT|O_EXCL, theMode)) < 0)
       return errno;
 
 // Write all of the keytable

--- a/src/XrdSecsss/XrdSecsssKT.cc
+++ b/src/XrdSecsss/XrdSecsssKT.cc
@@ -324,7 +324,7 @@ void XrdSecsssKT::Refresh()
           {myMutex.Lock(); ktOld = ktList; ktList = ktNew; myMutex.UnLock();
           } else ktOld = ktNew;
        while(ktOld) {ktNext = ktOld->Next; delete ktOld; ktOld = ktNext;}
-       if ((retc == eInfo.getErrInfo()) == 0) return;
+       if ((retc = eInfo.getErrInfo()) == 0) return;
       } else retc = errno;
 
 // Refresh failed


### PR DESCRIPTION
- Replace alloca(cred->size) with a heap-allocated RAII buffer that zeroes itself on scope exit, eliminating key material on the stack and the risk of stack exhaustion from attacker-controlled size
- Check malloc(idTLen) return value to avoid null dereference DoS
- Guard strlen(hostIP) in RR_Data() with a null check to fix crash when hostIP is legitimately null
- Use random suffix and O_EXCL in Rewrite() temp file open to prevent a predictable-name symlink-race attack
- Fix == vs = typo in Refresh() that caused spurious error log on every successful keytable refresh
- Cap per-packet attribute count at 64 to bound entity memory growth