### PR TITLE
[CI] Build and publish Python wheels on macOS and Linux arm64

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -9,6 +9,7 @@ on:
       - setup.py
       - pyproject.toml
       - 'bindings/**'
+      - .github/workflows/python.yml
     tags-ignore:
   pull_request:
     paths:
@@ -16,16 +17,52 @@ on:
       - pyproject.toml
       - 'bindings/**'
   workflow_dispatch:
+  release:
+    types:
+      - published
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  sdist:
+    name: Source distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.14"
+
+    - name: Install Python build dependencies
+      run: python -m pip install build
+
+    - name: Build source distribution tarball
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        ./genversion.sh >| VERSION
+        python -m build --sdist
+
+    - name: Upload source distribution
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-sdist
+        path: dist/*.tar.gz
+        retention-days: 14
+
   manylinux:
     name: Python ${{ matrix.version }} (Linux, ${{ matrix.platform.arch }})
     runs-on: ${{ matrix.platform.runs_on }}
     container: ${{ matrix.platform.container }}
+    needs: [ sdist ]
 
     strategy:
       fail-fast: false
@@ -47,20 +84,13 @@ jobs:
     - name: Install dependencies
       run: dnf install -y git krb5-devel libuuid-devel openssl-devel
 
-    - name: Clone repository
-      uses: actions/checkout@v6
+    - name: Download source distribution
+      uses: actions/download-artifact@v7
       with:
-        fetch-depth: 0
-        fetch-tags: true
-
-    - name: Build source distribution tarball
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        ./genversion.sh >| VERSION
-        ${PYTHON} -m build --sdist
+        name: python-sdist
 
     - name: Build binary wheel
-      run: ${PYTHON} -m pip wheel --use-pep517 --verbose dist/*.tar.gz
+      run: ${PYTHON} -m pip wheel --use-pep517 --verbose *.tar.gz
 
     - name: Fixup binary wheel
       run: auditwheel repair *.whl
@@ -87,6 +117,7 @@ jobs:
   macos:
     name: Python ${{ matrix.version }} (macOS, ${{ matrix.platform.arch }})
     runs-on: ${{ matrix.platform.runs_on }}
+    needs: [ sdist ]
 
     strategy:
       fail-fast: false
@@ -110,31 +141,24 @@ jobs:
       _PYTHON_HOST_PLATFORM: ${{ matrix.platform.host_platform }}
 
     steps:
-    - name: Clone repository
-      uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
-        fetch-tags: true
-
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.version }}
 
     - name: Install dependencies with Homebrew
-      run: brew install nlohmann-json openssl@3
+      run: brew install nlohmann-json
 
     - name: Install Python build dependencies
       run: python -m pip install build delocate
 
-    - name: Build source distribution tarball
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        ./genversion.sh >| VERSION
-        python -m build --sdist
+    - name: Download source distribution
+      uses: actions/download-artifact@v7
+      with:
+        name: python-sdist
 
     - name: Build binary wheel
-      run: python -m pip wheel --use-pep517 --verbose dist/*.tar.gz
+      run: python -m pip wheel --use-pep517 --verbose *.tar.gz
 
     - name: Fixup binary wheel
       run: delocate-wheel -w wheelhouse -v *.whl
@@ -157,3 +181,25 @@ jobs:
         name: python-${{ matrix.version }}-macos-${{ matrix.platform.arch }}
         path: wheelhouse
         retention-days: 14
+
+  pypi:
+    if: ${{ github.event_name == 'release' && github.repository_owner == 'xrootd' }}
+    name: Publish to PyPI
+    needs: [ macos, manylinux ]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v7
+      with:
+        path: dist
+        pattern: python-*
+        merge-multiple: true
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -23,15 +23,24 @@ concurrency:
 
 jobs:
   manylinux:
-    name: Python
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux_2_28_x86_64
+    name: Python ${{ matrix.version }} (Linux, ${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runs_on }}
+    container: ${{ matrix.platform.container }}
 
     strategy:
+      fail-fast: false
       matrix:
-        version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        platform:
+          - arch: arm64
+            runs_on: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
+          - arch: x86_64
+            runs_on: ubuntu-24.04
+            container: quay.io/pypa/manylinux_2_28_x86_64
 
     env:
+      CMAKE_ARGS: -DCMAKE_BUILD_TYPE=Release
       PYTHON: python${{ matrix.version }}
 
     steps:
@@ -39,14 +48,15 @@ jobs:
       run: dnf install -y git krb5-devel libuuid-devel openssl-devel
 
     - name: Clone repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
+        fetch-tags: true
 
     - name: Build source distribution tarball
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        ./genversion.sh --sanitize >| VERSION
+        ./genversion.sh >| VERSION
         ${PYTHON} -m build --sdist
 
     - name: Build binary wheel
@@ -68,8 +78,8 @@ jobs:
         ${PYTHON} -c 'from XRootD import client; print(client.FileSystem("root://localhost"))'
 
     - name: Upload Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
-        name: python-${{ matrix.version }}
+        name: python-${{ matrix.version }}-linux-${{ matrix.platform.arch }}
         path: wheelhouse
         retention-days: 14

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -83,3 +83,77 @@ jobs:
         name: python-${{ matrix.version }}-linux-${{ matrix.platform.arch }}
         path: wheelhouse
         retention-days: 14
+
+  macos:
+    name: Python ${{ matrix.version }} (macOS, ${{ matrix.platform.arch }})
+    runs-on: ${{ matrix.platform.runs_on }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [ "3.9", "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        platform:
+          - arch: arm64
+            runs_on: macos-15
+            host_platform: macosx-15.0-arm64
+            openssl_prefix: /opt/homebrew/opt/openssl@3
+          - arch: x86_64
+            runs_on: macos-15-intel
+            host_platform: macosx-15.0-x86_64
+            openssl_prefix: /usr/local/opt/openssl@3
+
+    env:
+      CMAKE_ARGS: -DPython_FIND_UNVERSIONED_NAMES=FIRST -DCMAKE_BUILD_TYPE=Release
+      CMAKE_PREFIX_PATH: ${{ matrix.platform.openssl_prefix }}
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      MACOSX_DEPLOYMENT_TARGET: "15.0"
+      _PYTHON_HOST_PLATFORM: ${{ matrix.platform.host_platform }}
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ matrix.version }}
+
+    - name: Install dependencies with Homebrew
+      run: brew install nlohmann-json openssl@3
+
+    - name: Install Python build dependencies
+      run: python -m pip install build delocate
+
+    - name: Build source distribution tarball
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        ./genversion.sh >| VERSION
+        python -m build --sdist
+
+    - name: Build binary wheel
+      run: python -m pip wheel --use-pep517 --verbose dist/*.tar.gz
+
+    - name: Fixup binary wheel
+      run: delocate-wheel -w wheelhouse -v *.whl
+
+    - name: Install binary wheel
+      run: python -m pip install wheelhouse/*.whl
+
+    - name: Run post-installation tests
+      run: |
+        command -v python && python --version
+        python -m pip show xrootd
+        python -c 'import XRootD; print(XRootD)'
+        python -c 'import pyxrootd; print(pyxrootd)'
+        python -c 'from XRootD import client; help(client)'
+        python -c 'from XRootD import client; print(client.FileSystem("root://localhost"))'
+
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: python-${{ matrix.version }}-macos-${{ matrix.platform.arch }}
+        path: wheelhouse
+        retention-days: 14

--- a/genversion.sh
+++ b/genversion.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # This script no longer generates XrdVersion.hh, but just
 # prints the version using the same strategy as in the module
@@ -8,7 +8,7 @@
 # not expanded by git, git describe is used. If a bad version is
 # set for any reason, a fallback version is used based on a date.
 
-function usage()
+usage()
 {
 	cat 1>&2 <<-EOF
 		Usage:
@@ -24,9 +24,9 @@ function usage()
 SRC="$(dirname "$0")"
 VF="${SRC}/VERSION"
 
-if [[ -n "${XRDVERSION}" ]]; then
+if [ -n "${XRDVERSION}" ]; then
 	VERSION="${XRDVERSION}";
-elif [[ -r "${VF}" ]] && grep -vq "Format:" "${VF}"; then
+elif [ -r "${VF}" ] && grep -vq "Format:" "${VF}"; then
 	VERSION="$(sed -e 's/-g/+git/' "${VF}")"
 elif git -C "${SRC}" describe --match 'v*' >/dev/null 2>&1; then
 	VERSION="$(git -C "${SRC}" describe --match 'v*' | sed -e 's/-g/+git/')"
@@ -34,7 +34,7 @@ else
 	VERSION="v5.9-rc$(date +%Y%m%d)"
 fi
 
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
 	case $1 in
 	--help)
 		usage
@@ -52,7 +52,7 @@ while [[ $# -gt 0 ]]; do
 
 	--version)
 		shift
-		if [[ $# == 0 ]]; then
+		if [ $# -eq 0 ]; then
 			echo "error: --version parameter needs an argument" 1>&2
 		fi
 		VERSION=$1
@@ -66,8 +66,8 @@ while [[ $# -gt 0 ]]; do
 	esac
 done
 
-if [[ -v SANITIZE ]]; then
-	VERSION=$(sed -e 's/v//; s/-rc/~rc/; s/-g/+git/; s/-/.post/; s/-/./' <<< "${VERSION}")
+if [ -n "${SANITIZE}" ]; then
+	VERSION=$(printf "%s\n" "${VERSION}" | sed -e 's/v//; s/-rc/~rc/; s/-g/+git/; s/-/.post/; s/-/./')
 fi
 
 printf "%s" "${VERSION}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,8 +3,12 @@
 # (this is especially important for plugins)
 #-------------------------------------------------------------------------------
 if( PYPI_BUILD )
-  set( CMAKE_INSTALL_RPATH "$ORIGIN" )
-  set( CMAKE_INSTALL_RPATH_USE_LINK_PATH true )
+  if( APPLE )
+    set(CMAKE_INSTALL_NAME_DIR "@rpath")
+  else()
+    set(CMAKE_INSTALL_RPATH "$ORIGIN")
+  endif()
+  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add native macOS wheel jobs for arm64 and x86_64 to the Python workflow
- fix PyPI-build rpaths on macOS so delocate can resolve and bundle XRootD dylib dependencies
- make genversion.sh's sanitize check work with macOS's Bash 3 and trigger the Python workflow when wheel inputs change

## Validation
- built an arm64 macOS wheel locally from sdist with `_PYTHON_HOST_PLATFORM=macosx-26.0-arm64`
- repaired the wheel with `delocate-wheel`
- installed the repaired wheel and verified `import XRootD` and `import pyxrootd` succeeded
