### PR TITLE
[Tests] Add link to atomic library for some 32 bit architectures

### DIFF
--- a/tests/XrdThrottleTests/CMakeLists.txt
+++ b/tests/XrdThrottleTests/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(XrdThrottleTestLib
   PRIVATE
     XrdUtils
     XrdServer
+    ${ATOMIC_LIBRARY}
 )
 
 target_include_directories(XrdThrottleTestLib


### PR DESCRIPTION
```
cd /build/reproducible-path/xrootd-6.0.0/obj-sh4-linux-gnu/tests/XrdThrottleTests && /usr/bin/cmake -E cmake_link_script CMakeFiles/xrdthrottle-unit-tests.dir/link.txt --verbose=1
/usr/bin/sh4-linux-gnu-ld.bfd: ../../lib/libXrdThrottleTestLib.a(XrdThrottleManager.cc.o): undefined reference to symbol '__atomic_exchange_8@@LIBATOMIC_1.0'
/usr/bin/sh4-linux-gnu-ld.bfd: /usr/lib/sh4-linux-gnu/libatomic.so.1: error adding symbols: DSO missing from command line
```
