### PR TITLE
Improve XrdPosix support: add support for links, add openat and fstatat, and fix multiple minor bugs

### DIFF
--- a/src/XrdPosix/XrdPosix.cc
+++ b/src/XrdPosix/XrdPosix.cc
@@ -48,11 +48,11 @@
 /******************************************************************************/
 /*                        G l o b a l   O b j e c t s                         */
 /******************************************************************************/
-  
+
        XrdPosixXrootd    Xroot;
 
        XrdPosixXrootPath XrootPath;
-  
+
 extern XrdPosixLinkage   Xunix;
 
 /******************************************************************************/
@@ -108,27 +108,58 @@ static inline void fseteof(FILE *fp)
 }
 
 /******************************************************************************/
+/*                       X r d R e s o l v e L i n k                          */
+/******************************************************************************/
+static ssize_t XrdResolveLink(const char *path, char *resolved){
+  char unref[2049], filename[2049];
+  // Make sure a path was passed
+  //
+  if (!path) {errno = EFAULT; return -1;}
+
+  strncpy(filename, path, 2048);
+  strncpy(unref, path, 2048);
+  // if it is a link, follow it until the end
+  int i = 0;
+  bzero(unref, 2049);
+  int lsize = readlink(filename, unref, 2048);
+  while (lsize > 0 && i<10){
+    strncpy(filename, unref, 2049);
+    // ensure zero termination
+    bzero(unref, 2049);
+    lsize = readlink(filename, unref, 2048);
+    i++;
+  }
+  if (i == 10){
+    errno = ELOOP;
+    return(-1);
+  }
+  strncpy(resolved, filename, 2049);
+  return(strlen(filename));
+}
+
+/******************************************************************************/
 /*                       X r d P o s i x _ A c c e s s                        */
 /******************************************************************************/
-  
 extern "C"
 {
 int XrdPosix_Access(const char *path, int amode)
 {
-   char *myPath, buff[2048];
+  char *myPath, buff[2048];
+  char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res > 0) {
+     // Return the results of a mkdir of a Unix file system
+     //
+     if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
+       return Xunix.Access( path, amode);
 
-// Return the results of a mkdir of a Unix file system
-//
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
-      return Xunix.Access(  path, amode);
-
-// Return the results of our version of access()
-//
-   return Xroot.Access(myPath, amode);
+     // Return the results of our version of access()
+     //
+     return Xroot.Access(myPath, amode);
+   } else {
+     return res;
+   }
 }
 }
 
@@ -142,12 +173,16 @@ extern "C"
 {
 int XrdPosix_Acl(const char *path, int cmd, int nentries, void *aclbufp)
 {
-   return (XrootPath.URL(path, 0, 0)
-        ? Xunix.Acl("/tmp", cmd,nentries,aclbufp)
-        : Xunix.Acl(path,   cmd,nentries,aclbufp));
+  char unref[2049];
+
+  ssize_t res=XrdResolveLink(path, unref);
+  if (res < 0) return res;
+  return (XrootPath.URL(unref, 0, 0)
+	  ? Xunix.Acl("/tmp", cmd,nentries,aclbufp)
+	  : Xunix.Acl(path,   cmd,nentries,aclbufp));
 }
 }
-  
+
 /******************************************************************************/
 /*                        X r d P o s i x _ C h d i r                         */
 /******************************************************************************/
@@ -156,15 +191,19 @@ extern "C"
 {
 int XrdPosix_Chdir(const char *path)
 {
-   int rc;
-
-// Set the working directory if the actual chdir succeeded
-//
-   if (!(rc = Xunix.Chdir(path))) XrootPath.CWD(path);
-   return rc;
-}
-}
+  int rc;
+  char unref[2049];
   
+  ssize_t res=XrdResolveLink(path, unref);
+  if (res < 0) return res;
+  
+  // Set the working directory if the actual chdir succeeded
+  //
+  if (!(rc = Xunix.Chdir(path))) XrootPath.CWD(unref);
+  return rc;
+}
+}
+
 /******************************************************************************/
 /*                        X r d P o s i x _ C l o s e                         */
 /******************************************************************************/
@@ -197,7 +236,7 @@ int XrdPosix_Closedir(DIR *dirp)
 /******************************************************************************/
 /*                        X r d P o s i x _ C r e a t                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     XrdPosix_Creat(const char *path, mode_t mode)
@@ -207,7 +246,7 @@ int     XrdPosix_Creat(const char *path, mode_t mode)
    return XrdPosix_Open(path, O_WRONLY | O_CREAT | O_TRUNC, mode);
 }
 }
-  
+
 /******************************************************************************/
 /*                       X r d P o s i x _ F c l o s e                        */
 /******************************************************************************/
@@ -231,7 +270,7 @@ int XrdPosix_Fclose(FILE *stream)
 /******************************************************************************/
 /*                        X r d P o s i x _ F c n t l                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fcntl(int fd, int cmd, ...)
@@ -250,7 +289,7 @@ int XrdPosix_Fcntl(int fd, int cmd, ...)
 /******************************************************************************/
 /*                    X r d P o s i x _ F d a t a s y n c                     */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fdatasync(int fildes)
@@ -266,7 +305,7 @@ int XrdPosix_Fdatasync(int fildes)
 /******************************************************************************/
 /*                    X r d P o s i x _ F g e t x a t t r                     */
 /******************************************************************************/
-  
+
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 extern "C"
 {
@@ -281,7 +320,7 @@ ssize_t XrdPosix_Fgetxattr (int fd, const char *name, void *value, size_t size)
 /******************************************************************************/
 /*                       X r d P o s i x _ F f l u s h                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fflush(FILE *stream)
@@ -295,13 +334,13 @@ int XrdPosix_Fflush(FILE *stream)
    return Xroot.Fsync(fileno(stream));
 }
 }
-  
+
 /******************************************************************************/
 /*                        X r d P o s i x _ F o p e n                         */
 /******************************************************************************/
 
 #define ISMODE(x) !strcmp(mode, x)
-  
+
 extern "C"
 {
 FILE *XrdPosix_Fopen(const char *path, const char *mode)
@@ -310,9 +349,14 @@ FILE *XrdPosix_Fopen(const char *path, const char *mode)
    int erc, fd, omode;
    FILE *stream;
 
+  char unref[2049];
+
+  ssize_t res=XrdResolveLink(path, unref);
+  if (res < 0) return 0;
+
 // Transfer to unix if this is not our path
 //
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
       return Xunix.Fopen64(path, mode);
 
 // Translate the mode flags
@@ -336,7 +380,7 @@ FILE *XrdPosix_Fopen(const char *path, const char *mode)
 
 // First obtain a free stream
 //
-   if (!(stream = fdopen(fd, mode))) 
+   if (!(stream = fdopen(fd, mode)))
       {erc = errno; Xroot.Close(fd); errno = erc;}
 
 // All done
@@ -348,7 +392,7 @@ FILE *XrdPosix_Fopen(const char *path, const char *mode)
 /******************************************************************************/
 /*                        X r d P o s i x _ F r e a d                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 size_t XrdPosix_Fread(void *ptr, size_t size, size_t nitems, FILE *stream)
@@ -370,11 +414,11 @@ size_t XrdPosix_Fread(void *ptr, size_t size, size_t nitems, FILE *stream)
    return rc;
 }
 }
-  
+
 /******************************************************************************/
 /*                        X r d P o s i x _ F s e e k                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fseek(FILE *stream, long offset, int whence)
@@ -392,7 +436,7 @@ int XrdPosix_Fseek(FILE *stream, long offset, int whence)
 /******************************************************************************/
 /*                       X r d P o s i x _ F s e e k o                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fseeko(FILE *stream, long long offset, int whence)
@@ -410,7 +454,7 @@ int XrdPosix_Fseeko(FILE *stream, long long offset, int whence)
 /******************************************************************************/
 /*                        X r d P o s i x _ F s t a t                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fstat(int fildes, struct stat *buf)
@@ -444,7 +488,7 @@ int XrdPosix_FstatV(int ver, int fildes, struct stat *buf)
 /******************************************************************************/
 /*                        X r d P o s i x _ F s y n c                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Fsync(int fildes)
@@ -456,11 +500,11 @@ int XrdPosix_Fsync(int fildes)
                               : Xunix.Fsync(fildes));
 }
 }
-  
+
 /******************************************************************************/
 /*                        X r d P o s i x _ F t e l l                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 long XrdPosix_Ftell(FILE *stream)
@@ -473,11 +517,11 @@ long XrdPosix_Ftell(FILE *stream)
    return static_cast<long>(Xroot.Lseek(fileno(stream), 0, SEEK_CUR));
 }
 }
-  
+
 /******************************************************************************/
 /*                       X r d P o s i x _ F t e l l o                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 long long XrdPosix_Ftello(FILE *stream)
@@ -490,11 +534,11 @@ long long XrdPosix_Ftello(FILE *stream)
    return Xroot.Lseek(fileno(stream), 0, SEEK_CUR);
 }
 }
-  
+
 /******************************************************************************/
 /*                    X r d P o s i x _ F t r u n c a t e                     */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Ftruncate(int fildes, long long offset)
@@ -510,7 +554,7 @@ int XrdPosix_Ftruncate(int fildes, long long offset)
 /******************************************************************************/
 /*                       X r d P o s i x _ F w r i t e                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 size_t XrdPosix_Fwrite(const void *ptr, size_t size, size_t nitems, FILE *stream)
@@ -530,19 +574,22 @@ size_t XrdPosix_Fwrite(const void *ptr, size_t size, size_t nitems, FILE *stream
    return rc;
 }
 }
-  
+
 /******************************************************************************/
 /*                     X r d P o s i x _ G e t x a t t r                      */
 /******************************************************************************/
-  
+
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 extern "C"
 {
 ssize_t XrdPosix_Getxattr (const char *path, const char *name, void *value, size_t size)
 {
    char *myPath, buff[2048];
+   char unref[2049];
 
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
       return Xunix.Getxattr(path, name, value, size);
 
    return Xroot.Getxattr(myPath, name, value, size);
@@ -553,14 +600,19 @@ ssize_t XrdPosix_Getxattr (const char *path, const char *name, void *value, size
 /******************************************************************************/
 /*                    X r d P o s i x _ L g e t x a t t r                     */
 /******************************************************************************/
-  
+
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 extern "C"
 {
 ssize_t XrdPosix_Lgetxattr (const char *path, const char *name, void *value, size_t size)
 {
-   if (XrootPath.URL(path, 0, 0)) {errno = ENOTSUP; return -1;}
-   return Xunix.Lgetxattr(path, name, value, size);
+  char unref[2049];
+
+  ssize_t res=XrdResolveLink(path, unref);
+  if (res < 0) return res;
+
+  if (XrootPath.URL(unref, 0, 0)) {errno = ENOTSUP; return -1;}
+  return Xunix.Lgetxattr(path, name, value, size);
 }
 }
 #endif
@@ -568,7 +620,7 @@ ssize_t XrdPosix_Lgetxattr (const char *path, const char *name, void *value, siz
 /******************************************************************************/
 /*                        X r d P o s i x _ L s e e k                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 off_t XrdPosix_Lseek(int fildes, off_t offset, int whence)
@@ -584,7 +636,7 @@ off_t XrdPosix_Lseek(int fildes, off_t offset, int whence)
 /******************************************************************************/
 /*                        X r d P o s i x _ L s t a t                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Lstat(const char *path, struct stat *buf)
@@ -606,7 +658,7 @@ int XrdPosix_Lstat(const char *path, struct stat *buf)
           : Xroot.Stat(myPath, buf));
 }
 }
-  
+
 /******************************************************************************/
 /*                        X r d P o s i x _ M k d i r                         */
 /******************************************************************************/
@@ -616,14 +668,14 @@ extern "C"
 int XrdPosix_Mkdir(const char *path, mode_t mode)
 {
    char *myPath, buff[2048];
+   char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
 
 // Return the results of a mkdir of a Unix file system
 //
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
       return Xunix.Mkdir(path, mode);
 
 // Return the results of an mkdir of an xrootd file system
@@ -635,31 +687,30 @@ int XrdPosix_Mkdir(const char *path, mode_t mode)
 /******************************************************************************/
 /*                         X r d P o s i x _ O p e n                          */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Open(const char *path, int oflag, ...)
 {
    char *myPath, buff[2048];
+   char unref[2049];
    va_list ap;
    int mode;
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
-
-// Return the results of an open of a Unix file
-//
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
-      {if (!(oflag & O_CREAT)) return Xunix.Open64(path, oflag);
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
+   // Return the results of an open of a Unix file
+   //
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
+     {if (!(oflag & O_CREAT)) return Xunix.Open64(unref, oflag);
        va_start(ap, oflag);
        mode = va_arg(ap, int);
        va_end(ap);
-       return Xunix.Open64(path, oflag, (mode_t)mode);
-      }
-
-// Return the results of an open of an xrootd file
-//
+       return Xunix.Open64(unref, oflag, (mode_t)mode);
+     }
+   
+   // Return the results of an open of an xrootd file
+   //
    if (!(oflag & O_CREAT)) return Xroot.Open(myPath, oflag);
    va_start(ap, oflag);
    mode = va_arg(ap, int);
@@ -677,14 +728,14 @@ extern "C"
 DIR* XrdPosix_Opendir(const char *path)
 {
    char *myPath, buff[2048];
+   char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return 0;}
-   
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return NULL;
+
 // Unix opendir
 //
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
       return Xunix.Opendir(path);
 
 // Xrootd opendir
@@ -696,22 +747,27 @@ DIR* XrdPosix_Opendir(const char *path)
 /******************************************************************************/
 /*                     X r d P o s i x _ P a t h c o n f                      */
 /******************************************************************************/
-  
+
 // This is a required addition for Solaris 10+ systems
 
 extern "C"
 {
 long XrdPosix_Pathconf(const char *path, int name)
 {
-   return (XrootPath.URL(path, 0, 0) ? Xunix.Pathconf("/tmp", name)
-                                     : Xunix.Pathconf(path,   name));
+  char unref[2049];
+
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
+
+   return (XrootPath.URL(unref, 0, 0) ? Xunix.Pathconf("/tmp", name)
+	                              : Xunix.Pathconf(unref,   name));
 }
 }
 
 /******************************************************************************/
 /*                        X r d P o s i x _ P r e a d                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t XrdPosix_Pread(int fildes, void *buf, size_t nbyte, off_t offset)
@@ -727,7 +783,7 @@ ssize_t XrdPosix_Pread(int fildes, void *buf, size_t nbyte, off_t offset)
 /******************************************************************************/
 /*                       X r d P o s i x _ P w r i t e                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t XrdPosix_Pwrite(int fildes, const void *buf, size_t nbyte, off_t offset)
@@ -743,7 +799,7 @@ ssize_t XrdPosix_Pwrite(int fildes, const void *buf, size_t nbyte, off_t offset)
 /******************************************************************************/
 /*                         X r d P o s i x _ R e a d                          */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t XrdPosix_Read(int fildes, void *buf, size_t nbyte)
@@ -755,11 +811,11 @@ ssize_t XrdPosix_Read(int fildes, void *buf, size_t nbyte)
                               : Xunix.Read(fildes, buf, nbyte));
 }
 }
- 
+
 /******************************************************************************/
 /*                        X r d P o s i x _ R e a d v                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t XrdPosix_Readv(int fildes, const struct iovec *iov, int iovcnt)
@@ -910,26 +966,30 @@ void XrdPosix_Seekdir(DIR *dirp, long loc)
 /******************************************************************************/
 /*                         X r d P o s i x _ S t a t                          */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Stat(const char *path, struct stat *buf)
 {
-   char *myPath, buff[2048];
+   char buff[2048];
+   char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
 
-// Return the results of an open of a Unix file
-//
-   return (!(myPath = XrootPath.URL(path, buff, sizeof(buff)))
-#if defined(__linux__) and defined(_STAT_VER)
-          ? Xunix.Stat64(_STAT_VER, path, (struct stat64 *)buf)
+   // links are pointing to file unref now which is not a link
+   if (char *myPath = XrootPath.URL(unref, buff, sizeof(buff))) {
+     int ret = Xroot.Stat(myPath, buf);
+     return (ret);
+   } else {
+     // not a root file
+#ifdef SYS_stat
+     return syscall(SYS_stat, unref, buf);
 #else
-          ? Xunix.Stat64(           path, (struct stat64 *)buf)
+     errno = ENOSYS;
+     return -1;
 #endif
-          : Xroot.Stat(myPath, buf));
+   }
 }
 }
 
@@ -940,15 +1000,38 @@ int XrdPosix_Statx(int dirfd, const char *path, int flags,
 {
   if (path && *path) {
     char buff[2048];
-    if (char *myPath = XrootPath.URL(path, buff, sizeof(buff))) {
-      struct stat st{};
+    char unref[2049];
 
-      if (int ret = XrdPosix_Stat(myPath, &st))
-        return ret;
-
-      XrdSysStatxHelpers::Stat2Statx(st, *stx);
-      return 0;
+    if (!(flags & AT_SYMLINK_NOFOLLOW)){
+      // We need to follow until path is no longer a link
+      ssize_t res=XrdResolveLink(path, unref);
+      if (res < 0) return res;
+      if (char *myPath = XrootPath.URL(unref, buff, sizeof(buff))) {
+	struct stat st{};
+	if (int ret = XrdPosix_Stat(myPath, &st))
+	  return ret;
+	XrdSysStatxHelpers::Stat2Statx(st, *stx);
+	return 0;
+      } else {
+#ifdef SYS_statx
+	int ret = syscall(SYS_statx, dirfd, unref, flags, mask, stx);
+	return ret;
+#else
+	errno = ENOSYS;
+	return -1;
+#endif
+      }
     }
+    else
+      {
+	if (char *myPath = XrootPath.URL(path, buff, sizeof(buff))) {
+	  struct stat st{};
+	  if (int ret = XrdPosix_Stat(myPath, &st))
+	    return ret;
+	  XrdSysStatxHelpers::Stat2Statx(st, *stx);
+	  return 0;
+	}
+      }
   }
 #ifdef SYS_statx
   return syscall(SYS_statx, dirfd, path, flags, mask, stx);
@@ -958,47 +1041,48 @@ int XrdPosix_Statx(int dirfd, const char *path, int flags,
 #endif
 }
 }
-  
+
 /******************************************************************************/
 /*                       X r d P o s i x _ S t a t f s                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Statfs(const char *path, struct statfs *buf)
 {
    char *myPath, buff[2048];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   char unref[2049];
+
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
 
 // Return the results of an open of a Unix file
 //
-   return ((myPath = XrootPath.URL(path, buff, sizeof(buff)))
-          ? Xroot.Statfs(myPath, buf) 
+   return ((myPath = XrootPath.URL(unref, buff, sizeof(buff)))
+          ? Xroot.Statfs(myPath, buf)
           : Xunix.Statfs64(path, (struct statfs64 *)buf));
 }
 }
-  
+
 /******************************************************************************/
 /*                      X r d P o s i x _ S t a t v f s                       */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Statvfs(const char *path, struct statvfs *buf)
 {
    char *myPath, buff[2048];
+   char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
 
 // Return the results of an open of a Unix file
 //
-   return ((myPath = XrootPath.URL(path, buff, sizeof(buff)))
-          ? Xroot.Statvfs(myPath, buf) 
+   return ((myPath = XrootPath.URL(unref, buff, sizeof(buff)))
+          ? Xroot.Statvfs(myPath, buf)
           : Xunix.Statvfs64(path, (struct statvfs64 *)buf));
 }
 }
@@ -1022,20 +1106,20 @@ long XrdPosix_Telldir(DIR *dirp)
 /******************************************************************************/
 /*                     X r d P o s i x _ T r u n c a t e                      */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int XrdPosix_Truncate(const char *path, off_t offset)
 {
    char *myPath, buff[2048];
+   char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
 
 // Return the results of a truncate of a Unix file system
 //
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
       return Xunix.Truncate64(path, offset);
 
 // Return the results of an truncate of an xrootd file system
@@ -1043,7 +1127,7 @@ int XrdPosix_Truncate(const char *path, off_t offset)
    return Xroot.Truncate(myPath, offset);
 }
 }
-  
+
 /******************************************************************************/
 /*                      X r d P o s i x _ U n l i n k                         */
 /******************************************************************************/
@@ -1051,16 +1135,16 @@ int XrdPosix_Truncate(const char *path, off_t offset)
 extern "C"
 {
 int XrdPosix_Unlink(const char *path)
-{   
+{
    char *myPath, buff[2048];
+   char unref[2049];
 
-// Make sure a path was passed
-//
-   if (!path) {errno = EFAULT; return -1;}
+   ssize_t res=XrdResolveLink(path, unref);
+   if (res < 0) return res;
 
 // Return the result of a unlink of a Unix file
 //
-   if (!(myPath = XrootPath.URL(path, buff, sizeof(buff))))
+   if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff))))
       return Xunix.Unlink(path);
 
 // Return the results of an unlink of an xrootd file
@@ -1072,7 +1156,7 @@ int XrdPosix_Unlink(const char *path)
 /******************************************************************************/
 /*                        X r d P o s i x _ W r i t e                         */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t XrdPosix_Write(int fildes, const void *buf, size_t nbyte)
@@ -1084,11 +1168,11 @@ ssize_t XrdPosix_Write(int fildes, const void *buf, size_t nbyte)
                               : Xunix.Write(fildes, buf, nbyte));
 }
 }
- 
+
 /******************************************************************************/
 /*                       X r d P o s i x _ W r i t e v                        */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t XrdPosix_Writev(int fildes, const struct iovec *iov, int iovcnt)
@@ -1104,7 +1188,7 @@ ssize_t XrdPosix_Writev(int fildes, const struct iovec *iov, int iovcnt)
 /******************************************************************************/
 /*                     X r d P o s i x _ i s M y P a t h                      */
 /******************************************************************************/
-  
+
 int XrdPosix_isMyPath(const char *path)
 {
     return (0 != XrootPath.URL(path, 0, 0));
@@ -1113,7 +1197,7 @@ int XrdPosix_isMyPath(const char *path)
 /******************************************************************************/
 /*                          X r d P o s i x _ U R L                           */
 /******************************************************************************/
-  
+
 char *XrdPosix_URL(const char *path, char *buff, int blen)
 {
    return XrootPath.URL(path, buff, blen);

--- a/src/XrdPosix/XrdPosix.cc
+++ b/src/XrdPosix/XrdPosix.cc
@@ -477,7 +477,6 @@ extern "C"
 #endif
     }
   }
-#if defined(__linux__) && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
   int XrdPosix_FstatV(int ver, int fildes, struct stat *buf)
   {
     if (Xroot.myFD(fildes)){
@@ -491,7 +490,6 @@ extern "C"
 #endif
     }
   }
-#endif
 }
 
 /******************************************************************************/

--- a/src/XrdPosix/XrdPosix.cc
+++ b/src/XrdPosix/XrdPosix.cc
@@ -35,6 +35,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <limits.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <sys/uio.h>
@@ -112,26 +113,32 @@ static inline void fseteof(FILE *fp)
 /******************************************************************************/
 static ssize_t XrdResolveLink(const char *path, char *resolved){
   char unref[2049], filename[2049];
+  char * result;
   // Make sure a path was passed
   //
   if (!path) {errno = EFAULT; return -1;}
-
-  strncpy(filename, path, 2048);
-  strncpy(unref, path, 2048);
-  // if it is a link, follow it until the end
-  int i = 0;
-  bzero(unref, 2049);
-  int lsize = readlink(filename, unref, 2048);
-  while (lsize > 0 && i<10){
-    strncpy(filename, unref, 2049);
-    // ensure zero termination
+  result = realpath(path, NULL);
+  if (result == NULL){
+    strncpy(filename, path, 2048);
+    strncpy(unref, path, 2048);
+    // if it is a link, follow it until the end
+    int i = 0;
     bzero(unref, 2049);
-    lsize = readlink(filename, unref, 2048);
-    i++;
-  }
-  if (i == 10){
-    errno = ELOOP;
-    return(-1);
+    int lsize = readlink(filename, unref, 2048);
+    while (lsize > 0 && i<10){
+      strncpy(filename, unref, 2049);
+      // ensure zero termination
+      bzero(unref, 2049);
+      lsize = readlink(filename, unref, 2048);
+      i++;
+    }
+    if (i == 10){
+      errno = ELOOP;
+      return(-1);
+    }
+  } else {
+    strncpy(filename, result, 2048);
+    free(result);
   }
   strncpy(resolved, filename, 2049);
   return(strlen(filename));
@@ -193,10 +200,10 @@ int XrdPosix_Chdir(const char *path)
 {
   int rc;
   char unref[2049];
-  
+
   ssize_t res=XrdResolveLink(path, unref);
   if (res < 0) return res;
-  
+
   // Set the working directory if the actual chdir succeeded
   //
   if (!(rc = Xunix.Chdir(path))) XrootPath.CWD(unref);
@@ -457,32 +464,76 @@ int XrdPosix_Fseeko(FILE *stream, long long offset, int whence)
 
 extern "C"
 {
-int XrdPosix_Fstat(int fildes, struct stat *buf)
-{
-
-// Return result of the close
-//
-   return (Xroot.myFD(fildes)
-          ? Xroot.Fstat(fildes, buf)
-#if defined(__linux__) and defined(_STAT_VER)
-          : Xunix.Fstat64(_STAT_VER, fildes, (struct stat64 *)buf));
+  int XrdPosix_Fstat(int fildes, struct stat *buf)
+  {
+    if (Xroot.myFD(fildes)){
+      return(Xroot.Fstat(fildes, buf));
+    } else {
+#ifdef SYS_fstat
+      return syscall(SYS_fstat, fildes, buf);
 #else
-          : Xunix.Fstat64(           fildes, (struct stat64 *)buf));
+      errno = ENOSYS;
+      return -1;
+#endif
+    }
+  }
+#if defined(__linux__) && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
+  int XrdPosix_FstatV(int ver, int fildes, struct stat *buf)
+  {
+    if (Xroot.myFD(fildes)){
+      return(Xroot.Fstat(fildes, buf));
+    } else {
+#ifdef SYS_fstat
+      return syscall(SYS_fstat, fildes, buf);
+#else
+      errno = ENOSYS;
+      return -1;
+#endif
+    }
+  }
 #endif
 }
 
-#ifdef __linux__
-int XrdPosix_FstatV(int ver, int fildes, struct stat *buf)
+/******************************************************************************/
+/*                        X r d P o s i x _ F s t a t a t                     */
+/******************************************************************************/
+
+extern "C"
 {
-   return (Xroot.myFD(fildes)
-          ? Xroot.Fstat(fildes, buf)
-#ifdef _STAT_VER
-          : Xunix.Fstat64(ver, fildes, (struct stat64 *)buf));
+  int XrdPosix_Fstatat(int dirfd, const char *path, struct stat *buf, int flags)
+{
+  if (path && *path) {
+    char buff[2048];
+    char unref[2049];
+
+    if (!(flags & AT_SYMLINK_NOFOLLOW)){
+      // We need to follow until path is no longer a link
+      ssize_t res=XrdResolveLink(path, unref);
+      if (res < 0) return res;
+      // links are pointing to file unref now which is not a link
+    } else {
+      if (!path) {errno = EFAULT; return -1;}
+      strncpy(unref, path, 2048);
+    }
+    if (char *myPath = XrootPath.URL(unref, buff, sizeof(buff))) {
+      int ret = Xroot.Stat(myPath,  (struct stat *)buf);
+      return (ret);
+    } else {
+      // not a root file
+#ifdef SYS_newfstatat
+      return syscall(SYS_newfstatat, dirfd, path, buf, flags);
 #else
-          : Xunix.Fstat64(     fildes, (struct stat64 *)buf));
+#ifdef SYS_fstatat
+      return syscall(SYS_fstatat, dirfd, path, buf, flags);
+#else
+      errno = ENOSYS;
+      return -1;
 #endif
+#endif
+    }
+  }
+  return -1;
 }
-#endif
 }
 
 /******************************************************************************/
@@ -641,21 +692,25 @@ extern "C"
 {
 int XrdPosix_Lstat(const char *path, struct stat *buf)
 {
-   char *myPath, buff[2048];
+  char *myPath, buff[2048];
 
 // Make sure a path was passed
 //
-   if (!path) {errno = EFAULT; return -1;}
+  if (!path) {errno = EFAULT; return -1;}
 
 // Return the results of an open of a Unix file
 //
-   return (!(myPath = XrootPath.URL(path, buff, sizeof(buff)))
-#if defined(__linux__) and defined(_STAT_VER)
-          ? Xunix.Lstat64(_STAT_VER, path, (struct stat64 *)buf)
+  myPath = XrootPath.URL(path, buff, sizeof(buff));
+  if (myPath){
+    return Xroot.Stat(myPath, buf);
+  } else {
+#ifdef SYS_lstat
+    return syscall(SYS_lstat, path, buf);
 #else
-          ? Xunix.Lstat64(           path, (struct stat64 *)buf)
+    errno = ENOSYS;
+    return -1;
 #endif
-          : Xroot.Stat(myPath, buf));
+  }
 }
 }
 
@@ -696,7 +751,6 @@ int XrdPosix_Open(const char *path, int oflag, ...)
    char unref[2049];
    va_list ap;
    int mode;
-
    ssize_t res=XrdResolveLink(path, unref);
    if (res < 0) return res;
    // Return the results of an open of a Unix file
@@ -708,7 +762,7 @@ int XrdPosix_Open(const char *path, int oflag, ...)
        va_end(ap);
        return Xunix.Open64(unref, oflag, (mode_t)mode);
      }
-   
+
    // Return the results of an open of an xrootd file
    //
    if (!(oflag & O_CREAT)) return Xroot.Open(myPath, oflag);
@@ -716,6 +770,46 @@ int XrdPosix_Open(const char *path, int oflag, ...)
    mode = va_arg(ap, int);
    va_end(ap);
    return Xroot.Open(myPath, oflag, (mode_t)mode);
+}
+}
+
+/******************************************************************************/
+/*                         X r d P o s i x _ O p e n a t                          */
+/******************************************************************************/
+
+extern "C"
+{
+int XrdPosix_Openat(int dirfd, const char *path, int flag, ...)
+{
+  char *myPath, buff[2048];
+  char unref[2049];
+  va_list ap;
+  int mode;
+  ssize_t res=XrdResolveLink(path, unref);
+  if (res < 0) return res;
+
+  if (!(myPath = XrootPath.URL(unref, buff, sizeof(buff)))){
+    mode_t mode = 0;
+    if (flag & (O_CREAT)) {
+      va_start(ap, flag);
+      mode = va_arg(ap, int);
+      va_end(ap);
+    }
+#ifdef SYS_openat
+    return (syscall(SYS_openat, dirfd, path, flag, (mode_t)mode));
+#else
+    errno = ENOSYS;
+    return -1;
+#endif
+  } else {
+    // Return the results of an open of an xrootd file
+    //
+    if (!(flag & O_CREAT)) return Xroot.Open(myPath, flag);
+    va_start(ap, flag);
+    mode = va_arg(ap, int);
+    va_end(ap);
+    return Xroot.Open(myPath, flag, (mode_t)mode);
+  }
 }
 }
 
@@ -756,10 +850,10 @@ long XrdPosix_Pathconf(const char *path, int name)
 {
   char unref[2049];
 
-   ssize_t res=XrdResolveLink(path, unref);
-   if (res < 0) return res;
+  ssize_t res=XrdResolveLink(path, unref);
+  if (res < 0) return res;
 
-   return (XrootPath.URL(unref, 0, 0) ? Xunix.Pathconf("/tmp", name)
+  return (XrootPath.URL(unref, 0, 0) ? Xunix.Pathconf("/tmp", name)
 	                              : Xunix.Pathconf(unref,   name));
 }
 }
@@ -984,7 +1078,7 @@ int XrdPosix_Stat(const char *path, struct stat *buf)
    } else {
      // not a root file
 #ifdef SYS_stat
-     return syscall(SYS_stat, unref, buf);
+     return syscall(SYS_stat, path, buf);
 #else
      errno = ENOSYS;
      return -1;
@@ -1006,39 +1100,27 @@ int XrdPosix_Statx(int dirfd, const char *path, int flags,
       // We need to follow until path is no longer a link
       ssize_t res=XrdResolveLink(path, unref);
       if (res < 0) return res;
-      if (char *myPath = XrootPath.URL(unref, buff, sizeof(buff))) {
-	struct stat st{};
-	if (int ret = XrdPosix_Stat(myPath, &st))
-	  return ret;
-	XrdSysStatxHelpers::Stat2Statx(st, *stx);
-	return 0;
-      } else {
-#ifdef SYS_statx
-	int ret = syscall(SYS_statx, dirfd, unref, flags, mask, stx);
-	return ret;
-#else
-	errno = ENOSYS;
-	return -1;
-#endif
-      }
+    } else {
+      if (!path) {errno = EFAULT; return -1;}
+      strncpy(unref, path, 2048);
     }
-    else
-      {
-	if (char *myPath = XrootPath.URL(path, buff, sizeof(buff))) {
-	  struct stat st{};
-	  if (int ret = XrdPosix_Stat(myPath, &st))
-	    return ret;
-	  XrdSysStatxHelpers::Stat2Statx(st, *stx);
-	  return 0;
-	}
-      }
-  }
+    if (char *myPath = XrootPath.URL(unref, buff, sizeof(buff))) {
+      struct stat st{};
+      if (int ret = XrdPosix_Stat(myPath, &st))
+	return ret;
+      XrdSysStatxHelpers::Stat2Statx(st, *stx);
+      return 0;
+    } else {
 #ifdef SYS_statx
-  return syscall(SYS_statx, dirfd, path, flags, mask, stx);
+      int ret = syscall(SYS_statx, dirfd, path, flags, mask, stx);
+      return ret;
 #else
-  errno = ENOSYS;
-  return -1;
+      errno = ENOSYS;
+      return -1;
 #endif
+    }
+  }
+  return -1;
 }
 }
 

--- a/src/XrdPosix/XrdPosix.hh
+++ b/src/XrdPosix/XrdPosix.hh
@@ -61,6 +61,8 @@
 
 #define fstat(a,b)       XrdPosix_Fstat(a,b)
 
+#define fstatat(a,b,c,d) XrdPosix_Fstatat(a,b,c,d)
+
 #define fsync(a)         XrdPosix_Fsync(a)
 
 #define ftell(a)         XrdPosix_Ftell(a)
@@ -74,6 +76,8 @@
 #define mkdir(a,b)       XrdPosix_Mkdir(a,b)
 
 #define open             XrdPosix_Open
+
+#define openat           XrdPosix_Openat
 
 #define opendir(a)       XrdPosix_Opendir(a)
 

--- a/src/XrdPosix/XrdPosix.hh
+++ b/src/XrdPosix/XrdPosix.hh
@@ -30,7 +30,7 @@
 /* specific prior written permission of the institution or contributor.       */
 /* Modified by Frank Winklmeier to add the full Posix file system definition. */
 /******************************************************************************/
-  
+
 // The following defines substitute our names for the common system names. We
 // would have liked to use wrappers but each platform uses a different mechanism
 // to accomplish this. So, redefinition is the most portable way of doing this.
@@ -76,11 +76,11 @@
 #define open             XrdPosix_Open
 
 #define opendir(a)       XrdPosix_Opendir(a)
-  
+
 #define pread(a,b,c,d)   XrdPosix_Pread(a,b,c,d)
 
 #define read(a,b,c)      XrdPosix_Read(a,b,c)
-  
+
 #define readv(a,b,c)     XrdPosix_Readv(a,b,c)
 
 #define readdir(a)       XrdPosix_Readdir(a)
@@ -100,6 +100,10 @@
 
 #define stat(a,b)        XrdPosix_Stat(a,b)
 
+#define lstat(a,b)        XrdPosix_Stat(a,b)
+
+#define fstat(a,b)        XrdPosix_Stat(a,b)
+
 #define statfs(a,b)      XrdPosix_Statfs(a,b)
 
 #define statvfs(a,b)     XrdPosix_Statvfs(a,b)
@@ -118,4 +122,11 @@
 
 #define statx(d,p,f,m,b)  XrdPosix_Statx(d,p,f,m,b)
 
+#define getxattr(a,b,c,d) XrdPosix_Getxattr(a,b,c,d)
+
+#define lgetxattr(a,b,c,d) XrdPosix_Lgetxattr(a,b,c,d)
+
+#define fgetxattr(a,b,c,d) XrdPosix_Fgetxattr(a,b,c,d)
+
+#define statvfs(a, b) XrdPosixStatvfs(a, b)
 #endif

--- a/src/XrdPosix/XrdPosixExtern.hh
+++ b/src/XrdPosix/XrdPosixExtern.hh
@@ -119,6 +119,8 @@ extern int        XrdPosix_Fseeko(FILE *stream, off_t offset, int whence);
 
 extern int        XrdPosix_Fstat(int fildes, struct stat *buf);
 
+extern int        XrdPosix_Fstatat(int dirfd, const char* path, struct stat *buf, int flags);
+
 #ifdef __linux__
 extern int        XrdPosix_FstatV(int ver, int fildes, struct stat *buf);
 #endif
@@ -182,6 +184,8 @@ extern int        XrdPosix_Statvfs(const char *path, struct statvfs *buf);
 extern int        XrdPosix_Statx(int dirfd, const char *path, int flags,
                                  unsigned int mask, XrdSysStatx *stx);
 
+extern int        XrdPosix_Openat(int dirfd, const char *path, int flag, ...);
+  
 extern ssize_t    XrdPosix_Pwrite(int fildes, const void *buf, size_t nbyte, off_t offset);
 
 extern long       XrdPosix_Telldir(DIR *dirp);

--- a/src/XrdPosix/XrdPosixLinkage.cc
+++ b/src/XrdPosix/XrdPosixLinkage.cc
@@ -136,7 +136,7 @@ XrdPosixLinkage Xunix;
       Retv_Lstat       Xrd_U_Lstat(Args_Lstat)
                          {return (Retv_Lstat)Xunix.Load_Error("lstat");}
       Retv_Lstat64     Xrd_U_Lstat64(Args_Lstat64)
-                         {return (Retv_Lstat64)Xunix.Load_Error("lstat");}
+                         {return (Retv_Lstat64)Xunix.Load_Error("lstat64");}
       Retv_Mkdir       Xrd_U_Mkdir(Args_Mkdir)
                          {return (Retv_Mkdir)Xunix.Load_Error("mkdir");}
       Retv_Open        Xrd_U_Open(Args_Open)

--- a/src/XrdPosix/XrdPosixLinkage.cc
+++ b/src/XrdPosix/XrdPosixLinkage.cc
@@ -71,7 +71,7 @@ XrdPosixLinkage Xunix;
 
       Retv_Access      Xrd_U_Access(Args_Access)
                          {return (Retv_Access)Xunix.Load_Error("access");}
-#if !defined(__APPLE__) and !defined(__linux__)
+#if !defined(__APPLE__) && !defined(__linux__)
       Retv_Acl         Xrd_U_Acl(Args_Acl)
                          {return (Retv_Acl)Xunix.Load_Error("acl");}
 #endif
@@ -107,6 +107,10 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Fstat)Xunix.Load_Error("fstat");}
       Retv_Fstat64     Xrd_U_Fstat64(Args_Fstat64)
                          {return (Retv_Fstat64)Xunix.Load_Error("fstat64");}
+      Retv_Fstatat     Xrd_U_Fstatat(Args_Fstatat)
+                         {return (Retv_Fstatat)Xunix.Load_Error("fstatat");}
+      Retv_Fstatat64   Xrd_U_Fstatat64(Args_Fstatat64)
+                         {return (Retv_Fstatat64)Xunix.Load_Error("fstatat64");}
       Retv_Fsync       Xrd_U_Fsync(Args_Fsync)
                          {return (Retv_Fsync)Xunix.Load_Error("fsync");}
       Retv_Ftell       Xrd_U_Ftell(Args_Ftell)
@@ -141,8 +145,12 @@ XrdPosixLinkage Xunix;
                          {return (Retv_Mkdir)Xunix.Load_Error("mkdir");}
       Retv_Open        Xrd_U_Open(Args_Open)
                          {return (Retv_Open)Xunix.Load_Error("open");}
+      Retv_Openat      Xrd_U_Openat(Args_Openat)
+                         {return (Retv_Openat)Xunix.Load_Error("openat");}
+      Retv_Openat64    Xrd_U_Openat64(Args_Openat64)
+                         {return (Retv_Openat64)Xunix.Load_Error("openat64");}
       Retv_Open64      Xrd_U_Open64(Args_Open64)
-                         {return (Retv_Open64)Xunix.Load_Error("open");}
+                         {return (Retv_Open64)Xunix.Load_Error("open64");}
       Retv_Opendir     Xrd_U_Opendir(Args_Opendir)
                          {Xunix.Load_Error("opendir"); return (Retv_Opendir)0;}
       Retv_Pathconf    Xrd_U_Pathconf(Args_Pathconf)
@@ -222,7 +230,7 @@ XrdPosixLinkage Xunix;
 int XrdPosixLinkage::Resolve()
 {
   LOOKUP_UNIX(Access)
-#if !defined(__APPLE__) and !defined(__linux__)
+#if !defined(__APPLE__) && !defined(__linux__)
   LOOKUP_UNIX(Acl)
 #endif
   LOOKUP_UNIX(Chdir)
@@ -240,6 +248,13 @@ int XrdPosixLinkage::Resolve()
   LOOKUP_UNIX(Fseeko)
   LOOKUP_UNIX(Fseeko64)
   LOOKUP_UNIX(Fstat)
+#ifdef HAVE_Fstatat
+  LOOKUP_UNIX(Fstatat)
+  LOOKUP_UNIX(Fstatat64)
+#else
+  Fstatat = Xrd_U_Fstatat;
+  Fstatat64 = Xrd_U_Fstatat64;
+#endif
   LOOKUP_UNIX(Fstat64)
   LOOKUP_UNIX(Fsync)
   LOOKUP_UNIX(Ftell)
@@ -260,6 +275,13 @@ int XrdPosixLinkage::Resolve()
   LOOKUP_UNIX(Fsync)
   LOOKUP_UNIX(Mkdir)
   LOOKUP_UNIX(Open)
+#ifdef HAVE_Openat
+  LOOKUP_UNIX(Openat)
+  LOOKUP_UNIX(Openat64)
+#else
+  Openat = Xrd_U_Openat;
+  Openat64 = Xrd_U_Openat64;
+#endif
   LOOKUP_UNIX(Open64)
   LOOKUP_UNIX(Opendir)
   LOOKUP_UNIX(Pathconf)

--- a/src/XrdPosix/XrdPosixLinkage.hh
+++ b/src/XrdPosix/XrdPosixLinkage.hh
@@ -57,15 +57,15 @@
 #define Symb_Access UNIX_PFX "access"
 #define Retv_Access int
 #define Args_Access const char *path, int amode
-  
+
 #define Symb_Acl UNIX_PFX "acl"
 #define Retv_Acl int
 #define Args_Acl const char *, int, int, void *
-  
+
 #define Symb_Chdir UNIX_PFX "chdir"
 #define Retv_Chdir int
 #define Args_Chdir const char *path
-  
+
 #define Symb_Close UNIX_PFX "close"
 #define Retv_Close int
 #define Args_Close int
@@ -136,7 +136,7 @@
 #define Args_Fseeko64 FILE *, off64_t, int
 #endif
 
-#if defined(__linux__) and defined(_STAT_VER)
+#if defined(__linux__) && defined(_STAT_VER)
 #define Symb_Fstat UNIX_PFX "__fxstat"
 #define Retv_Fstat int
 #define Args_Fstat int, int, struct stat *
@@ -146,7 +146,7 @@
 #define Args_Fstat int, struct stat *
 #endif
 
-#if defined(__linux__) and defined(_STAT_VER)
+#if defined(__linux__) && defined(_STAT_VER)
 #define Symb_Fstat64 UNIX_PFX "__fxstat64"
 #define Retv_Fstat64 int
 #define Args_Fstat64 int, int, struct stat64 *
@@ -161,6 +161,14 @@
 #define Args_Fstat64 int, struct stat64 *
 #endif
 #endif
+
+#define Symb_Fstatat UNIX_PFX "fstatat"
+#define Retv_Fstatat int
+#define Args_Fstatat int, const char*, struct stat *, int
+
+#define Symb_Fstatat64 UNIX_PFX "fstatat64"
+#define Retv_Fstatat64 int
+#define Args_Fstatat64 int, const char*, struct stat64 *, int
 
 #define Symb_Fsync UNIX_PFX "fsync"
 #define Retv_Fsync int
@@ -228,7 +236,7 @@
 #define Args_Lseek64 int, off64_t, int
 #endif
 
-#if defined(__linux__) and defined(_STAT_VER)
+#if defined(__linux__) && defined(_STAT_VER)
 #define Symb_Lstat UNIX_PFX "__lxstat"
 #define Retv_Lstat int
 #define Args_Lstat int, const char *, struct stat *
@@ -238,7 +246,7 @@
 #define Args_Lstat const char *, struct stat *
 #endif
 
-#if defined(__linux__) and defined(_STAT_VER)
+#if defined(__linux__) && defined(_STAT_VER)
 #define Symb_Lstat64 UNIX_PFX "__lxstat64"
 #define Retv_Lstat64 int
 #define Args_Lstat64 int, const char *, struct stat64 *
@@ -262,6 +270,14 @@
 #define Retv_Open int
 #define Args_Open const char *, int, ...
 
+#define Symb_Openat UNIX_PFX "openat"
+#define Retv_Openat int
+#define Args_Openat const char *, int, ...
+
+#define Symb_Openat64 UNIX_PFX "openat64"
+#define Retv_Openat64 int
+#define Args_Openat64 const char *, int, ...
+
 #ifdef __APPLE__
 #define Symb_Open64 UNIX_PFX "open"
 #define Retv_Open64 int
@@ -275,7 +291,7 @@
 #define Symb_Opendir UNIX_PFX "opendir"
 #define Retv_Opendir DIR *
 #define Args_Opendir const char *
-  
+
 #define Symb_Pathconf UNIX_PFX "pathconf"
 #define Retv_Pathconf long
 #define Args_Pathconf const char *, int
@@ -283,7 +299,7 @@
 #define Symb_Pread UNIX_PFX "pread"
 #define Retv_Pread ssize_t
 #define Args_Pread int, void *, size_t, off_t
-  
+
 #ifdef __APPLE__
 #define Symb_Pread64 UNIX_PFX "pread"
 #define Retv_Pread64 ssize_t
@@ -311,7 +327,7 @@
 #define Symb_Read UNIX_PFX "read"
 #define Retv_Read ssize_t
 #define Args_Read int, void *, size_t
-  
+
 #define Symb_Readv UNIX_PFX "readv"
 #define Retv_Readv ssize_t
 #define Args_Readv int, const struct iovec *, int
@@ -370,7 +386,7 @@
 #define Args_Stat const char *, struct stat *
 #endif
 
-#if defined(__linux__) and defined(_STAT_VER)
+#if defined(__linux__) && defined(_STAT_VER)
 #define Symb_Stat64 UNIX_PFX "__xstat64"
 #define Retv_Stat64 int
 #define Args_Stat64 int, const char *, struct stat64 *
@@ -451,7 +467,7 @@
 /******************************************************************************/
 /*            C a l l   O u t   V e c t o r   D e f i n i t i o n             */
 /******************************************************************************/
-  
+
 class XrdPosixLinkage
 {public:
       int              Init(int *X=0) {if (!Done) Done = Resolve(); return 0;}
@@ -474,6 +490,8 @@ class XrdPosixLinkage
       Retv_Fseeko64    (*Fseeko64)(Args_Fseeko64);
       Retv_Fstat       (*Fstat)(Args_Fstat);
       Retv_Fstat64     (*Fstat64)(Args_Fstat64);
+      Retv_Fstatat     (*Fstatat)(Args_Fstatat);
+      Retv_Fstatat64   (*Fstatat64)(Args_Fstatat64);
       Retv_Fsync       (*Fsync)(Args_Fsync);
       Retv_Ftell       (*Ftell)(Args_Ftell);
       Retv_Ftello      (*Ftello)(Args_Ftello);
@@ -491,6 +509,8 @@ class XrdPosixLinkage
       Retv_Mkdir       (*Mkdir)(Args_Mkdir);
       Retv_Open        (*Open)(Args_Open);
       Retv_Open64      (*Open64)(Args_Open64);
+      Retv_Openat      (*Openat)(Args_Openat);
+      Retv_Openat64    (*Openat64)(Args_Openat64);
       Retv_Opendir     (*Opendir)(Args_Opendir);
       Retv_Pathconf    (*Pathconf)(Args_Pathconf);
       Retv_Pread       (*Pread)(Args_Pread);

--- a/src/XrdPosix/XrdPosixPreload.cc
+++ b/src/XrdPosix/XrdPosixPreload.cc
@@ -64,20 +64,24 @@
 #undef statfs64
 #undef statvfs64
 #undef truncate64
+#undef fstat64
+#undef stat64
+#undef fstatat64
+#undef lstat64
 #endif
- 
+
 /******************************************************************************/
 /*                   G l o b a l   D e c l a r a t i o n s                    */
 /******************************************************************************/
-  
+
 extern XrdPosixLinkage Xunix;
 
 namespace {bool isLite = (getenv("XRD_POSIX_PRELOAD_LITE") != 0);}
-  
+
 /******************************************************************************/
 /*                                a c c e s s                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int access(const char *path, int amode)
@@ -103,7 +107,7 @@ int acl(const char *path, int cmd, int nentries, void *aclbufp)
    return XrdPosix_Acl(path, cmd, nentries, aclbufp);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 c h d i r                                  */
 /******************************************************************************/
@@ -135,7 +139,7 @@ int     close(int fildes)
 /******************************************************************************/
 /*                              c l o s e d i r                               */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     closedir(DIR *dirp)
@@ -149,7 +153,7 @@ int     closedir(DIR *dirp)
 /******************************************************************************/
 /*                                 c r e a t                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     creat64(const char *path, mode_t mode)
@@ -159,7 +163,7 @@ int     creat64(const char *path, mode_t mode)
    return XrdPosix_Creat(path, mode);
 }
 }
-  
+
 /******************************************************************************/
 /*                                f c l o s e                                 */
 /******************************************************************************/
@@ -177,7 +181,7 @@ int fclose(FILE *stream)
 /******************************************************************************/
 /*                               f c n t l 6 4                                */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     fcntl64(int fd, int cmd, ...)
@@ -212,7 +216,7 @@ int     fdatasync(int fildes)
 /******************************************************************************/
 /*                                f f l u s h                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int    fflush(FILE *stream)
@@ -222,11 +226,11 @@ int    fflush(FILE *stream)
    return XrdPosix_Fflush(stream);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 f o p e n                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 FILE  *fopen64(const char *path, const char *mode)
@@ -240,7 +244,7 @@ FILE  *fopen64(const char *path, const char *mode)
 /******************************************************************************/
 /*                                 f r e a d                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 size_t fread(void *ptr, size_t size, size_t nitems, FILE *stream)
@@ -250,7 +254,7 @@ size_t fread(void *ptr, size_t size, size_t nitems, FILE *stream)
    return XrdPosix_Fread(ptr, size, nitems, stream);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 f s e e k                                  */
 /******************************************************************************/
@@ -264,7 +268,7 @@ int fseek(FILE *stream, long offset, int whence)
    return XrdPosix_Fseek(stream, offset, whence);
 }
 }
-  
+
 /******************************************************************************/
 /*                                f s e e k o                                 */
 /******************************************************************************/
@@ -278,33 +282,44 @@ int fseeko64(FILE *stream, off64_t offset, int whence)
    return XrdPosix_Fseeko(stream, offset, whence);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 f s t a t                                  */
 /******************************************************************************/
 
 extern "C"
 {
-#if defined(__linux__) and defined(_STAT_VER) and __GNUC__ and __GNUC__ >= 2
-int  __fxstat64(int ver, int fildes, struct stat64 *buf)
+#if defined(__linux__) && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
+  int     __fxstat64( int ver, int fildes, struct stat64 *buf)
 #else
-int     fstat64(         int fildes, struct stat64 *buf)
+  int     fstat64( int fildes, struct stat64 *buf)
 #endif
 {
-   static int Init = Xunix.Init(&Init);
-
-#if defined(__linux__) and defined(_STAT_VER)
-   return XrdPosix_FstatV(ver, fildes, (struct stat *)buf);
+    static int Init = Xunix.Init(&Init);
+#if defined(__linux__) && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
+    return XrdPosix_FstatV ( ver, fildes,  (struct stat *)buf);
 #else
-   return XrdPosix_Fstat (     fildes, (struct stat *)buf);
+    return XrdPosix_Fstat (       fildes,  (struct stat *)buf);
 #endif
 }
+}
+
+/******************************************************************************/
+/*                                 f s t a t a t                              */
+/******************************************************************************/
+
+extern "C"
+{
+  int fstatat64(int dirfd, const char* path, struct stat64 *buf, int flags){
+    static int Init = Xunix.Init(&Init);
+    return XrdPosix_Fstatat (dirfd, path, (struct stat *)buf, flags);
+  }
 }
 
 /******************************************************************************/
 /*                                 f s y n c                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     fsync(int fildes)
@@ -314,7 +329,7 @@ int     fsync(int fildes)
    return XrdPosix_Fsync(fildes);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 f t e l l                                  */
 /******************************************************************************/
@@ -328,7 +343,7 @@ long    ftell(FILE *stream)
    return XrdPosix_Ftell(stream);
 }
 }
-  
+
 /******************************************************************************/
 /*                                f t e l l o                                 */
 /******************************************************************************/
@@ -342,11 +357,11 @@ off64_t ftello64(FILE *stream)
    return XrdPosix_Ftello(stream);
 }
 }
-  
+
 /******************************************************************************/
 /*                             f t r u n c a t e                              */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int ftruncate64(int fildes, off_t offset)
@@ -356,11 +371,11 @@ int ftruncate64(int fildes, off_t offset)
    return XrdPosix_Ftruncate(fildes, offset);
 }
 }
-  
+
 /******************************************************************************/
 /*                                f w r i t e                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 size_t fwrite(const void *ptr, size_t size, size_t nitems, FILE *stream)
@@ -370,11 +385,11 @@ size_t fwrite(const void *ptr, size_t size, size_t nitems, FILE *stream)
    return XrdPosix_Fwrite(ptr, size, nitems, stream);
 }
 }
-  
+
 /******************************************************************************/
 /*                             f g e t x a t t r                              */
 /******************************************************************************/
-  
+
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 extern "C"
 {
@@ -390,7 +405,7 @@ ssize_t fgetxattr (int fd, const char *name, void *value, size_t size)
 /******************************************************************************/
 /*                              g e t x a t t r                               */
 /******************************************************************************/
-  
+
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 extern "C"
 {
@@ -402,11 +417,11 @@ ssize_t getxattr (const char *path, const char *name, void *value, size_t size)
 }
 }
 #endif
-  
+
 /******************************************************************************/
 /*                             l g e t x a t t r                              */
 /******************************************************************************/
-  
+
 #if defined(__linux__) || defined(__GNU__) || (defined(__FreeBSD_kernel__) && defined(__GLIBC__))
 extern "C"
 {
@@ -422,7 +437,7 @@ ssize_t lgetxattr (const char *path, const char *name, void *value, size_t size)
 /******************************************************************************/
 /*                                 l s e e k                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 off64_t lseek64(int fildes, off64_t offset, int whence)
@@ -436,7 +451,7 @@ off64_t lseek64(int fildes, off64_t offset, int whence)
 /******************************************************************************/
 /*                                l l s e e k                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 #if defined(__linux__) || defined(__APPLE__)
@@ -457,14 +472,13 @@ offset_t   llseek(int fildes, offset_t offset, int whence)
 
 extern "C"
 {
-#if defined __linux__ && __GNUC__ && __GNUC__ >= 2
+#if defined __linux__ && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
 int     __lxstat64(int ver, const char *path, struct stat64 *buf)
 #else
 int        lstat64(         const char *path, struct stat64 *buf)
 #endif
 {
    static int Init = Xunix.Init(&Init);
-
    return XrdPosix_Lstat(path, (struct stat *)buf);
 }
 }
@@ -472,7 +486,7 @@ int        lstat64(         const char *path, struct stat64 *buf)
 /******************************************************************************/
 /*                                 m k d i r                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     mkdir(const char *path, mode_t mode)
@@ -503,9 +517,28 @@ int     open64(const char *path, int oflag, ...)
 }
 
 /******************************************************************************/
+/*                                  o p e n a t                               */
+/******************************************************************************/
+
+extern "C"
+{
+  int openat(int dirfd, const char *path, int flag, ...)
+{
+   static int Init = Xunix.Init(&Init);
+   va_list ap;
+   int mode;
+
+   va_start(ap, flag);
+   mode = va_arg(ap, int);
+   va_end(ap);
+   return XrdPosix_Openat(dirfd, path, flag, mode);
+}
+}
+
+/******************************************************************************/
 /*                               o p e n d i r                                */
 /******************************************************************************/
-  
+
 extern "C"
 {
 DIR*    opendir(const char *path)
@@ -515,7 +548,7 @@ DIR*    opendir(const char *path)
    return (isLite ? Xunix.Opendir(path) : XrdPosix_Opendir(path));
 }
 }
-  
+
 /******************************************************************************/
 /*                              p a t h c o n f                               */
 /******************************************************************************/
@@ -535,7 +568,7 @@ long pathconf(const char *path, int name)
 /******************************************************************************/
 /*                                 p r e a d                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t pread64(int fildes, void *buf, size_t nbyte, off_t offset)
@@ -549,7 +582,7 @@ ssize_t pread64(int fildes, void *buf, size_t nbyte, off_t offset)
 /******************************************************************************/
 /*                                p w r i t e                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t pwrite64(int fildes, const void *buf, size_t nbyte, off_t offset)
@@ -563,7 +596,7 @@ ssize_t pwrite64(int fildes, const void *buf, size_t nbyte, off_t offset)
 /******************************************************************************/
 /*                                  r e a d                                   */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t read(int fildes, void *buf, size_t nbyte)
@@ -573,11 +606,11 @@ ssize_t read(int fildes, void *buf, size_t nbyte)
    return XrdPosix_Read(fildes, buf, nbyte);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 r e a d v                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t readv(int fildes, const struct iovec *iov, int iovcnt)
@@ -605,7 +638,7 @@ struct dirent64* readdir64(DIR *dirp)
 /******************************************************************************/
 /*                             r e a d d i r _ r                              */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     readdir64_r(DIR *dirp, struct dirent64 *entry, struct dirent64 **result)
@@ -620,7 +653,7 @@ int     readdir64_r(DIR *dirp, struct dirent64 *entry, struct dirent64 **result)
 /******************************************************************************/
 /*                                r e n a m e                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     rename(const char *oldpath, const char *newpath)
@@ -650,7 +683,7 @@ void    rewinddir(DIR *dirp)
 /******************************************************************************/
 /*                                 r m d i r                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     rmdir(const char *path)
@@ -664,7 +697,7 @@ int     rmdir(const char *path)
 /******************************************************************************/
 /*                               s e e k d i r                                */
 /******************************************************************************/
-  
+
 extern "C"
 {
 void    seekdir(DIR *dirp, long loc)
@@ -681,7 +714,7 @@ void    seekdir(DIR *dirp, long loc)
 
 extern "C"
 {
-#if defined __linux__ && __GNUC__ && __GNUC__ >= 2
+#if defined __linux__ && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
 int     __xstat64(int ver, const char *path, struct stat64 *buf)
 #else
 int        stat64(         const char *path, struct stat64 *buf)
@@ -741,7 +774,7 @@ int statx(int dirfd, const char *path, int flags,
 /******************************************************************************/
 /*                               t e l l d i r                                */
 /******************************************************************************/
-  
+
 extern "C"
 {
 long    telldir(DIR *dirp)
@@ -751,11 +784,11 @@ long    telldir(DIR *dirp)
    return (isLite ? Xunix.Telldir(dirp) : XrdPosix_Telldir(dirp));
 }
 }
-  
+
 /******************************************************************************/
 /*                              t r u n c a t e                               */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int truncate64(const char *path, off_t offset)
@@ -769,7 +802,7 @@ int truncate64(const char *path, off_t offset)
 /******************************************************************************/
 /*                                u n l i n k                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     unlink(const char *path)
@@ -783,7 +816,7 @@ int     unlink(const char *path)
 /******************************************************************************/
 /*                                 w r i t e                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t write(int fildes, const void *buf, size_t nbyte)
@@ -797,7 +830,7 @@ ssize_t write(int fildes, const void *buf, size_t nbyte)
 /******************************************************************************/
 /*                                w r i t e v                                 */
 /******************************************************************************/
-  
+
 extern "C"
 {
 ssize_t writev(int fildes, const struct iovec *iov, int iovcnt)
@@ -808,4 +841,3 @@ ssize_t writev(int fildes, const struct iovec *iov, int iovcnt)
 }
 }
 #endif
-

--- a/src/XrdPosix/XrdPosixPreload32.cc
+++ b/src/XrdPosix/XrdPosixPreload32.cc
@@ -76,22 +76,22 @@
 #include "XrdPosix/XrdPosixXrootd.hh"
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysPlatform.hh"
- 
+
 /******************************************************************************/
 /*                   G l o b a l   D e c l a r a t i o n s                    */
 /******************************************************************************/
-  
+
 extern XrdPosixLinkage Xunix;
 
 namespace {bool isLite = (getenv("XRD_POSIX_PRELOAD_LITE") != 0);}
- 
+
 /******************************************************************************/
 /*               6 4 - t o 3 2   B i t   C o n v e r s i o n s                */
 /******************************************************************************/
 /******************************************************************************/
 /*                   X r d P o s i x _ C o p y D i r e n t                    */
 /******************************************************************************/
-  
+
 // Macos is a curious beast. It is not an LP64 platform but offsets are
 // defined as 64 bits anyway. So, the dirent structure is 64-bit conformable
 // making CopyDirent() superfluous. In Solaris x86 there are no 32 bit interfaces.
@@ -130,7 +130,7 @@ int XrdPosix_CopyDirent(struct dirent *dent, struct dirent64 *dent64)
 /******************************************************************************/
 /*                     X r d P o s i x _ C o p y S t a t                      */
 /******************************************************************************/
-  
+
 // Macos is a curious beast. It is not an LP64 platform but stat sizes are
 // defined as 64 bits anyway. So, the stat structure is 64-bit conformable
 // making CopyStat() seemingly superfluous. However, starting in Darwin 10.5
@@ -170,7 +170,7 @@ int XrdPosix_CopyStat(struct stat *buf, struct stat64 &buf64)
 /******************************************************************************/
 /*                                 c r e a t                                  */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -186,7 +186,7 @@ int     creat(const char *path, mode_t mode)
 /******************************************************************************/
 /*                                 f c n t l                                  */
 /******************************************************************************/
-  
+
 extern "C"
 {
 int     fcntl(int fd, int cmd, ...)
@@ -202,7 +202,7 @@ int     fcntl(int fd, int cmd, ...)
    return Xunix.Fcntl(fd, cmd, theArg);
 }
 }
-  
+
 /******************************************************************************/
 /*                                 f o p e n                                  */
 /******************************************************************************/
@@ -218,7 +218,7 @@ FILE  *fopen(const char *path, const char *mode)
 }
 */
 
-  
+
 /******************************************************************************/
 /*                                f s e e k o                                 */
 /******************************************************************************/
@@ -270,7 +270,7 @@ int     fstat(         int fildes, struct stat *buf)
 }
 #endif
 
-  
+
 /******************************************************************************/
 /*                                f t e l l o                                 */
 /******************************************************************************/
@@ -290,7 +290,7 @@ off_t ftello(FILE *stream)
 /******************************************************************************/
 /*                             f t r u n c a t e                              */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -306,7 +306,7 @@ int ftruncate(int fildes, off_t offset)
 /******************************************************************************/
 /*                                 l s e e k                                  */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -359,7 +359,7 @@ int        lstat(         const char *path, struct stat *buf)
 /******************************************************************************/
 /*                                  o p e n                                   */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -380,7 +380,7 @@ int     open(const char *path, int oflag, ...)
 /******************************************************************************/
 /*                                 p r e a d                                  */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -424,7 +424,7 @@ struct dirent* readdir(DIR *dirp)
 /******************************************************************************/
 /*                             r e a d d i r _ r                              */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -460,7 +460,7 @@ int     readdir_r(DIR *dirp, struct dirent *entry, struct dirent **result)
 /******************************************************************************/
 /*                                p w r i t e                                 */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
@@ -490,12 +490,12 @@ int        stat(         const char *path, struct stat *buf)
 {
    static int Init = Xunix.Init(&Init);
 
-   if (!XrdPosix_isMyPath(path))
-#ifdef __linux__
-      return Xunix.Stat(ver, path, buf);
-#else
-      return Xunix.Stat(     path, buf);
-#endif
+   //   if (!XrdPosix_isMyPath(path))
+   //#ifdef __linux__
+   //      return Xunix.Stat(ver, path, buf);
+   //#else
+   //      return Xunix.Stat(     path, buf);
+   //#endif
 
 #if defined(__LP64__) || defined(_LP64)
    return    XrdPosix_Stat(path,                 buf  );
@@ -571,7 +571,7 @@ int        statvfs(         const char *path, struct statvfs *buf)
 /******************************************************************************/
 /*                              t r u n c a t e                               */
 /******************************************************************************/
-  
+
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {

--- a/src/XrdPosix/XrdPosixPreload32.cc
+++ b/src/XrdPosix/XrdPosixPreload32.cc
@@ -239,27 +239,27 @@ int fseeko(FILE *stream, off_t offset, int whence)
 /*                                 f s t a t                                  */
 /******************************************************************************/
 
-#if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
-#if defined __linux__ && __GNUC__ && __GNUC__ >= 2
-int  __fxstat(int ver, int fildes, struct stat *buf)
+#if defined(__linux__) && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
+  int     __fxstat(int ver, int fildes, struct stat *buf)
 #elif defined(__solaris__) && defined(__i386)
-int   _fxstat(int ver, int fildes, struct stat *buf)
+    int   _fxstat(int ver, int fildes, struct stat *buf)
 #else
-int     fstat(         int fildes, struct stat *buf)
+  int     fstat(           int fildes, struct stat *buf)
 #endif
 {
-   static int Init = Xunix.Init(&Init);
+  static int Init = Xunix.Init(&Init);
 
-#if defined(__linux__) and defined(_STAT_VER)
-   if (!XrdPosixXrootd::myFD(fildes)) return Xunix.Fstat(ver, fildes, buf);
-#else
-   if (!XrdPosixXrootd::myFD(fildes)) return Xunix.Fstat(     fildes, buf);
+#if defined(__linux__) && defined(_STAT_VER) && __GNUC__ && __GNUC__ >= 2
+  if (!XrdPosixXrootd::myFD(fildes)) return Xunix.Fstat(ver, fildes, buf);
+#endif
+#ifdef __APPLE__
+  if (!XrdPosixXrootd::myFD(fildes)) return Xunix.Fstat(     fildes, buf);
 #endif
 
 #if defined(__LP64__) || defined(_LP64)
-   return    XrdPosix_Fstat(fildes,                 buf  );
+  return    XrdPosix_Fstat(fildes,                 buf  );
 #else
    int rc;
    struct stat64 buf64;
@@ -268,8 +268,26 @@ int     fstat(         int fildes, struct stat *buf)
 #endif
 }
 }
+
+/******************************************************************************/
+/*                                 f s t a t a t                              */
+/******************************************************************************/
+
+extern "C"
+{
+  int fstatat(int dirfd, const char* path, struct stat *buf, int flags){
+    static int Init = Xunix.Init(&Init);
+#if defined(__LP64__) || defined(_LP64)
+    return XrdPosix_Fstatat (dirfd, path, buf, flags);
+#else
+   int rc;
+   struct stat64 buf64;
+   if ((rc = XrdPosix_Fstatat(dirfd, path, (struct stat *)&buf64, flags))) return rc;
+   return XrdPosix_CopyStat(buf, buf64);
 #endif
 
+}
+}
 
 /******************************************************************************/
 /*                                f t e l l o                                 */
@@ -326,7 +344,7 @@ off_t   lseek(int fildes, off_t offset, int whence)
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
-#if defined __GNUC__ && __GNUC__ >= 2 && defined(__linux__)
+#if defined __GNUC__ && defined(_STAT_VER) &&  __GNUC__ >= 2 && defined(__linux__)
 int     __lxstat(int ver, const char *path, struct stat *buf)
 #elif defined(__solaris__) && defined(__i386)
 int      _lxstat(int ver, const char *path, struct stat *buf)
@@ -336,15 +354,17 @@ int        lstat(         const char *path, struct stat *buf)
 {
    static int Init = Xunix.Init(&Init);
 
-   if (!XrdPosix_isMyPath(path))
 #if defined(__linux__) and defined(_STAT_VER)
-      return Xunix.Lstat(ver, path, buf);
-#else
-      return Xunix.Lstat(     path, buf);
+   if (!XrdPosix_isMyPath(path))
+     return Xunix.Lstat(ver, path, buf);
+#endif
+#ifdef __APPLE__
+   if (!XrdPosix_isMyPath(path))
+     return Xunix.Lstat(     path, buf);
 #endif
 
 #if defined(__LP64__) || defined(_LP64)
-   return    XrdPosix_Lstat(path,                 buf  );
+   return    XrdPosix_Lstat(path, buf  );
 #else
    struct stat64 buf64;
    int rc;
@@ -480,7 +500,7 @@ ssize_t pwrite(int fildes, const void *buf, size_t nbyte, off_t offset)
 #if !defined(SUNX86) && !defined(__FreeBSD__)
 extern "C"
 {
-#if defined __GNUC__ && __GNUC__ >= 2
+#if defined __linux__ && defined(_STAT_VER) && defined __GNUC__ && __GNUC__ >= 2
 int     __xstat(int ver, const char *path, struct stat *buf)
 #elif defined(__solaris__) && defined(__i386)
 int      _xstat(int ver, const char *path, struct stat *buf)
@@ -489,16 +509,17 @@ int        stat(         const char *path, struct stat *buf)
 #endif
 {
    static int Init = Xunix.Init(&Init);
-
-   //   if (!XrdPosix_isMyPath(path))
-   //#ifdef __linux__
-   //      return Xunix.Stat(ver, path, buf);
-   //#else
-   //      return Xunix.Stat(     path, buf);
-   //#endif
+#if defined( __linux__) && defined(_STAT_VER)
+   if (!XrdPosix_isMyPath(path))
+     return Xunix.Stat(ver, path, buf);
+#endif
+#ifdef __APPLE__
+   if (!XrdPosix_isMyPath(path))
+     return Xunix.Stat(     path, buf);
+#endif
 
 #if defined(__LP64__) || defined(_LP64)
-   return    XrdPosix_Stat(path,                 buf  );
+   return    XrdPosix_Stat(path, buf);
 #else
    struct stat64 buf64;
    int rc;

--- a/tests/XRootD/posix.sh
+++ b/tests/XRootD/posix.sh
@@ -34,6 +34,13 @@ function test_posix() {
 
 	assert_failure xrdposix-cat "${HOST}"/does/not/exist.txt
 
+	# Check XrdPosix with link to remote
+	ln -sf "${HOST}"/remote.txt local-to-remote.txt
+	assert xrdposix-cat local-to-remote.txt
+
+	ln -sf  "${HOST}"/does/not/exist local-to-stale.txt
+	assert_failure xrdposix-cat local-to-stale.txt
+
 	# Use XrdPosix via virtual mount point
 
 	export XROOTD_VMP="${HOST#root://}:/xrootd/=/"
@@ -53,5 +60,14 @@ function test_posix() {
 		assert_failure xrdposix-statx "${HOST}"/this/does/not/exist.txt
 
 		assert xrdposix-statx /xrootd/remote.txt
+
+		# test links
+		assert xrdposix-statx local-to-remote.txt
+		assert xrdposix-statx local-to-stale.txt
+		assert_failure xrdposix-statx -L local-to-stale.txt
+		assert xrdposix-statx -L local-to-remote.txt
 	fi
+	# cleanup
+	rm -f local-to-remote.txt
+	rm -f local-to-stale.txt
 }


### PR DESCRIPTION
This patch introduces improved support for links in XrdPosix, specifically for XrdPosixPreload. Current override functions for  stat, statx, open etc do check if the current file is to be handled by xrootd or not. If the file is a local link pointing to e.g. EOS, these functions should resolve the link location and check the target rather than the local link itself (exception: lstat).
In addition, this patch introduces overrides for openat and fstatat (albeit they are likely not used much), and implements a few minor bug fixes.
 
