### PR TITLE
[XrdHttp] Fix crash due to unaligned memory access

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2822,7 +2822,8 @@ void XrdHttpReq::getReadResponse(XrdHttpIOList &received) {
 
       for (p = (char *) iovP[i].iov_base; p < (char *) iovP[i].iov_base + iovP[i].iov_len;) {
         l = (readahead_list *) p;
-        len = ntohl(l->rlen);
+        memcpy(&len, &l->rlen, sizeof(kXR_int32));
+        len = ntohl(len);
 
         received.emplace_back(p+sizeof(readahead_list), -1, len);
 


### PR DESCRIPTION
Fixes test failure with Debian on sparc64
```
Core was generated by `/home/ellert/xrootd/xrootd-6.0.0/obj-sparc64-linux-gnu/bin/xrootd -n origin -c'.
Program terminated with signal SIGUSR1, User defined signal 1.
#0  0xfff8000104b2b250 in XrdHttpReq::getReadResponse (
    this=0xfff800011803f570, received=...) at ./src/XrdHttp/XrdHttpReq.cc:2825
2825	        len = ntohl(l->rlen);
```
