### PR TITLE
[XrdPosix] Remove duplicate definitions and ensure that XrdPosix.hh works in C context

### DIFF
--- a/src/XrdPosix/XrdPosix.hh
+++ b/src/XrdPosix/XrdPosix.hh
@@ -106,8 +106,6 @@
 
 #define lstat(a,b)        XrdPosix_Stat(a,b)
 
-#define fstat(a,b)        XrdPosix_Stat(a,b)
-
 #define statfs(a,b)      XrdPosix_Statfs(a,b)
 
 #define statvfs(a,b)     XrdPosix_Statvfs(a,b)
@@ -132,5 +130,4 @@
 
 #define fgetxattr(a,b,c,d) XrdPosix_Fgetxattr(a,b,c,d)
 
-#define statvfs(a, b) XrdPosixStatvfs(a, b)
 #endif

--- a/src/XrdPosix/XrdPosixLinkage.cc
+++ b/src/XrdPosix/XrdPosixLinkage.cc
@@ -248,13 +248,6 @@ int XrdPosixLinkage::Resolve()
   LOOKUP_UNIX(Fseeko)
   LOOKUP_UNIX(Fseeko64)
   LOOKUP_UNIX(Fstat)
-#ifdef HAVE_Fstatat
-  LOOKUP_UNIX(Fstatat)
-  LOOKUP_UNIX(Fstatat64)
-#else
-  Fstatat = Xrd_U_Fstatat;
-  Fstatat64 = Xrd_U_Fstatat64;
-#endif
   LOOKUP_UNIX(Fstat64)
   LOOKUP_UNIX(Fsync)
   LOOKUP_UNIX(Ftell)
@@ -275,13 +268,6 @@ int XrdPosixLinkage::Resolve()
   LOOKUP_UNIX(Fsync)
   LOOKUP_UNIX(Mkdir)
   LOOKUP_UNIX(Open)
-#ifdef HAVE_Openat
-  LOOKUP_UNIX(Openat)
-  LOOKUP_UNIX(Openat64)
-#else
-  Openat = Xrd_U_Openat;
-  Openat64 = Xrd_U_Openat64;
-#endif
   LOOKUP_UNIX(Open64)
   LOOKUP_UNIX(Opendir)
   LOOKUP_UNIX(Pathconf)

--- a/src/XrdSys/XrdSysStatx.hh
+++ b/src/XrdSys/XrdSysStatx.hh
@@ -37,8 +37,8 @@
 
 #if defined(__linux__) || defined(__GNU__)
 #include <sys/sysmacros.h>
-using XrdSysStatx = struct statx;
-#define HAVE_STATX
+typedef struct statx XrdSysStatx;
+#define HAVE_STATX 1
 #else
 struct XrdSysStatx
 {uint32_t stx_mask;
@@ -52,6 +52,8 @@ struct XrdSysStatx
 typedef struct timespec statx_timestamp;
 
 #endif // __linux__
+
+#ifdef __cplusplus
 
 class XrdSysStatxHelpers {
 public:
@@ -174,5 +176,7 @@ inline void XrdSysStatxHelpers::Statx2Stat(const XrdSysStatx & stx, struct stat 
   st = stx.statx;
 #endif
 }
+
+#endif // __cplusplus
 
 #endif //XROOTD_XRDSYSSTATX_HH


### PR DESCRIPTION
This patch fixes some issues spotted on Fedora44. 
Specifically, there are issues trying to use XrdPosix.hh from a C context.