### PR TITLE
fix: set @loader_path rpath for macOS PyPI wheel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@
 if( PYPI_BUILD )
   if( APPLE )
     set(CMAKE_INSTALL_NAME_DIR "@rpath")
+    set(CMAKE_INSTALL_RPATH "@loader_path")
   else()
     set(CMAKE_INSTALL_RPATH "$ORIGIN")
   endif()


### PR DESCRIPTION
Fixes #2784.

Adds `CMAKE_INSTALL_RPATH = @loader_path` for the macOS branch of `PYPI_BUILD`, mirroring the existing Linux `$ORIGIN` setting. Without it, the wheel-bundled `libXrdCl`/`libXrdUtils` cannot find the protocol plugins (`libXrdSec-N.so`, `libXrdSecunix-N.so`, ...) sitting next to them, and any authenticated connection fails with `[FATAL] Auth failed: Could not load authentication handler`.