### PR TITLE
[Server] Encrypt sessionid to prevent spoofing

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,6 +86,7 @@ if( NOT XRDCL_ONLY )
   target_link_libraries(XrdServer
     PRIVATE
     XrdUtils
+    XrdCryptoLite
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
     ${ATOMIC_LIBRARY}

--- a/src/XrdCrypto/CMakeLists.txt
+++ b/src/XrdCrypto/CMakeLists.txt
@@ -18,7 +18,8 @@ target_sources(XrdUtils PRIVATE
 )
 
 add_library(XrdCryptoLite SHARED
-  XrdCryptoLite.cc  XrdCryptoLite.hh
+  XrdCryptoLite.cc       XrdCryptoLite.hh
+  XrdCryptoLite_bfecb.cc XrdCryptoLite_bfecb.hh
   XrdCryptoLite_bf32.cc
 )
 

--- a/src/XrdCrypto/CMakeLists.txt
+++ b/src/XrdCrypto/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(XrdUtils PRIVATE
 
 add_library(XrdCryptoLite SHARED
   XrdCryptoLite.cc       XrdCryptoLite.hh
-  XrdCryptoLite_bfecb.cc XrdCryptoLite_bfecb.hh
+  XrdCryptoLite_BFecb.cc XrdCryptoLite_BFecb.hh
   XrdCryptoLite_bf32.cc
 )
 

--- a/src/XrdCrypto/XrdCryptoLite_BFecb.cc
+++ b/src/XrdCrypto/XrdCryptoLite_BFecb.cc
@@ -1,0 +1,65 @@
+/******************************************************************************/
+/*                                                                            */
+/*                X r d C r y p t o L i t e _ B F e c b . c c                 */
+/*                                                                            */
+/* (c) 2026 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*   Produced by Andrew Hanushevsky for Stanford University under contract    */
+/*              DE-AC02-76-SFO0515 with the Department of Energy              */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include <openssl/blowfish.h>
+
+#include "XrdCrypto/XrdCryptoLite_BFecb.hh"
+
+/******************************************************************************/
+/*                           C o n s t r u c t o r                            */
+/******************************************************************************/
+
+XrdCryptoLite_BFecb::XrdCryptoLite_BFecb(const unsigned char* key,
+                                               unsigned int   keylen)
+{
+// Allocate and set the key. This is an expensive operation so we do it once.
+//
+   bfKey = new BF_KEY;
+   BF_set_key(bfKey, keylen, key);
+}
+
+/******************************************************************************/
+/*                            D e s t r u c t o r                             */
+/******************************************************************************/
+
+XrdCryptoLite_BFecb::~XrdCryptoLite_BFecb() {delete bfKey;}
+
+/******************************************************************************/
+/*                                 A p p l y                                  */
+/******************************************************************************/
+
+void XrdCryptoLite_BFecb::Apply(const unsigned char* in8, unsigned char* out8,
+                                bool encrypt)
+{
+   int action = (encrypt ? BF_ENCRYPT : BF_DECRYPT);
+
+// Perform the action
+//
+   BF_ecb_encrypt(in8, out8, bfKey, action);
+}

--- a/src/XrdCrypto/XrdCryptoLite_BFecb.cc
+++ b/src/XrdCrypto/XrdCryptoLite_BFecb.cc
@@ -27,28 +27,83 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
-#include <openssl/blowfish.h>
+#include <openssl/evp.h>
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#include <openssl/provider.h>
+#endif
 
 #include "XrdCrypto/XrdCryptoLite_BFecb.hh"
+#include "XrdOuc/XrdOucUtils.hh"
 
 /******************************************************************************/
 /*                           C o n s t r u c t o r                            */
 /******************************************************************************/
 
-XrdCryptoLite_BFecb::XrdCryptoLite_BFecb(const unsigned char* key,
+XrdCryptoLite_BFecb::XrdCryptoLite_BFecb(bool&                aOK,
+                                         const unsigned char* key,
                                                unsigned int   keylen)
+                    : decCTX(0), encCTX(0)
 {
-// Allocate and set the key. This is an expensive operation so we do it once.
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+// With openssl v3 the blowfish cipher is only available via the "legacy"
+// provider. Legacy is typically not enabled by default (but can be via
+// openssl.cnf) so it is loaded here. Explicitly loading a provider will
+// disable the automatic loading of the "default" one. The default might
+// not have already been loaded, or standard algorithms might be available
+// via another configured provider, such as FIPS. So an attempt is made to
+// fetch a common default algorithm, possibly automaticlly loading the
+// default provider. Afterwards the legacy provider is loaded.
 //
-   bfKey = new BF_KEY;
-   BF_set_key(bfKey, keylen, key);
+   static struct loadProviders {
+      loadProviders() {
+         EVP_MD *mdp = EVP_MD_fetch(NULL, "SHA2-256", NULL);
+         if (mdp) EVP_MD_free(mdp);
+         // Load legacy provider into the default (NULL) library context
+         (void) OSSL_PROVIDER_load(NULL, "legacy");
+      }
+   } lp;
+#endif
+
+// Handle auto generation of a random key
+//
+   unsigned char bfKey[16];
+   if (!key || !keylen)
+      {XrdOucUtils::Random(bfKey, sizeof(bfKey));
+       key    = bfKey;
+       keylen = sizeof(bfKey);
+      }
+
+// The legacy openssl EVP is rather outdated, cumbersome, non thread-safe,
+// and badly documented. Unfortunately, it is the only one generally availabe
+// on all platforms (modern versions like CryptoPP need manual installation).
+// So, we need to construct a decryption context and an encryption context
+// because the context can only do one type of action at a time and resetting
+// the key when switching actions is CPU intensive. What a pain in the but!
+//
+   aOK = false;
+   if (!(decCTX = EVP_CIPHER_CTX_new())) return;
+   if (1 != EVP_DecryptInit_ex(decCTX, EVP_bf_ecb(), NULL, NULL, NULL)) return;
+   EVP_CIPHER_CTX_set_padding(decCTX, 0);
+   EVP_CIPHER_CTX_set_key_length(decCTX, keylen);
+   if (1 != EVP_DecryptInit_ex(decCTX, NULL, NULL, key, NULL)) return;
+
+   if (!(encCTX = EVP_CIPHER_CTX_new())) return;
+   if (1 != EVP_EncryptInit_ex(encCTX, EVP_bf_ecb(), NULL, NULL, NULL)) return;
+   EVP_CIPHER_CTX_set_padding(encCTX, 0);
+   EVP_CIPHER_CTX_set_key_length(encCTX, keylen);
+   if (1 != EVP_EncryptInit_ex(encCTX, NULL, NULL, key, NULL)) return;
+   aOK = true;
 }
 
 /******************************************************************************/
 /*                            D e s t r u c t o r                             */
 /******************************************************************************/
 
-XrdCryptoLite_BFecb::~XrdCryptoLite_BFecb() {delete bfKey;}
+XrdCryptoLite_BFecb::~XrdCryptoLite_BFecb()
+{
+   EVP_CIPHER_CTX_free(decCTX);
+   EVP_CIPHER_CTX_free(encCTX);
+}
 
 /******************************************************************************/
 /*                               D e c r y p t                                */
@@ -57,9 +112,15 @@ XrdCryptoLite_BFecb::~XrdCryptoLite_BFecb() {delete bfKey;}
 void XrdCryptoLite_BFecb::Decrypt(const unsigned char* in8,
                                         unsigned char* out8)
 {
-// Perform the action
+   int dlen;
+
+// Perform the action. Since we said padding is zero and the input must be
+// 8 bytes, and we are using blowfish ECB when we decrypt the result will
+// not be buffered but placed in the output buffer upon return.
 //
-   BF_ecb_encrypt(in8, out8, bfKey, BF_DECRYPT);
+   evpMutex.Lock();
+   EVP_DecryptUpdate(decCTX, out8, &dlen, in8, 8);
+   evpMutex.UnLock();
 }
 
 /******************************************************************************/
@@ -69,7 +130,32 @@ void XrdCryptoLite_BFecb::Decrypt(const unsigned char* in8,
 void XrdCryptoLite_BFecb::Encrypt(const unsigned char* in8,
                                         unsigned char* out8)
 {
+   int dlen;
+
 // Perform the action
 //
-   BF_ecb_encrypt(in8, out8, bfKey, BF_ENCRYPT);
+// Perform the action. Since we said padding is zero and the input must be
+// 8 bytes, and we are using blowfish ECB when we encrypt the result will
+// not be buffered but placed in the output buffer upon return.
+//
+   evpMutex.Lock();
+   EVP_EncryptUpdate(encCTX, out8, &dlen, in8, 8);
+   evpMutex.UnLock();
+}
+
+/******************************************************************************/
+/* Static:                      I n s t a n c e                               */
+/******************************************************************************/
+
+XrdCryptoLite_BFecb* XrdCryptoLite_BFecb::Instance(const unsigned char* key,
+                                                         unsigned int   klen)
+{
+   XrdCryptoLite_BFecb* obj;
+   bool isOK;
+
+// Get an instance or return a nil pointer
+//
+   obj = new XrdCryptoLite_BFecb(isOK, key, klen);
+   if (!isOK) {delete obj; obj = 0;}
+   return obj;
 }

--- a/src/XrdCrypto/XrdCryptoLite_BFecb.cc
+++ b/src/XrdCrypto/XrdCryptoLite_BFecb.cc
@@ -51,15 +51,25 @@ XrdCryptoLite_BFecb::XrdCryptoLite_BFecb(const unsigned char* key,
 XrdCryptoLite_BFecb::~XrdCryptoLite_BFecb() {delete bfKey;}
 
 /******************************************************************************/
-/*                                 A p p l y                                  */
+/*                               D e c r y p t                                */
 /******************************************************************************/
 
-void XrdCryptoLite_BFecb::Apply(const unsigned char* in8, unsigned char* out8,
-                                bool encrypt)
+void XrdCryptoLite_BFecb::Decrypt(const unsigned char* in8,
+                                        unsigned char* out8)
 {
-   int action = (encrypt ? BF_ENCRYPT : BF_DECRYPT);
-
 // Perform the action
 //
-   BF_ecb_encrypt(in8, out8, bfKey, action);
+   BF_ecb_encrypt(in8, out8, bfKey, BF_DECRYPT);
+}
+
+/******************************************************************************/
+/*                               E n c r y p t                                */
+/******************************************************************************/
+
+void XrdCryptoLite_BFecb::Encrypt(const unsigned char* in8,
+                                        unsigned char* out8)
+{
+// Perform the action
+//
+   BF_ecb_encrypt(in8, out8, bfKey, BF_ENCRYPT);
 }

--- a/src/XrdCrypto/XrdCryptoLite_BFecb.hh
+++ b/src/XrdCrypto/XrdCryptoLite_BFecb.hh
@@ -1,0 +1,72 @@
+#ifndef __XRDCRYPTOLITE_BFecb_H__
+#define __XRDCRYPTOLITE_BFecb_H__
+/******************************************************************************/
+/*                                                                            */
+/*                X r d C r y p t o L i t e _ B F e c b . h h                 */
+/*                                                                            */
+/* (c) 2026 by the Board of Trustees of the Leland Stanford, Jr., University  */
+/*   Produced by Andrew Hanushevsky for Stanford University under contract    */
+/*              DE-AC02-76-SFO0515 with the Department of Energy              */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+/* This class implements Bflowfish ecb cipher which works on a single 64-bit
+   block to produce another 64-bit block. While not particularly secure it
+   is useful for encrypting short messages in order to prevent spoofing but
+   not necessarily to protect data privacy. Note that this object is thread
+   safe as blowfish ECB is stateless. So, the object can be used by multiple
+   threads to perform encrypption/decryption using the supplied key.
+*/
+
+struct  bf_key_st;
+typedef bf_key_st BF_KEY;
+
+class XrdCryptoLite_BFecb
+{
+public:
+
+//-----------------------------------------------------------------------------
+//! Construct an ECB encryption/decryption object.
+//!
+//! @param  key     Pointer to the encryption key which should be 128 bits.
+//! @param  keylen  The length of the key in bytes.
+//-----------------------------------------------------------------------------
+
+      XrdCryptoLite_BFecb(const unsigned char* key, unsigned int keylen);
+
+     ~XrdCryptoLite_BFecb();
+
+//-----------------------------------------------------------------------------
+//! Decrypt or encrypt exactly one blowfish block of 8 bytes (64 bits)
+//!
+//! @param  in8     Pointer to exactly 8 bytes of data to be encrypted.
+//! @param  out8    Pointer to a 8 bytes or more buffer to hold the result.
+//! @param  encrypt If true the encrypted result of in8 is placed in out8.
+//!                 Otherwise, the decrypted result of in8 is placed in out8.
+//-----------------------------------------------------------------------------
+
+void Apply(const unsigned char* in8, unsigned char* out8, bool encrypt=true);
+
+private:
+BF_KEY* bfKey;
+};
+#endif

--- a/src/XrdCrypto/XrdCryptoLite_BFecb.hh
+++ b/src/XrdCrypto/XrdCryptoLite_BFecb.hh
@@ -56,15 +56,22 @@ public:
      ~XrdCryptoLite_BFecb();
 
 //-----------------------------------------------------------------------------
-//! Decrypt or encrypt exactly one blowfish block of 8 bytes (64 bits)
+//! Decrypt exactly one blowfish block of 8 bytes (64 bits)
+//!
+//! @param  in8     Pointer to exactly 8 bytes of data to be decrypted.
+//! @param  out8    Pointer to a 8 bytes or more buffer to hold the result.
+//-----------------------------------------------------------------------------
+
+void Decrypt(const unsigned char* in8, unsigned char* out8);
+
+//-----------------------------------------------------------------------------
+//! Encrypt exactly one blowfish block of 8 bytes (64 bits)
 //!
 //! @param  in8     Pointer to exactly 8 bytes of data to be encrypted.
 //! @param  out8    Pointer to a 8 bytes or more buffer to hold the result.
-//! @param  encrypt If true the encrypted result of in8 is placed in out8.
-//!                 Otherwise, the decrypted result of in8 is placed in out8.
 //-----------------------------------------------------------------------------
 
-void Apply(const unsigned char* in8, unsigned char* out8, bool encrypt=true);
+void Encrypt(const unsigned char* in8, unsigned char* out8);
 
 private:
 BF_KEY* bfKey;

--- a/src/XrdCrypto/XrdCryptoLite_BFecb.hh
+++ b/src/XrdCrypto/XrdCryptoLite_BFecb.hh
@@ -32,13 +32,16 @@
 /* This class implements Bflowfish ecb cipher which works on a single 64-bit
    block to produce another 64-bit block. While not particularly secure it
    is useful for encrypting short messages in order to prevent spoofing but
-   not necessarily to protect data privacy. Note that this object is thread
-   safe as blowfish ECB is stateless. So, the object can be used by multiple
-   threads to perform encrypption/decryption using the supplied key.
+   not necessarily to protect data privacy. While blowfish ECB is naturally
+   thread-safe, the OPENSSL EVP implementation destroys that notion and we
+   must serialize all access to the underlying blowfish implementation to
+   make it thread-safe.
 */
 
-struct  bf_key_st;
-typedef bf_key_st BF_KEY;
+#include "XrdSys/XrdSysPthread.hh"
+
+struct  evp_cipher_ctx_st;
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
 
 class XrdCryptoLite_BFecb
 {
@@ -47,11 +50,18 @@ public:
 //-----------------------------------------------------------------------------
 //! Construct an ECB encryption/decryption object.
 //!
+//! @param  aOK     Upon return must be true if all went well. It will be
+//!                 false otherwise and this object will not be safely usable.
 //! @param  key     Pointer to the encryption key which should be 128 bits.
-//! @param  keylen  The length of the key in bytes.
+//!                 When null, a random 128 bit key is generated for use.
+//! @param  keylen  The length of the key in bytes if key is specified.
+//!
+//! @note When initializing a static pointer you may wish to use the Instance()
+//!       method that automatically returns a null pointer on a failure.
 //-----------------------------------------------------------------------------
 
-      XrdCryptoLite_BFecb(const unsigned char* key, unsigned int keylen);
+      XrdCryptoLite_BFecb(bool &aOK, const unsigned char* key=0,
+                                           unsigned int   keylen=0);
 
      ~XrdCryptoLite_BFecb();
 
@@ -73,7 +83,23 @@ void Decrypt(const unsigned char* in8, unsigned char* out8);
 
 void Encrypt(const unsigned char* in8, unsigned char* out8);
 
+//-----------------------------------------------------------------------------
+//! Return an instance of an ECB encryption/decryption object upon success.
+//!
+//! @param  key     Pointer to the encryption key which should be 128 bits.
+//!                 When null, a random 128 bit key is generated for use.
+//! @param  keylen  The length of the key in bytes if key is specified.
+//!
+//! @return A pointer to the crypto object or a null pointer upon failure.
+//-----------------------------------------------------------------------------
+
+static
+XrdCryptoLite_BFecb* Instance(const unsigned char* key=0,
+                                    unsigned int   klen=0);
+
 private:
-BF_KEY* bfKey;
+EVP_CIPHER_CTX* decCTX;
+EVP_CIPHER_CTX* encCTX;
+XrdSysMutex     evpMutex;
 };
 #endif

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -36,6 +36,7 @@
 #include <unordered_set>
 #include <algorithm>
 #include <charconv>
+#include <random>
 
 #include <regex.h>
 
@@ -71,7 +72,7 @@
 /******************************************************************************/
 /*                         L o c a l   M e t h o d s                          */
 /******************************************************************************/
-  
+
 namespace
 {
 struct idInfo
@@ -158,11 +159,11 @@ for (j = 0; j < argC; j++)
    argV[j] = 0;
    return j;
 }
-  
+
 /******************************************************************************/
 /*                               b i n 2 h e x                                */
 /******************************************************************************/
-  
+
 char *XrdOucUtils::bin2hex(char *inbuff, int dlen, char *buff, int blen,
                            bool sep)
 {
@@ -227,7 +228,7 @@ int XrdOucUtils::hex2bin(const char *hex, char *bin, int size)
 /******************************************************************************/
 /*                              e n d s W i t h                               */
 /******************************************************************************/
-  
+
 bool XrdOucUtils::endsWith(const char *text, const char *ending, int endlen)
 {
    int tlen = strlen(text);
@@ -238,7 +239,7 @@ bool XrdOucUtils::endsWith(const char *text, const char *ending, int endlen)
 /******************************************************************************/
 /*                                 e T e x t                                  */
 /******************************************************************************/
-  
+
 // eText() returns the text associated with the error.
 // The text buffer pointer is returned.
 
@@ -262,18 +263,18 @@ char *XrdOucUtils::eText(int rc, char *eBuff, int eBlen)
 /******************************************************************************/
 /*                                  d o I f                                   */
 /******************************************************************************/
-  
+
 // doIf() parses "if [<hostlist>] [<conds>]"
 // conds: <cond1> | <cond2> | <cond3>
 // cond1: defined <varlist> [&& <conds>]
 // cond2: exec <pgmlist> [&& <cond3>]
 // cond3: named <namelist>
 
-// Returning 1 if true (i.e., this machine is one of the named hosts in hostlist 
-// and is running one of the programs pgmlist and named by one of the names in 
+// Returning 1 if true (i.e., this machine is one of the named hosts in hostlist
+// and is running one of the programs pgmlist and named by one of the names in
 // namelist).
 // Return -1 (negative truth) if an error occurred.
-// Otherwise, returns false (0). Some combination of hostlist, pgm, and 
+// Otherwise, returns false (0). Some combination of hostlist, pgm, and
 // namelist, must be specified.
 
 int XrdOucUtils::doIf(XrdSysError *eDest, XrdOucStream &Config,
@@ -430,11 +431,11 @@ bool XrdOucUtils::findPgm(const char *pgm, XrdOucString& path)
         }
    return false;
 }
-  
+
 /******************************************************************************/
 /*                              f m t B y t e s                               */
 /******************************************************************************/
-  
+
 int XrdOucUtils::fmtBytes(long long val, char *buff, int bsz)
 {
    static const long long Kval = 1024LL;
@@ -502,7 +503,7 @@ std::string XrdOucUtils::genHumanSize(size_t size, uint64_t base) {
 /*                               g e n P a t h                                */
 /******************************************************************************/
 
-char *XrdOucUtils::genPath(const char *p_path, const char *inst, 
+char *XrdOucUtils::genPath(const char *p_path, const char *inst,
                            const char *s_path)
 {
    char buff[2048];
@@ -519,7 +520,7 @@ char *XrdOucUtils::genPath(const char *p_path, const char *inst,
 }
 
 /******************************************************************************/
-  
+
 int XrdOucUtils::genPath(char *buff, int blen, const char *path, const char *psfx)
 {
     int i, j;
@@ -597,7 +598,7 @@ char *XrdOucUtils::getFile(const char *path, int &rc, int maxsz, bool notempty)
 /******************************************************************************/
 /*                                g e t G I D                                 */
 /******************************************************************************/
-  
+
 bool XrdOucUtils::getGID(const char *gName, gid_t &gID)
 {
    struct group Grp, *result;
@@ -613,7 +614,7 @@ bool XrdOucUtils::getGID(const char *gName, gid_t &gID)
 /******************************************************************************/
 /*                                g e t U I D                                 */
 /******************************************************************************/
-  
+
 bool XrdOucUtils::getUID(const char *uName, uid_t &uID, gid_t *gID)
 {
    struct passwd pwd, *result;
@@ -627,11 +628,11 @@ bool XrdOucUtils::getUID(const char *uName, uid_t &uID, gid_t *gID)
 
    return true;
 }
-  
+
 /******************************************************************************/
 /*                               G i d N a m e                                */
 /******************************************************************************/
-  
+
 int XrdOucUtils::GidName(gid_t gID, char *gName, int gNsz, time_t keepT)
 {
    static const int maxgBsz = 256*1024;
@@ -680,7 +681,7 @@ int XrdOucUtils::GidName(gid_t gID, char *gName, int gNsz, time_t keepT)
 /******************************************************************************/
 /*                             G r o u p N a m e                              */
 /******************************************************************************/
-  
+
 int XrdOucUtils::GroupName(gid_t gID, char *gName, int gNsz)
 {
    static const int maxgBsz = 256*1024;
@@ -744,7 +745,7 @@ do{dBytes /= 1024.0; suffix++;
       else snprintf(buff, bsz, "%g%c", whole, *suffix);
    return buff;
 }
-  
+
 /******************************************************************************/
 /*                                i 2 b s t r                                 */
 /******************************************************************************/
@@ -766,7 +767,7 @@ const char *XrdOucUtils::i2bstr(char *buff, int blen, int val, bool pad)
 
    return &buff[blen+1];
 }
-  
+
 /******************************************************************************/
 /*                                 I d e n t                                  */
 /******************************************************************************/
@@ -843,11 +844,11 @@ char *XrdOucUtils::Ident(long long  &mySID, char *iBuff, int iBlen,
    h2nll(theSID, mySID);
    return strdup(theSIN);
 }
-  
+
 /******************************************************************************/
 /*                              I n s t N a m e                               */
 /******************************************************************************/
-  
+
 const char *XrdOucUtils::InstName(int TranOpt)
 {
    const char *iName = getenv("XRDNAME");
@@ -864,16 +865,16 @@ const char *XrdOucUtils::InstName(int TranOpt)
    return iName;
 }
 /******************************************************************************/
-  
+
 const char *XrdOucUtils::InstName(const char *name, int Fillit)
 { return (Fillit ? name && *name                        ? name : "anon"
                  : name && strcmp(name,"anon") && *name ? name :     0);
 }
-  
+
 /******************************************************************************/
 /*                                 i s 1 o f                                  */
 /******************************************************************************/
-  
+
 int XrdOucUtils::is1of(char *val, const char **clist)
 {
    int i = 0;
@@ -885,7 +886,7 @@ int XrdOucUtils::is1of(char *val, const char **clist)
 /******************************************************************************/
 /*                                 i s F W D                                  */
 /******************************************************************************/
-  
+
 int XrdOucUtils::isFWD(const char *path, int *port, char *hBuff, int hBLen,
                        bool pTrim)
 {
@@ -920,7 +921,7 @@ int XrdOucUtils::isFWD(const char *path, int *port, char *hBuff, int hBLen,
 
    return hPend-path;
 }
-  
+
 /******************************************************************************/
 /*                                  L o g 2                                   */
 /******************************************************************************/
@@ -944,7 +945,7 @@ int XrdOucUtils::Log2(unsigned long long n)
 
   #undef SHFT
 }
-  
+
 /******************************************************************************/
 /*                                 L o g 1 0                                  */
 /******************************************************************************/
@@ -955,17 +956,17 @@ int XrdOucUtils::Log10(unsigned long long n)
 
   #define SHFT(k, m) if (n >= m) { i += k; n /= m; }
 
-  SHFT(16,10000000000000000ULL); SHFT(8,100000000ULL); 
+  SHFT(16,10000000000000000ULL); SHFT(8,100000000ULL);
   SHFT(4,10000ULL);              SHFT(2,100ULL);       SHFT(1,10ULL);
   return i;
 
   #undef SHFT
 }
-  
+
 /******************************************************************************/
 /*                              m a k e H o m e                               */
 /******************************************************************************/
-  
+
 void XrdOucUtils::makeHome(XrdSysError &eDest, const char *inst)
 {
    char buff[2048];
@@ -983,7 +984,7 @@ void XrdOucUtils::makeHome(XrdSysError &eDest, const char *inst)
 }
 
 /******************************************************************************/
-  
+
 bool XrdOucUtils::makeHome(XrdSysError &eDest, const char *inst,
                                                const char *path, mode_t mode)
 {
@@ -1032,7 +1033,7 @@ bool XrdOucUtils::makeHome(XrdSysError &eDest, const char *inst,
 /******************************************************************************/
 /*                              m a k e P a t h                               */
 /******************************************************************************/
-  
+
 int XrdOucUtils::makePath(char *path, mode_t mode, bool reset)
 {
     char *next_path = path+1;
@@ -1059,7 +1060,7 @@ int XrdOucUtils::makePath(char *path, mode_t mode, bool reset)
 //
    return 0;
 }
- 
+
 /******************************************************************************/
 /*                             m o d e 2 m a s k                              */
 /******************************************************************************/
@@ -1090,9 +1091,9 @@ bool XrdOucUtils::mode2mask(const char *mode, mode_t &mask)
            {mlet = *mode++;
             if (mlet != '-')
                {if (mlet != mok[i]) return false;
-                mval[k] |= mbit[i]; 
+                mval[k] |= mbit[i];
                }
-           } 
+           }
        } while(++k < 3 && *mode);
 
 // Combine the modes and return success
@@ -1100,11 +1101,11 @@ bool XrdOucUtils::mode2mask(const char *mode, mode_t &mask)
    mask = mval[0]<<6 | mval[1]<<3 | mval[2];
    return true;
 }
-  
+
 /******************************************************************************/
 /*                              p a r s e L i b                               */
 /******************************************************************************/
-  
+
 bool XrdOucUtils::parseLib(XrdSysError &eDest, XrdOucStream &Config,
                            const char *libName, char *&libPath, char **libParm)
 {
@@ -1154,7 +1155,7 @@ bool XrdOucUtils::parseLib(XrdSysError &eDest, XrdOucStream &Config,
 /******************************************************************************/
 /*                             p a r s e H o m e                              */
 /******************************************************************************/
-  
+
 char *XrdOucUtils::parseHome(XrdSysError &eDest, XrdOucStream &Config, int &mode)
 {
    char *pval, *val, *HomePath = 0;
@@ -1185,6 +1186,22 @@ char *XrdOucUtils::parseHome(XrdSysError &eDest, XrdOucStream &Config, int &mode
                }
       }
    return HomePath;
+}
+/******************************************************************************/
+/*                                R a n d o m                                 */
+/******************************************************************************/
+
+void XrdOucUtils::Random(unsigned char* buff, unsigned int inblen)
+{
+   std::random_device rd;
+   std::mt19937 gen(rd());
+   std::uniform_int_distribution<unsigned short> dist(0, 255); // Byte distrib
+
+   // The following is the most portable way of getting random byte values
+   //
+   std::generate(buff, buff + inblen, [&]() {
+        return static_cast<unsigned char>(dist(gen));
+        });
 }
 
 /******************************************************************************/
@@ -1236,7 +1253,7 @@ void XrdOucUtils::Sanitize(char *str, char subc)
 /******************************************************************************/
 /*                              s u b L o g f n                               */
 /******************************************************************************/
-  
+
 char *XrdOucUtils::subLogfn(XrdSysError &eDest, const char *inst, char *logfn)
 {
    const mode_t lfm = S_IRWXU|S_IRWXG|S_IROTH|S_IXOTH;
@@ -1273,7 +1290,7 @@ void XrdOucUtils::toLower(char *str)
 //
    while(*ustr) {*ustr = tolower(*ustr); ustr++;}
 }
-  
+
 /******************************************************************************/
 /*                                 T o k e n                                  */
 /******************************************************************************/
@@ -1391,11 +1408,11 @@ void XrdOucUtils::Undercover(XrdSysError &eDest, int noLog, int *pipeFD)
   for (myfd = 3; myfd < maxFiles; myfd++)
       if( (!pipeFD || myfd != pipeFD[1]) && myfd != logFD ) close(myfd);
 }
-  
+
 /******************************************************************************/
 /*                               U i d N a m e                                */
 /******************************************************************************/
-  
+
 int XrdOucUtils::UidName(uid_t uID, char *uName, int uNsz, time_t keepT)
 {
    struct passwd *pEnt, pStruct;
@@ -1434,7 +1451,7 @@ int XrdOucUtils::UidName(uid_t uID, char *uName, int uNsz, time_t keepT)
 /******************************************************************************/
 /*                              U s e r N a m e                               */
 /******************************************************************************/
-  
+
 int XrdOucUtils::UserName(uid_t uID, char *uName, int uNsz)
 {
    struct passwd *pEnt, pStruct;
@@ -1487,11 +1504,11 @@ const char *XrdOucUtils::ValPath(const char *path, mode_t allow, bool isdir)
 //
    return 0;
 }
-  
+
 /******************************************************************************/
 /*                               P i d F i l e                                */
 /******************************************************************************/
-  
+
 bool XrdOucUtils::PidFile(XrdSysError &eDest, const char *path)
 {
    char buff[32];

--- a/src/XrdOuc/XrdOucUtils.cc
+++ b/src/XrdOuc/XrdOucUtils.cc
@@ -1193,9 +1193,11 @@ char *XrdOucUtils::parseHome(XrdSysError &eDest, XrdOucStream &Config, int &mode
 
 void XrdOucUtils::Random(unsigned char* buff, unsigned int inblen)
 {
-   std::random_device rd;
-   std::mt19937 gen(rd());
-   std::uniform_int_distribution<unsigned short> dist(0, 255); // Byte distrib
+   static XrdSysMutex randMutex;
+          XrdSysMutexHelper randMHelp(randMutex);
+   static std::random_device rd;
+   static std::mt19937 gen(rd());
+   static std::uniform_int_distribution<unsigned short> dist(0, 255); // Bytes
 
    // The following is the most portable way of getting random byte values
    //

--- a/src/XrdOuc/XrdOucUtils.hh
+++ b/src/XrdOuc/XrdOucUtils.hh
@@ -58,11 +58,11 @@ static bool  endsWith(const char *text, const char *ending, int endlen);
 static char *eText(int rc, char *eBuff, int eBlen);
 
 static int   doIf(XrdSysError *eDest, XrdOucStream &Config,
-                  const char *what, const char *hname, 
+                  const char *what, const char *hname,
                                     const char *nname, const char *pname);
 
 static bool  findPgm(const char *pgm, XrdOucString& path);
- 
+
 static int   fmtBytes(long long val, char *buff, int bsz);
 
 /**
@@ -124,10 +124,12 @@ static bool  parseLib(XrdSysError &eDest, XrdOucStream &Config,
 
 static char *parseHome(XrdSysError &eDest, XrdOucStream &Config, int &mode);
 
+static void  Random(unsigned char* buff, unsigned int inblen);
+
 static int   ReLink(const char *path, const char *target, mode_t mode=0);
 
 static void  Sanitize(char *instr, char subc='_');
- 
+
 static char *subLogfn(XrdSysError &eDest, const char *inst, char *logfn);
 
 static void  toLower(char *str);

--- a/src/XrdXrootd/XrdXrootdConfig.cc
+++ b/src/XrdXrootd/XrdXrootdConfig.cc
@@ -84,6 +84,8 @@
 #include "Xrd/XrdInet.hh"
 #include "Xrd/XrdLink.hh"
 
+#include "XrdCrypto/XrdCryptoLite_BFecb.hh"
+
 /******************************************************************************/
 /*         P r o t o c o l   C o m m a n d   L i n e   O p t i o n s          */
 /******************************************************************************/
@@ -146,6 +148,8 @@ namespace XrdXrootd
 extern XrdBuffManager       *BPool;
 extern XrdScheduler         *Sched;
 extern XrdXrootdStats       *SI;
+       XrdCryptoLite_BFecb*  bfEcb1;
+       XrdCryptoLite_BFecb*  bfEcb2;
 }
 
 /******************************************************************************/
@@ -542,6 +546,14 @@ int XrdXrootdProtocol::Configure(char *parms, XrdProtocol_Config *pi)
                                      "not a forwarding proxy.");
           }
       }
+
+// Create the blowfish objects to be used to mask/unmask the session ID
+//
+   {struct {unsigned char key1[16]; unsigned char key2[164];} bf;
+    XrdOucUtils::Random((unsigned char*)&bf, sizeof(bf));
+    XrdXrootd::bfEcb1 = new XrdCryptoLite_BFecb(bf.key1, sizeof(bf.key1));
+    XrdXrootd::bfEcb2 = new XrdCryptoLite_BFecb(bf.key2, sizeof(bf.key2));
+   }
 
 // Add any additional features
 //

--- a/src/XrdXrootd/XrdXrootdConfig.cc
+++ b/src/XrdXrootd/XrdXrootdConfig.cc
@@ -84,8 +84,6 @@
 #include "Xrd/XrdInet.hh"
 #include "Xrd/XrdLink.hh"
 
-#include "XrdCrypto/XrdCryptoLite_BFecb.hh"
-
 /******************************************************************************/
 /*         P r o t o c o l   C o m m a n d   L i n e   O p t i o n s          */
 /******************************************************************************/
@@ -148,8 +146,6 @@ namespace XrdXrootd
 extern XrdBuffManager       *BPool;
 extern XrdScheduler         *Sched;
 extern XrdXrootdStats       *SI;
-       XrdCryptoLite_BFecb*  bfEcb1;
-       XrdCryptoLite_BFecb*  bfEcb2;
 }
 
 /******************************************************************************/
@@ -546,14 +542,6 @@ int XrdXrootdProtocol::Configure(char *parms, XrdProtocol_Config *pi)
                                      "not a forwarding proxy.");
           }
       }
-
-// Create the blowfish objects to be used to mask/unmask the session ID
-//
-   {struct {unsigned char key1[16]; unsigned char key2[164];} bf;
-    XrdOucUtils::Random((unsigned char*)&bf, sizeof(bf));
-    XrdXrootd::bfEcb1 = new XrdCryptoLite_BFecb(bf.key1, sizeof(bf.key1));
-    XrdXrootd::bfEcb2 = new XrdCryptoLite_BFecb(bf.key2, sizeof(bf.key2));
-   }
 
 // Add any additional features
 //

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -98,39 +98,36 @@ extern XrdSysTrace  XrdXrootdTrace;
 /*                      L o c a l   S t r u c t u r e s                       */
 /******************************************************************************/
 
-namespace
-{
-XrdCryptoLite_BFecb* get_BFecb()
-                        {unsigned char bfKey[16];
-                         XrdOucUtils::Random(bfKey, sizeof(bfKey));
-                         return new XrdCryptoLite_BFecb(bfKey, sizeof(bfKey));
-                        }
-
-XrdCryptoLite_BFecb* bfEcb1 = get_BFecb();
-XrdCryptoLite_BFecb* bfEcb2 = get_BFecb();
-}
-
-
 struct XrdXrootdSessID
        {unsigned int       Sid;
                  int       Pid;
                  int       FD;
         unsigned int       Inst;
 
-        void Mask() {unsigned char buff[sizeof(int)*4];
-                     bfEcb1->Encrypt((unsigned char*)&Sid, buff);
-                     bfEcb2->Encrypt((unsigned char*)&FD,  buff+8);
-                     memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
+        void Mask() {if (bfEcb1 && bfEcb2)
+                        {unsigned char buff[sizeof(int)*4];
+                         bfEcb1->Encrypt((unsigned char*)&Sid, buff);
+                         bfEcb2->Encrypt((unsigned char*)&FD,  buff+8);
+                         memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
+                        }
                     }
 
-        void UnMask() {unsigned char buff[sizeof(int)*4];
-                       bfEcb1->Decrypt((unsigned char*)&Sid, buff);
-                       bfEcb2->Decrypt((unsigned char*)&FD, buff+8);
-                       memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
+        void UnMask() {if (bfEcb1 && bfEcb2)
+                          {unsigned char buff[sizeof(int)*4];
+                           bfEcb1->Decrypt((unsigned char*)&Sid, buff);
+                           bfEcb2->Decrypt((unsigned char*)&FD, buff+8);
+                           memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
+                          }
                       }
 
         XrdXrootdSessID() {}
        ~XrdXrootdSessID() {}
+
+        private:
+        inline static
+        XrdCryptoLite_BFecb* bfEcb1 = XrdCryptoLite_BFecb::Instance();
+        inline static
+        XrdCryptoLite_BFecb* bfEcb2 = XrdCryptoLite_BFecb::Instance();
        };
 
 /******************************************************************************/

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -31,6 +31,7 @@
 #include <cstdio>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <sys/time.h>
 #include <vector>
@@ -75,6 +76,8 @@
 #include "XrdXrootd/XrdXrootdXeq.hh"
 #include "XrdXrootd/XrdXrootdXPath.hh"
 
+#include "XrdCrypto/XrdCryptoLite_BFecb.hh"
+
 #include "XrdVersion.hh"
 
 #ifndef ENODATA
@@ -91,6 +94,12 @@
 
 extern XrdSysTrace  XrdXrootdTrace;
 
+namespace XrdXrootd
+{
+extern XrdCryptoLite_BFecb* bfEcb1;
+extern XrdCryptoLite_BFecb* bfEcb2;
+}
+
 /******************************************************************************/
 /*                      L o c a l   S t r u c t u r e s                       */
 /******************************************************************************/
@@ -100,6 +109,18 @@ struct XrdXrootdSessID
                  int       Pid;
                  int       FD;
         unsigned int       Inst;
+
+        void Mask() {unsigned char buff[sizeof(int)*4];
+                     XrdXrootd::bfEcb1->Apply((unsigned char*)&Sid, buff);
+                     XrdXrootd::bfEcb2->Apply((unsigned char*)&FD,  buff+8);
+                     memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
+                    }
+
+        void UnMask() {unsigned char buff[sizeof(int)*4];
+                       XrdXrootd::bfEcb1->Apply((unsigned char*)&Sid,buff,  false);
+                       XrdXrootd::bfEcb2->Apply((unsigned char*)&FD, buff+8,false);
+                       memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
+                      }
 
         XrdXrootdSessID() {}
        ~XrdXrootdSessID() {}
@@ -265,6 +286,7 @@ int XrdXrootdProtocol::do_Bind()
 
 // Find the link we are to bind to
 //
+   sp->UnMask();
    if (sp->FD <= 0 || !(lp = XrdLinkCtl::fd2link(sp->FD, sp->Inst)))
       return Response.Send(kXR_NotFound, "session not found");
 
@@ -908,9 +930,11 @@ int XrdXrootdProtocol::do_Endsess()
 // Extract out the FD and Instance from the session ID
 //
    sp = (XrdXrootdSessID *)Request.endsess.sessid;
+   memcpy((void *)&sessID.Sid,  &sp->Pid,  sizeof(sessID.Sid));
    memcpy((void *)&sessID.Pid,  &sp->Pid,  sizeof(sessID.Pid));
    memcpy((void *)&sessID.FD,   &sp->FD,   sizeof(sessID.FD));
    memcpy((void *)&sessID.Inst, &sp->Inst, sizeof(sessID.Inst));
+   sessID.UnMask();
 
 // Trace this request
 //
@@ -1084,6 +1108,7 @@ int XrdXrootdProtocol::do_Login()
        sessID.Pid  = myPID;
        mySID = getSID();
        sessID.Sid  = mySID;
+       sessID.Mask();
        sendSID = 1;
        if (!clientPV)
           {        if (i >= kXR_ver004) clientPV = (int)0x0310;

--- a/src/XrdXrootd/XrdXrootdXeq.cc
+++ b/src/XrdXrootd/XrdXrootdXeq.cc
@@ -94,15 +94,22 @@
 
 extern XrdSysTrace  XrdXrootdTrace;
 
-namespace XrdXrootd
-{
-extern XrdCryptoLite_BFecb* bfEcb1;
-extern XrdCryptoLite_BFecb* bfEcb2;
-}
-
 /******************************************************************************/
 /*                      L o c a l   S t r u c t u r e s                       */
 /******************************************************************************/
+
+namespace
+{
+XrdCryptoLite_BFecb* get_BFecb()
+                        {unsigned char bfKey[16];
+                         XrdOucUtils::Random(bfKey, sizeof(bfKey));
+                         return new XrdCryptoLite_BFecb(bfKey, sizeof(bfKey));
+                        }
+
+XrdCryptoLite_BFecb* bfEcb1 = get_BFecb();
+XrdCryptoLite_BFecb* bfEcb2 = get_BFecb();
+}
+
 
 struct XrdXrootdSessID
        {unsigned int       Sid;
@@ -111,14 +118,14 @@ struct XrdXrootdSessID
         unsigned int       Inst;
 
         void Mask() {unsigned char buff[sizeof(int)*4];
-                     XrdXrootd::bfEcb1->Apply((unsigned char*)&Sid, buff);
-                     XrdXrootd::bfEcb2->Apply((unsigned char*)&FD,  buff+8);
+                     bfEcb1->Encrypt((unsigned char*)&Sid, buff);
+                     bfEcb2->Encrypt((unsigned char*)&FD,  buff+8);
                      memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
                     }
 
         void UnMask() {unsigned char buff[sizeof(int)*4];
-                       XrdXrootd::bfEcb1->Apply((unsigned char*)&Sid,buff,  false);
-                       XrdXrootd::bfEcb2->Apply((unsigned char*)&FD, buff+8,false);
+                       bfEcb1->Decrypt((unsigned char*)&Sid, buff);
+                       bfEcb2->Decrypt((unsigned char*)&FD, buff+8);
                        memcpy((void*)&Sid, (const void*)buff, sizeof(int)*4);
                       }
 
@@ -920,7 +927,7 @@ int XrdXrootdProtocol::do_DirStat(XrdSfsDirectory *dp, char *pbuff,
 
 int XrdXrootdProtocol::do_Endsess()
 {
-   XrdXrootdSessID *sp, sessID;
+   XrdXrootdSessID sessID;
    int rc;
 
 // Update misc stats count
@@ -929,11 +936,7 @@ int XrdXrootdProtocol::do_Endsess()
 
 // Extract out the FD and Instance from the session ID
 //
-   sp = (XrdXrootdSessID *)Request.endsess.sessid;
-   memcpy((void *)&sessID.Sid,  &sp->Pid,  sizeof(sessID.Sid));
-   memcpy((void *)&sessID.Pid,  &sp->Pid,  sizeof(sessID.Pid));
-   memcpy((void *)&sessID.FD,   &sp->FD,   sizeof(sessID.FD));
-   memcpy((void *)&sessID.Inst, &sp->Inst, sizeof(sessID.Inst));
+   memcpy((void*)&sessID, Request.endsess.sessid, sizeof(sessID));
    sessID.UnMask();
 
 // Trace this request


### PR DESCRIPTION
This patch encrypts the session id used in the kXR_bind and kXR_endsess requests. The information itself does not need to be secret so we can use blowfish ecb for simplicity. However, by using a large enough key (i.e. 256 effective  bits) makes it very difficult to spoof a session id without knowing the encryption key and cracking the key would take more time than its lifetime. While the standard solution would be to sign the session id; backward compatibility makes it impossible to take this route. So, a size preserving encryption mechanism is used instead.