### PR TITLE
[XrdClHttp] Fix bug preventing the configuration of threads

### DIFF
--- a/src/XrdClHttp/XrdClHttpFactory.cc
+++ b/src/XrdClHttp/XrdClHttpFactory.cc
@@ -194,7 +194,7 @@ Factory::Initialize()
         auto &cache = XrdClHttp::VerbsCache::Instance();
 
         // Startup curl workers after we've set the configs to avoid race conditions
-        for (unsigned idx=0; idx<m_poll_threads; idx++) {
+        for (int idx=0; idx<num_threads; idx++) {
             auto wk = std::make_unique<XrdClHttp::CurlWorker>(m_queue, cache, m_log);
             auto wkp = wk.get();
             std::thread t(XrdClHttp::CurlWorker::RunStatic, wkp);


### PR DESCRIPTION
Appears a prior refactoring caused the thread configuration to use the wrong variable, causing 8 worker threads to be used regardless of the current configuration.

It was found in testing that, for relatively short tests (<10s), the cost to create 8 TLS sessions to the server across the 8 threads was a fairly significant performance hit compared to just having one worker thread where the session was reused.  That indicates someone sane may want to tune this lower in the case of a serial application that does not benefit from a thread pool (XrdClHttp inside XCache would be a different story).

This raises the question of the correct default value and auto-tuning.  I don't known the answer to those questions currently.

Note: this is the first (hopefully!) of several small fixes affecting performance of XrdClHttp in testing.

H/T to Diego Davila for helping unearth this issue.