### PR TITLE
[XrdClHttp] Add a knob to disable prefetch

### DIFF
--- a/src/XrdClHttp/XrdClHttpFactory.cc
+++ b/src/XrdClHttp/XrdClHttpFactory.cc
@@ -154,6 +154,17 @@ Factory::Initialize()
         }
         XrdClHttp::CurlOperation::SetStallTimeout(stall_timeout);
 
+        // Whether prefetching is enabled by default for newly-opened files.
+        // Per-file overrides are still possible via the XrdClHttpPrefetch property.
+        env->PutInt("HttpPrefetch", 1);
+        env->ImportInt("HttpPrefetch", "XRD_HTTPPREFETCH");
+        int prefetch_enabled = 1;
+        if (env->GetInt("HttpPrefetch", prefetch_enabled)) {
+            XrdClHttp::File::SetDefaultPrefetch(prefetch_enabled != 0);
+            m_log->Debug(kLogXrdClHttp, "Default prefetch behavior is %s",
+                         prefetch_enabled != 0 ? "enabled" : "disabled");
+        }
+
         // The slow transfer rate, in bytes per second, for timing out slow uploads/downloads.
         env->PutInt("HttpSlowRateBytesSec", XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec());
         env->ImportInt("HttpSlowRateBytesSec", "XRD_HTTPSLOWRATEBYTESSEC");

--- a/src/XrdClHttp/XrdClHttpFile.cc
+++ b/src/XrdClHttp/XrdClHttpFile.cc
@@ -26,6 +26,8 @@
 
 using namespace XrdClHttp;
 
+std::atomic<bool> File::m_default_prefetch_enabled{true};
+
 std::atomic<uint64_t> File::m_prefetch_count = 0;
 std::atomic<uint64_t> File::m_prefetch_expired_count = 0;
 std::atomic<uint64_t> File::m_prefetch_failed_count = 0;
@@ -365,10 +367,21 @@ File::Open(const std::string      &url,
     auto ts = GetHeaderTimeout(timeout);
 
     bool full_download = m_full_download.load(std::memory_order_relaxed);
-    m_default_prefetch_handler.reset(new PrefetchDefaultHandler(*this));
-    if (full_download) {
-        m_default_prefetch_handler->m_prefetch_enabled.store(true, std::memory_order_relaxed);
+    // Determine the initial prefetch-enabled state: full download always requires
+    // prefetch; otherwise honor a per-file XrdClHttpPrefetch property if set, falling
+    // back to the global default cached at plugin load time.
+    bool prefetch_enabled = m_default_prefetch_enabled.load(std::memory_order_relaxed);
+    {
+        std::shared_lock lock(m_properties_mutex);
+        auto it = m_properties.find("XrdClHttpPrefetch");
+        if (it != m_properties.end()) {
+            prefetch_enabled = (it->second == "true" || it->second == "1");
+        }
     }
+    if (full_download) {
+        prefetch_enabled = true;
+    }
+    m_default_prefetch_handler.reset(new PrefetchDefaultHandler(*this, prefetch_enabled));
 
     if (full_download && !(flags & XrdCl::OpenFlags::Write)) {
         m_logger->Debug(kLogXrdClHttp, "Opening %s in full download mode", m_url.c_str());
@@ -1035,6 +1048,13 @@ File::SetProperty(const std::string &name,
                 prefetch_handler->m_prefetch_enabled.store(true, std::memory_order_relaxed);
             }
             m_full_download.store(true, std::memory_order_relaxed);
+        }
+    } else if (name == "XrdClHttpPrefetch") {
+        bool enabled = (value == "true" || value == "1");
+        auto prefetch_handler = m_default_prefetch_handler;
+        if (prefetch_handler) {
+            std::unique_lock lock(prefetch_handler->m_prefetch_mutex);
+            prefetch_handler->m_prefetch_enabled.store(enabled, std::memory_order_relaxed);
         }
     }
 

--- a/src/XrdClHttp/XrdClHttpFile.hh
+++ b/src/XrdClHttp/XrdClHttpFile.hh
@@ -136,6 +136,12 @@ public:
     // Get the federation metadata timeout
     static struct timespec GetFederationMetadataTimeout() {return m_fed_timeout;}
 
+    // Set the default prefetch-enabled behavior for newly-opened files.
+    static void SetDefaultPrefetch(bool enabled) {m_default_prefetch_enabled.store(enabled, std::memory_order_relaxed);}
+
+    // Get the default prefetch-enabled behavior for newly-opened files.
+    static bool GetDefaultPrefetch() {return m_default_prefetch_enabled.load(std::memory_order_relaxed);}
+
     // Get the global monitoring statistics data
     static std::string GetMonitoringJson();
 
@@ -351,7 +357,8 @@ private:
     // prefetching.
     class PrefetchDefaultHandler : public XrdCl::ResponseHandler {
     public:
-        PrefetchDefaultHandler(File &file) : m_logger(file.m_logger), m_url(file.m_url) {}
+        PrefetchDefaultHandler(File &file, bool enabled)
+            : m_logger(file.m_logger), m_url(file.m_url), m_prefetch_enabled(enabled) {}
 
         virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response);
 
@@ -387,7 +394,7 @@ private:
         // If set to "true", then you must re-read the value with
         // m_prefetch_mutex held to ensure is actually true and not
         // a spurious reading.
-        mutable std::atomic<bool> m_prefetch_enabled{true};
+        mutable std::atomic<bool> m_prefetch_enabled;
     };
 
     // "Default" handler for prefetching
@@ -416,6 +423,10 @@ private:
     };
 
     HeaderCallout m_default_header_callout{*this};
+
+    // Default prefetch-enabled setting for newly-opened files; populated from the
+    // HttpPrefetch environment variable at plugin load time.
+    static std::atomic<bool> m_default_prefetch_enabled;
 
     static std::atomic<uint64_t> m_prefetch_count; // Count of prefetch operations that have been initiated.
     static std::atomic<uint64_t> m_prefetch_expired_count; // Count of prefetch operations that have expired due to unused data.


### PR DESCRIPTION
The prefetch code is designed for the Pelican use case (typical use trends to whole-files); we are just now starting to test more heavily the sub-file requests and its performance impact.

It was probably a mistake to upstream XrdClHttp leaving this on-by-default; it was definitely a mistake to not make it configurable.

This is a RFC for the latter.  Whether we consider the former correct behavior, needing a bugfix (6.0.x), or changing it is a new feature (6.1.x), I'll defer to the collective wisdom.