### PR TITLE
Add the resource type tag for non-collections in xml response

### DIFF
--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -2429,6 +2429,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                 stringresp += "<lp1:resourcetype><D:collection/></lp1:resourcetype>\n";
                 stringresp += "<lp1:iscollection>1</lp1:iscollection>\n";
               } else {
+                stringresp += "<lp1:resourcetype/>\n";
                 stringresp += "<lp1:iscollection>0</lp1:iscollection>\n";
               }
 
@@ -2545,6 +2546,7 @@ int XrdHttpReq::PostProcessHTTPReq(bool final_) {
                   stringresp += "<lp1:resourcetype><D:collection/></lp1:resourcetype>\n";
                   stringresp += "<lp1:iscollection>1</lp1:iscollection>\n";
                 } else {
+                  stringresp += "<lp1:resourcetype/>\n";
                   stringresp += "<lp1:iscollection>0</lp1:iscollection>\n";
                 }
 


### PR DESCRIPTION
This is a PR to address https://github.com/xrootd/xrootd/issues/2783 in the 5.9.x branch.

Actually choosing the proper branch this time.