### PR TITLE
[Python] Fix standalone build against an installed XRootD

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -41,6 +41,7 @@ if not srcdir.startswith('$'):
         '-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}',
         '-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}',
         '-DXRootD_CLIENT_LIBRARY=${CMAKE_BINARY_DIR}/lib/libXrdCl${CMAKE_SHARED_LIBRARY_SUFFIX}',
+        '-DXRootD_UTILS_LIBRARY=${CMAKE_BINARY_DIR}/lib/libXrdUtils${CMAKE_SHARED_LIBRARY_SUFFIX}',
         '-DXRootD_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/src;${CMAKE_BINARY_DIR}/src',
     ]
 else:

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -36,12 +36,18 @@ endif()
 # variables when building the module as part of a standard CMake build.
 
 if(TARGET XrdCl)
-  target_link_libraries(client PRIVATE XrdCl)
+  target_link_libraries(client PRIVATE XrdCl XrdUtils)
 else()
   find_library(XRootD_CLIENT_LIBRARY NAMES XrdCl)
 
   if(NOT XRootD_CLIENT_LIBRARY)
     message(FATAL_ERROR "Could not find XRootD client library")
+  endif()
+
+  find_library(XRootD_UTILS_LIBRARY NAMES XrdUtils)
+
+  if(NOT XRootD_UTILS_LIBRARY)
+    message(FATAL_ERROR "Could not find XRootD utils library")
   endif()
 
   find_path(XRootD_INCLUDE_DIR XrdVersion.hh PATH_SUFFIXES include/xrootd)
@@ -54,6 +60,6 @@ else()
   # extra include for it to allow building the Python bindings against
   # a pre-installed XRootD.
 
-  target_link_libraries(client PRIVATE ${XRootD_CLIENT_LIBRARY})
+  target_link_libraries(client PRIVATE ${XRootD_CLIENT_LIBRARY} ${XRootD_UTILS_LIBRARY})
   target_include_directories(client PRIVATE ${XRootD_INCLUDE_DIR} ${XRootD_INCLUDE_DIR}/private)
 endif()

--- a/src/XrdHeaders.cmake
+++ b/src/XrdHeaders.cmake
@@ -33,6 +33,7 @@ set( XROOTD_PUBLIC_HEADERS
   XrdNet/XrdNetPMark.hh
   XrdNet/XrdNetSockAddr.hh
   XrdNet/XrdNetSocket.hh
+  XrdCks/XrdCksData.hh
   XrdOuc/XrdOucBuffer.hh
   XrdOuc/XrdOucCRC.hh
   XrdOuc/XrdOucCache.hh
@@ -109,7 +110,6 @@ if( NOT XRDCL_ONLY )
     XrdCks/XrdCks.hh
     XrdCks/XrdCksAssist.hh
     XrdCks/XrdCksCalc.hh
-    XrdCks/XrdCksData.hh
     XrdCks/XrdCksManager.hh
     XrdCks/XrdCksWrapper.hh
     XrdCms/XrdCmsClient.hh
@@ -139,12 +139,15 @@ endif()
 set( XROOTD_PRIVATE_HEADERS
   Xrd/XrdPoll.hh
   Xrd/XrdSendQ.hh
+  XrdCks/XrdCksXAttr.hh
   XrdNet/XrdNetPeer.hh
   XrdNet/XrdNetBuffer.hh
   XrdNet/XrdNetIF.hh
   XrdSecsss/XrdSecsssID.hh
+  XrdSys/XrdSysFAttr.hh
   XrdSys/XrdSysPriv.hh
   XrdOuc/XrdOucCRC32C.hh
+  XrdOuc/XrdOucXAttr.hh
   XrdOuc/XrdOucExport.hh
   XrdOuc/XrdOucGatherConf.hh
   XrdOuc/XrdOucPList.hh


### PR DESCRIPTION
PyXRootDAdler32.cc includes XrdCks/XrdCksXAttr.hh and XrdOuc/XrdOucXAttr.hh (which in turn includes XrdSys/XrdSysFAttr.hh), none of which were installed by 'make install'. This broke the fallback in python/src/CMakeLists.txt that allows building the Python bindings against a pre-installed XRootD, since the bindings could no longer be compiled without the full source tree.

Install the three headers into the private include tree, which the Python bindings already use for XrdCl private headers, and install XrdCksData.hh (included by XrdCksXAttr.hh) unconditionally since the XrdCks code is built into libXrdUtils even for client-only builds. Also link XrdUtils explicitly, as the bindings depend on XrdSysFAttr from libXrdUtils, which until now was only resolved transitively through libXrdCl.