### PR TITLE
[Python] Add xattr convenience helpers

### DIFF
--- a/python/docs/source/modules/client/file.rst
+++ b/python/docs/source/modules/client/file.rst
@@ -39,3 +39,9 @@ Methods
 .. automethod:: XRootD.client.File.is_open
 .. automethod:: XRootD.client.File.set_property
 .. automethod:: XRootD.client.File.get_property
+.. automethod:: XRootD.client.File.set_xattr
+.. automethod:: XRootD.client.File.get_xattr
+.. automethod:: XRootD.client.File.del_xattr
+.. automethod:: XRootD.client.File.list_xattr
+.. automethod:: XRootD.client.File.xattrs
+.. automethod:: XRootD.client.File.xattr

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -36,3 +36,9 @@ Methods
 .. automethod:: XRootD.client.FileSystem.prepare
 .. automethod:: XRootD.client.FileSystem.set_property
 .. automethod:: XRootD.client.FileSystem.get_property
+.. automethod:: XRootD.client.FileSystem.set_xattr
+.. automethod:: XRootD.client.FileSystem.get_xattr
+.. automethod:: XRootD.client.FileSystem.del_xattr
+.. automethod:: XRootD.client.FileSystem.list_xattr
+.. automethod:: XRootD.client.FileSystem.xattrs
+.. automethod:: XRootD.client.FileSystem.xattr

--- a/python/libs/client/file.py
+++ b/python/libs/client/file.py
@@ -26,6 +26,7 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, VectorReadInfo
 from XRootD.client.utils import CallbackWrapper
+from XRootD.client.utils import _xattr_mapping, _xattr_value
 
 class File(object):
   """Interact with an ``xrootd`` server to perform file-based operations such
@@ -373,6 +374,58 @@ class File(object):
 
     status, response = self.__file.list_xattr(timeout)
     return XRootDStatus(status), response
+
+  def xattrs(self, timeout=0, callback=None):
+    """Get all extended file attributes as a mapping.
+
+    :returns:     tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                  object and dict mapping xattr names to values
+    """
+    if callback:
+      def handle_xattrs(status, response, hostlist):
+        if status.ok:
+          item_status, response = _xattr_mapping(response)
+          if item_status:
+            status, response = item_status, None
+        else:
+          response = None
+        callback(status, response, hostlist)
+      return self.list_xattr(timeout, handle_xattrs)
+
+    status, response = self.list_xattr(timeout)
+    if not status.ok:
+      return status, None
+    item_status, response = _xattr_mapping(response)
+    if item_status:
+      return item_status, None
+    return status, response
+
+  def xattr(self, attr, timeout=0, callback=None):
+    """Get one extended file attribute value.
+
+    :param attr:  extended attribute name
+    :type  attr:  string
+    :returns:     tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                  object and the attribute value
+    """
+    if callback:
+      def handle_xattr(status, response, hostlist):
+        if status.ok:
+          item_status, response = _xattr_value(response)
+          if item_status:
+            status, response = item_status, None
+        else:
+          response = None
+        callback(status, response, hostlist)
+      return self.get_xattr([attr], timeout, handle_xattr)
+
+    status, response = self.get_xattr([attr], timeout)
+    if not status.ok:
+      return status, None
+    item_status, response = _xattr_value(response)
+    if item_status:
+      return item_status, None
+    return status, response
 
   def clone(self, locs, timeout=0, callback=None):
     """Duplicate ranges from other files into this file by using range based cloning.

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
-from XRootD.client.utils import CallbackWrapper
+from XRootD.client.utils import CallbackWrapper, _xattr_mapping, _xattr_value
 from XRootD.client.flags import AccessMode
 
 class FileSystem(object):
@@ -394,8 +394,8 @@ class FileSystem(object):
     """Get extended file attributes.
     :param path:  path to the file
     :type  path:  string
-    :param attrs: extended attributes to be set on the file
-    :type  attrs: list of tuples of name/value pairs
+    :param attrs: list of extended attribute names to be retrieved
+    :type  attrs: list of strings
     :returns:     tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                   object and :mod:`list of touples (name, value, XRootD.client.responses.XRootDStatus)` object
     """
@@ -423,11 +423,9 @@ class FileSystem(object):
     return XRootDStatus(status), response
 
   def list_xattr(self, path, timeout=0, callback=None):
-    """Delete extended file attributes.
+    """List all extended file attributes.
     :param path:  path to the file
     :type  path:  string
-    :param attrs: extended attributes to be set on the file
-    :type  attrs: list of tuples of name/value pairs
     :returns:     tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                   object and :mod:`list of touples (name, value, XRootD.client.responses.XRootDStatus)` object
     """
@@ -437,3 +435,57 @@ class FileSystem(object):
 
     status, response = self.__fs.list_xattr(path, timeout)
     return XRootDStatus(status), response
+
+  def xattrs(self, path, timeout=0, callback=None):
+    """Get all extended file attributes as a mapping.
+    :param path:  path to the file
+    :type  path:  string
+    :returns:     tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                  object and dict mapping xattr names to values
+    """
+    if callback:
+      def handle_xattrs(status, response, hostlist):
+        if status.ok:
+          item_status, response = _xattr_mapping(response)
+          if item_status:
+            status, response = item_status, None
+        else:
+          response = None
+        callback(status, response, hostlist)
+      return self.list_xattr(path, timeout, handle_xattrs)
+
+    status, response = self.list_xattr(path, timeout)
+    if not status.ok:
+      return status, None
+    item_status, response = _xattr_mapping(response)
+    if item_status:
+      return item_status, None
+    return status, response
+
+  def xattr(self, path, attr, timeout=0, callback=None):
+    """Get one extended file attribute value.
+    :param path:  path to the file
+    :type  path:  string
+    :param attr:  extended attribute name
+    :type  attr:  string
+    :returns:     tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                  object and the attribute value
+    """
+    if callback:
+      def handle_xattr(status, response, hostlist):
+        if status.ok:
+          item_status, response = _xattr_value(response)
+          if item_status:
+            status, response = item_status, None
+        else:
+          response = None
+        callback(status, response, hostlist)
+      return self.get_xattr(path, [attr], timeout, handle_xattr)
+
+    status, response = self.get_xattr(path, [attr], timeout)
+    if not status.ok:
+      return status, None
+    item_status, response = _xattr_value(response)
+    if item_status:
+      return item_status, None
+    return status, response

--- a/python/libs/client/utils.py
+++ b/python/libs/client/utils.py
@@ -20,6 +20,30 @@ from __future__ import absolute_import, division, print_function
 from threading import Lock
 from XRootD.client.responses import XRootDStatus, HostList
 
+def _coerce_status(status):
+  if isinstance(status, XRootDStatus):
+    return status
+  return XRootDStatus(status)
+
+def _xattr_mapping(response):
+  attrs = {}
+
+  for name, value, status in response or []:
+    status = _coerce_status(status)
+    if not status.ok:
+      return status, None
+    attrs[name] = value
+
+  return None, attrs
+
+def _xattr_value(response):
+  status, attrs = _xattr_mapping(response)
+  if status:
+    return status, None
+  for value in attrs.values():
+    return None, value
+  return None, None
+
 class CallbackWrapper(object):
   def __init__(self, callback, responsetype):
     if not hasattr(callback, '__call__'):

--- a/python/tests/test_xattr_helpers.py
+++ b/python/tests/test_xattr_helpers.py
@@ -1,0 +1,158 @@
+from XRootD import client
+from XRootD.client.utils import AsyncResponseHandler
+
+
+OK_STATUS = {
+  'ok': True,
+  'message': 'OK'
+}
+
+ERR_STATUS = {
+  'ok': False,
+  'message': 'xattr failed'
+}
+
+
+class FakeFileSystemBackend(object):
+  def __init__(self, list_response=None, get_response=None):
+    self.list_response = list_response or []
+    self.get_response = get_response or []
+    self.calls = []
+
+  def list_xattr(self, path, timeout=0, callback=None):
+    self.calls.append(('list_xattr', path, timeout))
+    if callback:
+      callback(OK_STATUS, self.list_response)
+      return OK_STATUS
+    return OK_STATUS, self.list_response
+
+  def get_xattr(self, path, attrs, timeout=0, callback=None):
+    self.calls.append(('get_xattr', path, attrs, timeout))
+    if callback:
+      callback(OK_STATUS, self.get_response)
+      return OK_STATUS
+    return OK_STATUS, self.get_response
+
+
+class FakeFileBackend(object):
+  def __init__(self, list_response=None, get_response=None):
+    self.list_response = list_response or []
+    self.get_response = get_response or []
+    self.calls = []
+
+  def list_xattr(self, timeout=0, callback=None):
+    self.calls.append(('list_xattr', timeout))
+    if callback:
+      callback(OK_STATUS, self.list_response)
+      return OK_STATUS
+    return OK_STATUS, self.list_response
+
+  def get_xattr(self, attrs, timeout=0, callback=None):
+    self.calls.append(('get_xattr', attrs, timeout))
+    if callback:
+      callback(OK_STATUS, self.get_response)
+      return OK_STATUS
+    return OK_STATUS, self.get_response
+
+  def is_open(self):
+    return False
+
+
+def filesystem(backend):
+  fs = object.__new__(client.FileSystem)
+  fs._FileSystem__fs = backend
+  return fs
+
+
+def file(backend):
+  f = object.__new__(client.File)
+  f._File__file = backend
+  return f
+
+
+def test_filesystem_xattrs_returns_mapping():
+  backend = FakeFileSystemBackend(
+    list_response=[('first', 'one', OK_STATUS), ('second', 'two', OK_STATUS)]
+  )
+  fs = filesystem(backend)
+
+  status, response = fs.xattrs('/tmp/data')
+
+  assert status.ok
+  assert response == {'first': 'one', 'second': 'two'}
+  assert backend.calls == [('list_xattr', '/tmp/data', 0)]
+
+
+def test_filesystem_xattr_returns_single_value():
+  backend = FakeFileSystemBackend(
+    get_response=[('spacetoken.description?test', 'quota-info', OK_STATUS)]
+  )
+  fs = filesystem(backend)
+
+  status, response = fs.xattr('/tmp/data', 'spacetoken.description?test',
+                              timeout=15)
+
+  assert status.ok
+  assert response == 'quota-info'
+  assert backend.calls == [
+    ('get_xattr', '/tmp/data', ['spacetoken.description?test'], 15)
+  ]
+
+
+def test_xattrs_returns_per_attribute_failure():
+  backend = FakeFileSystemBackend(
+    list_response=[('broken', '', ERR_STATUS)]
+  )
+  fs = filesystem(backend)
+
+  status, response = fs.xattrs('/tmp/data')
+
+  assert not status.ok
+  assert status.message == 'xattr failed'
+  assert response is None
+
+
+def test_filesystem_xattrs_callback_returns_mapping():
+  backend = FakeFileSystemBackend(
+    list_response=[('first', 'one', OK_STATUS)]
+  )
+  fs = filesystem(backend)
+  handler = AsyncResponseHandler()
+
+  status = fs.xattrs('/tmp/data', callback=handler)
+  callback_status, response, hostlist = handler.wait()
+
+  assert status.ok
+  assert callback_status.ok
+  assert response == {'first': 'one'}
+  assert len(hostlist.hosts) == 0
+
+
+def test_file_xattrs_returns_mapping():
+  backend = FakeFileBackend(
+    list_response=[('first', 'one', OK_STATUS), ('second', 'two', OK_STATUS)]
+  )
+  f = file(backend)
+
+  status, response = f.xattrs()
+
+  assert status.ok
+  assert response == {'first': 'one', 'second': 'two'}
+  assert backend.calls == [('list_xattr', 0)]
+
+
+def test_file_xattr_callback_returns_single_value():
+  backend = FakeFileBackend(
+    get_response=[('first', 'one', OK_STATUS)]
+  )
+  f = file(backend)
+  handler = AsyncResponseHandler()
+
+  status = f.xattr('first', timeout=5, callback=handler)
+  callback_status, response, hostlist = handler.wait()
+
+  assert status.ok
+  assert callback_status.ok
+  assert response == 'one'
+  assert len(hostlist.hosts) == 0
+  assert backend.calls == [('get_xattr', ['first'], 5)]


### PR DESCRIPTION
## Summary

- Add mapping-style xattr helpers on `FileSystem` and `File`.
- Preserve the existing low-level `get_xattr()` / `list_xattr()` APIs while adding direct helpers for common metadata use cases.
- Document the xattr APIs and add focused sync/callback tests.

## Motivation

Downstream users such as DIRAC and Rucio consume xattrs as metadata. The existing bindings expose the low-level tuple-shaped xattr response, which is useful for preserving per-attribute status, but it makes callers repeatedly unpack response tuples when they only need a metadata mapping or one attribute value.

This is especially relevant for GFAL2 replacement work:

- DIRAC currently lists all xattr names and then fetches each value into a dictionary: https://github.com/DIRACGrid/DIRAC/blob/517d12a1900558f1d778f9d4d0a599850e43895c/src/DIRAC/Resources/Storage/GFAL2_StorageBase.py#L1532-L1541
- Rucio currently fetches a single space-token xattr for space usage: https://github.com/rucio/rucio/blob/2262ce73fffff1b163aa3bd56d756f4051d7496a/lib/rucio/rse/protocols/gfal.py#L592-L594

These helpers do not add new protocol behavior. They provide a small Python convenience layer over the existing xattr binding methods.

## Before / After

Before, callers that wanted all xattrs had to unpack the low-level response shape and inspect each per-attribute status manually:

```python
status, attrs = fs.list_xattr(path)
if not status.ok:
    raise RuntimeError(status.message)

metadata = {}
for name, value, attr_status in attrs:
    attr_status = client.responses.XRootDStatus(attr_status)
    if not attr_status.ok:
        raise RuntimeError(attr_status.message)
    metadata[name] = value
```

After this change, the common metadata case is direct:

```python
status, metadata = fs.xattrs(path)
if not status.ok:
    raise RuntimeError(status.message)
```

Before, callers that wanted a single xattr had to pass a list and unpack the first tuple:

```python
status, attrs = fs.get_xattr(path, ["spacetoken.description?" + space_token])
if not status.ok:
    raise RuntimeError(status.message)

name, value, attr_status = attrs[0]
attr_status = client.responses.XRootDStatus(attr_status)
if not attr_status.ok:
    raise RuntimeError(attr_status.message)
```

After this change:

```python
status, value = fs.xattr(path, "spacetoken.description?" + space_token)
if not status.ok:
    raise RuntimeError(status.message)
```

## Tests

- `python3 -m py_compile python/libs/client/utils.py python/libs/client/filesystem.py python/libs/client/file.py python/tests/test_xattr_helpers.py`
- `PYTHONPATH=build/lib.macosx-10.13-universal2-cpython-313 pytest -q python/tests/test_xattr_helpers.py`
- `git diff --check upstream/master...HEAD`