### PR TITLE
[CI] Run Python binding tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,6 +63,7 @@ jobs:
           py3-setuptools \
           py3-wheel \
           python3-dev \
+          pytest \
           readline-dev \
           sudo \
           util-linux-dev \
@@ -262,7 +263,7 @@ jobs:
     - name: Install development tools
       run: |
         sudo apt update -qq
-        sudo apt install -y build-essential devscripts equivs git
+        sudo apt install -y build-essential devscripts equivs git python3-pytest
 
     - name: Clone repository
       uses: actions/checkout@v6
@@ -304,7 +305,7 @@ jobs:
       run: sudo sed -i -e "s/localhost/localhost $(hostname)/g" /etc/hosts
 
     - name: Install dependencies with Homebrew
-      run: brew install googletest libzip nlohmann-json python-setuptools
+      run: brew install googletest libzip nlohmann-json pytest python-setuptools
 
     - name: Clone repository
       uses: actions/checkout@v6

--- a/debian/control
+++ b/debian/control
@@ -24,6 +24,7 @@ Build-Depends:
  libsystemd-dev [linux-any],
  python3-dev,
  python3-pip,
+ python3-pytest,
  python3-setuptools,
  python3-wheel,
  libjson-c-dev,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,6 +10,51 @@ else()
   configure_file(setup.py setup.py)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/VERSION "${XRootD_VERSION_STRING}")
 
+  if(BUILD_TESTS AND ENABLE_SERVER_TESTS)
+    execute_process(COMMAND ${Python_EXECUTABLE} -m pytest --version
+      RESULT_VARIABLE PYTEST_STATUS OUTPUT_QUIET ERROR_QUIET)
+
+    if(PYTEST_STATUS EQUAL 0)
+      set(PYXROOTD_TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/test-install)
+
+      add_subdirectory(src)
+      set_target_properties(client PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${PYXROOTD_TEST_DIR}/pyxrootd)
+
+      file(MAKE_DIRECTORY ${PYXROOTD_TEST_DIR}/pyxrootd)
+      file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/libs
+        ${PYXROOTD_TEST_DIR}/XRootD SYMBOLIC)
+      configure_file(src/__init__.py
+        ${PYXROOTD_TEST_DIR}/pyxrootd/__init__.py COPYONLY)
+
+      set(PYXROOTD_TEST_ENV
+        PYTHONPATH=${PYXROOTD_TEST_DIR}
+        PYTHONDONTWRITEBYTECODE=1
+        PYXROOTD_SERVER_URL=root://localhost:3094/)
+
+      if(APPLE)
+        list(APPEND PYXROOTD_TEST_ENV
+          DYLD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+      else()
+        list(APPEND PYXROOTD_TEST_ENV
+          LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+      endif()
+
+      add_test(NAME PyXRootD::pytest
+        COMMAND ${Python_EXECUTABLE} -m pytest -v
+          ${CMAKE_CURRENT_SOURCE_DIR}/tests
+          -k "not test_glob_remote and not test_multiple_glob_with_url_params and not test_folder_glob_with_url_params")
+
+      set_tests_properties(PyXRootD::pytest
+        PROPERTIES
+          FIXTURES_REQUIRED XRootD::noauth
+          ENVIRONMENT "${PYXROOTD_TEST_ENV}"
+          RUN_SERIAL TRUE)
+    else()
+      message(STATUS "pytest not found; Python binding tests disabled")
+    endif()
+  endif()
+
   option(INSTALL_PYTHON_BINDINGS "Install Python bindings" TRUE)
 
   if(INSTALL_PYTHON_BINDINGS)

--- a/python/tests/env.py
+++ b/python/tests/env.py
@@ -1,6 +1,8 @@
-SERVER_URL  = 'root://localhost/'
-smallfile   = SERVER_URL + '/tmp/spam'
-smallcopy   = SERVER_URL + '/tmp/eggs'
+import os
+
+SERVER_URL = os.getenv('PYXROOTD_SERVER_URL', 'root://localhost/')
+smallfile = SERVER_URL + '/tmp/spam'
+smallcopy = SERVER_URL + '/tmp/eggs'
 smallbuffer = 'gre\0en\neggs\nand\nham\n'
-bigfile     = SERVER_URL + '/tmp/bigfile'
-bigcopy     = SERVER_URL + '/tmp/bigcopy'
+bigfile = SERVER_URL + '/tmp/bigfile'
+bigcopy = SERVER_URL + '/tmp/bigcopy'

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -88,6 +88,7 @@ BuildRequires:	krb5-server
 BuildRequires:	krb5-workstation
 BuildRequires:	openssl
 BuildRequires:	procps-ng
+BuildRequires:	python3-pytest
 BuildRequires:	sqlite
 %endif
 


### PR DESCRIPTION
## Summary

- register the Python binding pytest suite as a CTest test using the existing `XRootD::noauth` fixture
- build the test extension as a normal CMake target and stage its build-tree package layout for pytest
- let CMake track the declared binding sources and `XrdCl`/`XrdUtils` target graph instead of maintaining a recursive glob, stamp, and nested `pip install`
- keep the post-install import checks, but drop the separate explicit pytest CI step now that standard CTest runs the suite
- add pytest to the relevant CI and package test dependencies
- allow the Python test endpoint to be overridden with `PYXROOTD_SERVER_URL`

## Rationale

The Python CI previously built and imported the bindings, but did not run the pytest suite through the normal CTest workflow. Running pytest as a CTest entry lets the existing test driver manage the noauth server fixture and keeps Python tests aligned with the rest of CI.

The existing `python/src` CMake target already declares the extension sources and links the `XrdCl` and `XrdUtils` targets. Reusing that target gives the test build complete, native dependency tracking without a second CMake build inside `pip`, a recursive source glob, or a hand-maintained stamp dependency list. Pure Python modules are exposed through the staged package layout, so their changes are picked up directly without rebuilding the extension.

The remote public-data glob tests remain excluded from the CTest invocation so CI does not depend on external EOS availability.

## Validation

- full local CMake build
- `ctest --test-dir build -R '^PyXRootD::pytest$' --output-on-failure`
  - `XRootD::noauth::setup`, `PyXRootD::pytest`, and `XRootD::noauth::teardown` passed
  - pytest result: `55 passed, 4 deselected`
- immediate verbose rebuild of the `client` target performed no compile, link, or `pip` step
- `python3 -m flake8 python/tests/env.py`
- `git diff --check upstream/master...HEAD`
- local YAML parser check for `.github/workflows/CI.yml`

