### PR TITLE
[Tests] Use private Kerberos test state

### DIFF
--- a/tests/krb5/kdc.conf
+++ b/tests/krb5/kdc.conf
@@ -12,6 +12,7 @@ XROOTD.ORG = {
 [realms]
 
 XROOTD.ORG = {
+  database_module = XROOTD.ORG
   acl_file = ""
   allow_pkinit = yes
   max_life = 1h 0m 0s
@@ -22,6 +23,7 @@ XROOTD.ORG = {
   kadmind_listen  = 50749
   kpasswd_listen  = 50464
 
+  iprop_logfile   = @CMAKE_CURRENT_BINARY_DIR@/kdc/db.ulog
   key_stash_file  = @CMAKE_CURRENT_BINARY_DIR@/kdc/.k5.XROOTD.ORG
   pkinit_anchors  = FILE:@CMAKE_CURRENT_BINARY_DIR@/kdc/cacert.pem
   pkinit_identity = FILE:@CMAKE_CURRENT_BINARY_DIR@/kdc/kdc.pem,@CMAKE_CURRENT_BINARY_DIR@/kdc/kdckey.pem

--- a/tests/krb5/kerberos.sh
+++ b/tests/krb5/kerberos.sh
@@ -5,6 +5,7 @@ set -e
 export KRB5CCNAME="${PWD}/krb5cc"
 export KRB5_CONFIG="${PWD}/krb5.conf"
 export KRB5_KDC_PROFILE="${PWD}/kdc.conf"
+export KRB5_DB_NAME="${PWD}/kdc/db"
 
 function setup() {
 	pushd kdc >/dev/null || exit 1
@@ -34,16 +35,16 @@ function setup() {
 	popd >/dev/null || exit 1
 
 	# Create the KDC database
-	kdb5_util create -s -r XROOTD.ORG -P xrootd
+	kdb5_util -r XROOTD.ORG -d "${KRB5_DB_NAME}" -P xrootd create -s
 
 	# Start the KDC daemons
-	krb5kdc -P "${PWD}"/krb5kdc.pid
+	krb5kdc -r XROOTD.ORG -d "${KRB5_DB_NAME}" -P "${PWD}"/krb5kdc.pid
 
 	# Not really needed, since we use kadmin.local
 	# kadmind -P ${PWD}/kadmind.pid
 
 	# Add principals for the server and client to KDC database
-	kadmin.local -r XROOTD.ORG <<-EOF
+	kadmin.local -r XROOTD.ORG -d "${KRB5_DB_NAME}" <<-EOF
 	add_principal -randkey -kvno 1 host/localhost@XROOTD.ORG
 	ktadd -k krb5.keytab host/localhost
 	add_principal xrootd@XROOTD.ORG
@@ -52,7 +53,7 @@ function setup() {
 	EOF
 
 	# Display KDC database entries
-	kdb5_util tabdump -o - keyinfo
+	kdb5_util -r XROOTD.ORG -d "${KRB5_DB_NAME}" tabdump -o - keyinfo
 
 	# Display contents of server keytab
 	klist -kte krb5.keytab


### PR DESCRIPTION
## Summary

- select the build-tree Kerberos database module for the test realm
- keep the KDC incremental propagation log in the build tree as well

## Rationale

The Kerberos fixture already defines a private database path under `[dbmodules]`, but the `XROOTD.ORG` realm did not select that module. In CI logs, `kdb5_util` can therefore fall back to system KDC database paths such as `/var/lib/krb5kdc/principal`, making the fixture depend on runner state instead of the private test directory.

Selecting the database module explicitly keeps the KDC database under the build tree, matching the existing fixture cleanup. Setting `iprop_logfile` avoids another KDC state file falling back to a system-derived default.

## Validation

- `git diff --check -- tests/krb5/kdc.conf`
- checked that the `XROOTD.ORG` realm contains both `database_module = XROOTD.ORG` and the build-tree `iprop_logfile`
