### PR TITLE
[Python] Expose stat ownership

### DIFF
--- a/python/libs/client/responses.py
+++ b/python/libs/client/responses.py
@@ -169,11 +169,21 @@ class StatInfo(Struct):
   """Status information for files and directories.
 
   :var         id: This file's unique identifier
+  :var       size: The file size (in bytes)
   :var      flags: Informational flags. An `ORed` combination of
                    :mod:`XRootD.client.flags.StatInfoFlags`
-  :var       size: The file size (in bytes)
-  :var    modtime: Modification time (in seconds since epoch)
-  :var modtimestr: Modification time (as readable string)
+  :var      mtime: Modification time (in seconds since epoch)
+  :var    modtime: Deprecated alias for ``mtime``
+  :var modtimestr: Deprecated modification time (as readable string)
+  :var      ctime: Change time (in seconds since epoch)
+  :var      atime: Access time (in seconds since epoch)
+  :var       mode: File mode
+  :var modeoctstr: File mode as a readable permissions string
+  :var      owner: File owner
+  :var      group: File group
+  :var   extended: Whether extended stat information is available
+  :var haschecksum: Whether checksum information is available
+  :var   checksum: File checksum
   """
   def __init__(self, info):
     super(StatInfo, self).__init__(info)

--- a/python/src/Conversions.hh
+++ b/python/src/Conversions.hh
@@ -125,13 +125,22 @@ namespace PyXRootD
   {
       static PyObject* Convert( XrdCl::StatInfo *info )
       {
-        return Py_BuildValue("{sNsNsNsNsN}",
+        return Py_BuildValue("{sNsNsNsNsNsNsNsNsNsNsNsNsNsNsN}",
             "id",         Py_BuildValue("s", info->GetId().c_str()),
             "size",       Py_BuildValue("k", info->GetSize()),
             "flags",      Py_BuildValue("I", info->GetFlags()),
+            "mtime",      Py_BuildValue("k", info->GetModTime()),
             "modtime",    Py_BuildValue("k", info->GetModTime()),
-            "modtimestr", Py_BuildValue("s",
-                                        info->GetModTimeAsString().c_str()));
+            "modtimestr", Py_BuildValue("s", info->GetModTimeAsString().c_str()),
+            "ctime",      Py_BuildValue("k", info->GetChangeTime()),
+            "atime",      Py_BuildValue("k", info->GetAccessTime()),
+            "mode",       Py_BuildValue("s", info->GetModeAsString().c_str()),
+            "modeoctstr", Py_BuildValue("s", info->GetModeAsOctString().c_str()),
+            "owner",      Py_BuildValue("s", info->GetOwner().c_str()),
+            "group",      Py_BuildValue("s", info->GetGroup().c_str()),
+            "extended",   PyBool_FromLong(info->ExtendedFormat()),
+            "haschecksum", PyBool_FromLong(info->HasChecksum()),
+            "checksum",   Py_BuildValue("s", info->GetChecksum().c_str()));
       }
   };
 

--- a/python/tests/test_file.py
+++ b/python/tests/test_file.py
@@ -324,6 +324,28 @@ def test_stat_sync():
   assert status.ok
   f.close()
 
+def test_stat_fields():
+  f = client.File()
+  status, __ = f.open(smallfile, OpenFlags.DELETE, open_mode)
+  assert status.ok
+  status, __ = f.write(smallbuffer)
+  assert status.ok
+  status, stat_info = f.stat(force=True)
+  assert status.ok
+  assert isinstance(stat_info.mtime, int)
+  assert isinstance(stat_info.modtime, int)
+  assert isinstance(stat_info.modtimestr, str)
+  assert isinstance(stat_info.ctime, int)
+  assert isinstance(stat_info.atime, int)
+  assert isinstance(stat_info.mode, str)
+  assert isinstance(stat_info.modeoctstr, str)
+  assert isinstance(stat_info.owner, str)
+  assert isinstance(stat_info.group, str)
+  assert isinstance(stat_info.extended, bool)
+  assert isinstance(stat_info.haschecksum, bool)
+  assert isinstance(stat_info.checksum, str)
+  f.close()
+
 def test_stat_async():
   f = client.File()
   status, response = f.open(bigfile)


### PR DESCRIPTION
## Summary

- expose `owner` and `group` on Python `StatInfo` objects
- document the new fields in `XRootD.client.responses.StatInfo`
- add a binding test that verifies `File.stat()` provides both attributes

## Rationale

PR #2789 included this binding-side improvement as part of a larger native fsspec filesystem implementation. Since the fsspec filesystem code duplicates functionality maintained elsewhere, this PR extracts only the reusable Python binding piece needed by external filesystem adapters.

`XrdCl::StatInfo` already parses owner and group information, but the Python conversion did not expose those fields. Making them available avoids downstream adapters having to fill ownership fields with placeholder values.

## Validation

- `python3 -m py_compile python/libs/client/responses.py python/tests/test_file.py`
- `git diff --check -- python/src/Conversions.hh python/libs/client/responses.py python/tests/test_file.py`
