### PR TITLE
[XrdHttp] Tests - Improve smuggling test for header parsing

### DIFF
--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -3,7 +3,7 @@
 export XRD_PLUGINCONFDIR="${BINARY_DIR}/config"
 
 function setup_http() {
-	require_commands openssl curl
+	require_commands openssl curl python3
 	openssl rand -base64 -out macaroons-secret 64
 	mkdir -p "${XRD_PLUGINCONFDIR}"
 	cat >| "${XRD_PLUGINCONFDIR}/http.conf" <<-EOF
@@ -463,27 +463,13 @@ function test_http() {
   smugglingPort="${smugglingTarget##*:}"
 
   # Sends $1 verbatim over a fresh TCP connection and prints the first
-  # response line (CRLF stripped). If no status line arrives we emit a
-  # distinct diagnostic for each failure mode so assertion logs are
-  # readable: bash `read -t` returns >128 on the read timer firing (server
-  # left us hanging) versus a small non-zero exit when the peer closed the
-  # socket before sending anything.
+  # response line (CRLF stripped). Use Python's socket module as a raw TCP
+  # client; bash /dev/tcp can lose the response when the peer sends an error
+  # and immediately tears down the connection.
   _smuggling_send() {
     local payload="$1"
-    local status=""
-    local rc=0
-    exec 3<>"/dev/tcp/${smugglingHost}/${smugglingPort}"
-    printf '%s' "$payload" >&3
-    IFS= read -r -t 10 status <&3 || rc=$?
-    exec 3<&-
-    status="${status//$'\r'/}"
-    if [[ -n "${status}" ]]; then
-      printf '%s' "${status}"
-    elif (( rc > 128 )); then
-      printf '<request stalled — read timed out waiting for a status line>'
-    else
-      printf '<server closed the connection without sending a status line>'
-    fi
+    printf '%s' "$payload" | python3 "${SOURCE_DIR}/utils/raw_tcp_status.py" \
+      "${smugglingHost}" "${smugglingPort}"
   }
 
   # Asserts the smuggled file at $1 was NOT created on the server.

--- a/tests/XRootD/utils/raw_tcp_status.py
+++ b/tests/XRootD/utils/raw_tcp_status.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import socket
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} HOST PORT", file=sys.stderr)
+        return 2
+
+    host = sys.argv[1]
+    port = int(sys.argv[2])
+    payload = sys.stdin.buffer.read()
+    response = bytearray()
+    timed_out = False
+    closed = False
+
+    try:
+        with socket.create_connection((host, port), timeout=10) as sock:
+            sock.settimeout(10)
+            sock.sendall(payload)
+            while b"\n" not in response:
+                chunk = sock.recv(4096)
+                if not chunk:
+                    closed = True
+                    break
+                response.extend(chunk)
+    except TimeoutError:
+        timed_out = True
+    except OSError as exc:
+        print(f"<TCP exchange failed: {exc}>", end="")
+        return 0
+
+    if response:
+        line = bytes(response).split(b"\n", 1)[0].replace(b"\r", b"")
+        print(line.decode("iso-8859-1", errors="replace"), end="")
+    elif timed_out:
+        print("<request stalled - read timed out waiting for a status line>", end="")
+    elif closed:
+        print("<server closed the connection without sending a status line>", end="")
+    else:
+        print("<TCP exchange failed without a status line>", end="")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
It reads the crafted request bytes from stdin, connects to the given
HOST PORT, sends the payload unchanged with sendall(), then reads from
the socket until it gets the first response line, the server closes the
connection, or a 10 second timeout expires.

http.sh just calls that script and can assert on values returned by it
like HTTP/1.1 Bad Request.