### PR TITLE
[XrdApps] Prototype thin gfal2-util migration frontend

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -8,6 +8,10 @@ set(MAN1PAGES
   xrdmapc.1
 )
 
+# Keep the provisional migration frontend page renderable for review without
+# installing it before its final name and packaging policy are agreed.
+configure_file(xrd.1 xrd.1 @ONLY)
+
 set(MAN8PAGES
     cmsd.8
     frm_admin.8

--- a/docs/man/xrd.1
+++ b/docs/man/xrd.1
@@ -1,0 +1,223 @@
+.TH xrd 1 "@XRootD_VERSION_STRING@"
+.SH NAME
+xrd \- provisional thin migration frontend for XRootD client commands
+.SH SYNOPSIS
+.B xrd
+.I command
+[\fIoptions\fR] \fIarguments\fR
+.SH DESCRIPTION
+.B xrd
+provides a small command-oriented compatibility surface for operators moving
+from the GFAL command-line utilities to native XRootD tools.
+The executable name and packaging are provisional and remain subject to
+upstream review.
+.PP
+The frontend performs command and option translation only. It replaces itself
+with
+.BR xrdfs (1)
+for filesystem operations or
+.BR xrdcp (1)
+for transfers. It does not implement storage operations, protocol handling,
+output formatting, or transfer logic.
+.PP
+Standard output, standard error, signals, and the delegated command's exit
+status are preserved. The initial implementation therefore produces native
+XRootD output and exit codes; exact GFAL output and POSIX-errno compatibility
+are not yet provided.
+.SH COMMANDS
+.TP
+.BI "stat " URL
+Execute
+.BR "xrdfs stat " URL .
+.TP
+.BI "ls [" options "] " URL
+Execute
+.BR "xrdfs ls " URL
+with supported option translations.
+.TP
+.BI "cat [" options "] " URL...
+Execute
+.BR "xrdfs cat " URL...
+and concatenate one or more files from the same endpoint.
+.TP
+.BI "xattr " URL " [" ATTRIBUTE "]"
+Execute a read-only
+.B xrdfs xattr
+list or get operation. Attribute assignment is rejected.
+.TP
+.BI "copy [" options "] " SOURCE " " DESTINATION
+Execute
+.BR xrdcp (1)
+with supported option translations.
+.TP
+.BI "cp [" options "] " SOURCE " " DESTINATION
+Alias for
+.BR copy .
+.SH COMMON OPTIONS
+.TP
+.B \-h, \-\-help
+Show command help and exit.
+.TP
+.B \-V, \-\-version
+Show the XRootD version and exit.
+.TP
+.B \-v, \-\-verbose
+Increase native client logging. One occurrence sets
+.BR XRD_LOGLEVEL=Warning ,
+two set
+.BR Info ,
+and three or more set
+.BR Debug .
+.TP
+.BI "\-t, \-\-timeout " SECONDS
+Set
+.B XRD_REQUESTTIMEOUT
+for the delegated command.
+A value of zero is accepted as a GFAL compatibility no-op because zero has
+different immediate-expiry semantics in XrdCl.
+.TP
+.BI "\-E, \-\-cert " FILE
+Set the X.509 certificate for native XRootD and HTTP clients.
+.TP
+.BI "\-\-key " FILE
+Override the X.509 key selected by
+.BR \-\-cert .
+Without this option, the certificate file is also used as the key. Explicit
+credentials take precedence over an inherited
+.BR X509_USER_PROXY
+and the default
+.B /tmp/x509up_u<uid>
+GSI proxy path. Inherited serialized
+.B XrdSecCREDS
+are also cleared.
+.TP
+.B \-4
+Set
+.B XRD_NETWORKSTACK=IPv4
+for the delegated command.
+.TP
+.B \-6
+Set
+.B XRD_NETWORKSTACK=IPv6
+for the delegated command.
+.TP
+.BI "\-\-log-file " FILE
+Set
+.B XRD_LOGFILE
+for the delegated command.
+.TP
+.BI "\-D, \-\-definition " VALUE
+Accepted for command-line migration and ignored with a warning because it has
+no direct XRootD equivalent.
+.TP
+.BI "\-C, \-\-client-info " INFO
+Accepted for command-line migration and ignored with a warning until native
+client-information plumbing is selected.
+.SH LS OPTIONS
+.TP
+.B \-a, \-\-all
+Accepted as a no-op. Native
+.B xrdfs
+does not hide dot-prefixed directory entries.
+.TP
+.B \-l, \-\-long
+Translate to
+.BR "xrdfs ls -l" .
+.TP
+.B \-H, \-\-human-readable
+Translate to
+.BR "xrdfs ls -h" .
+.TP
+.BI "\-\-color " auto|never
+Accepted as a no-op because native output is not colored.
+.PP
+Options that require GFAL-specific formatting, including
+.BR \-\-time-style ,
+.BR \-\-full-time ,
+.BR \-\-xattr ,
+.BR "\-\-color always" ,
+and
+.BR \-d ,
+fail clearly instead of claiming unsupported behavior.
+.SH CAT OPTIONS
+.TP
+.B \-b, \-\-bytes
+Accepted as a no-op because
+.B xrdfs cat
+already streams raw bytes.
+.PP
+All URLs must use the same endpoint. A single delegated
+.B xrdfs
+invocation does not yet provide the mixed-endpoint behavior of
+.BR gfal-cat .
+.SH COPY OPTIONS
+.TP
+.B \-f, \-\-force
+Translate to
+.BR "xrdcp --force" .
+.TP
+.B \-p, \-\-parent
+Translate to
+.BR "xrdcp --path"
+to create missing destination directories.
+.TP
+.B \-r, \-\-recursive
+Translate to
+.BR "xrdcp --recursive" .
+.TP
+.BI "\-K, \-\-checksum " TYPE[:VALUE]
+Translate to
+.BR "xrdcp --cksum" .
+The algorithm spelling is normalized to lowercase.
+.TP
+.BI "\-n, \-\-nbstreams " COUNT
+Translate to
+.BR "xrdcp --streams" .
+Zero keeps the native default control-stream behavior.
+.TP
+.BI "\-T, \-\-transfer-timeout " SECONDS
+Set
+.B XRD_CPTIMEOUT
+for the delegated classical copy job.
+Zero disables this native timeout.
+.TP
+.BI "\-\-from-file " FILE
+Translate to
+.BR "xrdcp --infiles" .
+Exactly one destination must also be supplied.
+.PP
+The initial compatibility surface accepts one source and one destination.
+GFAL chained destinations and copy options without a faithful
+.B xrdcp
+equivalent are rejected with an explanation.
+.SH XATTR OPERATIONS
+Without an attribute name,
+.B xrd xattr
+delegates to
+.BR "xrdfs xattr URL list" .
+With an attribute name, it delegates to
+.BR "xrdfs xattr URL get ATTRIBUTE" .
+An argument containing
+.B =
+is rejected so this initial surface cannot set an extended attribute.
+.SH EXAMPLES
+Inspect a complete XRootD URL:
+.PP
+.nf
+xrd stat root://eospublic.cern.ch//eos/opendata/example
+.fi
+.PP
+List a directory using familiar GFAL option spellings:
+.PP
+.nf
+xrd ls -lH root://eospublic.cern.ch//eos/opendata/
+.fi
+.PP
+Download a remote file without modifying remote storage:
+.PP
+.nf
+xrd copy root://host//path/file /tmp/file
+.fi
+.SH SEE ALSO
+.BR xrdfs (1),
+.BR xrdcp (1)

--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -19,6 +19,10 @@ The \fBxrdfs\fR utility executes meta-data oriented operations
 In batch mode, the endpoint may either be provided separately before the
 command or inferred from complete URL path operands following the command.
 All complete URLs in one command must refer to the same endpoint.
+The command-first complete-URL form is supported by cache, cat, chmod, locate,
+ls, mkdir, mv, prepare, rm, rmdir, spaceinfo, stat, statvfs, tail, truncate,
+and xattr. Raw query arguments remain available only through the server-first
+form because their positional layout is query-specific.
 Command help is available by invoking \fBxrdfs\fR with no command
 line options or parameters and then typing "help" in response to the
 input prompt.

--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -6,14 +6,19 @@ xrdfs - xrootd file and directory meta-data utility
 
 \fBxrdfs\fR \fI[--no-cwd]\fR \fIhost[:port]\fR \fI[command [args]]\fR
 
-\fBcommand\fR: help, chmod, ls, locate, mkdir, mv, stat, statvfs, query, rm, rmdir,
-           truncate, prepare, cat, tail, spaceinfo
+\fBxrdfs\fR \fIcommand\fR \fI[args containing complete URLs]\fR
+
+\fBcommand\fR: help, cache, chmod, ls, locate, mkdir, mv, stat, statvfs, query,
+           rm, rmdir, truncate, prepare, cat, tail, spaceinfo, xattr
 .fi
 .br
 .ad l
 .SH DESCRIPTION
 The \fBxrdfs\fR utility executes meta-data oriented operations
 (e.g., ls, mv, rm, etc.) on one or more xrootd servers.
+In batch mode, the endpoint may either be provided separately before the
+command or inferred from complete URL path operands following the command.
+All complete URLs in one command must refer to the same endpoint.
 Command help is available by invoking \fBxrdfs\fR with no command
 line options or parameters and then typing "help" in response to the
 input prompt.
@@ -22,6 +27,22 @@ input prompt.
 \fB--no-cwd\fR
 .RS 3
 No CWD is being preset in interactive mode.
+.RE
+
+.SH EXAMPLES
+The existing server-first form remains supported:
+.PP
+.nf
+\fBxrdfs root.example.org stat /store/file\fR
+.fi
+.PP
+Path-oriented commands also accept complete URLs:
+.PP
+.nf
+\fBxrdfs stat root://root.example.org//store/file\fR
+\fBxrdfs ls root://root.example.org//store/directory\fR
+\fBxrdfs mv root://root.example.org//store/old root://root.example.org//store/new\fR
+.fi
 
 .SH COMMANDS
 \fBchmod\fR \fIpath\fR \fI<user><group><other>\fR

--- a/docs/xrd-gfal-compatibility.md
+++ b/docs/xrd-gfal-compatibility.md
@@ -1,0 +1,99 @@
+# Native XRootD CLI migration compatibility
+
+This document records the behavior of the first migration frontend prototype
+tracked by [issue #2863](https://github.com/xrootd/xrootd/issues/2863).
+`xrd` is a working name only. The final executable name, syntax, packaging,
+and installation policy remain open for review.
+
+The frontend is intentionally thin: it translates arguments and environment
+settings, then replaces itself with `xrdfs` or `xrdcp`. Storage operations,
+protocol handling, transfer progress, normal output, signals, and exit status
+remain owned by the native commands.
+
+The prototype target is built for review and testing but is deliberately not
+installed or added to distribution packages while its name and packaging
+policy remain unresolved.
+
+The compatibility inventory is based on the captured `gfal2-util` help and
+behavioral tests maintained in the
+[`lobis/gfal`](https://github.com/lobis/gfal) reference repository.
+
+## Implemented first slice
+
+| Migration command | Delegated invocation | Supported compatibility behavior |
+| --- | --- | --- |
+| `xrd stat URL` | `xrdfs stat URL` | Command name and complete URL |
+| `xrd cat URL...` | `xrdfs cat URL...` | Multiple same-endpoint files; `-b/--bytes` is a safe no-op |
+| `xrd ls URL` | `xrdfs ls URL` | `-a`, `-l`, `-H`, and non-coloring modes |
+| `xrd xattr URL [NAME]` | `xrdfs xattr URL list/get` | Read-only list and get; assignment is rejected |
+| `xrd copy SRC DST` | `xrdcp SRC DST` | `-f`, `-p`, `-r`, `-K`, `-n`, `-T`, and `--from-file` |
+| `xrd cp SRC DST` | `xrdcp SRC DST` | Alias for `copy` |
+
+Complete-URL dispatch depends on the `xrdfs` command-first URL grammar from
+issue #1664. The existing server-first and interactive `xrdfs` forms remain
+unchanged.
+
+## Common option translation
+
+| GFAL spelling | Native setting |
+| --- | --- |
+| `-v` (repeatable) | `XRD_LOGLEVEL=Warning`, `Info`, or `Debug` |
+| `-t/--timeout SECONDS` | `XRD_REQUESTTIMEOUT`; zero is accepted without forcing XrdCl's immediate-expiry value |
+| `-E/--cert FILE` | Explicit GSI/native/HTTP certificate, key, and proxy selection; inherited proxy and serialized XrdSec credentials are cleared |
+| `--key FILE` | Override the key selected by `--cert`; otherwise the certificate file is also used as the key |
+| `-4` / `-6` | `XRD_NETWORKSTACK=IPv4` / `IPv6` |
+| `--log-file FILE` | `XRD_LOGFILE` |
+| `-D/--definition`, `-C/--client-info` | accepted with an explicit warning |
+
+Options are translated only when their native behavior is sufficiently close.
+Unsupported options fail before delegation with a specific diagnostic. This
+avoids silently claiming SRM, GridFTP, formatting, or third-party-copy behavior
+that XRootD does not provide through the selected command.
+
+## Deliberate current boundaries
+
+- Output is native `xrdfs`/`xrdcp` output. In particular, `stat` and long
+  `ls` are not formatted to look like `gfal-stat` or `gfal-ls`.
+- Exit status is the delegated native status. Exact GFAL POSIX-errno mapping is
+  a later script-compatibility layer.
+- `sum` is deferred until a native command accepts a complete URL and checksum
+  algorithm without making the frontend split URLs or parse output.
+- `xattr` exposes read-only get/list only. An attribute containing `=` is
+  rejected so mutation cannot be introduced accidentally.
+- Copy accepts a single source and destination, or `--from-file` plus one
+  destination. GFAL chained destinations are rejected because passing them
+  unchanged to `xrdcp` would mean multiple sources and change semantics.
+- `--` protects dash-prefixed local copy operands; they are normalized to an
+  equivalent `./-name` spelling before delegation because `xrdcp` does not
+  preserve the delimiter itself.
+- `ls -d`, time styles, xattr columns, and forced color need native `xrdfs`
+  support before the frontend can offer them.
+- HTTP(S) behavior depends on the installed `XrdClHttp` plugin and its native
+  operation coverage. The dispatcher does not add protocol-specific code.
+- Against the EOS Public reference fixture, native HTTPS `stat`, `cat`, and
+  remote-to-local copy succeed, while HTTPS `ls` currently returns
+  `NOT_IMPLEMENTED`; `gfal-ls` succeeds on the same directory. Directory
+  listing must therefore be completed in XrdClHttp/`xrdfs`, not reconstructed
+  in this frontend.
+- Multi-file `cat` currently requires all URLs to use one endpoint because one
+  delegated `xrdfs` invocation owns the operation. Unlike `gfal-cat`, it does
+  not yet span unrelated endpoints.
+
+## Validation policy
+
+The in-tree unit and BATS tests validate argument/environment translation,
+delegation, stream preservation, and status preservation without contacting
+storage.
+
+Server-backed tests use an isolated local XRootD fixture. Live acceptance checks
+must use read-only public data or download to a local temporary file. The
+reference fixture is:
+
+```text
+root://eospublic.cern.ch//eos/opendata/phenix/emcal-finding-pi0s-and-photons/single_cluster_r5.C
+```
+
+Its expected size is 2184 bytes, MD5 is
+`93f402e24c6f870470e1c5fcc5400e25`, and ADLER32 is `335e754f`.
+No validation should create, rename, chmod, stage, evict, or remove data on
+production storage.

--- a/src/XrdApps/CMakeLists.txt
+++ b/src/XrdApps/CMakeLists.txt
@@ -37,6 +37,19 @@ target_link_libraries(xrdreplay
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
+add_executable(xrd
+  XrdCli.cc
+  XrdCliCommandLine.cc
+)
+
+set_target_properties(xrd PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED TRUE
+)
+
+# The target is intentionally not installed while its name and packaging are
+# still under discussion in issue #2863.
+
 install(
   TARGETS
     xrdreplay

--- a/src/XrdApps/XrdCli.cc
+++ b/src/XrdApps/XrdCli.cc
@@ -1,0 +1,176 @@
+/******************************************************************************/
+/*                                                                            */
+/*                         X r d C l i . c c                                  */
+/*                                                                            */
+/* (c) 2026 by the XRootD Collaboration                                       */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/******************************************************************************/
+
+#include "XrdApps/XrdCliCommandLine.hh"
+#include "XrdVersion.hh"
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <unistd.h>
+
+namespace
+{
+  void PrintTopLevelHelp()
+  {
+    std::cout <<
+      "Usage: xrd <command> [options] arguments\n\n"
+      "Thin migration frontend for native XRootD commands. The name 'xrd'\n"
+      "is provisional while the command and packaging design are reviewed.\n\n"
+      "Commands:\n"
+      "  stat URL             Delegate metadata lookup to xrdfs\n"
+      "  ls [options] URL     Delegate directory listing to xrdfs\n"
+      "  cat [options] URL... Delegate same-endpoint file streaming to xrdfs\n"
+      "  xattr URL [NAME]    Delegate read-only xattr list/get to xrdfs\n"
+      "  copy SRC DST         Delegate a transfer to xrdcp\n"
+      "  cp SRC DST           Alias for copy\n\n"
+      "Run 'xrd <command> --help' for supported compatibility options.\n";
+  }
+
+  void PrintCommonOptions()
+  {
+    std::cout <<
+      "Common options:\n"
+      "  -h, --help              Show command help\n"
+      "  -V, --version           Show the XRootD version\n"
+      "  -v, --verbose           Increase client logs (Warning/Info/Debug)\n"
+      "  -t, --timeout SECONDS   Set XRD_REQUESTTIMEOUT\n"
+      "  -E, --cert FILE         Set the X.509 client certificate\n"
+      "      --key FILE          Set the X.509 client key used with --cert\n"
+      "  -4 / -6                 Select the IPv4 or IPv6 network stack\n"
+      "      --log-file FILE     Set XRD_LOGFILE\n"
+      "  -D, --definition VALUE  Accepted with a warning; not translated\n"
+      "  -C, --client-info INFO  Accepted with a warning; not translated\n";
+  }
+
+  void PrintCommandHelp( const std::string &command )
+  {
+    if( command == "stat" )
+      std::cout << "Usage: xrd stat [common-options] URL\n\n";
+    else if( command == "cat" )
+      std::cout <<
+        "Usage: xrd cat [common-options] [-b|--bytes] URL...\n\n"
+        "The bytes flag is accepted as a no-op because xrdfs cat already\n"
+        "streams raw bytes. All URLs must use the same endpoint.\n\n";
+    else if( command == "ls" )
+      std::cout <<
+        "Usage: xrd ls [common-options] [-a] [-l] [-H] URL\n\n"
+        "  -a, --all             Accepted as a no-op; xrdfs does not filter\n"
+        "                        dot-prefixed entries\n"
+        "  -l, --long            Request the native xrdfs long listing\n"
+        "  -H, --human-readable  Request human-readable sizes\n"
+        "      --color auto|never Accepted as a no-op\n\n";
+    else if( command == "xattr" )
+      std::cout <<
+        "Usage: xrd xattr [common-options] URL [ATTRIBUTE]\n\n"
+        "Without an attribute, list attributes through xrdfs. With an\n"
+        "attribute name, retrieve it. ATTRIBUTE=VALUE is rejected because\n"
+        "this initial command is deliberately read-only.\n\n";
+    else if( command == "copy" )
+      std::cout <<
+        "Usage: xrd copy [common-options] [copy-options] SRC DST\n"
+        "       xrd copy [common-options] --from-file FILE DST\n\n"
+        "  -f, --force            Replace an existing destination\n"
+        "  -p, --parent           Create missing destination directories\n"
+        "  -r, --recursive        Copy directories recursively\n"
+        "  -K, --checksum VALUE   Translate to xrdcp --cksum\n"
+        "  -n, --nbstreams N      Translate to xrdcp --streams\n"
+        "  -T, --transfer-timeout SECONDS\n"
+        "                         Set XRD_CPTIMEOUT\n"
+        "      --from-file FILE   Translate to xrdcp --infiles\n\n";
+    PrintCommonOptions();
+  }
+
+  int Execute( const XrdApps::CommandInvocation &invocation )
+  {
+    for( const std::string &name : invocation.environmentToUnset )
+    {
+      if( unsetenv( name.c_str() ) != 0 )
+      {
+        std::cerr << "xrd: unable to unset " << name << ": "
+                  << std::strerror( errno ) << '\n';
+        return 126;
+      }
+    }
+
+    for( const auto &entry : invocation.environment )
+    {
+      if( setenv( entry.first.c_str(), entry.second.c_str(), 1 ) != 0 )
+      {
+        std::cerr << "xrd: unable to set " << entry.first << ": "
+                  << std::strerror( errno ) << '\n';
+        return 126;
+      }
+    }
+
+    for( const std::string &warning : invocation.warnings )
+      std::cerr << "xrd: warning: " << warning << '\n';
+
+    std::vector<char *> arguments;
+    arguments.reserve( invocation.arguments.size() + 2 );
+    arguments.push_back( const_cast<char *>( invocation.executable.c_str() ) );
+    for( const std::string &argument : invocation.arguments )
+      arguments.push_back( const_cast<char *>( argument.c_str() ) );
+    arguments.push_back( nullptr );
+
+    execvp( invocation.executable.c_str(), arguments.data() );
+    const int error = errno;
+    std::cerr << "xrd: unable to execute " << invocation.executable << ": "
+              << std::strerror( error ) << '\n';
+    return error == ENOENT ? 127 : 126;
+  }
+}
+
+int main( int argc, char **argv )
+{
+  const std::vector<std::string> arguments( argv + 1, argv + argc );
+  const XrdApps::CommandLineResult result = XrdApps::ParseCommandLine( arguments );
+
+  switch( result.action )
+  {
+    case XrdApps::CommandLineAction::Execute:
+      return Execute( result.invocation );
+    case XrdApps::CommandLineAction::Help:
+      if( result.command.empty() )
+        PrintTopLevelHelp();
+      else
+        PrintCommandHelp( result.command );
+      return 0;
+    case XrdApps::CommandLineAction::Version:
+      std::cout << "xrd " << XrdVERSION << '\n';
+      return 0;
+    case XrdApps::CommandLineAction::Error:
+      std::cerr << "xrd: " << result.error << '\n';
+      if( !result.command.empty() )
+        std::cerr << "Try 'xrd " << result.command << " --help' for more information.\n";
+      else
+        std::cerr << "Try 'xrd --help' for more information.\n";
+      return 2;
+  }
+  return 2;
+}

--- a/src/XrdApps/XrdCliCommandLine.cc
+++ b/src/XrdApps/XrdCliCommandLine.cc
@@ -1,0 +1,818 @@
+/******************************************************************************/
+/*                                                                            */
+/*                 X r d C l i C o m m a n d L i n e . c c                  */
+/*                                                                            */
+/* (c) 2026 by the XRootD Collaboration                                       */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/******************************************************************************/
+
+#include "XrdApps/XrdCliCommandLine.hh"
+
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <limits>
+#include <string_view>
+
+namespace
+{
+  enum class OptionAction
+  {
+    Help,
+    Version,
+    Verbose,
+    Timeout,
+    Certificate,
+    Key,
+    IPv4,
+    IPv6,
+    LogFile,
+    Forward,
+    Ignore,
+    Warn,
+    Reject,
+    CopyTimeout,
+    CopyFromFile,
+    CopyStreams,
+    CopyChecksum,
+    Color
+  };
+
+  struct OptionSpec
+  {
+    char shortName;
+    const char *longName;
+    bool takesValue;
+    OptionAction action;
+    const char *value;
+  };
+
+  constexpr OptionSpec CommonOptions[] = {
+    {'h', "help",        false, OptionAction::Help,        nullptr},
+    {'V', "version",     false, OptionAction::Version,     nullptr},
+    {'v', "verbose",     false, OptionAction::Verbose,     nullptr},
+    {'D', "definition",  true,  OptionAction::Warn,
+      "--definition has no XRootD equivalent and was ignored"},
+    {'t', "timeout",     true,  OptionAction::Timeout,     nullptr},
+    {'E', "cert",        true,  OptionAction::Certificate, nullptr},
+    {0,   "key",         true,  OptionAction::Key,         nullptr},
+    {'4', nullptr,       false, OptionAction::IPv4,        nullptr},
+    {'6', nullptr,       false, OptionAction::IPv6,        nullptr},
+    {'C', "client-info", true,  OptionAction::Warn,
+      "--client-info is not exposed by the delegated commands and was ignored"},
+    {0,   "log-file",    true,  OptionAction::LogFile,     nullptr},
+  };
+
+  constexpr OptionSpec CatOptions[] = {
+    {'b', "bytes", false, OptionAction::Ignore, nullptr},
+  };
+
+  constexpr OptionSpec LsOptions[] = {
+    {'a', "all",            false, OptionAction::Ignore,  nullptr},
+    {'l', "long",           false, OptionAction::Forward, "-l"},
+    {'H', "human-readable", false, OptionAction::Forward, "-h"},
+    {'d', "directory",      false, OptionAction::Reject,
+      "--directory requires native xrdfs output support"},
+    {0,   "xattr",          true,  OptionAction::Reject,
+      "--xattr requires native xrdfs output support"},
+    {0,   "time-style",     true,  OptionAction::Reject,
+      "--time-style requires native xrdfs output support"},
+    {0,   "full-time",      false, OptionAction::Reject,
+      "--full-time requires native xrdfs output support"},
+    {0,   "color",          true,  OptionAction::Color,   nullptr},
+  };
+
+  constexpr OptionSpec CopyOptions[] = {
+    {'f', "force",           false, OptionAction::Forward,      "--force"},
+    {'p', "parent",          false, OptionAction::Forward,      "--path"},
+    {'n', "nbstreams",       true,  OptionAction::CopyStreams,  nullptr},
+    {0,   "tcp-buffersize",  true,  OptionAction::Reject,
+      "--tcp-buffersize has no xrdcp equivalent"},
+    {'s', "src-spacetoken",  true,  OptionAction::Reject,
+      "--src-spacetoken is not supported by XRootD protocols"},
+    {'S', "dst-spacetoken",  true,  OptionAction::Reject,
+      "--dst-spacetoken is not supported by XRootD protocols"},
+    {'T', "transfer-timeout", true, OptionAction::CopyTimeout,  nullptr},
+    {'K', "checksum",        true,  OptionAction::CopyChecksum, nullptr},
+    {0,   "checksum-mode",   true,  OptionAction::Reject,
+      "--checksum-mode requires a separate native compatibility design"},
+    {0,   "from-file",       true,  OptionAction::CopyFromFile, nullptr},
+    {0,   "copy-mode",       true,  OptionAction::Reject,
+      "--copy-mode cannot be translated faithfully to xrdcp"},
+    {0,   "just-copy",       false, OptionAction::Reject,
+      "--just-copy cannot be translated faithfully to xrdcp"},
+    {0,   "disable-cleanup", false, OptionAction::Reject,
+      "--disable-cleanup has no xrdcp equivalent"},
+    {0,   "no-delegation",   false, OptionAction::Reject,
+      "--no-delegation requires an explicit third-party-copy mode"},
+    {0,   "evict",           false, OptionAction::Reject,
+      "--evict is not yet exposed through this compatibility command"},
+    {0,   "scitag",          true,  OptionAction::Reject,
+      "--scitag is not yet exposed through this compatibility command"},
+    {'r', "recursive",       false, OptionAction::Forward,      "--recursive"},
+    {0,   "abort-on-failure", false, OptionAction::Reject,
+      "--abort-on-failure is not needed for a single xrdcp job"},
+    {0,   "dry-run",         false, OptionAction::Reject,
+      "--dry-run is not supported by xrdcp"},
+  };
+
+  struct ParseState
+  {
+    unsigned int verbosity = 0;
+    bool fromFile = false;
+    std::string networkStack;
+    bool certificateSpecified = false;
+    bool keySpecified = false;
+    std::string certificate;
+    std::string key;
+  };
+
+  struct TranslatedOptions
+  {
+    std::vector<std::string> arguments;
+    std::vector<std::string> flags;
+    std::vector<std::pair<std::string, std::size_t>> valueIndexes;
+  };
+
+  template<std::size_t Size>
+  const OptionSpec *FindLongOption( std::string_view name,
+                                    const OptionSpec (&options)[Size] )
+  {
+    for( const OptionSpec &option : options )
+    {
+      if( option.longName && name == option.longName )
+        return &option;
+    }
+    return nullptr;
+  }
+
+  template<std::size_t Size>
+  const OptionSpec *FindShortOption( char name,
+                                     const OptionSpec (&options)[Size] )
+  {
+    for( const OptionSpec &option : options )
+    {
+      if( option.shortName == name )
+        return &option;
+    }
+    return nullptr;
+  }
+
+  template<std::size_t Size>
+  const OptionSpec *FindLongOption( std::string_view name,
+                                    const OptionSpec (&commandOptions)[Size],
+                                    bool &isCommon )
+  {
+    if( const OptionSpec *option = FindLongOption( name, CommonOptions ) )
+    {
+      isCommon = true;
+      return option;
+    }
+    isCommon = false;
+    return FindLongOption( name, commandOptions );
+  }
+
+  template<std::size_t Size>
+  const OptionSpec *FindShortOption( char name,
+                                     const OptionSpec (&commandOptions)[Size],
+                                     bool &isCommon )
+  {
+    if( const OptionSpec *option = FindShortOption( name, CommonOptions ) )
+    {
+      isCommon = true;
+      return option;
+    }
+    isCommon = false;
+    return FindShortOption( name, commandOptions );
+  }
+
+  bool NormalizeInteger( const std::string &value, std::string &normalized,
+                         unsigned int minimum = 1,
+                         unsigned int maximum =
+                           std::numeric_limits<int>::max() )
+  {
+    if( value.empty() )
+      return false;
+
+    unsigned int parsed = 0;
+    const std::size_t firstDigit = value[0] == '+' ? 1 : 0;
+    if( firstDigit == value.size() )
+      return false;
+    for( std::size_t index = firstDigit; index < value.size(); ++index )
+    {
+      const unsigned char character = value[index];
+      if( std::isdigit( character ) == 0 )
+        return false;
+      const unsigned int digit = character - '0';
+      if( parsed > (maximum - digit) / 10 )
+        return false;
+      parsed = parsed * 10 + digit;
+    }
+
+    if( parsed < minimum )
+      return false;
+    normalized = std::to_string( parsed );
+    return true;
+  }
+
+  void SetEnvironment( XrdApps::CommandInvocation &invocation,
+                       const std::string &name, const std::string &value )
+  {
+    for( auto &entry : invocation.environment )
+    {
+      if( entry.first == name )
+      {
+        entry.second = value;
+        return;
+      }
+    }
+    invocation.environment.emplace_back( name, value );
+  }
+
+  void RemoveEnvironment( XrdApps::CommandInvocation &invocation,
+                          const std::string &name )
+  {
+    invocation.environment.erase(
+      std::remove_if( invocation.environment.begin(),
+                      invocation.environment.end(),
+                      [&name]( const auto &entry ) { return entry.first == name; } ),
+      invocation.environment.end() );
+  }
+
+  void UnsetEnvironment( XrdApps::CommandInvocation &invocation,
+                         const std::string &name )
+  {
+    if( std::find( invocation.environmentToUnset.begin(),
+                   invocation.environmentToUnset.end(), name ) ==
+        invocation.environmentToUnset.end() )
+      invocation.environmentToUnset.emplace_back( name );
+  }
+
+  void AddTranslatedFlag( TranslatedOptions &options,
+                          const std::string &flag )
+  {
+    if( std::find( options.flags.begin(), options.flags.end(), flag ) ==
+        options.flags.end() )
+    {
+      options.flags.emplace_back( flag );
+      options.arguments.emplace_back( flag );
+    }
+  }
+
+  void SetTranslatedOption( TranslatedOptions &options,
+                            const std::string &name,
+                            const std::string &value )
+  {
+    for( const auto &entry : options.valueIndexes )
+    {
+      if( entry.first == name )
+      {
+        options.arguments[entry.second] = value;
+        return;
+      }
+    }
+
+    options.arguments.emplace_back( name );
+    options.arguments.emplace_back( value );
+    options.valueIndexes.emplace_back( name, options.arguments.size() - 1 );
+  }
+
+  void RemoveTranslatedOption( TranslatedOptions &options,
+                               const std::string &name )
+  {
+    for( auto entry = options.valueIndexes.begin();
+         entry != options.valueIndexes.end(); ++entry )
+    {
+      if( entry->first != name )
+        continue;
+
+      const std::size_t valueIndex = entry->second;
+      options.arguments.erase( options.arguments.begin() + valueIndex - 1,
+                               options.arguments.begin() + valueIndex + 1 );
+      options.valueIndexes.erase( entry );
+      for( auto &remaining : options.valueIndexes )
+      {
+        if( remaining.second > valueIndex )
+          remaining.second -= 2;
+      }
+      return;
+    }
+  }
+
+  std::string NormalizeChecksum( std::string checksum )
+  {
+    const std::size_t separator = checksum.find( ':' );
+    const std::size_t algorithmLength = separator == std::string::npos
+                                      ? checksum.size() : separator;
+    std::transform( checksum.begin(), checksum.begin() + algorithmLength,
+                    checksum.begin(), []( unsigned char character )
+    {
+      return static_cast<char>( std::tolower( character ) );
+    } );
+    return checksum;
+  }
+
+  bool ApplyOption( const OptionSpec &option, const std::string &displayName,
+                    const std::string &argument,
+                    XrdApps::CommandLineResult &result, ParseState &state,
+                    TranslatedOptions &translatedOptions )
+  {
+    switch( option.action )
+    {
+      case OptionAction::Help:
+        result.action = XrdApps::CommandLineAction::Help;
+        return false;
+      case OptionAction::Version:
+        result.action = XrdApps::CommandLineAction::Version;
+        return false;
+      case OptionAction::Verbose:
+        ++state.verbosity;
+        return true;
+      case OptionAction::Timeout:
+      {
+        std::string normalized;
+        if( !NormalizeInteger( argument, normalized, 0 ) )
+        {
+          result.error = displayName + " requires a non-negative integer";
+          return false;
+        }
+        if( normalized == "0" )
+          RemoveEnvironment( result.invocation, "XRD_REQUESTTIMEOUT" );
+        else
+          SetEnvironment( result.invocation, "XRD_REQUESTTIMEOUT", normalized );
+        return true;
+      }
+      case OptionAction::Certificate:
+        if( argument.empty() )
+        {
+          result.error = displayName + " requires a non-empty file name";
+          return false;
+        }
+        state.certificateSpecified = true;
+        state.certificate = argument;
+        return true;
+      case OptionAction::Key:
+        if( argument.empty() )
+        {
+          result.error = displayName + " requires a non-empty file name";
+          return false;
+        }
+        state.keySpecified = true;
+        state.key = argument;
+        return true;
+      case OptionAction::IPv4:
+      case OptionAction::IPv6:
+      {
+        const std::string value = option.action == OptionAction::IPv4
+                                ? "IPv4" : "IPv6";
+        if( !state.networkStack.empty() && state.networkStack != value )
+        {
+          result.error = "-4 and -6 are mutually exclusive";
+          return false;
+        }
+        state.networkStack = value;
+        SetEnvironment( result.invocation, "XRD_NETWORKSTACK", value );
+        return true;
+      }
+      case OptionAction::LogFile:
+        SetEnvironment( result.invocation, "XRD_LOGFILE", argument );
+        return true;
+      case OptionAction::Forward:
+        if( option.takesValue )
+          SetTranslatedOption( translatedOptions, option.value, argument );
+        else
+          AddTranslatedFlag( translatedOptions, option.value );
+        return true;
+      case OptionAction::Ignore:
+        return true;
+      case OptionAction::Warn:
+        result.invocation.warnings.emplace_back( option.value );
+        return true;
+      case OptionAction::Reject:
+        result.error = displayName + ": " + option.value;
+        return false;
+      case OptionAction::CopyTimeout:
+      {
+        std::string normalized;
+        if( !NormalizeInteger( argument, normalized, 0 ) )
+        {
+          result.error = displayName + " requires a non-negative integer";
+          return false;
+        }
+        SetEnvironment( result.invocation, "XRD_CPTIMEOUT", normalized );
+        return true;
+      }
+      case OptionAction::CopyFromFile:
+        if( argument.empty() )
+        {
+          result.error = displayName + " requires a non-empty file name";
+          return false;
+        }
+        state.fromFile = true;
+        SetTranslatedOption( translatedOptions, "--infiles", argument );
+        return true;
+      case OptionAction::CopyStreams:
+      {
+        std::string normalized;
+        if( !NormalizeInteger( argument, normalized, 0, 15 ) )
+        {
+          result.error = displayName + " requires an integer from 0 to 15";
+          return false;
+        }
+        if( normalized == "0" )
+          RemoveTranslatedOption( translatedOptions, "--streams" );
+        else
+          SetTranslatedOption( translatedOptions, "--streams", normalized );
+        return true;
+      }
+      case OptionAction::CopyChecksum:
+        if( argument.empty() || argument[0] == ':' )
+        {
+          result.error = displayName + " requires a checksum algorithm";
+          return false;
+        }
+        SetTranslatedOption( translatedOptions, "--cksum",
+                             NormalizeChecksum( argument ) );
+        return true;
+      case OptionAction::Color:
+        if( argument == "never" || argument == "auto" )
+          return true;
+        if( argument == "always" )
+        {
+          result.error = "--color=always requires native xrdfs output support";
+          return false;
+        }
+        result.error = "--color must be one of always, never, or auto";
+        return false;
+    }
+    return false;
+  }
+
+  bool IsOptionToken( const std::string &value )
+  {
+    return value.size() > 1 && value[0] == '-';
+  }
+
+  template<std::size_t Size>
+  bool ParseOptions( const std::vector<std::string> &arguments,
+                     const OptionSpec (&commandOptions)[Size],
+                     XrdApps::CommandLineResult &result, ParseState &state,
+                     TranslatedOptions &translatedOptions,
+                     std::vector<std::string> &operands )
+  {
+    bool optionsEnabled = true;
+    for( std::size_t index = 0; index < arguments.size(); ++index )
+    {
+      const std::string &token = arguments[index];
+      if( optionsEnabled && token == "--" )
+      {
+        optionsEnabled = false;
+        continue;
+      }
+
+      if( optionsEnabled && token.size() > 2 && token.compare( 0, 2, "--" ) == 0 )
+      {
+        const std::size_t separator = token.find( '=' );
+        const std::string name = token.substr( 2, separator == std::string::npos
+                                                 ? std::string::npos
+                                                 : separator - 2 );
+        bool isCommon = false;
+        const OptionSpec *option = FindLongOption( name, commandOptions, isCommon );
+        (void)isCommon;
+        if( !option )
+        {
+          result.error = "unknown option '--" + name + "'";
+          return false;
+        }
+
+        std::string value;
+        if( option->takesValue )
+        {
+          if( separator != std::string::npos )
+            value = token.substr( separator + 1 );
+          else if( index + 1 < arguments.size() &&
+                   !IsOptionToken( arguments[index + 1] ) )
+            value = arguments[++index];
+          else
+          {
+            result.error = "option '--" + name + "' requires an argument";
+            return false;
+          }
+        }
+        else if( separator != std::string::npos )
+        {
+          result.error = "option '--" + name + "' does not take an argument";
+          return false;
+        }
+
+        if( !ApplyOption( *option, "--" + name, value, result, state,
+                          translatedOptions ) )
+          return false;
+        continue;
+      }
+
+      if( optionsEnabled && token.size() > 1 && token[0] == '-' && token != "-" )
+      {
+        for( std::size_t position = 1; position < token.size(); ++position )
+        {
+          const char name = token[position];
+          bool isCommon = false;
+          const OptionSpec *option = FindShortOption( name, commandOptions, isCommon );
+          (void)isCommon;
+          if( !option )
+          {
+            result.error = std::string( "unknown option '-" ) + name + "'";
+            return false;
+          }
+
+          std::string value;
+          if( option->takesValue )
+          {
+            if( position + 1 < token.size() )
+            {
+              value = token.substr( position + 1 );
+              position = token.size();
+            }
+            else if( index + 1 < arguments.size() &&
+                     !IsOptionToken( arguments[index + 1] ) )
+              value = arguments[++index];
+            else
+            {
+              result.error = std::string( "option '-" ) + name +
+                             "' requires an argument";
+              return false;
+            }
+          }
+
+          if( !ApplyOption( *option, std::string( "-" ) + name, value,
+                            result, state, translatedOptions ) )
+            return false;
+          if( option->takesValue )
+            break;
+        }
+        continue;
+      }
+
+      if( !optionsEnabled && result.command == "copy" && token.size() > 1 &&
+          token[0] == '-' )
+        operands.emplace_back( "./" + token );
+      else
+        operands.emplace_back( token );
+    }
+    return true;
+  }
+
+  bool IsCompleteRemoteURL( const std::string &value )
+  {
+    const std::size_t separator = value.find( "://" );
+    if( separator == std::string::npos || separator == 0 ||
+        std::isalpha( static_cast<unsigned char>( value[0] ) ) == 0 )
+      return false;
+
+    for( std::size_t index = 1; index < separator; ++index )
+    {
+      const unsigned char character = value[index];
+      if( std::isalnum( character ) == 0 && character != '+' &&
+          character != '-' && character != '.' )
+        return false;
+    }
+
+    std::string protocol = value.substr( 0, separator );
+    std::transform( protocol.begin(), protocol.end(), protocol.begin(),
+                    []( unsigned char character )
+    {
+      return static_cast<char>( std::tolower( character ) );
+    } );
+    if( protocol == "file" || protocol == "stdio" )
+      return false;
+
+    const std::size_t authority = separator + 3;
+    return authority < value.size() && value[authority] != '/' &&
+           value[authority] != '?' && value[authority] != '#';
+  }
+
+  void ApplyCredentialOptions( XrdApps::CommandLineResult &result,
+                               const ParseState &state )
+  {
+    if( !state.certificateSpecified )
+    {
+      if( state.keySpecified )
+        result.invocation.warnings.emplace_back(
+          "--key was ignored because --cert was not provided" );
+      return;
+    }
+
+    const std::string &key = state.keySpecified ? state.key : state.certificate;
+    SetEnvironment( result.invocation, "X509_USER_CERT", state.certificate );
+    SetEnvironment( result.invocation, "X509_USER_KEY", key );
+    SetEnvironment( result.invocation, "XrdSecGSIUSERCERT", state.certificate );
+    SetEnvironment( result.invocation, "XrdSecGSIUSERKEY", key );
+    SetEnvironment( result.invocation, "XrdSecGSIUSERPROXY", state.certificate );
+    SetEnvironment( result.invocation, "XRD_HTTPCLIENTCERTFILE",
+                    state.certificate );
+    SetEnvironment( result.invocation, "XRD_HTTPCLIENTKEYFILE", key );
+    UnsetEnvironment( result.invocation, "X509_USER_PROXY" );
+    UnsetEnvironment( result.invocation, "XrdSecCREDS" );
+  }
+
+  bool ValidateOperands( XrdApps::CommandLineResult &result,
+                         const ParseState &state,
+                         const std::vector<std::string> &operands )
+  {
+    if( result.command == "stat" || result.command == "ls" )
+    {
+      if( operands.size() != 1 )
+      {
+        result.error = "xrd " + result.command + " requires exactly one URL";
+        return false;
+      }
+      if( !IsCompleteRemoteURL( operands[0] ) )
+      {
+        result.error = "xrd " + result.command +
+                       " requires a complete remote URL";
+        return false;
+      }
+      return true;
+    }
+
+    if( result.command == "cat" )
+    {
+      if( operands.empty() )
+      {
+        result.error = "xrd cat requires at least one URL";
+        return false;
+      }
+      if( !std::all_of( operands.begin(), operands.end(), IsCompleteRemoteURL ) )
+      {
+        result.error = "xrd cat requires complete remote URLs";
+        return false;
+      }
+      return true;
+    }
+
+    if( result.command == "xattr" )
+    {
+      if( operands.empty() || operands.size() > 2 )
+      {
+        result.error = "xrd xattr requires a URL and optional attribute name";
+        return false;
+      }
+      if( !IsCompleteRemoteURL( operands[0] ) )
+      {
+        result.error = "xrd xattr requires a complete remote URL";
+        return false;
+      }
+      if( operands.size() == 2 && operands[1].find( '=' ) != std::string::npos )
+      {
+        result.error = "xrd xattr currently supports read-only list/get operations";
+        return false;
+      }
+      return true;
+    }
+
+    if( result.command == "copy" )
+    {
+      const std::size_t expected = state.fromFile ? 1 : 2;
+      if( operands.size() != expected )
+      {
+        if( state.fromFile )
+          result.error = "xrd copy --from-file requires one destination";
+        else if( operands.size() > 2 )
+          result.error = "xrd copy does not yet support chained destinations";
+        else
+          result.error = "xrd copy requires one source and one destination";
+        return false;
+      }
+      return true;
+    }
+
+    return false;
+  }
+
+  template<std::size_t Size>
+  XrdApps::CommandLineResult ParseCommand(
+    const std::string &command, const std::vector<std::string> &arguments,
+    const OptionSpec (&commandOptions)[Size] )
+  {
+    XrdApps::CommandLineResult result;
+    result.command = command;
+    result.invocation.executable = command == "copy" ? "xrdcp" : "xrdfs";
+
+    ParseState state;
+    TranslatedOptions translatedOptions;
+    std::vector<std::string> operands;
+    if( !ParseOptions( arguments, commandOptions, result, state,
+                       translatedOptions, operands ) )
+    {
+      if( result.action != XrdApps::CommandLineAction::Help &&
+          result.action != XrdApps::CommandLineAction::Version )
+        result.action = XrdApps::CommandLineAction::Error;
+      return result;
+    }
+
+    if( !ValidateOperands( result, state, operands ) )
+    {
+      result.action = XrdApps::CommandLineAction::Error;
+      return result;
+    }
+
+    ApplyCredentialOptions( result, state );
+
+    if( state.verbosity != 0 )
+    {
+      const char *level = state.verbosity == 1 ? "Warning"
+                        : state.verbosity == 2 ? "Info" : "Debug";
+      SetEnvironment( result.invocation, "XRD_LOGLEVEL", level );
+    }
+
+    if( command == "xattr" )
+    {
+      result.invocation.arguments.emplace_back( command );
+      result.invocation.arguments.emplace_back( operands[0] );
+      result.invocation.arguments.emplace_back( operands.size() == 1
+                                                ? "list" : "get" );
+      if( operands.size() == 2 )
+        result.invocation.arguments.emplace_back( operands[1] );
+      result.action = XrdApps::CommandLineAction::Execute;
+      return result;
+    }
+
+    if( command != "copy" )
+      result.invocation.arguments.emplace_back( command );
+    result.invocation.arguments.insert( result.invocation.arguments.end(),
+                                        translatedOptions.arguments.begin(),
+                                        translatedOptions.arguments.end() );
+    result.invocation.arguments.insert( result.invocation.arguments.end(),
+                                        operands.begin(), operands.end() );
+    result.action = XrdApps::CommandLineAction::Execute;
+    return result;
+  }
+
+  constexpr OptionSpec NoOptions[] = {
+    {0, nullptr, false, OptionAction::Ignore, nullptr},
+  };
+}
+
+namespace XrdApps
+{
+  CommandLineResult ParseCommandLine( const std::vector<std::string> &arguments )
+  {
+    if( arguments.empty() )
+    {
+      CommandLineResult result;
+      result.action = CommandLineAction::Help;
+      return result;
+    }
+
+    if( arguments[0] == "-h" || arguments[0] == "--help" )
+    {
+      CommandLineResult result;
+      result.action = CommandLineAction::Help;
+      return result;
+    }
+    if( arguments[0] == "-V" || arguments[0] == "--version" )
+    {
+      CommandLineResult result;
+      result.action = CommandLineAction::Version;
+      return result;
+    }
+
+    std::string command = arguments[0];
+    if( command == "cp" )
+      command = "copy";
+    const std::vector<std::string> commandArguments( arguments.begin() + 1,
+                                                     arguments.end() );
+
+    if( command == "stat" )
+      return ParseCommand( command, commandArguments, NoOptions );
+    if( command == "ls" )
+      return ParseCommand( command, commandArguments, LsOptions );
+    if( command == "cat" )
+      return ParseCommand( command, commandArguments, CatOptions );
+    if( command == "xattr" )
+      return ParseCommand( command, commandArguments, NoOptions );
+    if( command == "copy" )
+      return ParseCommand( command, commandArguments, CopyOptions );
+
+    CommandLineResult result;
+    result.command = command;
+    result.error = "unknown command '" + command + "'";
+    return result;
+  }
+}

--- a/src/XrdApps/XrdCliCommandLine.hh
+++ b/src/XrdApps/XrdCliCommandLine.hh
@@ -1,0 +1,62 @@
+/******************************************************************************/
+/*                                                                            */
+/*                 X r d C l i C o m m a n d L i n e . h h                  */
+/*                                                                            */
+/* (c) 2026 by the XRootD Collaboration                                       */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/******************************************************************************/
+
+#ifndef __XRD_APPS_CLI_COMMAND_LINE_HH__
+#define __XRD_APPS_CLI_COMMAND_LINE_HH__
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace XrdApps
+{
+  enum class CommandLineAction
+  {
+    Execute,
+    Help,
+    Version,
+    Error
+  };
+
+  struct CommandInvocation
+  {
+    std::string executable;
+    std::vector<std::string> arguments;
+    std::vector<std::pair<std::string, std::string>> environment;
+    std::vector<std::string> environmentToUnset;
+    std::vector<std::string> warnings;
+  };
+
+  struct CommandLineResult
+  {
+    CommandLineAction action = CommandLineAction::Error;
+    std::string command;
+    CommandInvocation invocation;
+    std::string error;
+  };
+
+  CommandLineResult ParseCommandLine( const std::vector<std::string> &arguments );
+}
+
+#endif // __XRD_APPS_CLI_COMMAND_LINE_HH__

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -38,6 +38,7 @@
 #include "XrdSys/XrdSysE2T.hh"
 
 #include <algorithm>
+#include <cctype>
 #include <cstdlib>
 #include <cstdio>
 #include <getopt.h>
@@ -76,7 +77,30 @@ namespace
 
   bool IsCompleteURL( const std::string &argument )
   {
-    return argument.find( "://" ) != std::string::npos;
+    const std::size_t separator = argument.find( "://" );
+    if( separator == std::string::npos || separator == 0 ||
+        std::isalpha( static_cast<unsigned char>( argument[0] ) ) == 0 )
+      return false;
+
+    for( std::size_t i = 1; i < separator; ++i )
+    {
+      const unsigned char character = argument[i];
+      if( std::isalnum( character ) == 0 && character != '+' &&
+          character != '-' && character != '.' )
+        return false;
+    }
+    return true;
+  }
+
+  bool IsPathOperand( const FSExecutor::CommandParams &arguments,
+                      std::size_t index )
+  {
+    if( arguments[0] == "xattr" )
+      return index == 1;
+    if( arguments[0] == "prepare" && index > 1 &&
+        (arguments[index - 1] == "-a" || arguments[index - 1] == "-p") )
+      return false;
+    return true;
   }
 
   URL EndpointURL( const URL &url )
@@ -120,14 +144,19 @@ namespace
     bool foundURL = false;
     for( std::size_t i = 1; i < arguments.size(); ++i )
     {
-      if( !IsCompleteURL( arguments[i] ) )
+      if( !IsPathOperand( arguments, i ) || !IsCompleteURL( arguments[i] ) )
         continue;
 
       URL operand( arguments[i] );
+      std::string protocol = operand.GetProtocol();
+      std::transform( protocol.begin(), protocol.end(), protocol.begin(),
+                      []( unsigned char character )
+      {
+        return static_cast<char>( std::tolower( character ) );
+      } );
       if( !operand.IsValid() || operand.GetProtocol().empty()
           || operand.GetHostName().empty()
-          || operand.GetProtocol() == "file"
-          || operand.GetProtocol() == "stdio" )
+          || protocol == "file" || protocol == "stdio" )
       {
         error = "invalid remote URL operand";
         return InvalidURLCommand;

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -37,10 +37,13 @@
 #include "XrdOuc/XrdOucPrivateUtils.hh"
 #include "XrdSys/XrdSysE2T.hh"
 
+#include <algorithm>
 #include <cstdlib>
 #include <cstdio>
+#include <getopt.h>
 #include <iostream>
 #include <iomanip>
+#include <iterator>
 #include <cmath>
 
 #ifdef HAVE_READLINE
@@ -49,6 +52,105 @@
 #endif
 
 using namespace XrdCl;
+
+namespace
+{
+  enum URLCommandResult
+  {
+    NotURLCommand,
+    ValidURLCommand,
+    InvalidURLCommand
+  };
+
+  bool SupportsFullURLs( const std::string &command )
+  {
+    static const char *commands[] = {
+      "cache", "cat", "chmod", "locate", "ls", "mkdir", "mv",
+      "prepare", "rm", "rmdir", "spaceinfo", "stat", "statvfs",
+      "tail", "truncate", "xattr"
+    };
+
+    return std::find( std::begin( commands ), std::end( commands ), command )
+           != std::end( commands );
+  }
+
+  bool IsCompleteURL( const std::string &argument )
+  {
+    return argument.find( "://" ) != std::string::npos;
+  }
+
+  URL EndpointURL( const URL &url )
+  {
+    URL endpoint( url );
+    endpoint.SetPath( "" );
+    endpoint.SetParams( URL::ParamsMap() );
+    return endpoint;
+  }
+
+  std::string OperandPath( const URL &url )
+  {
+    std::string path = url.GetPathWithParams();
+    if( path.empty() || path[0] != '/' )
+      path.insert( path.begin(), '/' );
+    return path;
+  }
+
+  URLCommandResult ParseURLCommand( FSExecutor::CommandParams &arguments,
+                                    URL &endpoint, std::string &error )
+  {
+    if( arguments.empty() )
+      return NotURLCommand;
+
+    if( arguments[0] == "query" )
+    {
+      for( std::size_t i = 1; i < arguments.size(); ++i )
+      {
+        if( IsCompleteURL( arguments[i] ) )
+        {
+          error = "command-first full URLs are not supported for 'query'";
+          return InvalidURLCommand;
+        }
+      }
+      return NotURLCommand;
+    }
+
+    if( !SupportsFullURLs( arguments[0] ) )
+      return NotURLCommand;
+
+    bool foundURL = false;
+    for( std::size_t i = 1; i < arguments.size(); ++i )
+    {
+      if( !IsCompleteURL( arguments[i] ) )
+        continue;
+
+      URL operand( arguments[i] );
+      if( !operand.IsValid() || operand.GetProtocol().empty()
+          || operand.GetHostName().empty()
+          || operand.GetProtocol() == "file"
+          || operand.GetProtocol() == "stdio" )
+      {
+        error = "invalid remote URL operand";
+        return InvalidURLCommand;
+      }
+
+      URL operandEndpoint = EndpointURL( operand );
+      if( !foundURL )
+      {
+        endpoint = operandEndpoint;
+        foundURL = true;
+      }
+      else if( endpoint.GetURL() != operandEndpoint.GetURL() )
+      {
+        error = "all URL operands must use the same endpoint";
+        return InvalidURLCommand;
+      }
+
+      arguments[i] = OperandPath( operand );
+    }
+
+    return foundURL ? ValidURLCommand : NotURLCommand;
+  }
+}
 
 //------------------------------------------------------------------------------
 // Build a path
@@ -1959,6 +2061,7 @@ XRootDStatus PrintHelp( FileSystem *, Env *,
   printf( "Usage:\n"                                                          );
   printf( "   xrdfs [--no-cwd] host[:port]              - interactive mode\n" );
   printf( "   xrdfs            host[:port] command args - batch mode\n\n"     );
+  printf( "   xrdfs            command args-with-URLs   - URL batch mode\n\n" );
 
   printf( "Available options:\n\n"                                            );
 
@@ -2135,15 +2238,8 @@ FSExecutor *CreateExecutor( const URL &url )
 //------------------------------------------------------------------------------
 // Execute command
 //------------------------------------------------------------------------------
-int ExecuteCommand( FSExecutor *ex, int argc, char **argv )
+int ExecuteCommand( FSExecutor *ex, const FSExecutor::CommandParams &args )
 {
-  // std::vector<std::string> args (argv, argv + argc);
-  std::vector<std::string> args;
-  args.reserve(argc);
-  for (int i = 0; i < argc; ++i)
-  {
-    args.push_back(argv[i]);
-  }
   XRootDStatus st = ex->Execute( args );
   if( !st.IsOK() )
     std::cerr << st.ToStr() << std::endl;
@@ -2326,21 +2422,11 @@ int ExecuteInteractive( const URL &url, bool noCwd = false )
 //------------------------------------------------------------------------------
 // Execute command
 //------------------------------------------------------------------------------
-int ExecuteCommand( const URL &url, int argc, char **argv )
+int ExecuteCommand( const URL &url, const FSExecutor::CommandParams &args )
 {
-  //----------------------------------------------------------------------------
-  // Build the command to be executed
-  //----------------------------------------------------------------------------
-  std::string commandline;
-  for( int i = 0; i < argc; ++i )
-  {
-    commandline += argv[i];
-    commandline += " ";
-  }
-
   FSExecutor *ex = CreateExecutor( url );
   ex->GetEnv()->PutInt( "NoCWD", 1 );
-  int st = ExecuteCommand( ex, argc, argv );
+  int st = ExecuteCommand( ex, args );
   delete ex;
   return st;
 }
@@ -2350,40 +2436,62 @@ int ExecuteCommand( const URL &url, int argc, char **argv )
 //------------------------------------------------------------------------------
 int main( int argc, char **argv )
 {
-  //----------------------------------------------------------------------------
-  // Check the commandline parameters
-  //----------------------------------------------------------------------------
   XrdCl::FSExecutor::CommandParams params;
-  if( argc == 1 )
+  enum { NoCwdOption = 256 };
+  static const option options[] = {
+    { "help",   no_argument, 0, 'h' },
+    { "no-cwd", no_argument, 0, NoCwdOption },
+    { 0, 0, 0, 0 }
+  };
+
+  bool noCwd = false;
+  opterr = 0;
+  int option = 0;
+  while( (option = getopt_long( argc, argv, "+h", options, 0 )) != -1 )
+  {
+    switch( option )
+    {
+      case 'h':
+        PrintHelp( 0, 0, params );
+        return 0;
+      case NoCwdOption:
+        noCwd = true;
+        break;
+      default:
+        PrintHelp( 0, 0, params );
+        return 1;
+    }
+  }
+
+  if( optind == argc )
   {
     PrintHelp( 0, 0, params );
     return 1;
   }
 
-  if( !strcmp( argv[1], "--help" ) ||
-      !strcmp( argv[1], "-h" ) )
+  FSExecutor::CommandParams arguments( argv + optind, argv + argc );
+  URL url;
+  std::string error;
+  URLCommandResult result = ParseURLCommand( arguments, url, error );
+  if( result == InvalidURLCommand )
   {
-    PrintHelp( 0, 0, params );
-    return 0;
+    std::cerr << "xrdfs: " << error << std::endl;
+    return 1;
   }
 
-  bool noCwd = false;
-  int urlIndex = 1;
-  if( !strcmp( argv[1], "--no-cwd") )
-  {
-    ++urlIndex;
-    noCwd = true;
-  }
+  if( result == ValidURLCommand )
+    return ExecuteCommand( url, arguments );
 
-  URL url( argv[urlIndex] );
+  url = URL( arguments[0] );
   if( !url.IsValid() )
   {
     PrintHelp( 0, 0, params );
     return 1;
   }
 
-  if( argc == urlIndex + 1 )
+  if( arguments.size() == 1 )
     return ExecuteInteractive( url, noCwd );
-  int shift = urlIndex + 1;
-  return ExecuteCommand( url, argc-shift, argv+shift );
+
+  arguments.erase( arguments.begin() );
+  return ExecuteCommand( url, arguments );
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ if(NOT ENABLE_SERVER_TESTS)
   return()
 endif()
 
+add_subdirectory(end-to-end)
+
 add_subdirectory(krb5)
 add_subdirectory(scitokens)
 add_subdirectory(tls)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(unit)
 add_subdirectory(common)
 
 add_subdirectory(XrdCl)
+add_subdirectory(XrdApps)
 add_subdirectory(XrdCeph)
 add_subdirectory(XrdEc)
 add_subdirectory(XrdPosix)

--- a/tests/XrdApps/CMakeLists.txt
+++ b/tests/XrdApps/CMakeLists.txt
@@ -1,0 +1,33 @@
+add_executable(xrd-cli-unit-tests
+  XrdCliCommandLineTest.cc
+  ${PROJECT_SOURCE_DIR}/src/XrdApps/XrdCliCommandLine.cc
+)
+
+set_target_properties(xrd-cli-unit-tests PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED TRUE
+)
+
+target_link_libraries(xrd-cli-unit-tests
+  GTest::gtest
+  GTest::gtest_main
+)
+
+gtest_discover_tests(xrd-cli-unit-tests
+  TEST_PREFIX XrdApps::xrd-cli::
+  PROPERTIES DISCOVERY_TIMEOUT 10
+)
+
+if(TARGET xrd)
+  set(XRD_CLI_DELEGATION_ENV
+    "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
+    "XRD=$<TARGET_FILE:xrd>"
+  )
+
+  add_test(NAME XrdApps::xrd-cli-delegation
+    COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
+            ${CMAKE_CURRENT_SOURCE_DIR}/xrd-cli-delegation.bats)
+
+  set_tests_properties(XrdApps::xrd-cli-delegation PROPERTIES
+    ENVIRONMENT "${XRD_CLI_DELEGATION_ENV}")
+endif()

--- a/tests/XrdApps/XrdCliCommandLineTest.cc
+++ b/tests/XrdApps/XrdCliCommandLineTest.cc
@@ -1,0 +1,360 @@
+/******************************************************************************/
+/*                                                                            */
+/*              X r d C l i C o m m a n d L i n e T e s t . c c             */
+/*                                                                            */
+/* (c) 2026 by the XRootD Collaboration                                       */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/******************************************************************************/
+
+#include "XrdApps/XrdCliCommandLine.hh"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace
+{
+  using XrdApps::CommandLineAction;
+  using XrdApps::CommandLineResult;
+  using XrdApps::ParseCommandLine;
+
+  const std::string *EnvironmentValue( const CommandLineResult &result,
+                                       const std::string &name )
+  {
+    for( const auto &entry : result.invocation.environment )
+    {
+      if( entry.first == name )
+        return &entry.second;
+    }
+    return nullptr;
+  }
+
+  bool EnvironmentIsUnset( const CommandLineResult &result,
+                           const std::string &name )
+  {
+    for( const std::string &entry : result.invocation.environmentToUnset )
+    {
+      if( entry == name )
+        return true;
+    }
+    return false;
+  }
+
+  TEST( XrdCliCommandLine, ShowsTopLevelHelpWithoutArguments )
+  {
+    const CommandLineResult result = ParseCommandLine( {} );
+    EXPECT_EQ( result.action, CommandLineAction::Help );
+    EXPECT_TRUE( result.command.empty() );
+  }
+
+  TEST( XrdCliCommandLine, DelegatesStatToXrdfs )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"stat", "root://host//file"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.executable, "xrdfs" );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"stat", "root://host//file"}) );
+  }
+
+  TEST( XrdCliCommandLine, TranslatesCommonOptionsToEnvironment )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"stat", "-vv", "--timeout=+0030", "--cert", "/tmp/cert",
+       "--key=/tmp/key", "-4", "--log-file", "/tmp/xrd.log",
+       "root://host//file"} );
+
+    ASSERT_EQ( result.action, CommandLineAction::Execute );
+    ASSERT_NE( EnvironmentValue( result, "XRD_LOGLEVEL" ), nullptr );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_LOGLEVEL" ), "Info" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_REQUESTTIMEOUT" ), "30" );
+    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_CERT" ), "/tmp/cert" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTCERTFILE" ),
+               "/tmp/cert" );
+    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_KEY" ), "/tmp/key" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTKEYFILE" ),
+               "/tmp/key" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_NETWORKSTACK" ), "IPv4" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_LOGFILE" ), "/tmp/xrd.log" );
+    EXPECT_TRUE( EnvironmentIsUnset( result, "X509_USER_PROXY" ) );
+    EXPECT_TRUE( EnvironmentIsUnset( result, "XrdSecCREDS" ) );
+  }
+
+  TEST( XrdCliCommandLine, DefaultsCredentialKeyToCertificate )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"stat", "--cert", "/tmp/proxy.pem", "root://host//file"} );
+
+    ASSERT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_CERT" ),
+               "/tmp/proxy.pem" );
+    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_KEY" ),
+               "/tmp/proxy.pem" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTCERTFILE" ),
+               "/tmp/proxy.pem" );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTKEYFILE" ),
+               "/tmp/proxy.pem" );
+    EXPECT_EQ( *EnvironmentValue( result, "XrdSecGSIUSERCERT" ),
+               "/tmp/proxy.pem" );
+    EXPECT_EQ( *EnvironmentValue( result, "XrdSecGSIUSERKEY" ),
+               "/tmp/proxy.pem" );
+    EXPECT_EQ( *EnvironmentValue( result, "XrdSecGSIUSERPROXY" ),
+               "/tmp/proxy.pem" );
+    EXPECT_TRUE( EnvironmentIsUnset( result, "X509_USER_PROXY" ) );
+    EXPECT_TRUE( EnvironmentIsUnset( result, "XrdSecCREDS" ) );
+  }
+
+  TEST( XrdCliCommandLine, AcceptsIgnoredCommonOptionsWithWarnings )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"stat", "-D", "X=Y", "--client-info", "workflow",
+       "root://host//file"} );
+
+    ASSERT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.warnings.size(), 2U );
+  }
+
+  TEST( XrdCliCommandLine, DropsCatBytesAndPreservesMultipleUrls )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"cat", "-b", "root://host//one", "root://host//two"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"cat", "root://host//one",
+                                         "root://host//two"}) );
+  }
+
+  TEST( XrdCliCommandLine, TranslatesCombinedLsOptions )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"ls", "-alH", "root://host//directory"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"ls", "-l", "-h",
+                                         "root://host//directory"}) );
+  }
+
+  TEST( XrdCliCommandLine, DelegatesXAttrListAndGetToXrdfs )
+  {
+    const CommandLineResult list =
+      ParseCommandLine( {"xattr", "root://host//file"} );
+    const CommandLineResult get =
+      ParseCommandLine( {"xattr", "root://host//file", "user.name"} );
+
+    EXPECT_EQ( list.action, CommandLineAction::Execute );
+    EXPECT_EQ( list.invocation.arguments,
+               (std::vector<std::string>{"xattr", "root://host//file",
+                                         "list"}) );
+    EXPECT_EQ( get.action, CommandLineAction::Execute );
+    EXPECT_EQ( get.invocation.arguments,
+               (std::vector<std::string>{"xattr", "root://host//file",
+                                         "get", "user.name"}) );
+  }
+
+  TEST( XrdCliCommandLine, RejectsXAttrMutation )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"xattr", "root://host//file", "user.name=value"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "read-only" ), std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, AcceptsNonColoringLsModes )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"ls", "root://host//directory", "--color=auto"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"ls", "root://host//directory"}) );
+  }
+
+  TEST( XrdCliCommandLine, RejectsLsFormattingThatXrdfsCannotProvide )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"ls", "--time-style", "full-iso",
+                         "root://host//directory"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "native xrdfs output support" ),
+               std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, TranslatesCopyOptions )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"copy", "-fpr", "-n04", "-T0030", "-K", "ADLER32:01234567",
+       "root://host//file", "/tmp/file"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.executable, "xrdcp" );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"--force", "--path", "--recursive",
+                 "--streams", "4", "--cksum", "adler32:01234567",
+                 "root://host//file", "/tmp/file"}) );
+    EXPECT_EQ( *EnvironmentValue( result, "XRD_CPTIMEOUT" ), "30" );
+  }
+
+  TEST( XrdCliCommandLine, DeduplicatesFlagsAndUsesLastOptionValue )
+  {
+    const CommandLineResult listing =
+      ParseCommandLine( {"ls", "-llHH", "root://host//directory"} );
+    const CommandLineResult copy = ParseCommandLine(
+      {"copy", "-K", "MD5", "-K", "ADLER32", "--from-file", "one",
+       "--from-file", "two", "/tmp/output"} );
+
+    EXPECT_EQ( listing.invocation.arguments,
+               (std::vector<std::string>{"ls", "-l", "-h",
+                                         "root://host//directory"}) );
+    EXPECT_EQ( copy.invocation.arguments,
+               (std::vector<std::string>{"--cksum", "adler32", "--infiles",
+                                         "two", "/tmp/output"}) );
+  }
+
+  TEST( XrdCliCommandLine, SupportsCpAlias )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"cp", "root://host//file", "/tmp/file"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.command, "copy" );
+    EXPECT_EQ( result.invocation.executable, "xrdcp" );
+  }
+
+  TEST( XrdCliCommandLine, TranslatesCopyFromFile )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"copy", "--from-file=sources.txt", "/tmp/output"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"--infiles", "sources.txt",
+                                         "/tmp/output"}) );
+  }
+
+  TEST( XrdCliCommandLine, RejectsChainedCopyDestinations )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"copy", "root://host//source", "/tmp/one", "/tmp/two"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "chained destinations" ), std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, RejectsUnsupportedCopyOptions )
+  {
+    const CommandLineResult result = ParseCommandLine(
+      {"copy", "--tcp-buffersize", "4096", "root://host//source",
+       "/tmp/output"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "no xrdcp equivalent" ), std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, RejectsInvalidTimeout )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"stat", "-t-1", "root://host//file"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "non-negative integer" ), std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, AcceptsDisabledTimeouts )
+  {
+    const CommandLineResult common = ParseCommandLine(
+      {"stat", "-t30", "-t0", "root://host//file"} );
+    const CommandLineResult copy = ParseCommandLine(
+      {"copy", "-n4", "-n0", "-T0", "root://host//file", "/tmp/file"} );
+
+    EXPECT_EQ( common.action, CommandLineAction::Execute );
+    EXPECT_EQ( EnvironmentValue( common, "XRD_REQUESTTIMEOUT" ), nullptr );
+    ASSERT_NE( EnvironmentValue( copy, "XRD_CPTIMEOUT" ), nullptr );
+    EXPECT_EQ( *EnvironmentValue( copy, "XRD_CPTIMEOUT" ), "0" );
+    EXPECT_EQ( copy.invocation.arguments,
+               (std::vector<std::string>{"root://host//file", "/tmp/file"}) );
+  }
+
+  TEST( XrdCliCommandLine, DoesNotConsumeOptionsAsMissingValues )
+  {
+    const CommandLineResult certificate = ParseCommandLine(
+      {"stat", "--cert", "--help", "root://host//file"} );
+    const CommandLineResult fromFile = ParseCommandLine(
+      {"copy", "--from-file", "--force", "/tmp/output"} );
+
+    EXPECT_EQ( certificate.action, CommandLineAction::Error );
+    EXPECT_NE( certificate.error.find( "requires an argument" ),
+               std::string::npos );
+    EXPECT_EQ( fromFile.action, CommandLineAction::Error );
+    EXPECT_NE( fromFile.error.find( "requires an argument" ),
+               std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, PreservesDashPrefixedCopyOperandsAfterDelimiter )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"copy", "--", "-source", "-destination"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Execute );
+    EXPECT_EQ( result.invocation.arguments,
+               (std::vector<std::string>{"./-source", "./-destination"}) );
+  }
+
+  TEST( XrdCliCommandLine, RejectsNonUrlFilesystemOperands )
+  {
+    const CommandLineResult stat = ParseCommandLine( {"stat", "/tmp/file"} );
+    const CommandLineResult cat = ParseCommandLine(
+      {"cat", "root://host//one", "relative-file"} );
+
+    EXPECT_EQ( stat.action, CommandLineAction::Error );
+    EXPECT_NE( stat.error.find( "complete remote URL" ), std::string::npos );
+    EXPECT_EQ( cat.action, CommandLineAction::Error );
+    EXPECT_NE( cat.error.find( "complete remote URLs" ), std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, RejectsConflictingNetworkStacks )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"cat", "-4", "-6", "root://host//file"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "mutually exclusive" ), std::string::npos );
+  }
+
+  TEST( XrdCliCommandLine, ShowsPerCommandHelpWithoutOperands )
+  {
+    const CommandLineResult result = ParseCommandLine( {"ls", "--help"} );
+    EXPECT_EQ( result.action, CommandLineAction::Help );
+    EXPECT_EQ( result.command, "ls" );
+  }
+
+  TEST( XrdCliCommandLine, RejectsUnknownCommands )
+  {
+    const CommandLineResult result =
+      ParseCommandLine( {"mkdir", "root://host//directory"} );
+
+    EXPECT_EQ( result.action, CommandLineAction::Error );
+    EXPECT_NE( result.error.find( "unknown command" ), std::string::npos );
+  }
+}

--- a/tests/XrdApps/XrdCliCommandLineTest.cc
+++ b/tests/XrdApps/XrdCliCommandLineTest.cc
@@ -46,6 +46,19 @@ namespace
     return nullptr;
   }
 
+  void ExpectEnvironmentValue( const CommandLineResult &result,
+                               const std::string &name,
+                               const std::string &expected )
+  {
+    const std::string *value = EnvironmentValue( result, name );
+    if( value == nullptr )
+    {
+      ADD_FAILURE() << "Missing environment value: " << name;
+      return;
+    }
+    EXPECT_EQ( *value, expected );
+  }
+
   bool EnvironmentIsUnset( const CommandLineResult &result,
                            const std::string &name )
   {
@@ -83,17 +96,14 @@ namespace
        "root://host//file"} );
 
     ASSERT_EQ( result.action, CommandLineAction::Execute );
-    ASSERT_NE( EnvironmentValue( result, "XRD_LOGLEVEL" ), nullptr );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_LOGLEVEL" ), "Info" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_REQUESTTIMEOUT" ), "30" );
-    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_CERT" ), "/tmp/cert" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTCERTFILE" ),
-               "/tmp/cert" );
-    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_KEY" ), "/tmp/key" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTKEYFILE" ),
-               "/tmp/key" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_NETWORKSTACK" ), "IPv4" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_LOGFILE" ), "/tmp/xrd.log" );
+    ExpectEnvironmentValue( result, "XRD_LOGLEVEL", "Info" );
+    ExpectEnvironmentValue( result, "XRD_REQUESTTIMEOUT", "30" );
+    ExpectEnvironmentValue( result, "X509_USER_CERT", "/tmp/cert" );
+    ExpectEnvironmentValue( result, "XRD_HTTPCLIENTCERTFILE", "/tmp/cert" );
+    ExpectEnvironmentValue( result, "X509_USER_KEY", "/tmp/key" );
+    ExpectEnvironmentValue( result, "XRD_HTTPCLIENTKEYFILE", "/tmp/key" );
+    ExpectEnvironmentValue( result, "XRD_NETWORKSTACK", "IPv4" );
+    ExpectEnvironmentValue( result, "XRD_LOGFILE", "/tmp/xrd.log" );
     EXPECT_TRUE( EnvironmentIsUnset( result, "X509_USER_PROXY" ) );
     EXPECT_TRUE( EnvironmentIsUnset( result, "XrdSecCREDS" ) );
   }
@@ -104,20 +114,15 @@ namespace
       {"stat", "--cert", "/tmp/proxy.pem", "root://host//file"} );
 
     ASSERT_EQ( result.action, CommandLineAction::Execute );
-    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_CERT" ),
-               "/tmp/proxy.pem" );
-    EXPECT_EQ( *EnvironmentValue( result, "X509_USER_KEY" ),
-               "/tmp/proxy.pem" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTCERTFILE" ),
-               "/tmp/proxy.pem" );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_HTTPCLIENTKEYFILE" ),
-               "/tmp/proxy.pem" );
-    EXPECT_EQ( *EnvironmentValue( result, "XrdSecGSIUSERCERT" ),
-               "/tmp/proxy.pem" );
-    EXPECT_EQ( *EnvironmentValue( result, "XrdSecGSIUSERKEY" ),
-               "/tmp/proxy.pem" );
-    EXPECT_EQ( *EnvironmentValue( result, "XrdSecGSIUSERPROXY" ),
-               "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "X509_USER_CERT", "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "X509_USER_KEY", "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "XRD_HTTPCLIENTCERTFILE",
+                            "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "XRD_HTTPCLIENTKEYFILE",
+                            "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "XrdSecGSIUSERCERT", "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "XrdSecGSIUSERKEY", "/tmp/proxy.pem" );
+    ExpectEnvironmentValue( result, "XrdSecGSIUSERPROXY", "/tmp/proxy.pem" );
     EXPECT_TRUE( EnvironmentIsUnset( result, "X509_USER_PROXY" ) );
     EXPECT_TRUE( EnvironmentIsUnset( result, "XrdSecCREDS" ) );
   }
@@ -213,7 +218,7 @@ namespace
                (std::vector<std::string>{"--force", "--path", "--recursive",
                  "--streams", "4", "--cksum", "adler32:01234567",
                  "root://host//file", "/tmp/file"}) );
-    EXPECT_EQ( *EnvironmentValue( result, "XRD_CPTIMEOUT" ), "30" );
+    ExpectEnvironmentValue( result, "XRD_CPTIMEOUT", "30" );
   }
 
   TEST( XrdCliCommandLine, DeduplicatesFlagsAndUsesLastOptionValue )
@@ -290,8 +295,7 @@ namespace
 
     EXPECT_EQ( common.action, CommandLineAction::Execute );
     EXPECT_EQ( EnvironmentValue( common, "XRD_REQUESTTIMEOUT" ), nullptr );
-    ASSERT_NE( EnvironmentValue( copy, "XRD_CPTIMEOUT" ), nullptr );
-    EXPECT_EQ( *EnvironmentValue( copy, "XRD_CPTIMEOUT" ), "0" );
+    ExpectEnvironmentValue( copy, "XRD_CPTIMEOUT", "0" );
     EXPECT_EQ( copy.invocation.arguments,
                (std::vector<std::string>{"root://host//file", "/tmp/file"}) );
   }

--- a/tests/XrdApps/fake-native-command.bash
+++ b/tests/XrdApps/fake-native-command.bash
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+printf '%s\n' "$@" > "$TRACE_FILE"
+{
+    printf 'XRD_LOGLEVEL=%s\n' "${XRD_LOGLEVEL-}"
+    printf 'XRD_REQUESTTIMEOUT=%s\n' "${XRD_REQUESTTIMEOUT-}"
+    printf 'XRD_CPTIMEOUT=%s\n' "${XRD_CPTIMEOUT-}"
+    printf 'XRD_NETWORKSTACK=%s\n' "${XRD_NETWORKSTACK-}"
+    printf 'X509_USER_CERT=%s\n' "${X509_USER_CERT-}"
+    printf 'X509_USER_KEY=%s\n' "${X509_USER_KEY-}"
+    printf 'X509_USER_PROXY=%s\n' "${X509_USER_PROXY-unset}"
+    printf 'XrdSecGSIUSERCERT=%s\n' "${XrdSecGSIUSERCERT-}"
+    printf 'XrdSecGSIUSERKEY=%s\n' "${XrdSecGSIUSERKEY-}"
+    printf 'XrdSecGSIUSERPROXY=%s\n' "${XrdSecGSIUSERPROXY-}"
+    printf 'XrdSecCREDS=%s\n' "${XrdSecCREDS-unset}"
+    printf 'XRD_HTTPCLIENTCERTFILE=%s\n' "${XRD_HTTPCLIENTCERTFILE-}"
+    printf 'XRD_HTTPCLIENTKEYFILE=%s\n' "${XRD_HTTPCLIENTKEYFILE-}"
+    printf 'XRD_LOGFILE=%s\n' "${XRD_LOGFILE-}"
+} > "$ENV_FILE"
+printf 'delegated output\n'
+exit "${FAKE_STATUS:-0}"

--- a/tests/XrdApps/xrd-cli-delegation.bats
+++ b/tests/XrdApps/xrd-cli-delegation.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+setup() {
+    export TEST_BIN="$BATS_TEST_TMPDIR/bin"
+    export TRACE_FILE="$BATS_TEST_TMPDIR/arguments"
+    export ENV_FILE="$BATS_TEST_TMPDIR/environment"
+    mkdir -p "$TEST_BIN"
+
+    for executable in xrdfs xrdcp; do
+        cp "$BATS_TEST_DIRNAME/fake-native-command.bash" "$TEST_BIN/$executable"
+        chmod +x "$TEST_BIN/$executable"
+    done
+    export PATH="$TEST_BIN:$PATH"
+}
+
+@test "stat delegates to xrdfs and preserves its exit status" {
+    export FAKE_STATUS=37
+    run "$XRD" stat root://example.test//file
+
+    assert_failure 37
+    assert_output "delegated output"
+    assert_equal "$(sed -n '1p' "$TRACE_FILE")" "stat"
+    assert_equal "$(sed -n '2p' "$TRACE_FILE")" "root://example.test//file"
+}
+
+@test "cat drops the bytes flag and keeps every URL" {
+    run "$XRD" cat -b root://example.test//one root://example.test//two
+
+    assert_success
+    assert_equal "$(sed -n '1p' "$TRACE_FILE")" "cat"
+    assert_equal "$(sed -n '2p' "$TRACE_FILE")" "root://example.test//one"
+    assert_equal "$(sed -n '3p' "$TRACE_FILE")" "root://example.test//two"
+}
+
+@test "ls translates compatible gfal options" {
+    run "$XRD" ls -alH root://example.test//directory
+
+    assert_success
+    assert_equal "$(sed -n '1p' "$TRACE_FILE")" "ls"
+    assert_equal "$(sed -n '2p' "$TRACE_FILE")" "-l"
+    assert_equal "$(sed -n '3p' "$TRACE_FILE")" "-h"
+    assert_equal "$(sed -n '4p' "$TRACE_FILE")" \
+        "root://example.test//directory"
+}
+
+@test "copy delegates remote to local with translated options" {
+    run "$XRD" copy -fp -n 04 -T 30 -K ADLER32 \
+        root://example.test//file "$BATS_TEST_TMPDIR/file"
+
+    assert_success
+    assert_equal "$(sed -n '1p' "$TRACE_FILE")" "--force"
+    assert_equal "$(sed -n '2p' "$TRACE_FILE")" "--path"
+    assert_equal "$(sed -n '3p' "$TRACE_FILE")" "--streams"
+    assert_equal "$(sed -n '4p' "$TRACE_FILE")" "4"
+    assert_equal "$(sed -n '5p' "$TRACE_FILE")" "--cksum"
+    assert_equal "$(sed -n '6p' "$TRACE_FILE")" "adler32"
+    assert_equal "$(sed -n '7p' "$TRACE_FILE")" "root://example.test//file"
+    assert_equal "$(sed -n '8p' "$TRACE_FILE")" "$BATS_TEST_TMPDIR/file"
+    assert grep -q '^XRD_CPTIMEOUT=30$' "$ENV_FILE"
+}
+
+@test "xattr delegates only read-only get operations" {
+    run "$XRD" xattr root://example.test//file user.name
+
+    assert_success
+    assert_equal "$(sed -n '1p' "$TRACE_FILE")" "xattr"
+    assert_equal "$(sed -n '2p' "$TRACE_FILE")" "root://example.test//file"
+    assert_equal "$(sed -n '3p' "$TRACE_FILE")" "get"
+    assert_equal "$(sed -n '4p' "$TRACE_FILE")" "user.name"
+
+    rm -f "$TRACE_FILE"
+    run "$XRD" xattr root://example.test//file user.name=value
+    assert_failure 2
+    assert_output --partial "read-only"
+    refute [ -e "$TRACE_FILE" ]
+}
+
+@test "common options become native XRootD environment variables" {
+    export X509_USER_PROXY=/tmp/inherited-proxy
+    export XrdSecCREDS=inherited-serialized-credential
+    run "$XRD" stat -vv -t 45 -4 --cert /tmp/cert --key /tmp/key \
+        --log-file /tmp/client.log root://example.test//file
+
+    assert_success
+    assert grep -q '^XRD_LOGLEVEL=Info$' "$ENV_FILE"
+    assert grep -q '^XRD_REQUESTTIMEOUT=45$' "$ENV_FILE"
+    assert grep -q '^XRD_NETWORKSTACK=IPv4$' "$ENV_FILE"
+    assert grep -q '^X509_USER_CERT=/tmp/cert$' "$ENV_FILE"
+    assert grep -q '^X509_USER_KEY=/tmp/key$' "$ENV_FILE"
+    assert grep -q '^X509_USER_PROXY=unset$' "$ENV_FILE"
+    assert grep -q '^XrdSecGSIUSERCERT=/tmp/cert$' "$ENV_FILE"
+    assert grep -q '^XrdSecGSIUSERKEY=/tmp/key$' "$ENV_FILE"
+    assert grep -q '^XrdSecGSIUSERPROXY=/tmp/cert$' "$ENV_FILE"
+    assert grep -q '^XrdSecCREDS=unset$' "$ENV_FILE"
+    assert grep -q '^XRD_HTTPCLIENTCERTFILE=/tmp/cert$' "$ENV_FILE"
+    assert grep -q '^XRD_HTTPCLIENTKEYFILE=/tmp/key$' "$ENV_FILE"
+    assert grep -q '^XRD_LOGFILE=/tmp/client.log$' "$ENV_FILE"
+}
+
+@test "https URLs are passed unchanged to native commands" {
+    run "$XRD" stat https://example.test/data/file
+
+    assert_success
+    assert_equal "$(sed -n '1p' "$TRACE_FILE")" "stat"
+    assert_equal "$(sed -n '2p' "$TRACE_FILE")" \
+        "https://example.test/data/file"
+}
+
+@test "unsupported compatibility options fail before delegation" {
+    run "$XRD" ls --time-style full-iso root://example.test//directory
+
+    assert_failure 2
+    assert_output --partial "requires native xrdfs output support"
+    refute [ -e "$TRACE_FILE" ]
+}
+
+@test "top-level help states that the command name is provisional" {
+    run "$XRD" --help
+
+    assert_success
+    assert_output --partial "name 'xrd'"
+    assert_output --partial "provisional"
+}

--- a/tests/end-to-end/CMakeLists.txt
+++ b/tests/end-to-end/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(xrdfs)
+add_subdirectory(xrd)

--- a/tests/end-to-end/CMakeLists.txt
+++ b/tests/end-to-end/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(xrdfs)

--- a/tests/end-to-end/xrd/CMakeLists.txt
+++ b/tests/end-to-end/xrd/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(XRD_CLI_BATS_ENV
+  "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
+  "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}"
+  "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+  "PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}"
+  "XRD=$<TARGET_FILE:xrd>"
+)
+
+add_test(NAME XrdApps::xrd-cli-read-only
+  COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
+          ${CMAKE_CURRENT_SOURCE_DIR}/xrd-cli-read-only.bats)
+
+set_tests_properties(XrdApps::xrd-cli-read-only PROPERTIES
+  ENVIRONMENT "${XRD_CLI_BATS_ENV}")

--- a/tests/end-to-end/xrd/xrd-cli-read-only.bats
+++ b/tests/end-to-end/xrd/xrd-cli-read-only.bats
@@ -20,7 +20,9 @@ setup() {
 }
 
 teardown() {
-    kill_pid_files
+    # The server can exit between the last command and teardown. Cleanup must
+    # remain idempotent when a recorded PID has already disappeared.
+    kill_pid_files 2>/dev/null || true
 }
 
 bats::on_failure() {

--- a/tests/end-to-end/xrd/xrd-cli-read-only.bats
+++ b/tests/end-to-end/xrd/xrd-cli-read-only.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../helper/common.bash
+
+setup() {
+    mkdir -p "$BATS_TEST_TMPDIR/xrd-cli-read-only/data"
+    printf 'thin frontend test\n' \
+        > "$BATS_TEST_TMPDIR/xrd-cli-read-only/data/sample.txt"
+
+    launch_xrootd xrd-cli-read-only.cfg xrd-cli-read-only
+    sleep 0.5
+
+    export TEST_FILE=root://localhost:11966//data/sample.txt
+    export TEST_DIRECTORY=root://localhost:11966//data/
+}
+
+teardown() {
+    kill_pid_files
+}
+
+bats::on_failure() {
+    print_log_files
+}
+
+@test "stat reads metadata through delegated xrdfs" {
+    run "$XRD" stat "$TEST_FILE"
+
+    assert_success
+    assert_output --partial "Size:   19"
+}
+
+@test "ls reads a directory through delegated xrdfs" {
+    run "$XRD" ls -lH "$TEST_DIRECTORY"
+
+    assert_success
+    assert_output --partial "sample.txt"
+}
+
+@test "cat streams file content through delegated xrdfs" {
+    run "$XRD" cat -b "$TEST_FILE"
+
+    assert_success
+    assert_output "thin frontend test"
+}
+
+@test "copy downloads from the fixture to a local file" {
+    local destination="$BATS_TEST_TMPDIR/download/nested/file.txt"
+
+    run "$XRD" copy --parent "$TEST_FILE" "$destination"
+
+    assert_success
+    run cmp "$BATS_TEST_TMPDIR/xrd-cli-read-only/data/sample.txt" "$destination"
+    assert_success
+}

--- a/tests/end-to-end/xrd/xrd-cli-read-only.cfg
+++ b/tests/end-to-end/xrd/xrd-cli-read-only.cfg
@@ -1,0 +1,10 @@
+set name = xrd-cli-read-only
+set port = 11966
+set test = $BATS_TEST_TMPDIR
+
+all.adminpath $test/$name
+all.export /data
+all.pidpath $test/$name
+oss.localroot $test/$name
+
+xrd.port $port

--- a/tests/end-to-end/xrdfs/CMakeLists.txt
+++ b/tests/end-to-end/xrdfs/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(XRDFS_BATS_ENV
+  "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
+  "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}"
+  "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+  "PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}"
+  "XRDCP=$<TARGET_FILE:xrdcp>"
+  "XRDFS=$<TARGET_FILE:xrdfs>"
+)
+
+add_test(NAME XrdCl::xrdfs-full-url
+  COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
+          ${CMAKE_CURRENT_SOURCE_DIR}/xrdfs-full-url.bats)
+
+set_tests_properties(XrdCl::xrdfs-full-url
+  PROPERTIES ENVIRONMENT "${XRDFS_BATS_ENV}")

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.bats
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.bats
@@ -53,6 +53,23 @@ bats::on_failure() {
     assert_success
 }
 
+@test "URL-valued xattrs are not treated as path operands" {
+    run "$XRDFS" xattr root://localhost:11965//examplefile set \
+        'user.url=https://example.test/value'
+    assert_success
+
+    run "$XRDFS" xattr root://localhost:11965//examplefile get user.url
+    assert_success
+    assert_output --partial 'https://example.test/value'
+}
+
+@test "URL-shaped prepare request IDs are not treated as path operands" {
+    run "$XRDFS" prepare -a 'https://request.example/id' \
+        root://localhost:11965//examplefile
+
+    refute_output --partial 'all URL operands must use the same endpoint'
+}
+
 @test "mixed URL endpoints are rejected before execution" {
     run "$XRDFS" mv root://localhost:11965//examplefile \
         root://127.0.0.1:11965//renamed
@@ -61,9 +78,12 @@ bats::on_failure() {
 }
 
 @test "local URLs are rejected" {
-    run "$XRDFS" stat file:///tmp/examplefile
-    assert_failure 1
-    assert_output 'xrdfs: invalid remote URL operand'
+    for url in file:///tmp/examplefile FILE://localhost/tmp/examplefile \
+        STDIO://-/examplefile; do
+        run "$XRDFS" stat "$url"
+        assert_failure 1
+        assert_output 'xrdfs: invalid remote URL operand'
+    done
 }
 
 @test "command-first raw queries remain unsupported" {

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.bats
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../helper/common.bash
+
+setup() {
+    launch_xrootd xrdfs-full-url.cfg xrdfs-full-url
+    sleep 0.5
+
+    run bats_pipe -0 echo 'full URL test' \| "$XRDCP" - \
+        root://localhost:11965//examplefile
+}
+
+teardown() {
+    kill_pid_files
+}
+
+bats::on_failure() {
+    print_log_files
+}
+
+@test "legacy server-first syntax remains supported" {
+    run "$XRDFS" root://localhost:11965 stat //examplefile
+    assert_success
+}
+
+@test "command-first syntax accepts a full URL" {
+    run "$XRDFS" stat root://localhost:11965//examplefile
+    assert_success
+}
+
+@test "subcommand options are not consumed as global options" {
+    run "$XRDFS" ls -l root://localhost:11965//
+    assert_success
+    assert_output --partial examplefile
+}
+
+@test "URL parameters are preserved in the operand path" {
+    run "$XRDFS" stat 'root://localhost:11965//examplefile?xrdcl.test=1'
+    assert_success
+}
+
+@test "multiple URLs on the same endpoint are normalized" {
+    run "$XRDFS" mv root://localhost:11965//examplefile \
+        root://localhost:11965//renamed
+    assert_success
+
+    run "$XRDFS" stat root://localhost:11965//renamed
+    assert_success
+}
+
+@test "mixed URL endpoints are rejected before execution" {
+    run "$XRDFS" mv root://localhost:11965//examplefile \
+        root://127.0.0.1:11965//renamed
+    assert_failure 1
+    assert_output 'xrdfs: all URL operands must use the same endpoint'
+}
+
+@test "local URLs are rejected" {
+    run "$XRDFS" stat file:///tmp/examplefile
+    assert_failure 1
+    assert_output 'xrdfs: invalid remote URL operand'
+}
+
+@test "command-first raw queries remain unsupported" {
+    run "$XRDFS" query root://localhost:11965//examplefile
+    assert_failure 1
+    assert_output "xrdfs: command-first full URLs are not supported for 'query'"
+}

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.bats
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.bats
@@ -16,7 +16,9 @@ setup() {
 }
 
 teardown() {
-    kill_pid_files
+    # The server can exit between the last command and teardown. Cleanup must
+    # remain idempotent when a recorded PID has already disappeared.
+    kill_pid_files 2>/dev/null || true
 }
 
 bats::on_failure() {

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.cfg
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.cfg
@@ -1,0 +1,10 @@
+set name = xrdfs-full-url
+set port = 11965
+set test = $BATS_TEST_TMPDIR
+
+all.adminpath $test/$name
+all.export /
+all.pidpath $test/$name
+oss.localroot $test/$name
+
+xrd.port $port


### PR DESCRIPTION
## Summary

This intentionally replaces the earlier direct-implementation prototype with the first thin-frontend slice of #2863.

- Stack the current #2865 full-URL change so complete URLs can be delegated to `xrdfs` without splitting them again.
- Restrict that URL normalization to actual path operands, including URL-valued xattrs and prepare request IDs, and document the server-first-only `query` form.
- Add a provisional, build-only `xrd` frontend (working name) for `stat`, `ls`, `cat`, read-only `xattr`, and `copy`/`cp`.
- Translate supported gfal2-util option spellings, then use `execvp` to replace the frontend with `xrdfs` or `xrdcp`.
- Preserve the native implementation, streams, signals, logging, transfer behavior, and exit status; the frontend contains no storage, protocol, transfer, or output implementation.

The `xrd` name, syntax, packaging, and installation policy are **not final**. The target and draft man page are available for review and testing, but neither is installed or added to RPM/DEB packages.

The first commit is the current #2865 head and should be dropped when that PR merges. Follow-up commits contain operand-classification and test-portability fixes found while exercising the frontend.

## Prototype command surface

| Command | Native delegation | Initial compatibility |
| --- | --- | --- |
| `xrd stat URL` | `xrdfs stat URL` | Complete remote URL |
| `xrd ls URL` | `xrdfs ls URL` | `-a`, `-l`, `-H`, non-coloring modes |
| `xrd cat URL...` | `xrdfs cat URL...` | `-b` no-op; same-endpoint files |
| `xrd xattr URL [NAME]` | `xrdfs xattr URL list/get` | Read-only list/get; assignment rejected |
| `xrd copy SRC DST` | `xrdcp SRC DST` | `-f`, `-p`, `-r`, `-n`, `-T`, `-K`, `--from-file` |
| `xrd cp SRC DST` | `xrdcp SRC DST` | Alias for `copy` |

Common timeout, verbosity, certificate/key, IPv4/IPv6, and log-file options are translated to existing XRootD environment settings. Explicit certificate selection also overrides native GSI proxy discovery and inherited serialized XrdSec credentials. Unsupported GFAL-specific behavior fails before delegation with a focused diagnostic.

## Deliberate boundaries

- Output and exit codes are native `xrdfs`/`xrdcp` behavior, not exact gfal2-util formatting or POSIX errno compatibility.
- `sum` is deferred until a native command accepts a complete URL plus checksum algorithm without frontend URL splitting or output parsing.
- Multi-file `cat` currently requires one endpoint; gfal-cat can span endpoints.
- Copy accepts one source/destination pair, or `--from-file` plus one destination. Chained GFAL destinations are rejected because xrdcp would interpret them as multiple sources.
- No mutating namespace command is exposed in this slice. `xattr` is read-only.
- HTTPS delegates correctly when XrdClHttp is installed. Against EOS Public, `stat`, `cat`, and remote-to-local copy work; `ls` currently returns native `NOT_IMPLEMENTED` while `gfal-ls` succeeds. That listing gap belongs in XrdClHttp/`xrdfs`, not in this frontend.

The complete matrix and rationale are in `docs/xrd-gfal-compatibility.md`.

## Validation

- The final upstream Actions run is green: all 17 CI matrix jobs, ABI compatibility, and coverage passed.
- 28/28 focused CTest entries passed: 25 table-driven GTest cases, process-level delegation BATS, the `xrdfs` full-URL BATS suite, and a local-server read-only BATS suite.
- Both local-server BATS suites passed ten consecutive stress runs after making fixture cleanup idempotent.
- GCC 16 Release compiled the parser tests cleanly with `-O3 -Wall -Wextra -Wnull-dereference -Werror`; all 26 parser and process-delegation tests passed in that configuration.
- Strict standalone parser compile passed with `-Wall -Wextra -Werror`.
- ShellCheck, `git diff --check`, and man-page rendering checks passed (apart from existing man-title/version lint conventions).
- A clean configure confirmed that the provisional executable and man page are absent from install metadata.
- EOS Public `root://` validation used only `stat`, `ls`, `cat`, and download to a local temporary file: 2184 bytes, MD5 `93f402e24c6f870470e1c5fcc5400e25`.
- EOS Public HTTPS validation used only `stat`, `cat`, and download to a local temporary file with the same size and MD5; the native listing limitation above was reproduced.
- Reference gfal2-util behavior was checked read-only on lxplus, including successful `gfal-ls` of the same HTTPS directory.

No production storage was modified. Copy acceptance checks wrote only to local temporary destinations; mutation coverage uses only ephemeral local XRootD fixtures.

Refs #2863
