### PR TITLE
[Python] Add Env delete bindings

### DIFF
--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -32,7 +32,7 @@ API Reference
    modules/client/file
    modules/client/copyprocess
    modules/client/responses
+   modules/client/env
    modules/client/flags
    modules/client/url
    modules/client/utils
-

--- a/python/docs/source/modules/client/env.rst
+++ b/python/docs/source/modules/client/env.rst
@@ -1,0 +1,19 @@
+=======================================
+:mod:`XRootD.client.env`: Client config
+=======================================
+
+.. module:: XRootD.client
+   :noindex:
+
+Functions
+*********
+
+.. autofunction:: XRootD.client.EnvPutString
+.. autofunction:: XRootD.client.EnvGetString
+.. autofunction:: XRootD.client.EnvDelString
+.. autofunction:: XRootD.client.EnvPutInt
+.. autofunction:: XRootD.client.EnvGetInt
+.. autofunction:: XRootD.client.EnvDelInt
+.. autofunction:: XRootD.client.EnvGetDefault
+.. autofunction:: XRootD.client.SetLogLevel
+.. autofunction:: XRootD.client.SetLogMask

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -8,8 +8,10 @@ from .url import URL as URL
 from .copyprocess import CopyProcess as CopyProcess
 from .env import EnvPutString as EnvPutString
 from .env import EnvGetString as EnvGetString
+from .env import EnvDelString as EnvDelString
 from .env import EnvPutInt as EnvPutInt
 from .env import EnvGetInt as EnvGetInt
+from .env import EnvDelInt as EnvDelInt
 from ._version import __version__ as __version__
 from .env import EnvGetDefault as EnvGetDefault
 from .env import SetLogLevel as SetLogLevel

--- a/python/libs/client/env.py
+++ b/python/libs/client/env.py
@@ -37,6 +37,13 @@ def EnvGetString( key ):
         If key does not exist in the environment returns None.
      """
      return client.EnvGetString_cpp( key )
+
+def EnvDelString( key ):
+     """Deletes the given key from the xrootd client string environment.
+        Returns False if there is a shell-imported setting for this key,
+        True otherwise.
+     """
+     return client.EnvDelString_cpp( key )
  
 def EnvPutInt( key, value ):
      """Sets the given key in the xrootd client environment to 
@@ -50,6 +57,13 @@ def EnvGetInt( key ):
         If key does not exist in the environment returns None.
      """
      return client.EnvGetInt_cpp( key )
+
+def EnvDelInt( key ):
+     """Deletes the given key from the xrootd client integer environment.
+        Returns False if there is a shell-imported setting for this key,
+        True otherwise.
+     """
+     return client.EnvDelInt_cpp( key )
 
 def EnvGetDefault( key ):
      """ Get the default value for the given key.

--- a/python/src/PyXRootDEnv.hh
+++ b/python/src/PyXRootDEnv.hh
@@ -69,6 +69,23 @@ namespace PyXRootD
   }
 
   //----------------------------------------------------------------------------
+  //! Deletes the given key from the xrootd client string environment.
+  //! @return : false if there is a shell-imported setting for this key,
+  //! true otherwise
+  //----------------------------------------------------------------------------
+  PyObject* EnvDelString_cpp( PyObject *self, PyObject *args )
+  {
+    char *key = 0;
+    // parse arguments
+    if( !PyArg_ParseTuple( args, "s", &key ) )
+    {
+      return NULL;
+    }
+
+    return PyBool_FromLong( XrdCl::DefaultEnv::GetEnv()->DelString( key ) );
+  }
+
+  //----------------------------------------------------------------------------
    //! Sets the given key in the xrootd client environment to the given value.
    //! @return : false if there is already a shell-imported setting for this key,
    // true otherwise
@@ -104,6 +121,23 @@ namespace PyXRootD
       Py_RETURN_NONE;
 
     return Py_BuildValue( "i", value );
+  }
+
+  //----------------------------------------------------------------------------
+  //! Deletes the given key from the xrootd client integer environment.
+  //! @return : false if there is a shell-imported setting for this key,
+  //! true otherwise
+  //----------------------------------------------------------------------------
+  PyObject* EnvDelInt_cpp( PyObject *self, PyObject *args )
+  {
+    char *key = 0;
+    // parse arguments
+    if( !PyArg_ParseTuple( args, "s", &key ) )
+    {
+      return NULL;
+    }
+
+    return PyBool_FromLong( XrdCl::DefaultEnv::GetEnv()->DelInt( key ) );
   }
 
   //----------------------------------------------------------------------------

--- a/python/src/PyXRootDModule.cc
+++ b/python/src/PyXRootDModule.cc
@@ -48,8 +48,10 @@ namespace PyXRootD
       // Ths XRootD Env
       { "EnvPutString_cpp",     EnvPutString_cpp,     METH_VARARGS, "Puts a string into XrdCl environment." },
       { "EnvGetString_cpp",     EnvGetString_cpp,     METH_VARARGS, "Gets a string from XrdCl environment." },
+      { "EnvDelString_cpp",     EnvDelString_cpp,     METH_VARARGS, "Deletes a string from XrdCl environment." },
       { "EnvPutInt_cpp",        EnvPutInt_cpp,        METH_VARARGS, "Puts an int into XrdCl environment." },
       { "EnvGetInt_cpp",        EnvGetInt_cpp,        METH_VARARGS, "Gets an int from XrdCl environment." },
+      { "EnvDelInt_cpp",        EnvDelInt_cpp,        METH_VARARGS, "Deletes an int from XrdCl environment." },
       { "XrdVersion_cpp",       XrdVersion_cpp,       METH_VARARGS, "Get the XRootD client version." },
       { "EnvGetDefault_cpp",    EnvGetDefault_cpp,    METH_VARARGS, "Get default values from XrdCl environment" },
       { "SetLogLevel_cpp",      SetLogLevel_cpp,      METH_VARARGS, "Set XrdCl log level" },

--- a/python/tests/test_env.py
+++ b/python/tests/test_env.py
@@ -1,0 +1,15 @@
+from XRootD import client
+
+
+def test_env_delete_helpers():
+  assert client.EnvPutString('XROOTD_TEST_ENV_DELETE_STRING', 'temporary')
+  assert client.EnvGetString('XROOTD_TEST_ENV_DELETE_STRING') == 'temporary'
+  assert client.EnvDelString('XROOTD_TEST_ENV_DELETE_STRING')
+  assert client.EnvGetString('XROOTD_TEST_ENV_DELETE_STRING') is None
+  assert client.EnvDelString('XROOTD_TEST_ENV_DELETE_STRING')
+
+  assert client.EnvPutInt('XROOTD_TEST_ENV_DELETE_INT', 42)
+  assert client.EnvGetInt('XROOTD_TEST_ENV_DELETE_INT') == 42
+  assert client.EnvDelInt('XROOTD_TEST_ENV_DELETE_INT')
+  assert client.EnvGetInt('XROOTD_TEST_ENV_DELETE_INT') is None
+  assert client.EnvDelInt('XROOTD_TEST_ENV_DELETE_INT')

--- a/src/XrdCl/XrdClEnv.cc
+++ b/src/XrdCl/XrdClEnv.cc
@@ -84,6 +84,32 @@ namespace XrdCl
   }
 
   //----------------------------------------------------------------------------
+  // Delete string
+  //----------------------------------------------------------------------------
+  bool Env::DelString( const std::string &k )
+  {
+    std::string key = UnifyKey( k );
+    XrdSysRWLockHelper scopedLock( pLock, false ); // obtain write lock
+
+    StringMap::iterator it;
+    it = pStringMap.find( key );
+    if( it == pStringMap.end() )
+      return true;
+
+    Log *log = DefaultEnv::GetLog();
+    if( it->second.second )
+    {
+      log->Debug( UtilityMsg,
+                  "Env: trying to delete a shell-imported string entry: %s",
+                  key.c_str() );
+      return false;
+    }
+    log->Debug( UtilityMsg, "Env: deleting string entry: %s", key.c_str() );
+    pStringMap.erase( it );
+    return true;
+  }
+
+  //----------------------------------------------------------------------------
   // Get int
   //----------------------------------------------------------------------------
   bool Env::GetInt( const std::string &k, int &value )
@@ -139,6 +165,32 @@ namespace XrdCl
                 key.c_str(), it->second.first, value );
 
     pIntMap[key] = std::make_pair( value, false );
+    return true;
+  }
+
+  //----------------------------------------------------------------------------
+  // Delete int
+  //----------------------------------------------------------------------------
+  bool Env::DelInt( const std::string &k )
+  {
+    std::string key = UnifyKey( k );
+    XrdSysRWLockHelper scopedLock( pLock, false ); // obtain write lock
+
+    IntMap::iterator it;
+    it = pIntMap.find( key );
+    if( it == pIntMap.end() )
+      return true;
+
+    Log *log = DefaultEnv::GetLog();
+    if( it->second.second )
+    {
+      log->Debug( UtilityMsg,
+                  "Env: trying to delete a shell-imported integer entry: %s",
+                  key.c_str() );
+      return false;
+    }
+    log->Debug( UtilityMsg, "Env: deleting integer entry: %s", key.c_str() );
+    pIntMap.erase( it );
     return true;
   }
 

--- a/src/XrdCl/XrdClEnv.hh
+++ b/src/XrdCl/XrdClEnv.hh
@@ -58,6 +58,14 @@ namespace XrdCl
       bool PutString( const std::string &key, const std::string &value );
 
       //------------------------------------------------------------------------
+      //! Remove the string associated with the given key
+      //!
+      //! @return false if there is a shell-imported setting for this key,
+      //!         true otherwise
+      //------------------------------------------------------------------------
+      bool DelString( const std::string &key );
+
+      //------------------------------------------------------------------------
       //! Get an int associated to the given key
       //!
       //! @return true if the value was found, false otherwise
@@ -71,6 +79,14 @@ namespace XrdCl
       //!         key, true otherwise
       //------------------------------------------------------------------------
       bool PutInt( const std::string &key, int value );
+
+      //------------------------------------------------------------------------
+      //! Remove the int associated with the given key
+      //!
+      //! @return false if there is a shell-imported setting for this key,
+      //!         true otherwise
+      //------------------------------------------------------------------------
+      bool DelInt( const std::string &key );
 
       //------------------------------------------------------------------------
       //! Get a pointer associated to the given key


### PR DESCRIPTION
## Summary

Adds an ABI-compatible way to remove values from the XRootD client environment:

- adds non-virtual `XrdCl::Env::DelString` and `DelInt` helpers
- exposes them through the Python extension as `EnvDelString_cpp` and `EnvDelInt_cpp`
- adds Python client wrappers/exports as `EnvDelString` and `EnvDelInt`
- documents the environment helpers and adds focused Python tests

## Validation

- `python3 -m compileall python/libs/client python/tests/test_env.py`
- `python3 setup.py build_ext`
- `python3 setup.py build_py`
- `PYTHONPATH=build/lib.macosx-10.13-universal2-cpython-313 python3 -m pytest python/tests/test_env.py -q` -> `1 passed`
- `git diff --check`
