### PR TITLE
[Python] Add filesystem query helpers

### DIFF
--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -17,6 +17,8 @@ Attributes
 Methods
 *******
 
+.. automethod:: XRootD.client.FileSystem.__enter__
+.. automethod:: XRootD.client.FileSystem.__exit__
 .. automethod:: XRootD.client.FileSystem.copy
 .. automethod:: XRootD.client.FileSystem.checksum
 .. automethod:: XRootD.client.FileSystem.locate

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -18,6 +18,7 @@ Methods
 *******
 
 .. automethod:: XRootD.client.FileSystem.copy
+.. automethod:: XRootD.client.FileSystem.checksum
 .. automethod:: XRootD.client.FileSystem.locate
 .. automethod:: XRootD.client.FileSystem.deeplocate
 .. automethod:: XRootD.client.FileSystem.mv
@@ -25,12 +26,14 @@ Methods
 .. automethod:: XRootD.client.FileSystem.truncate
 .. automethod:: XRootD.client.FileSystem.rm
 .. automethod:: XRootD.client.FileSystem.mkdir
+.. automethod:: XRootD.client.FileSystem.mkdir_p
 .. automethod:: XRootD.client.FileSystem.rmdir
 .. automethod:: XRootD.client.FileSystem.chmod
 .. automethod:: XRootD.client.FileSystem.ping
 .. automethod:: XRootD.client.FileSystem.stat
 .. automethod:: XRootD.client.FileSystem.statvfs
 .. automethod:: XRootD.client.FileSystem.protocol
+.. automethod:: XRootD.client.FileSystem.probe
 .. automethod:: XRootD.client.FileSystem.dirlist
 .. automethod:: XRootD.client.FileSystem.sendinfo
 .. automethod:: XRootD.client.FileSystem.prepare

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -18,6 +18,7 @@ Methods
 *******
 
 .. automethod:: XRootD.client.FileSystem.copy
+.. automethod:: XRootD.client.FileSystem.checksum
 .. automethod:: XRootD.client.FileSystem.locate
 .. automethod:: XRootD.client.FileSystem.deeplocate
 .. automethod:: XRootD.client.FileSystem.mv

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -26,6 +26,7 @@ Methods
 .. automethod:: XRootD.client.FileSystem.truncate
 .. automethod:: XRootD.client.FileSystem.rm
 .. automethod:: XRootD.client.FileSystem.mkdir
+.. automethod:: XRootD.client.FileSystem.mkdir_p
 .. automethod:: XRootD.client.FileSystem.rmdir
 .. automethod:: XRootD.client.FileSystem.chmod
 .. automethod:: XRootD.client.FileSystem.ping

--- a/python/docs/source/modules/client/responses.rst
+++ b/python/docs/source/modules/client/responses.rst
@@ -19,3 +19,5 @@ requests to an `XRootD` server.
 .. autoclass:: XRootD.client.responses.HostList()
 .. autoclass:: XRootD.client.responses.HostInfo()
 .. autoclass:: XRootD.client.responses.ProtocolInfo()
+.. autoclass:: XRootD.client.responses.ChecksumInfo()
+.. autoclass:: XRootD.client.responses.CapabilityInfo()

--- a/python/docs/source/modules/client/responses.rst
+++ b/python/docs/source/modules/client/responses.rst
@@ -30,3 +30,4 @@ requests to an `XRootD` server.
 .. autoclass:: XRootD.client.responses.HostList()
 .. autoclass:: XRootD.client.responses.HostInfo()
 .. autoclass:: XRootD.client.responses.ProtocolInfo()
+.. autoclass:: XRootD.client.responses.ChecksumInfo()

--- a/python/examples/client_workflows.py
+++ b/python/examples/client_workflows.py
@@ -9,7 +9,6 @@ queries, copy, rename, and delete.
 from __future__ import print_function
 
 from XRootD import client
-from XRootD.client.flags import QueryCode
 
 
 endpoint = 'root://localhost/'
@@ -32,7 +31,7 @@ print(status, protocol)
 status, _ = fs.copy(source, target, force=True)
 print(status)
 
-status, checksum = fs.query(QueryCode.CHECKSUM, target, timeout=10)
+status, checksum = fs.checksum(target, timeout=10)
 print(status, checksum)
 
 status, _ = fs.mv(target, renamed, timeout=10)

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -14,5 +14,7 @@ from ._version import __version__ as __version__
 from .env import EnvGetDefault as EnvGetDefault
 from .env import SetLogLevel as SetLogLevel
 from .env import SetLogMask as SetLogMask
+from .responses import ChecksumInfo as ChecksumInfo
+from .responses import CapabilityInfo as CapabilityInfo
 
 import XRootD.client.finalize

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -24,5 +24,6 @@ from .responses import XRootDTimeoutError
 from .responses import XRootDChecksumError
 from .responses import XRootDOperationError
 from .responses import raise_on_error
+from .responses import ChecksumInfo
 
 import XRootD.client.finalize

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -42,6 +42,14 @@ class FileSystem(object):
   def __init__(self, url):
     self.__fs = client.FileSystem(url)
 
+  def __enter__(self):
+    """Return this filesystem instance for use in a ``with`` statement."""
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    """Exit a ``with`` statement without suppressing exceptions."""
+    return None
+
   @property
   def url(self):
     """The server URL object, instance of :mod:`XRootD.client.URL`"""

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -26,8 +26,9 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
+from XRootD.client.responses import ChecksumInfo, CapabilityInfo
 from XRootD.client.utils import CallbackWrapper
-from XRootD.client.flags import AccessMode
+from XRootD.client.flags import AccessMode, MkDirFlags, QueryCode
 
 class FileSystem(object):
   """Interact with an ``xrootd`` server to perform filesystem-based operations
@@ -141,6 +142,23 @@ class FileSystem(object):
     status, response = self.__fs.query(querycode, arg, timeout)
     return XRootDStatus(status), response
 
+  def checksum(self, path, timeout=0, callback=None):
+    """Obtain a structured checksum for a path.
+
+    :param path: path to the file
+    :type  path: string
+    :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                 object and :mod:`XRootD.client.responses.ChecksumInfo` object
+    """
+    if callback:
+      callback = CallbackWrapper(callback, ChecksumInfo)
+      return XRootDStatus(self.__fs.query(QueryCode.CHECKSUM, path, timeout,
+                                          callback))
+
+    status, response = self.__fs.query(QueryCode.CHECKSUM, path, timeout)
+    if response: response = ChecksumInfo(response)
+    return XRootDStatus(status), response
+
   def truncate(self, path, size, timeout=0, callback=None):
     """Truncate a file.
 
@@ -196,6 +214,14 @@ class FileSystem(object):
 
     status, response = self.__fs.mkdir(path, flags, mode, timeout)
     return XRootDStatus(status), None
+
+  def mkdir_p(self, path, mode=0, timeout=0, callback=None):
+    """Create a directory and any missing parent directories.
+
+    This is a convenience wrapper around :meth:`mkdir` using
+    :data:`XRootD.client.flags.MkDirFlags.MAKEPATH`.
+    """
+    return self.mkdir(path, MkDirFlags.MAKEPATH, mode, timeout, callback)
 
   def rmdir(self, path, timeout=0, callback=None):
     """Remove a directory.
@@ -286,6 +312,29 @@ class FileSystem(object):
     status, response = self.__fs.protocol(timeout)
     if response: response = ProtocolInfo(response)
     return XRootDStatus(status), response
+
+  def probe(self, config_arg=None, timeout=10):
+    """Probe basic endpoint capabilities.
+
+    :param config_arg: optional argument for ``QueryCode.CONFIG``. If omitted,
+                       the filesystem host id is used.
+    :type  config_arg: string
+    :returns: tuple containing the ping status and a
+              :mod:`XRootD.client.responses.CapabilityInfo` object
+    """
+    ping_status, _ = self.ping(timeout=timeout)
+    protocol_status, protocol = self.protocol(timeout=timeout)
+
+    if config_arg is None:
+      config_arg = self.__fs.url.hostid
+
+    config_status, config = self.query(QueryCode.CONFIG, config_arg,
+                                       timeout=timeout)
+    return ping_status, CapabilityInfo(ping_status=ping_status,
+                                       protocol_status=protocol_status,
+                                       protocol=protocol,
+                                       config_status=config_status,
+                                       config=config)
 
   def dirlist(self, path, flags=0, timeout=0, callback=None):
     """List entries of a directory.

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -28,7 +28,7 @@ from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
 from XRootD.client.responses import ChecksumInfo
 from XRootD.client.utils import CallbackWrapper
-from XRootD.client.flags import AccessMode, QueryCode
+from XRootD.client.flags import AccessMode, MkDirFlags, QueryCode
 
 class FileSystem(object):
   """Interact with an ``xrootd`` server to perform filesystem-based operations
@@ -214,6 +214,22 @@ class FileSystem(object):
 
     status, response = self.__fs.mkdir(path, flags, mode, timeout)
     return XRootDStatus(status), None
+
+  def mkdir_p(self, path, flags=0, mode=0, timeout=0, callback=None):
+    """Create a directory and any missing parent directories.
+
+    This is a convenience wrapper around :meth:`mkdir` using
+    :data:`XRootD.client.flags.MkDirFlags.MAKEPATH`.
+
+    :param  path: path to the directory to create
+    :type   path: string
+    :param flags: Additional `ORed` flags from
+                  :mod:`XRootD.client.flags.MkDirFlags`
+    :param  mode: the initial file access mode, an `ORed` combination of
+                  :mod:`XRootD.client.flags.AccessMode`
+    """
+    return self.mkdir(path, flags | MkDirFlags.MAKEPATH, mode, timeout,
+                      callback)
 
   def rmdir(self, path, timeout=0, callback=None):
     """Remove a directory.

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -26,8 +26,9 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
+from XRootD.client.responses import ChecksumInfo
 from XRootD.client.utils import CallbackWrapper
-from XRootD.client.flags import AccessMode
+from XRootD.client.flags import AccessMode, QueryCode
 
 class FileSystem(object):
   """Interact with an ``xrootd`` server to perform filesystem-based operations
@@ -139,6 +140,23 @@ class FileSystem(object):
       return XRootDStatus(self.__fs.query(querycode, arg, timeout, callback))
 
     status, response = self.__fs.query(querycode, arg, timeout)
+    return XRootDStatus(status), response
+
+  def checksum(self, path, timeout=0, callback=None):
+    """Obtain a structured checksum for a path.
+
+    :param path: path to the file
+    :type  path: string
+    :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                 object and :mod:`XRootD.client.responses.ChecksumInfo` object
+    """
+    if callback:
+      callback = CallbackWrapper(callback, ChecksumInfo)
+      return XRootDStatus(self.__fs.query(QueryCode.CHECKSUM, path, timeout,
+                                          callback))
+
+    status, response = self.__fs.query(QueryCode.CHECKSUM, path, timeout)
+    if response: response = ChecksumInfo(response)
     return XRootDStatus(status), response
 
   def truncate(self, path, size, timeout=0, callback=None):

--- a/python/libs/client/responses.py
+++ b/python/libs/client/responses.py
@@ -165,6 +165,56 @@ class ProtocolInfo(Struct):
   def __init__(self, info):
     super(ProtocolInfo, self).__init__(info)
 
+
+class ChecksumInfo(Struct):
+  """Structured checksum response.
+
+  :var algorithm: checksum algorithm name, for example ``adler32``
+  :var value:     checksum value
+  """
+
+  def __init__(self, algorithm, value=None):
+    if value is None:
+      algorithm, value = self._parse(algorithm)
+    super(ChecksumInfo, self).__init__({
+      'algorithm': algorithm,
+      'value': value,
+    })
+
+  @classmethod
+  def from_query_response(cls, response):
+    """Build a checksum object from a ``QueryCode.CHECKSUM`` response."""
+    algorithm, value = cls._parse(response)
+    return cls(algorithm, value)
+
+  @staticmethod
+  def _parse(response):
+    parts = response.strip('\n\0').split(None, 1)
+    if len(parts) != 2:
+      raise ValueError('Invalid checksum response: %r' % response)
+    return parts
+
+
+class CapabilityInfo(Struct):
+  """Summary of endpoint capability probing.
+
+  :var ping_status:     status returned by :meth:`FileSystem.ping`
+  :var protocol_status: status returned by :meth:`FileSystem.protocol`
+  :var protocol:        protocol response when available
+  :var config_status:   status returned by ``QueryCode.CONFIG`` probing
+  :var config:          config response when available
+  """
+
+  def __init__(self, ping_status, protocol_status=None, protocol=None,
+               config_status=None, config=None):
+    super(CapabilityInfo, self).__init__({
+      'ping_status': ping_status,
+      'protocol_status': protocol_status,
+      'protocol': protocol,
+      'config_status': config_status,
+      'config': config,
+    })
+
 class StatInfo(Struct):
   """Status information for files and directories.
 

--- a/python/libs/client/responses.py
+++ b/python/libs/client/responses.py
@@ -354,6 +354,28 @@ class ProtocolInfo(Struct):
   def __init__(self, info):
     super(ProtocolInfo, self).__init__(info)
 
+
+class ChecksumInfo(Struct):
+  """Structured checksum response.
+
+  :param response: raw response returned by ``QueryCode.CHECKSUM``
+  :type  response: string
+  :var algorithm: checksum algorithm name, for example ``adler32``
+  :var value:     checksum value
+  """
+
+  def __init__(self, response):
+    if isinstance(response, bytes):
+      response = response.decode('ascii')
+    parts = response.strip('\n\0').split(None, 1)
+    if len(parts) != 2:
+      raise ValueError('Invalid checksum response: %r' % response)
+    algorithm, value = parts
+    super(ChecksumInfo, self).__init__({
+      'algorithm': algorithm,
+      'value': value,
+    })
+
 class StatInfo(Struct):
   """Status information for files and directories.
 

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -218,6 +218,14 @@ def test_creation():
   c = client.FileSystem(SERVER_URL)
   assert c.url is not None
 
+def test_context_manager():
+  with client.FileSystem(SERVER_URL) as c:
+    assert c.url is not None
+
+  with pytest.raises(RuntimeError):
+    with client.FileSystem(SERVER_URL):
+      raise RuntimeError('failure')
+
 def test_deletion():
   c = client.FileSystem(SERVER_URL)
   del c

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -160,6 +160,27 @@ def test_query_sync():
   assert response
   print(response)
 
+def test_checksum_sync():
+  c = client.FileSystem(SERVER_URL)
+  f = client.File()
+  status, response = f.open(smallfile, OpenFlags.DELETE)
+  assert status.ok
+  f.write(smallbuffer)
+  f.close()
+
+  status, response = c.checksum(smallfile)
+  assert status.ok
+  assert response.algorithm
+  assert response.value
+
+def test_probe_sync():
+  c = client.FileSystem(SERVER_URL)
+  status, response = c.probe()
+  assert status.ok
+  assert response.ping_status.ok
+  assert response.protocol_status.ok
+  assert response.protocol
+
 def test_query_async():
   c = client.FileSystem(SERVER_URL)
   handler = AsyncResponseHandler()
@@ -174,6 +195,13 @@ def test_query_async():
 def test_mkdir_flags():
   c = client.FileSystem(SERVER_URL)
   status, response = c.mkdir('/tmp/dir1/dir2', MkDirFlags.MAKEPATH)
+  assert status.ok
+  c.rm('/tmp/dir1/dir2')
+  c.rm('/tmp/dir1')
+
+def test_mkdir_p():
+  c = client.FileSystem(SERVER_URL)
+  status, response = c.mkdir_p('/tmp/dir1/dir2')
   assert status.ok
   c.rm('/tmp/dir1/dir2')
   c.rm('/tmp/dir1')

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -169,6 +169,47 @@ def test_query_sync():
   assert response
   print(response)
 
+def test_checksum_sync():
+  c = client.FileSystem(SERVER_URL)
+  f = client.File()
+  status, response = f.open(smallfile, OpenFlags.DELETE)
+  assert status.ok
+  f.write(smallbuffer)
+  f.close()
+
+  status, response = c.checksum('/tmp/spam')
+  assert status.ok
+  assert response.algorithm
+  assert response.value
+
+
+def test_checksum_async_response():
+  raw_status = {'ok': True, 'message': 'ok'}
+
+  class Recorder(object):
+    def query(self, querycode, path, timeout, callback):
+      self.args = (querycode, path, timeout)
+      callback(raw_status, 'adler32 deadbeef\0', [])
+      return raw_status
+
+  class FileSystem(object):
+    def __init__(self):
+      self._FileSystem__fs = Recorder()
+
+  responses = []
+  filesystem = FileSystem()
+  status = client.FileSystem.checksum(
+    filesystem, '/tmp/file', timeout=12,
+    callback=lambda *args: responses.append(args))
+
+  assert status.ok
+  assert filesystem._FileSystem__fs.args == (
+    QueryCode.CHECKSUM, '/tmp/file', 12)
+  assert len(responses) == 1
+  assert responses[0][0].ok
+  assert responses[0][1].algorithm == 'adler32'
+  assert responses[0][1].value == 'deadbeef'
+
 def test_query_async():
   c = client.FileSystem(SERVER_URL)
   handler = AsyncResponseHandler()

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -227,7 +227,29 @@ def test_mkdir_flags():
   assert status.ok
   c.rm('/tmp/dir1/dir2')
   c.rm('/tmp/dir1')
-  
+
+def test_mkdir_p():
+  c = client.FileSystem(SERVER_URL)
+  status, response = c.mkdir_p('/tmp/dir1/dir2', flags=MkDirFlags.NONE)
+  assert status.ok
+  c.rm('/tmp/dir1/dir2')
+  c.rm('/tmp/dir1')
+
+
+def test_mkdir_p_preserves_flags():
+  class Recorder(object):
+    def mkdir(self, path, flags=0, mode=0, timeout=0, callback=None):
+      self.args = (path, flags, mode, timeout, callback)
+      return 'result'
+
+  recorder = Recorder()
+  callback = object()
+  result = client.FileSystem.mkdir_p(recorder, '/tmp/dir', flags=4, mode=0o750,
+                                     timeout=12, callback=callback)
+
+  assert result == 'result'
+  assert recorder.args == ('/tmp/dir', 4 | MkDirFlags.MAKEPATH, 0o750, 12,
+                           callback)
 
 def test_args():
   c = client.FileSystem(url=SERVER_URL)

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -262,6 +262,14 @@ def test_creation():
   c = client.FileSystem(SERVER_URL)
   assert c.url is not None
 
+def test_context_manager():
+  with client.FileSystem(SERVER_URL) as c:
+    assert c.url is not None
+
+  with pytest.raises(RuntimeError):
+    with client.FileSystem(SERVER_URL):
+      raise RuntimeError('failure')
+
 def test_deletion():
   c = client.FileSystem(SERVER_URL)
   del c

--- a/python/tests/test_responses.py
+++ b/python/tests/test_responses.py
@@ -3,7 +3,7 @@ import pytest
 from XRootD.client.responses import XRootDStatus, XRootDNotFoundError, \
   XRootDAuthorizationError, \
   XRootDTimeoutError, XRootDChecksumError, XRootDOperationError, \
-  raise_on_error
+  ChecksumInfo, raise_on_error
 
 
 def status(code, ok=False, shellcode=0, message='error', errno=0):
@@ -59,3 +59,23 @@ def test_raise_on_error():
   with pytest.raises(XRootDNotFoundError) as excinfo:
     status(XRootDStatus.errNotFound).raise_on_error()
   assert excinfo.value.status.code == XRootDStatus.errNotFound
+
+
+def test_checksum_info():
+  checksum = ChecksumInfo('adler32 deadbeef\n')
+  assert checksum.algorithm == 'adler32'
+  assert checksum.value == 'deadbeef'
+
+  checksum = ChecksumInfo('md5 abc123\0')
+  assert checksum.algorithm == 'md5'
+  assert checksum.value == 'abc123'
+
+  checksum = ChecksumInfo(b'adler32 cafebabe\0')
+  assert checksum.algorithm == 'adler32'
+  assert checksum.value == 'cafebabe'
+
+
+@pytest.mark.parametrize('response', ['', 'adler32', 'adler32\0'])
+def test_checksum_info_rejects_invalid_response(response):
+  with pytest.raises(ValueError, match='Invalid checksum response'):
+    ChecksumInfo(response)

--- a/python/tests/test_structured_responses.py
+++ b/python/tests/test_structured_responses.py
@@ -1,0 +1,31 @@
+from XRootD.client.responses import ChecksumInfo, CapabilityInfo, XRootDStatus
+
+
+def status(code, ok=False, message='error'):
+  return XRootDStatus({
+    'message': message,
+    'ok': ok,
+    'error': not ok,
+    'fatal': False,
+    'status': 0 if ok else 1,
+    'code': code,
+    'shellcode': 0,
+    'errno': 0,
+  })
+
+
+def test_checksum_info():
+  checksum = ChecksumInfo('adler32 deadbeef\n')
+  assert checksum.algorithm == 'adler32'
+  assert checksum.value == 'deadbeef'
+
+  checksum = ChecksumInfo.from_query_response('md5 abc123\0')
+  assert checksum.algorithm == 'md5'
+  assert checksum.value == 'abc123'
+
+
+def test_capability_info():
+  ping_status = status(XRootDStatus.errNone, ok=True, message='ok')
+  capability = CapabilityInfo(ping_status=ping_status)
+  assert capability.ping_status.ok
+  assert capability.protocol is None

--- a/python/tests/xrootd.cfg
+++ b/python/tests/xrootd.cfg
@@ -12,3 +12,4 @@ all.export    /
 all.adminpath $basedir
 all.pidpath   $basedir
 oss.localroot $basedir/data
+xrootd.chksum adler32


### PR DESCRIPTION
## Summary

Adds Python filesystem helpers for common query-style operations:

- `ChecksumInfo` for structured checksum query responses
- `CapabilityInfo` for endpoint probing summaries
- `FileSystem.checksum()` wrapping `QueryCode.CHECKSUM`
- `FileSystem.mkdir_p()` wrapping recursive mkdir flags
- `FileSystem.probe()` combining ping, protocol, and config query results
- docs and tests for the new response objects and filesystem helpers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added context-manager support for filesystem clients.
  - Added checksum retrieval with structured algorithm and value results.
  - Added recursive directory creation through `mkdir_p`.
  - Exported the new checksum response type for public use.

- **Documentation**
  - Expanded filesystem method documentation.
  - Documented checksum response details.

- **Tests**
  - Added coverage for checksum parsing, recursive directory creation, argument handling, and context-manager behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->