### PR TITLE
[Python] Add copy convenience helpers

### DIFF
--- a/python/docs/source/modules/client/copyprocess.rst
+++ b/python/docs/source/modules/client/copyprocess.rst
@@ -14,5 +14,6 @@ Methods
 *******
 
 .. automethod:: XRootD.client.CopyProcess.add_job
+.. automethod:: XRootD.client.CopyProcess.copy
 .. automethod:: XRootD.client.CopyProcess.prepare
 .. automethod:: XRootD.client.CopyProcess.run

--- a/python/libs/client/copyprocess.py
+++ b/python/libs/client/copyprocess.py
@@ -62,6 +62,12 @@ class CopyProcess(object):
   def __init__(self):
     self.__process = client.CopyProcess()
 
+  def __enter__(self):
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    return False
+
   def parallel(self, parallel):
     """ Add a config job to the copy process in order to set the number of
         parallel copy jobs.
@@ -143,7 +149,7 @@ class CopyProcess(object):
     :type      retry: integer
     :param     cont: continue copying a file from the point where the previous copy was interrupted
     :type      cont: boolean
-    :param     rtrplc: the retry polic (force or continue)
+    :param     rtrplc: the retry policy (force or continue)
     :type      rtrplc: string
     """
     self.__process.add_job(source, target, sourcelimit, force, posc,
@@ -170,3 +176,56 @@ class CopyProcess(object):
       if 'status' in x:
         x['status'] = XRootDStatus(x['status'])
     return XRootDStatus(status), results
+
+  def copy(self, source, target, force=False, mkdir=False, timeout=0,
+           handler=None, retry=None, thirdparty='none', checksummode='none',
+           checksumtype='', checksumpreset='', posc=False, coerce=False,
+           cont=False, chunksize=None, parallelchunks=None):
+    """Run a single copy job with common high-level options.
+
+    :param source: source URL
+    :type  source: string
+    :param target: target URL
+    :type  target: string
+    :param force: overwrite the target if it exists
+    :type  force: boolean
+    :param mkdir: create parent directories for the target
+    :type  mkdir: boolean
+    :param timeout: timeout applied to copy initialization and execution
+    :type  timeout: integer
+    :param handler: optional copy progress handler. Returning ``True`` from
+                    ``handler.should_cancel(jobId)`` cancels the job.
+    :param retry: number of retries
+    :type  retry: integer
+    :returns: tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+              object and copy job results
+    """
+    kwargs = {
+      'source': source,
+      'target': target,
+      'force': force,
+      'mkdir': mkdir,
+      'thirdparty': thirdparty,
+      'checksummode': checksummode,
+      'checksumtype': checksumtype,
+      'checksumpreset': checksumpreset,
+      'posc': posc,
+      'coerce': coerce,
+      'cont': cont,
+    }
+    if timeout:
+      kwargs['cptimeout'] = timeout
+      kwargs['inittimeout'] = timeout
+      kwargs['tpctimeout'] = timeout
+    if retry is not None:
+      kwargs['retry'] = retry
+    if chunksize is not None:
+      kwargs['chunksize'] = chunksize
+    if parallelchunks is not None:
+      kwargs['parallelchunks'] = parallelchunks
+
+    self.add_job(**kwargs)
+    status = self.prepare()
+    if not status.ok:
+      return status, []
+    return self.run(handler=handler)

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -28,6 +28,7 @@ from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
 from XRootD.client.utils import CallbackWrapper
 from XRootD.client.flags import AccessMode
+from XRootD.client.copyprocess import CopyProcess
 
 class FileSystem(object):
   """Interact with an ``xrootd`` server to perform filesystem-based operations
@@ -46,7 +47,11 @@ class FileSystem(object):
     """The server URL object, instance of :mod:`XRootD.client.URL`"""
     return self.__fs.url
 
-  def copy(self, source, target, force=False):
+  def copy(self, source, target, force=False, mkdir=False, timeout=0,
+           handler=None, retry=None, thirdparty='none', checksummode='none',
+           checksumtype='', checksumpreset='', posc=False, coerce=False,
+           cont=False, chunksize=None, parallelchunks=None,
+           return_results=False):
     """Copy a file.
 
     .. note:: This method is less configurable than using
@@ -62,11 +67,49 @@ class FileSystem(object):
     :type  target: string
     :param  force: overwrite target if it exists
     :type   force: boolean
+    :param  mkdir: create parent directories for the target
+    :type   mkdir: boolean
+    :param timeout: copy timeout in seconds
+    :type  timeout: integer
+    :param handler: optional copy progress handler
+    :param retry: number of copy retries
+    :type  retry: integer
+    :param thirdparty: third-party-copy mode
+    :type  thirdparty: string
+    :param checksummode: checksum mode for the copy
+    :type  checksummode: string
+    :param checksumtype: checksum type for the copy
+    :type  checksumtype: string
+    :param checksumpreset: preset checksum value
+    :type  checksumpreset: string
+    :param return_results: return copy job results instead of ``None``
+    :type  return_results: boolean
     :returns:      tuple containing :mod:`XRootD.client.responses.XRootDStatus`
-                   object and None
+                   object and None, or copy results if ``return_results`` is set
     """
-    result = self.__fs.copy(source=source, target=target, force=force)[0]
-    return XRootDStatus(result), None
+    advanced = mkdir or timeout or handler or retry is not None or \
+               thirdparty != 'none' or checksummode != 'none' or \
+               checksumtype or checksumpreset or posc or coerce or cont or \
+               chunksize is not None or parallelchunks is not None or \
+               return_results
+
+    if not advanced:
+      result = self.__fs.copy(source=source, target=target, force=force)[0]
+      return XRootDStatus(result), None
+
+    with CopyProcess() as copy_process:
+      status, results = copy_process.copy(source=source, target=target,
+                                          force=force, mkdir=mkdir,
+                                          timeout=timeout, handler=handler,
+                                          retry=retry,
+                                          thirdparty=thirdparty,
+                                          checksummode=checksummode,
+                                          checksumtype=checksumtype,
+                                          checksumpreset=checksumpreset,
+                                          posc=posc, coerce=coerce, cont=cont,
+                                          chunksize=chunksize,
+                                          parallelchunks=parallelchunks)
+    return status, results if return_results else None
 
   def locate(self, path, flags, timeout=0, callback=None):
     """Locate a file.

--- a/python/tests/test_copy.py
+++ b/python/tests/test_copy.py
@@ -25,6 +25,26 @@ def test_copy_smallfile():
   assert size1 == size2
   f.close()
 
+def test_copyprocess_context_manager():
+  f = client.File()
+  s, r = f.open(smallfile, OpenFlags.DELETE)
+  assert s.ok
+  f.write(smallbuffer)
+  size1 = f.stat(force=True)[1].size
+  f.close()
+
+  with client.CopyProcess() as c:
+    s, __ = c.copy(source=smallfile, target=smallcopy, force=True,
+                   mkdir=True, timeout=10)
+  assert s.ok
+
+  f = client.File()
+  s, r = f.open(smallcopy, OpenFlags.READ)
+  size2 = f.stat()[1].size
+
+  assert size1 == size2
+  f.close()
+
 def test_create_bigfile():
   f = client.File()
   s, r = f.open(bigfile, OpenFlags.DELETE)


### PR DESCRIPTION
## Summary

Adds higher-level Python copy conveniences:

- `CopyProcess` can be used as a context manager
- `CopyProcess.copy()` runs a single copy job with common options such as mkdir, timeout, retry, checksum settings, progress handler, and cancellation via `should_cancel`
- `FileSystem.copy()` preserves its existing simple path, but routes advanced options through `CopyProcess.copy()`
- docs and server-backed test coverage for the new helper path

