### PR TITLE
[Python] Add client workflow examples

### DIFF
--- a/python/docs/source/examples/filesystem.rst
+++ b/python/docs/source/examples/filesystem.rst
@@ -116,3 +116,16 @@ rest of the examples::
    :start-line: 4
    :end-line: 11
 
+.. -----------------------------------------------------------------------------
+.. common workflows
+.. -----------------------------------------------------------------------------
+
+Common workflows
+----------------
+
+The following example maps common ``xrdcp`` and ``xrdfs`` workflows to Python,
+including authentication environment values, endpoint checks, copy, checksum
+lookup, rename, and delete.
+
+.. literalinclude:: ../../../examples/client_workflows.py
+   :lines: 9-

--- a/python/examples/client_workflows.py
+++ b/python/examples/client_workflows.py
@@ -1,0 +1,42 @@
+"""
+Common FileSystem workflows.
+
+This example maps common ``xrdfs`` and ``xrdcp`` operations to the Python
+bindings, including authentication environment values, endpoint checks, checksum
+queries, copy, rename, and delete.
+"""
+
+from __future__ import print_function
+
+from XRootD import client
+from XRootD.client.flags import QueryCode
+
+
+endpoint = 'root://localhost/'
+source = endpoint + '/tmp/source.dat'
+target = endpoint + '/tmp/target.dat'
+renamed = endpoint + '/tmp/renamed.dat'
+
+
+client.EnvPutString('XrdSecPROTOCOL', 'ztn')
+client.EnvPutString('BEARER_TOKEN', 'replace-with-token')
+
+fs = client.FileSystem(endpoint)
+
+status, _ = fs.ping(timeout=10)
+print(status)
+
+status, protocol = fs.protocol(timeout=10)
+print(status, protocol)
+
+status, _ = fs.copy(source, target, force=True)
+print(status)
+
+status, checksum = fs.query(QueryCode.CHECKSUM, target, timeout=10)
+print(status, checksum)
+
+status, _ = fs.mv(target, renamed, timeout=10)
+print(status)
+
+status, _ = fs.rm(renamed, timeout=10)
+print(status)


### PR DESCRIPTION
## Summary

Adds a standalone Python client workflow example mapping common `xrdcp` and `xrdfs` tasks to the existing bindings:

- auth environment values
- endpoint ping/protocol checks
- copy
- checksum query
- rename and delete

The example intentionally uses APIs already available on `xrootd/xrootd:master`, so this docs PR is independent of the helper API PRs. This branch is based on `xrootd/xrootd:master`; fork-only commits such as `08c97cb6a53536f2cb88e77ca0caa9257e99be48` are not included.

## Validation

- `python3 -m compileall python/examples/client_workflows.py`
- `git diff --check`
