### PR TITLE
[Python] Include py.typed marker

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -135,6 +135,9 @@ setup(name='xrootd',
       long_description=open(srcdir + '/README.md').read(),
       long_description_content_type='text/plain',
       packages = ['XRootD', 'XRootD.client', 'pyxrootd'],
+      package_data = {
+        'XRootD.client': ['py.typed'],
+      },
       package_dir = {
         'pyxrootd'     : srcdir + '/src',
         'XRootD'       : srcdir + '/libs',

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,9 @@ setup(name='xrootd',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',
       packages = ['XRootD', 'XRootD.client', 'pyxrootd'],
+      package_data = {
+        'XRootD.client': ['py.typed'],
+      },
       package_dir = {
         'pyxrootd'     : 'python/src',
         'XRootD'       : 'python/libs',


### PR DESCRIPTION
## Summary

Marks the Python client package as typed for PEP 561-aware tooling:

- adds `python/libs/client/py.typed`
- includes the marker in both setup entry points via `package_data`
