### PR TITLE
[Python] Add recursive filesystem utilities

### DIFF
--- a/python/libs/client/fsutils.py
+++ b/python/libs/client/fsutils.py
@@ -1,0 +1,213 @@
+# -------------------------------------------------------------------------------
+# Copyright (c) 2026 by European Organization for Nuclear Research (CERN)
+# -------------------------------------------------------------------------------
+# This file is part of the XRootD software suite.
+#
+# XRootD is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# XRootD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+import posixpath
+import stat
+
+from XRootD.client.flags import DirListFlags, MkDirFlags, StatInfoFlags
+
+
+class DirectoryEntry:
+    """A normalized directory-listing entry with its absolute remote path."""
+
+    def __init__(self, parent, entry):
+        self.parent = parent
+        self.name = entry.name
+        self.path = remote_join(parent, entry.name)
+        self.hostaddr = getattr(entry, "hostaddr", None)
+        self.statinfo = entry.statinfo
+
+    @property
+    def is_directory(self):
+        return is_directory(self.statinfo)
+
+    @property
+    def is_file(self):
+        return is_file(self.statinfo)
+
+    @property
+    def size(self):
+        return file_size(self.statinfo)
+
+
+class DirectorySize:
+    """Directory accounting information.
+
+    :var files:      number of files
+    :var size:       summed file size in bytes
+    :var subdirs:    number of sub-directories
+    """
+
+    def __init__(self):
+        self.files = 0
+        self.size = 0
+        self.subdirs = 0
+
+    def add(self, entry):
+        if entry.is_directory:
+            self.subdirs += 1
+        elif entry.is_file:
+            self.files += 1
+            self.size += entry.size
+
+    def as_dict(self):
+        return {
+            "Files": self.files,
+            "Size": self.size,
+            "SubDirs": self.subdirs,
+        }
+
+
+class RemoveTreeResult:
+    """Recursive deletion accounting information."""
+
+    def __init__(self):
+        self.files_removed = 0
+        self.directories_removed = 0
+        self.size_removed = 0
+
+    def as_dict(self):
+        return {
+            "FilesRemoved": self.files_removed,
+            "DirectoriesRemoved": self.directories_removed,
+            "SizeRemoved": self.size_removed,
+        }
+
+
+def remote_join(parent, name):
+    """Join XRootD paths without using platform-specific path separators."""
+    if not parent:
+        parent = "/"
+    return posixpath.join(parent.rstrip("/") or "/", name)
+
+
+def is_directory(statinfo):
+    """Return ``True`` when a stat response describes a directory."""
+    if not statinfo:
+        return False
+    mode = getattr(statinfo, "mode", None)
+    if mode is not None:
+        return stat.S_ISDIR(mode)
+    return bool(statinfo.flags & StatInfoFlags.IS_DIR)
+
+
+def is_file(statinfo):
+    """Return ``True`` when a stat response describes a regular file."""
+    if not statinfo:
+        return False
+    mode = getattr(statinfo, "mode", None)
+    if mode is not None:
+        return stat.S_ISREG(mode)
+    return not bool(
+        statinfo.flags & (StatInfoFlags.IS_DIR | StatInfoFlags.OTHER)
+    )
+
+
+def file_size(statinfo):
+    """Return a stat response size, or ``0`` when no size is available."""
+    if not statinfo:
+        return 0
+    return int(getattr(statinfo, "size", 0) or 0)
+
+
+def mkdir_p(filesystem, path, mode=0, timeout=0):
+    """Create a directory and its parents.
+
+    This is a small GFAL-style convenience wrapper around
+    :meth:`XRootD.client.FileSystem.mkdir` using ``MkDirFlags.MAKEPATH``.
+    """
+    return filesystem.mkdir(path, MkDirFlags.MAKEPATH, mode, timeout)
+
+
+def list_directory(filesystem, path, timeout=0):
+    """List one directory with stat information.
+
+    :returns: tuple containing ``XRootDStatus`` and a list of
+              :class:`DirectoryEntry` objects.
+    """
+    status, directory = filesystem.dirlist(path, DirListFlags.STAT, timeout)
+    if not status.ok:
+        return status, []
+    return status, [DirectoryEntry(path, entry) for entry in directory]
+
+
+def list_tree(filesystem, path, timeout=0):
+    """Recursively list a directory tree.
+
+    The returned list is depth-first and contains entries below ``path``; the
+    root path itself is not included.
+    """
+    status, entries = list_directory(filesystem, path, timeout)
+    if not status.ok:
+        return status, []
+
+    tree = []
+    for entry in entries:
+        tree.append(entry)
+        if entry.is_directory:
+            status, children = list_tree(filesystem, entry.path, timeout)
+            tree.extend(children)
+            if not status.ok:
+                return status, tree
+    return status, tree
+
+
+def directory_size(filesystem, path, recursive=False, timeout=0):
+    """Return file, byte, and sub-directory counts for a directory."""
+    if recursive:
+        status, entries = list_tree(filesystem, path, timeout)
+    else:
+        status, entries = list_directory(filesystem, path, timeout)
+
+    result = DirectorySize()
+    for entry in entries:
+        result.add(entry)
+    return status, result
+
+
+def remove_tree(filesystem, path, timeout=0):
+    """Recursively remove a directory tree.
+
+    Files are removed before directories. The returned result contains counts
+    for successfully removed files/directories and the summed size of removed
+    files.
+    """
+    result = RemoveTreeResult()
+    status, entries = list_directory(filesystem, path, timeout)
+    if not status.ok:
+        return status, result
+
+    for entry in entries:
+        if entry.is_directory:
+            status, child_result = remove_tree(filesystem, entry.path, timeout)
+            result.files_removed += child_result.files_removed
+            result.directories_removed += child_result.directories_removed
+            result.size_removed += child_result.size_removed
+            if not status.ok:
+                return status, result
+        elif entry.is_file:
+            status, _ = filesystem.rm(entry.path, timeout)
+            if not status.ok:
+                return status, result
+            result.files_removed += 1
+            result.size_removed += entry.size
+
+    status, _ = filesystem.rmdir(path, timeout)
+    if status.ok:
+        result.directories_removed += 1
+    return status, result

--- a/python/tests/test_fsutils.py
+++ b/python/tests/test_fsutils.py
@@ -1,0 +1,122 @@
+import stat
+
+from XRootD.client import fsutils
+from XRootD.client.flags import MkDirFlags, StatInfoFlags
+
+
+class Status:
+    def __init__(self, ok=True):
+        self.ok = ok
+        self.message = "OK" if ok else "error"
+
+
+class StatInfo:
+    def __init__(self, size=0, flags=0, mode=None):
+        self.size = size
+        self.flags = flags
+        self.mode = mode
+
+
+class Entry:
+    def __init__(self, name, statinfo):
+        self.name = name
+        self.hostaddr = None
+        self.statinfo = statinfo
+
+
+class FakeFileSystem:
+    def __init__(self):
+        self.removed_files = []
+        self.removed_dirs = []
+        self.mkdir_calls = []
+        self.tree = {
+            "/data": [
+                Entry("one.dat", StatInfo(size=10)),
+                Entry("nested", StatInfo(flags=StatInfoFlags.IS_DIR)),
+            ],
+            "/data/nested": [
+                Entry("two.dat", StatInfo(size=20)),
+            ],
+        }
+
+    def dirlist(self, path, flags, timeout=0):
+        return Status(), list(self.tree.get(path, []))
+
+    def mkdir(self, path, flags, mode=0, timeout=0):
+        self.mkdir_calls.append((path, flags, mode, timeout))
+        return Status(), None
+
+    def rm(self, path, timeout=0):
+        self.removed_files.append(path)
+        return Status(), None
+
+    def rmdir(self, path, timeout=0):
+        self.removed_dirs.append(path)
+        return Status(), None
+
+
+def test_list_tree_returns_absolute_entries():
+    status, entries = fsutils.list_tree(FakeFileSystem(), "/data")
+
+    assert status.ok
+    assert [entry.path for entry in entries] == [
+        "/data/one.dat",
+        "/data/nested",
+        "/data/nested/two.dat",
+    ]
+
+
+def test_directory_size_can_be_recursive():
+    status, result = fsutils.directory_size(
+        FakeFileSystem(),
+        "/data",
+        recursive=True,
+    )
+
+    assert status.ok
+    assert result.files == 2
+    assert result.subdirs == 1
+    assert result.size == 30
+    assert result.as_dict() == {"Files": 2, "Size": 30, "SubDirs": 1}
+
+
+def test_is_file_requires_regular_file_mode_when_available():
+    assert fsutils.is_file(StatInfo(mode=stat.S_IFREG | 0o644))
+    assert not fsutils.is_file(StatInfo(mode=stat.S_IFDIR | 0o755))
+    assert not fsutils.is_file(StatInfo(mode=stat.S_IFIFO | 0o644))
+
+
+def test_is_file_rejects_other_stat_flag_without_mode():
+    assert not fsutils.is_file(StatInfo(flags=StatInfoFlags.OTHER))
+
+
+def test_remove_tree_removes_files_before_directories():
+    filesystem = FakeFileSystem()
+
+    status, result = fsutils.remove_tree(filesystem, "/data")
+
+    assert status.ok
+    assert filesystem.removed_files == [
+        "/data/one.dat",
+        "/data/nested/two.dat",
+    ]
+    assert filesystem.removed_dirs == ["/data/nested", "/data"]
+    assert result.files_removed == 2
+    assert result.directories_removed == 2
+    assert result.size_removed == 30
+
+
+def test_mkdir_p_uses_makepath_flag():
+    filesystem = FakeFileSystem()
+
+    status, _ = fsutils.mkdir_p(
+        filesystem,
+        "/data/new/path",
+        mode=493,
+        timeout=7,
+    )
+
+    assert status.ok
+    assert filesystem.mkdir_calls == [
+        ("/data/new/path", MkDirFlags.MAKEPATH, 493, 7),
+    ]


### PR DESCRIPTION
## Summary

This adds a standalone `XRootD.client.fsutils` module with small high-level helpers for recursive filesystem workflows:

- `mkdir_p` for simple parent-directory creation semantics
- `list_tree` for recursive directory traversal with absolute remote paths
- `directory_size` for file count, byte total, and subdirectory accounting
- `remove_tree` for recursive deletion in the correct order: files first, child directories next, parent directory last

## Motivation

Storage clients such as Rucio and DIRAC can already call low-level XRootD operations like `dirlist`, `rm`, `rmdir`, and `mkdir`, but GFAL currently provides higher-level behavior that applications rely on when replacing GFAL-backed storage plugins with native XRootD bindings.

For DIRAC, this maps to GFAL storage behavior such as directory size/accounting, recursive directory removal, and pieces of recursive directory upload/download workflows. For Rucio, this avoids each integration having to reimplement the same recursive `xrdfs`-style traversal and cleanup logic on top of low-level calls.

The goal is to move this GFAL replacement glue into the Python bindings so clients can share one tested implementation while the lower-level API remains available for callers that need full control.
