### PR TITLE
[Python] Add lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,49 @@
+name: Lint
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - '**'
+    paths:
+      - .github/workflows/lint.yml
+      - .pre-commit-config.yaml
+      - pyproject.toml
+      - 'python/**'
+  pull_request:
+    paths:
+      - .github/workflows/lint.yml
+      - .pre-commit-config.yaml
+      - pyproject.toml
+      - 'python/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v6
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.14"
+
+    - name: Install pre-commit
+      run: python -m pip install pre-commit
+
+    - name: Run Python linters
+      run: pre-commit run ruff --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+        files: ^(\.github/workflows/.*\.ya?ml|\.pre-commit-config\.yaml|pyproject\.toml)$
+      - id: trailing-whitespace
+        files: ^(\.github/workflows/.*\.ya?ml|\.pre-commit-config\.yaml|pyproject\.toml)$
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.15
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^python/(libs|src|tests)/.*\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,33 @@
 [build-system]
 requires = ["setuptools>=42"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+line-length = 88
+target-version = "py39"
+force-exclude = true
+extend-exclude = [
+    "python/examples",
+]
+
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = [
+    # Existing Python binding code predates the lint setup. Keep the initial
+    # hook focused on syntax and serious name errors, then tighten in follow-up
+    # cleanup PRs.
+    "E401",
+    "E701",
+    "E703",
+    "E712",
+    "E741",
+    "F401",
+    "F403",
+    "F405",
+    "F841",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "auto"


### PR DESCRIPTION
## Summary
- add a dedicated lint workflow that currently runs the Python Ruff pre-commit hook
- add a root pre-commit configuration with YAML/TOML checks and scoped whitespace cleanup for config/workflow files
- configure Ruff for the Python bindings, package entrypoints, and tests

## Notes
- The lint workflow is structured as a general "Lint" workflow with a Python job, so C++ linting can be added later as a separate job.
- This PR intentionally does not modify existing Python source files. Historical whitespace and formatting cleanup can be handled separately.
- Ruff is initially scoped to python/libs, python/src, and python/tests. The legacy python/examples tree still contains Python 2 style snippets, so it is excluded from Ruff until that cleanup is handled separately.
- The initial Ruff rule set focuses on syntax and serious name errors, with historical Python binding issues ignored so the hook can be enabled incrementally.

## Validation
- pre-commit run --all-files --show-diff-on-failure
- pre-commit run ruff --all-files --show-diff-on-failure
- git diff --check origin/master...HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated lint checks for code changes and manual runs.
  * Added pre-commit checks for formatting, file consistency, and Python linting.
  * Configured standardized Python linting and formatting rules, including legacy-code exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->