### PR TITLE
[XrdCl] Extract curl helper utilities

### DIFF
--- a/src/XrdCl/XrdClCurlUtil.cc
+++ b/src/XrdCl/XrdClCurlUtil.cc
@@ -1,0 +1,340 @@
+/******************************************************************************/
+/*                                                                            */
+/*                    X r d C l C u r l U t i l . c c                         */
+/*                                                                            */
+/* (c) 2026 by the XRootD Collaboration                                       */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/******************************************************************************/
+
+#include "XrdClCurlUtil.hh"
+
+#include "XrdCl/XrdClEnv.hh"
+#include "XrdCl/XrdClLog.hh"
+#include "XrdCl/XrdClXRootDResponses.hh"
+#include "XrdVersion.hh"
+#include "XProtocol/XProtocol.hh"
+
+#include <cerrno>
+#include <cstdlib>
+
+#include <unistd.h>
+
+namespace
+{
+  void SetIfEmpty( XrdCl::Env *env, XrdCl::Log &log,
+                   const std::string &optName, const std::string &envName,
+                   uint64_t logTopic )
+  {
+    if( !env ) return;
+
+    std::string val;
+    if( !env->GetString( optName, val ) || val.empty() )
+    {
+      env->PutString( optName, "" );
+      env->ImportString( optName, envName );
+    }
+    if( env->GetString( optName, val ) && !val.empty() )
+    {
+      log.Info( logTopic, "Setting %s to value '%s'",
+                optName.c_str(), val.c_str() );
+    }
+  }
+}
+
+namespace XrdCl
+{
+namespace CurlUtil
+{
+  bool HTTPStatusIsError( unsigned status )
+  {
+    return (status < 100) || (status >= 400);
+  }
+
+  std::pair<uint16_t, uint32_t> HTTPStatusConvert( unsigned status )
+  {
+    switch( status )
+    {
+      case 400: // Bad Request
+        return std::make_pair( XrdCl::errErrorResponse, kXR_InvalidRequest );
+      case 401: // Unauthorized (needs authentication)
+        return std::make_pair( XrdCl::errErrorResponse, kXR_NotAuthorized );
+      case 402: // Payment Required
+      case 403: // Forbidden (failed authorization)
+        return std::make_pair( XrdCl::errErrorResponse, kXR_NotAuthorized );
+      case 404:
+        return std::make_pair( XrdCl::errErrorResponse, kXR_NotFound );
+      case 405: // Method not allowed
+      case 406: // Not acceptable
+        return std::make_pair( XrdCl::errErrorResponse, kXR_InvalidRequest );
+      case 407: // Proxy Authentication Required
+        return std::make_pair( XrdCl::errErrorResponse, kXR_NotAuthorized );
+      case 408: // Request timeout
+        return std::make_pair( XrdCl::errErrorResponse, kXR_ReqTimedOut );
+      case 409: // Conflict
+        return std::make_pair( XrdCl::errErrorResponse, kXR_Conflict );
+      case 410: // Gone
+        return std::make_pair( XrdCl::errErrorResponse, kXR_NotFound );
+      case 411: // Length required
+      case 412: // Precondition failed
+      case 413: // Payload too large
+      case 414: // URI too long
+      case 415: // Unsupported Media Type
+      case 416: // Range Not Satisfiable
+      case 417: // Expectation Failed
+      case 418: // I'm a teapot
+        return std::make_pair( XrdCl::errErrorResponse, kXR_InvalidRequest );
+      case 421: // Misdirected Request
+      case 422: // Unprocessable Content
+        return std::make_pair( XrdCl::errErrorResponse, kXR_InvalidRequest );
+      case 423: // Locked
+        return std::make_pair( XrdCl::errErrorResponse, kXR_FileLocked );
+      case 424: // Failed Dependency
+      case 425: // Too Early
+      case 426: // Upgrade Required
+      case 428: // Precondition Required
+        return std::make_pair( XrdCl::errErrorResponse, kXR_InvalidRequest );
+      case 429: // Too Many Requests
+        return std::make_pair( XrdCl::errErrorResponse, kXR_Overloaded );
+      case 431: // Request Header Fields Too Large
+        return std::make_pair( XrdCl::errErrorResponse, kXR_InvalidRequest );
+      case 451: // Unavailable For Legal Reasons
+        return std::make_pair( XrdCl::errErrorResponse, kXR_Impossible );
+      case 500: // Internal Server Error
+      case 501: // Not Implemented
+      case 502: // Bad Gateway
+      case 503: // Service Unavailable
+        return std::make_pair( XrdCl::errErrorResponse, kXR_ServerError );
+      case 504: // Gateway Timeout
+        return std::make_pair( XrdCl::errErrorResponse, kXR_ReqTimedOut );
+      case 507: // Insufficient Storage
+        return std::make_pair( XrdCl::errErrorResponse, kXR_overQuota );
+      case 508: // Loop Detected
+      case 510: // Not Extended
+      case 511: // Network Authentication Required
+        return std::make_pair( XrdCl::errErrorResponse, kXR_ServerError );
+    }
+    return std::make_pair( XrdCl::errUnknown, status );
+  }
+
+  std::pair<uint16_t, uint32_t> CurlCodeConvert( CURLcode result )
+  {
+    switch( result )
+    {
+      case CURLE_OK:
+        return std::make_pair( XrdCl::errNone, 0 );
+      case CURLE_COULDNT_RESOLVE_PROXY:
+      case CURLE_COULDNT_RESOLVE_HOST:
+        return std::make_pair( XrdCl::errInvalidAddr, 0 );
+      case CURLE_LOGIN_DENIED:
+      // Commented-out cases are for platforms (RHEL7) where the error
+      // codes are undefined.
+      //case CURLE_AUTH_ERROR:
+      //case CURLE_SSL_CLIENTCERT:
+      case CURLE_REMOTE_ACCESS_DENIED:
+        return std::make_pair( XrdCl::errLoginFailed, EACCES );
+      case CURLE_SSL_CONNECT_ERROR:
+      case CURLE_SSL_ENGINE_NOTFOUND:
+      case CURLE_SSL_ENGINE_SETFAILED:
+      case CURLE_SSL_CERTPROBLEM:
+      case CURLE_SSL_CIPHER:
+      case 51: // In old curl versions, this is CURLE_PEER_FAILED_VERIFICATION
+      case CURLE_SSL_SHUTDOWN_FAILED:
+      case CURLE_SSL_CRL_BADFILE:
+      case CURLE_SSL_ISSUER_ERROR:
+      case CURLE_SSL_CACERT:
+        return std::make_pair( XrdCl::errTlsError, 0 );
+      case CURLE_SEND_ERROR:
+      case CURLE_RECV_ERROR:
+        return std::make_pair( XrdCl::errSocketError, EIO );
+      case CURLE_COULDNT_CONNECT:
+      case CURLE_GOT_NOTHING:
+        return std::make_pair( XrdCl::errConnectionError, ECONNREFUSED );
+      case CURLE_OPERATION_TIMEDOUT:
+#ifdef HAVE_XPROTOCOL_TIMEREXPIRED
+        return std::make_pair( XrdCl::errErrorResponse,
+                               XErrorCode::kXR_TimerExpired );
+#else
+        return std::make_pair( XrdCl::errOperationExpired, ESTALE );
+#endif
+      case CURLE_UNSUPPORTED_PROTOCOL:
+      case CURLE_NOT_BUILT_IN:
+        return std::make_pair( XrdCl::errNotSupported, ENOSYS );
+      case CURLE_FAILED_INIT:
+        return std::make_pair( XrdCl::errInternal, 0 );
+      case CURLE_URL_MALFORMAT:
+        return std::make_pair( XrdCl::errInvalidArgs, result );
+      //case CURLE_WEIRD_SERVER_REPLY:
+      //case CURLE_HTTP2:
+      //case CURLE_HTTP2_STREAM:
+        return std::make_pair( XrdCl::errCorruptedHeader, result );
+      case CURLE_PARTIAL_FILE:
+        return std::make_pair( XrdCl::errDataError, result );
+      // These two errors indicate a failure in the callback. That should
+      // generate its own failure, meaning this should never get used.
+      case CURLE_READ_ERROR:
+      case CURLE_WRITE_ERROR:
+        return std::make_pair( XrdCl::errInternal, result );
+      case CURLE_RANGE_ERROR:
+      case CURLE_BAD_CONTENT_ENCODING:
+        return std::make_pair( XrdCl::errNotSupported, result );
+      case CURLE_TOO_MANY_REDIRECTS:
+        return std::make_pair( XrdCl::errRedirectLimit, result );
+      default:
+        return std::make_pair( XrdCl::errUnknown, result );
+    }
+  }
+
+  void ConfigureX509Env( Env *env, Log &log, uint64_t logTopic )
+  {
+    if( !env ) return;
+
+    SetIfEmpty( env, log, "HttpCertFile", "XRD_HTTPCERTFILE", logTopic );
+    SetIfEmpty( env, log, "HttpCertDir", "XRD_HTTPCERTDIR", logTopic );
+    SetIfEmpty( env, log, "HttpClientCertFile",
+                "XRD_HTTPCLIENTCERTFILE", logTopic );
+    SetIfEmpty( env, log, "HttpClientKeyFile",
+                "XRD_HTTPCLIENTKEYFILE", logTopic );
+
+    int disableProxy = 0;
+    env->PutInt( "HttpDisableX509", 0 );
+    env->ImportInt( "HttpDisableX509", "XRD_HTTPDISABLEX509" );
+
+    std::string filename;
+    char *filenameChar;
+    if( !disableProxy &&
+        (!env->GetString( "HttpClientCertFile", filename ) || filename.empty()) )
+    {
+      if( (filenameChar = getenv( "X509_USER_PROXY" )) )
+      {
+        filename = filenameChar;
+      }
+      if( filename.empty() )
+      {
+        filename = "/tmp/x509up_u" + std::to_string( geteuid() );
+      }
+      if( access( filename.c_str(), R_OK ) == 0 )
+      {
+        log.Debug( logTopic,
+                   "Using X509 proxy file found at %s for TLS client credential",
+                   filename.c_str() );
+        env->PutString( "HttpClientCertFile", filename );
+        env->PutString( "HttpClientKeyFile", filename );
+      }
+    }
+    if( (!env->GetString( "HttpCertDir", filename ) || filename.empty()) &&
+        (filenameChar = getenv( "X509_CERT_DIR" )) )
+    {
+      env->PutString( "HttpCertDir", filenameChar );
+    }
+  }
+
+  bool UseClientX509( Env *env )
+  {
+    int disableX509;
+    return env && env->GetInt( "HttpDisableX509", disableX509 ) && !disableX509;
+  }
+
+  X509Credentials GetClientX509Credentials( Env *env )
+  {
+    X509Credentials credentials;
+    if( !env ) return credentials;
+    env->GetString( "HttpClientCertFile", credentials.cert );
+    env->GetString( "HttpClientKeyFile", credentials.key );
+    return credentials;
+  }
+
+  void ApplyCurlCAConfig( CURL *curl, Env *env )
+  {
+    if( !curl || !env ) return;
+
+    std::string caFile;
+    if( !env->GetString( "HttpCertFile", caFile ) || caFile.empty() )
+    {
+      char *x509CAFile = getenv( "X509_CERT_FILE" );
+      if( x509CAFile )
+      {
+        caFile = std::string( x509CAFile );
+      }
+    }
+    if( !caFile.empty() )
+    {
+      curl_easy_setopt( curl, CURLOPT_CAINFO, caFile.c_str() );
+    }
+
+    std::string caDir;
+    if( !env->GetString( "HttpCertDir", caDir ) || caDir.empty() )
+    {
+      char *x509CADir = getenv( "X509_CERT_DIR" );
+      if( x509CADir )
+      {
+        caDir = std::string( x509CADir );
+      }
+    }
+    if( !caDir.empty() )
+    {
+      curl_easy_setopt( curl, CURLOPT_CAPATH, caDir.c_str() );
+    }
+  }
+
+  void ApplyClientX509Credentials( CURL *curl,
+                                   const X509Credentials &credentials,
+                                   Log *log,
+                                   uint64_t logTopic,
+                                   bool requireKey )
+  {
+    if( !curl || credentials.cert.empty() ) return;
+
+    if( log )
+    {
+      log->Debug( logTopic, "Using client X.509 credential found at %s",
+                  credentials.cert.c_str() );
+    }
+    curl_easy_setopt( curl, CURLOPT_SSLCERT, credentials.cert.c_str() );
+    if( credentials.key.empty() )
+    {
+      if( requireKey && log )
+      {
+        log->Error( logTopic,
+                    "X.509 client credential specified but not the client key" );
+      }
+    }
+    else
+    {
+      curl_easy_setopt( curl, CURLOPT_SSLKEY, credentials.key.c_str() );
+    }
+  }
+
+  CURL *CreateCurlHandle( const char *userAgent, bool verbose, Env *env )
+  {
+    CURL *curl = curl_easy_init();
+    if( !curl ) return curl;
+
+    if( userAgent )
+    {
+      curl_easy_setopt( curl, CURLOPT_USERAGENT, userAgent );
+    }
+    if( verbose )
+    {
+      curl_easy_setopt( curl, CURLOPT_VERBOSE, 1L );
+    }
+    ApplyCurlCAConfig( curl, env );
+    return curl;
+  }
+}
+}

--- a/src/XrdCl/XrdClCurlUtil.hh
+++ b/src/XrdCl/XrdClCurlUtil.hh
@@ -1,0 +1,65 @@
+/******************************************************************************/
+/*                                                                            */
+/*                    X r d C l C u r l U t i l . h h                         */
+/*                                                                            */
+/* (c) 2026 by the XRootD Collaboration                                       */
+/*                                                                            */
+/* This file is part of the XRootD software suite.                            */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* You should have received a copy of the GNU Lesser General Public License   */
+/* along with XRootD in a file called COPYING.LESSER (LGPL license) and file  */
+/* COPYING (GPL license).  If not, see <http://www.gnu.org/licenses/>.        */
+/*                                                                            */
+/******************************************************************************/
+
+#ifndef __XRD_CL_CURL_UTIL_HH__
+#define __XRD_CL_CURL_UTIL_HH__
+
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include <curl/curl.h>
+
+namespace XrdCl
+{
+  class Env;
+  class Log;
+
+  namespace CurlUtil
+  {
+    struct X509Credentials
+    {
+      std::string cert;
+      std::string key;
+    };
+
+    bool HTTPStatusIsError( unsigned status );
+    std::pair<uint16_t, uint32_t> HTTPStatusConvert( unsigned status );
+    std::pair<uint16_t, uint32_t> CurlCodeConvert( CURLcode result );
+
+    void ConfigureX509Env( Env *env, Log &log, uint64_t logTopic );
+    bool UseClientX509( Env *env );
+    X509Credentials GetClientX509Credentials( Env *env );
+
+    void ApplyCurlCAConfig( CURL *curl, Env *env );
+    void ApplyClientX509Credentials( CURL *curl,
+                                     const X509Credentials &credentials,
+                                     Log *log = nullptr,
+                                     uint64_t logTopic = 0,
+                                     bool requireKey = false );
+    CURL *CreateCurlHandle( const char *userAgent, bool verbose, Env *env );
+  }
+}
+
+#endif // __XRD_CL_CURL_UTIL_HH__

--- a/src/XrdClHttp/CMakeLists.txt
+++ b/src/XrdClHttp/CMakeLists.txt
@@ -9,6 +9,8 @@ if(NOT CURL_FOUND)
 endif()
 
 add_library(XrdClHttpObj OBJECT
+  ../XrdCl/XrdClCurlUtil.cc
+  ../XrdCl/XrdClCurlUtil.hh
   XrdClHttpFactory.cc        XrdClHttpFactory.hh
   XrdClHttpFile.cc           XrdClHttpFile.hh
   XrdClHttpFilesystem.cc     XrdClHttpFilesystem.hh

--- a/src/XrdClHttp/XrdClHttpFactory.cc
+++ b/src/XrdClHttp/XrdClHttpFactory.cc
@@ -27,6 +27,7 @@
 #include "XrdClHttpWorker.hh"
 
 #include "XrdCl/XrdClConstants.hh"
+#include "XrdCl/XrdClCurlUtil.hh"
 #include "XrdCl/XrdClDefaultEnv.hh"
 #include "XrdCl/XrdClLog.hh"
 #include "XrdXrootd/XrdXrootdGStream.hh"
@@ -267,54 +268,10 @@ Factory::Monitor()
     }
 }
 
-namespace {
-
-void SetIfEmpty(XrdCl::Env *env, XrdCl::Log &log, const std::string &optName, const std::string &envName) {
-    if (!env) return;
-
-    std::string val;
-    if (!env->GetString(optName, val) || val.empty()) {
-        env->PutString(optName, "");
-        env->ImportString(optName, envName);
-    }
-    if (env->GetString(optName, val) && !val.empty()) {
-        log.Info(kLogXrdClHttp, "Setting %s to value '%s'", optName.c_str(), val.c_str());
-    }
-}
-
-} // namespace
-
 void
 Factory::SetupX509() {
-
-    auto env = XrdCl::DefaultEnv::GetEnv();
-    SetIfEmpty(env, *m_log, "HttpCertFile", "XRD_HTTPCERTFILE");
-    SetIfEmpty(env, *m_log, "HttpCertDir", "XRD_HTTPCERTDIR");
-    SetIfEmpty(env, *m_log, "HttpClientCertFile", "XRD_HTTPCLIENTCERTFILE");
-    SetIfEmpty(env, *m_log, "HttpClientKeyFile", "XRD_HTTPCLIENTKEYFILE");
-
-    int disable_proxy = 0;
-    env->PutInt("HttpDisableX509", 0);
-    env->ImportInt("HttpDisableX509", "XRD_HTTPDISABLEX509");
-
-    std::string filename;
-    char *filename_char;
-    if (!disable_proxy && (!env->GetString("HttpClientCertFile", filename) || filename.empty())) {
-        if ((filename_char = getenv("X509_USER_PROXY"))) {
-            filename = filename_char;
-        }
-        if (filename.empty()) {
-            filename = "/tmp/x509up_u" + std::to_string(geteuid());
-        }
-        if (access(filename.c_str(), R_OK) == 0) {
-            m_log->Debug(kLogXrdClHttp, "Using X509 proxy file found at %s for TLS client credential", filename.c_str());
-            env->PutString("HttpClientCertFile", filename);
-            env->PutString("HttpClientKeyFile", filename);
-        }
-    }
-    if ((!env->GetString("HttpCertDir", filename) || filename.empty()) && (filename_char = getenv("X509_CERT_DIR"))) {
-        env->PutString("HttpCertDir", filename_char);
-    }
+    XrdCl::CurlUtil::ConfigureX509Env(
+        XrdCl::DefaultEnv::GetEnv(), *m_log, kLogXrdClHttp);
 }
 
 void

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -23,6 +23,7 @@
 #include "XrdClHttpUtil.hh"
 #include "XrdClHttpWorker.hh"
 
+#include <XrdCl/XrdClCurlUtil.hh>
 #include <XrdCl/XrdClDefaultEnv.hh>
 #include <XrdCl/XrdClLog.hh>
 #include <XrdCl/XrdClXRootDResponses.hh>
@@ -332,16 +333,10 @@ CurlOperation::Redirect(std::string &target)
     m_logger->Debug(kLogXrdClHttp, "Request for %s redirected to %s", m_url.c_str(), location.c_str());
     target = location;
     curl_easy_setopt(m_curl.get(), CURLOPT_URL, location.c_str());
-    int disable_x509;
     auto env = XrdCl::DefaultEnv::GetEnv();
-    if (env->GetInt("HttpDisableX509", disable_x509) && !disable_x509) {
-        std::string cert, key;
-        env->GetString("HttpClientCertFile", cert);
-        env->GetString("HttpClientKeyFile", key);
-        if (!cert.empty())
-            curl_easy_setopt(m_curl.get(), CURLOPT_SSLCERT, cert.c_str());
-        if (!key.empty())
-            curl_easy_setopt(m_curl.get(), CURLOPT_SSLKEY, key.c_str());
+    if (XrdCl::CurlUtil::UseClientX509(env)) {
+        XrdCl::CurlUtil::ApplyClientX509Credentials(
+            m_curl.get(), XrdCl::CurlUtil::GetClientX509Credentials(env));
     }
     m_headers = HeaderParser();
 
@@ -550,18 +545,10 @@ CurlOperation::Setup(CURL *curl, CurlWorker &worker)
 
     m_parsed_url.reset(new XrdCl::URL(m_url));
     auto env = XrdCl::DefaultEnv::GetEnv();
-    int disable_x509;
-    if ((env->GetInt("HttpDisableX509", disable_x509) && !disable_x509)) {
-        auto [cert, key] = worker.ClientX509CertKeyFile();
-        if (!cert.empty()) {
-            m_logger->Debug(kLogXrdClHttp, "Using client X.509 credential found at %s", cert.c_str());
-            curl_easy_setopt(m_curl.get(), CURLOPT_SSLCERT, cert.c_str());
-            if (key.empty()) {
-                m_logger->Error(kLogXrdClHttp, "X.509 client credential specified but not the client key");
-            } else {
-                curl_easy_setopt(m_curl.get(), CURLOPT_SSLKEY, key.c_str());
-            }
-        }
+    if (XrdCl::CurlUtil::UseClientX509(env)) {
+        XrdCl::CurlUtil::ApplyClientX509Credentials(
+            m_curl.get(), worker.ClientX509Credentials(), m_logger,
+            kLogXrdClHttp, true);
     }
 
     if (m_conn_callout) {

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -25,6 +25,7 @@
 #include "XrdClHttpWorker.hh"
 
 #include <XProtocol/XProtocol.hh>
+#include <XrdCl/XrdClCurlUtil.hh>
 #include <XrdCl/XrdClDefaultEnv.hh>
 #include <XrdCl/XrdClLog.hh>
 #include <XrdCl/XrdClURL.hh>
@@ -104,139 +105,15 @@ pid_t getthreadid() {
 }
 
 bool XrdClHttp::HTTPStatusIsError(unsigned status) {
-     return (status < 100) || (status >= 400);
+     return XrdCl::CurlUtil::HTTPStatusIsError(status);
 }
 
 std::pair<uint16_t, uint32_t> XrdClHttp::HTTPStatusConvert(unsigned status) {
-    switch (status) {
-        case 400: // Bad Request
-            return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
-        case 401: // Unauthorized (needs authentication)
-            return std::make_pair(XrdCl::errErrorResponse, kXR_NotAuthorized);
-        case 402: // Payment Required
-        case 403: // Forbidden (failed authorization)
-            return std::make_pair(XrdCl::errErrorResponse, kXR_NotAuthorized);
-        case 404:
-            return std::make_pair(XrdCl::errErrorResponse, kXR_NotFound);
-        case 405: // Method not allowed
-        case 406: // Not acceptable
-            return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
-        case 407: // Proxy Authentication Required
-            return std::make_pair(XrdCl::errErrorResponse, kXR_NotAuthorized);
-        case 408: // Request timeout
-            return std::make_pair(XrdCl::errErrorResponse, kXR_ReqTimedOut);
-        case 409: // Conflict
-            return std::make_pair(XrdCl::errErrorResponse, kXR_Conflict);
-        case 410: // Gone
-            return std::make_pair(XrdCl::errErrorResponse, kXR_NotFound);
-        case 411: // Length required
-        case 412: // Precondition failed
-        case 413: // Payload too large
-        case 414: // URI too long
-        case 415: // Unsupported Media Type
-        case 416: // Range Not Satisfiable
-        case 417: // Expectation Failed
-        case 418: // I'm a teapot
-	        return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
-        case 421: // Misdirected Request
-        case 422: // Unprocessable Content
-            return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
-        case 423: // Locked
-            return std::make_pair(XrdCl::errErrorResponse, kXR_FileLocked);
-        case 424: // Failed Dependency
-        case 425: // Too Early
-        case 426: // Upgrade Required
-        case 428: // Precondition Required
-            return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
-        case 429: // Too Many Requests
-            return std::make_pair(XrdCl::errErrorResponse, kXR_Overloaded);
-        case 431: // Request Header Fields Too Large
-            return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
-        case 451: // Unavailable For Legal Reasons
-            return std::make_pair(XrdCl::errErrorResponse, kXR_Impossible);
-        case 500: // Internal Server Error
-        case 501: // Not Implemented
-        case 502: // Bad Gateway
-        case 503: // Service Unavailable
-            return std::make_pair(XrdCl::errErrorResponse, kXR_ServerError);
-        case 504: // Gateway Timeout
-            return std::make_pair(XrdCl::errErrorResponse, kXR_ReqTimedOut);
-        case 507: // Insufficient Storage
-            return std::make_pair(XrdCl::errErrorResponse, kXR_overQuota);
-        case 508: // Loop Detected
-        case 510: // Not Extended
-        case 511: // Network Authentication Required
-            return std::make_pair(XrdCl::errErrorResponse, kXR_ServerError);
-    }
-    return std::make_pair(XrdCl::errUnknown, status);
+    return XrdCl::CurlUtil::HTTPStatusConvert(status);
 }
 
 std::pair<uint16_t, uint32_t> CurlCodeConvert(CURLcode res) {
-    switch (res) {
-        case CURLE_OK:
-            return std::make_pair(XrdCl::errNone, 0);
-        case CURLE_COULDNT_RESOLVE_PROXY:
-        case CURLE_COULDNT_RESOLVE_HOST:
-            return std::make_pair(XrdCl::errInvalidAddr, 0);
-        case CURLE_LOGIN_DENIED:
-        // Commented-out cases are for platforms (RHEL7) where the error
-        // codes are undefined.
-        //case CURLE_AUTH_ERROR:
-        //case CURLE_SSL_CLIENTCERT:
-        case CURLE_REMOTE_ACCESS_DENIED:
-            return std::make_pair(XrdCl::errLoginFailed, EACCES);
-        case CURLE_SSL_CONNECT_ERROR:
-        case CURLE_SSL_ENGINE_NOTFOUND:
-        case CURLE_SSL_ENGINE_SETFAILED:
-        case CURLE_SSL_CERTPROBLEM:
-        case CURLE_SSL_CIPHER:
-        case 51: // In old curl versions, this is CURLE_PEER_FAILED_VERIFICATION; that constant was changed to be 60 / CURLE_SSL_CACERT
-        case CURLE_SSL_SHUTDOWN_FAILED:
-        case CURLE_SSL_CRL_BADFILE:
-        case CURLE_SSL_ISSUER_ERROR:
-        case CURLE_SSL_CACERT: // value is 60; merged with CURLE_PEER_FAILED_VERIFICATION
-        //case CURLE_SSL_PINNEDPUBKEYNOTMATCH:
-        //case CURLE_SSL_INVALIDCERTSTATUS:
-            return std::make_pair(XrdCl::errTlsError, 0);
-        case CURLE_SEND_ERROR:
-        case CURLE_RECV_ERROR:
-            return std::make_pair(XrdCl::errSocketError, EIO);
-        case CURLE_COULDNT_CONNECT:
-        case CURLE_GOT_NOTHING:
-            return std::make_pair(XrdCl::errConnectionError, ECONNREFUSED);
-        case CURLE_OPERATION_TIMEDOUT:
-#ifdef HAVE_XPROTOCOL_TIMEREXPIRED
-            return std::make_pair(XrdCl::errErrorResponse, XErrorCode::kXR_TimerExpired);
-#else
-            return std::make_pair(XrdCl::errOperationExpired, ESTALE);
-#endif
-        case CURLE_UNSUPPORTED_PROTOCOL:
-        case CURLE_NOT_BUILT_IN:
-            return std::make_pair(XrdCl::errNotSupported, ENOSYS);
-        case CURLE_FAILED_INIT:
-            return std::make_pair(XrdCl::errInternal, 0);
-        case CURLE_URL_MALFORMAT:
-            return std::make_pair(XrdCl::errInvalidArgs, res);
-        //case CURLE_WEIRD_SERVER_REPLY:
-        //case CURLE_HTTP2:
-        //case CURLE_HTTP2_STREAM:
-            return std::make_pair(XrdCl::errCorruptedHeader, res);
-        case CURLE_PARTIAL_FILE:
-            return std::make_pair(XrdCl::errDataError, res);
-        // These two errors indicate a failure in the callback.  That
-        // should generate their own failures, meaning this should never
-        // get use.
-        case CURLE_READ_ERROR:
-        case CURLE_WRITE_ERROR:
-            return std::make_pair(XrdCl::errInternal, res);
-        case CURLE_RANGE_ERROR:
-        case CURLE_BAD_CONTENT_ENCODING:
-            return std::make_pair(XrdCl::errNotSupported, res);
-        case CURLE_TOO_MANY_REDIRECTS:
-            return std::make_pair(XrdCl::errRedirectLimit, res);
-        default:
-            return std::make_pair(XrdCl::errUnknown, res);
-    }
+    return XrdCl::CurlUtil::CurlCodeConvert(res);
 }
 
 bool HeaderParser::Base64Decode(std::string_view input, std::array<unsigned char, 32> &output) {
@@ -629,39 +506,14 @@ std::string_view XrdClHttp::ltrim_view(const std::string_view &input_view) {
 
 CURL *
 XrdClHttp::GetHandle(bool verbose) {
-    auto result = curl_easy_init();
+    auto result = XrdCl::CurlUtil::CreateCurlHandle(
+        "xrdcl-http/" XrdVERSION, verbose, XrdCl::DefaultEnv::GetEnv());
     if (result == nullptr) {
         return result;
     }
 
-    curl_easy_setopt(result, CURLOPT_USERAGENT, "xrdcl-http/" XrdVERSION);
     curl_easy_setopt(result, CURLOPT_DEBUGFUNCTION, DumpHeader);
     curl_easy_setopt(result, CURLOPT_DEBUGDATA, XrdCl::DefaultEnv::GetLog());
-    if (verbose)
-        curl_easy_setopt(result, CURLOPT_VERBOSE, 1L);
-
-    auto env = XrdCl::DefaultEnv::GetEnv();
-    std::string ca_file;
-    if (!env->GetString("HttpCertFile", ca_file) || ca_file.empty()) {
-        char *x509_ca_file = getenv("X509_CERT_FILE");
-        if (x509_ca_file) {
-            ca_file = std::string(x509_ca_file);
-        }
-    }
-    if (!ca_file.empty()) {
-        curl_easy_setopt(result, CURLOPT_CAINFO, ca_file.c_str());
-    }
-    std::string ca_dir;
-    if (!env->GetString("HttpCertDir", ca_dir) || ca_dir.empty()) {
-        char *x509_ca_dir = getenv("X509_CERT_DIR");
-        if (x509_ca_dir) {
-            ca_dir = std::string(x509_ca_dir);
-        }
-    }
-    if (!ca_dir.empty()) {
-        curl_easy_setopt(result, CURLOPT_CAPATH, ca_dir.c_str());
-    }
-
     curl_easy_setopt(result, CURLOPT_BUFFERSIZE, 32*1024);
 
     return result;
@@ -902,15 +754,13 @@ CurlWorker::CurlWorker(std::shared_ptr<HandlerQueue> queue, VerbsCache &cache, X
     m_shutdown_pipe_r = pipeInfo[0];
     m_shutdown_pipe_w = pipeInfo[1];
 
-    // Handle setup of the X509 authentication
-    auto env = XrdCl::DefaultEnv::GetEnv();
-    env->GetString("HttpClientCertFile", m_x509_client_cert_file);
-    env->GetString("HttpClientKeyFile", m_x509_client_key_file);
+    m_x509_credentials =
+        XrdCl::CurlUtil::GetClientX509Credentials(XrdCl::DefaultEnv::GetEnv());
 }
 
-std::tuple<std::string, std::string> CurlWorker::ClientX509CertKeyFile() const
+XrdCl::CurlUtil::X509Credentials CurlWorker::ClientX509Credentials() const
 {
-    return std::make_tuple(m_x509_client_cert_file, m_x509_client_key_file);
+    return m_x509_credentials;
 }
 
 std::string

--- a/src/XrdClHttp/XrdClHttpWorker.hh
+++ b/src/XrdClHttp/XrdClHttpWorker.hh
@@ -21,6 +21,7 @@
 #ifndef XRDCLHTTPWORKER_HH
 #define XRDCLHTTPWORKER_HH
 
+#include "XrdCl/XrdClCurlUtil.hh"
 #include "XrdClHttpOps.hh"
 
 #include <array>
@@ -61,7 +62,7 @@ public:
     void Start(std::unique_ptr<XrdClHttp::CurlWorker> self, std::thread tid);
 
     // Returns the configured X509 client certificate and key file name
-    std::tuple<std::string, std::string> ClientX509CertKeyFile() const;
+    XrdCl::CurlUtil::X509Credentials ClientX509Credentials() const;
 
     // Change the period (in seconds) for queue maintenance.
     //
@@ -96,8 +97,7 @@ private:
 
     std::unordered_map<CURL*, std::pair<std::shared_ptr<CurlOperation>, std::chrono::system_clock::time_point>> m_op_map;
     XrdCl::Log* m_logger;
-    std::string m_x509_client_cert_file;
-    std::string m_x509_client_key_file;
+    XrdCl::CurlUtil::X509Credentials m_x509_credentials;
 
     const static unsigned m_max_ops{20};
     static std::atomic<unsigned> m_maintenance_period;


### PR DESCRIPTION
## Summary
- add a reusable `XrdCl::CurlUtil` helper for curl status mapping, CA setup, X.509 env import, client credential lookup, and client credential application
- update `XrdClHttp` to consume the shared helper instead of carrying local copies of this setup logic
- keep the helper source under `src/XrdCl` so a later Tape REST implementation in XrdCl can reuse it without depending on the XrdClHttp plugin
