### PR TITLE
Disallow relative path mkdirs and rmdir with davs

### DIFF
--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -63,7 +63,15 @@ XRootDStatus BuildPath( std::string &newPath, Env *env,
   Log *log = DefaultEnv::GetLog();
 
   if( path.empty() )
-    return XRootDStatus( stError, errInvalidArgs );
+  {
+    std::string msg;
+    if( op )
+      msg = std::string( op ) + " requires a path.";
+    else
+      msg = "path is required.";
+    log->Error( AppMsg, "%s", msg.c_str() );
+    return XRootDStatus( stError, errInvalidArgs, 0, msg );
+  }
 
   int noCwd = 0;
   env->GetInt( "NoCWD", noCwd );
@@ -108,7 +116,15 @@ XRootDStatus BuildPath( std::string &newPath, Env *env,
     if( *it == ".." )
     {
       if( it == pathComponents.begin() )
-        return XRootDStatus( stError, errInvalidArgs );
+      {
+        std::string msg;
+        if( op )
+          msg = std::string( op ) + " path '" + path + "' escapes above root.";
+        else
+          msg = "path '" + path + "' escapes above root.";
+        log->Error( AppMsg, "%s", msg.c_str() );
+        return XRootDStatus( stError, errInvalidArgs, 0, msg );
+      }
       std::list<std::string>::iterator it1 = it;
       --it1;
       it = pathComponents.erase( it1 );

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -22,30 +22,33 @@
 // or submit itself to any jurisdiction.
 //------------------------------------------------------------------------------
 
-#include "XrdCl/XrdClFileSystem.hh"
-#include "XrdCl/XrdClFileSystemUtils.hh"
-#include "XrdCl/XrdClFSExecutor.hh"
-#include "XrdCl/XrdClURL.hh"
-#include "XrdCl/XrdClLog.hh"
-#include "XrdCl/XrdClDefaultEnv.hh"
+#include "XProtocol/XProtocol.hh"
 #include "XrdCl/XrdClConstants.hh"
-#include "XrdCl/XrdClUtils.hh"
 #include "XrdCl/XrdClCopyProcess.hh"
+#include "XrdCl/XrdClDefaultEnv.hh"
+#include "XrdCl/XrdClFSExecutor.hh"
 #include "XrdCl/XrdClFile.hh"
+#include "XrdCl/XrdClFileSystem.hh"
 #include "XrdCl/XrdClFileSystemOperations.hh"
+#include "XrdCl/XrdClFileSystemUtils.hh"
+#include "XrdCl/XrdClLog.hh"
 #include "XrdCl/XrdClParallelOperation.hh"
+#include "XrdCl/XrdClStatus.hh"
+#include "XrdCl/XrdClURL.hh"
+#include "XrdCl/XrdClUtils.hh"
+#include "XrdCl/XrdClXRootDResponses.hh"
 #include "XrdOuc/XrdOucPrivateUtils.hh"
 #include "XrdSys/XrdSysE2T.hh"
 
-#include <cstdlib>
-#include <cstdio>
-#include <iostream>
-#include <iomanip>
 #include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
 
 #ifdef HAVE_READLINE
-#include <readline/readline.h>
 #include <readline/history.h>
+#include <readline/readline.h>
 #endif
 
 using namespace XrdCl;
@@ -54,18 +57,31 @@ using namespace XrdCl;
 // Build a path
 //------------------------------------------------------------------------------
 XRootDStatus BuildPath( std::string &newPath, Env *env,
-                        const std::string &path )
+                        const std::string &path,
+                        const char *op = nullptr )
 {
+  Log *log = DefaultEnv::GetLog();
+
   if( path.empty() )
     return XRootDStatus( stError, errInvalidArgs );
 
   int noCwd = 0;
   env->GetInt( "NoCWD", noCwd );
 
-  if( path[0] == '/' || noCwd )
+  if( path[0] == '/' )
   {
     newPath = path;
     return XRootDStatus();
+  }
+  else if( noCwd )
+  {
+    std::string msg;
+    if( op )
+      msg = std::string( op ) + " relative path '" + path + "' is disallowed.";
+    else
+      msg = "relative path '" + path + "' is disallowed.";
+    log->Error( AppMsg, "%s", msg.c_str() );
+    return XRootDStatus( stError, errInvalidArgs, 0, msg );
   }
 
   std::string cwd = "/";
@@ -560,11 +576,9 @@ XRootDStatus DoMkDir( FileSystem                      *fs,
   }
 
   std::string newPath;
-  if( !BuildPath( newPath, env, path ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( newPath, env, path, "Creating" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Run the query
@@ -601,11 +615,9 @@ XRootDStatus DoRmDir( FileSystem                      *query,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "Removing" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Run the query

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -202,11 +202,9 @@ XRootDStatus DoCache( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[2] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid cache path." );
-    return XRootDStatus( stError, errInvalidArgs, 0, "Invalid cache path." );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[2], "cache" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Create the command 
@@ -260,11 +258,9 @@ XRootDStatus DoCD( FileSystem                      *fs,
   env->PutInt( "NoCWD", 0 );
 
   std::string newPath;
-  if( !BuildPath( newPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( newPath, env, args[1], "cd" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Check if the path exist and is not a directory
@@ -432,11 +428,9 @@ XRootDStatus DoLS( FileSystem                      *fs,
     env->GetString( "CWD", newPath );
   else
   {
-    if( !BuildPath( newPath, env, path ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid arguments. Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( newPath, env, path, "ls" );
+    if( !pathSt.IsOK() )
+      return pathSt;
   }
 
   //----------------------------------------------------------------------------
@@ -576,7 +570,7 @@ XRootDStatus DoMkDir( FileSystem                      *fs,
   }
 
   std::string newPath;
-  XRootDStatus pathSt = BuildPath( newPath, env, path, "Creating" );
+  XRootDStatus pathSt = BuildPath( newPath, env, path, "mkdir" );
   if( !pathSt.IsOK() )
     return pathSt;
 
@@ -615,7 +609,7 @@ XRootDStatus DoRmDir( FileSystem                      *query,
   }
 
   std::string fullPath;
-  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "Removing" );
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "rmdir" );
   if( !pathSt.IsOK() )
     return pathSt;
 
@@ -654,18 +648,14 @@ XRootDStatus DoMv( FileSystem                      *fs,
   }
 
   std::string fullPath1;
-  if( !BuildPath( fullPath1, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid source path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath1, env, args[1], "mv" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   std::string fullPath2;
-  if( !BuildPath( fullPath2, env, args[2] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid destination path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  pathSt = BuildPath( fullPath2, env, args[2], "mv" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   if( is_subdirectory(fullPath1, fullPath2) )
     return XRootDStatus( stError, errInvalidArgs, 0,
@@ -723,11 +713,9 @@ XRootDStatus DoRm( FileSystem                      *fs,
   for( size_t i = 1; i < argc; ++i )
   {
     std::string fullPath;
-    if( !BuildPath( fullPath, env, args[i] ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path: %s", fullPath.c_str() );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( fullPath, env, args[i], "rm" );
+    if( !pathSt.IsOK() )
+      return pathSt;
     rms.emplace_back( Rm( fs, fullPath ) >>
                       [log, fullPath, print]( XRootDStatus &st )
                       {
@@ -777,11 +765,9 @@ XRootDStatus DoTruncate( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "truncate" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   char *result;
   uint64_t size = ::strtoll( args[2].c_str(), &result, 0 );
@@ -826,11 +812,9 @@ XRootDStatus DoChMod( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "chmod" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   Access::Mode mode = Access::None;
   XRootDStatus st = ConvertMode( mode, args[2] );
@@ -912,11 +896,9 @@ XRootDStatus DoLocate( FileSystem                      *fs,
     fullPath = path;
   else
   {
-    if( !BuildPath( fullPath, env, path ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( fullPath, env, path, "locate" );
+    if( !pathSt.IsOK() )
+      return pathSt;
   }
 
   //----------------------------------------------------------------------------
@@ -1097,11 +1079,9 @@ XRootDStatus DoStat( FileSystem                      *fs,
   for( auto &path : paths )
   {
     std::string fullPath;
-    if( !BuildPath( fullPath, env, path ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( fullPath, env, path, "stat" );
+    if( !pathSt.IsOK() )
+      return pathSt;
     std::future<XrdCl::StatInfo> ftr;
     stats.emplace_back( XrdCl::Stat( fs, fullPath ) >> ftr );
     results.emplace_back( std::move( ftr ), std::move( fullPath ) );
@@ -1207,11 +1187,9 @@ XRootDStatus DoStatVFS( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "statvfs" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Run the query
@@ -1307,11 +1285,9 @@ XRootDStatus DoQuery( FileSystem                      *fs,
     for( size_t i = 3; i < args.size(); ++i )
     {
       std::string path = args[i];
-      if( !BuildPath( path, env, path ).IsOK() )
-      {
-        log->Error( AppMsg, "Invalid path." );
-        return XRootDStatus( stError, errInvalidArgs );
-      }
+      XRootDStatus pathSt = BuildPath( path, env, path, "prepare" );
+      if( !pathSt.IsOK() )
+        return pathSt;
       // we use new line character as delimiter
       strArg += '\n';
       strArg += path;
@@ -1324,11 +1300,9 @@ XRootDStatus DoQuery( FileSystem                      *fs,
         qCode == QueryCode::Checksum       ||
         qCode == QueryCode::XAttr )
     {
-      if( !BuildPath( strArg, env, args[2] ).IsOK() )
-      {
-        log->Error( AppMsg, "Invalid path." );
-        return XRootDStatus( stError, errInvalidArgs );
-      }
+      XRootDStatus pathSt = BuildPath( strArg, env, args[2], "query" );
+      if( !pathSt.IsOK() )
+        return pathSt;
     }
   }
 
@@ -1571,11 +1545,9 @@ XRootDStatus DoCat( FileSystem                      *fs,
   for( auto &remote : remotes )
   {
     std::string remoteFile;
-    if( !BuildPath( remoteFile, env, remote ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( remoteFile, env, remote, "cat" );
+    if( !pathSt.IsOK() )
+      return pathSt;
 
     remoteUrls.emplace_back( server );
     remoteUrls.back().SetPath( remoteFile );
@@ -1686,11 +1658,9 @@ XRootDStatus DoTail( FileSystem                      *fs,
   }
 
   std::string remoteFile;
-  if( !BuildPath( remoteFile, env, remote ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( remoteFile, env, remote, "tail" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   URL remoteUrl( server );
   remoteUrl.SetPath( remoteFile );
@@ -1833,11 +1803,9 @@ XRootDStatus DoXAttr( FileSystem                      *fs,
   }
 
   std::string path;
-  if( !BuildPath( path, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( path, env, args[1], "xattr" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Issue the xattr operation

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -63,7 +63,11 @@ XRootDStatus BuildPath( std::string &newPath, Env *env,
   Log *log = DefaultEnv::GetLog();
 
   if( path.empty() )
-    return XRootDStatus( stError, errInvalidArgs );
+  {
+    const std::string msg = "A path is required.";
+    log->Error( AppMsg, "%s", msg.c_str() );
+    return XRootDStatus( stError, errInvalidArgs, 0, msg );
+  }
 
   int noCwd = 0;
   env->GetInt( "NoCWD", noCwd );
@@ -79,7 +83,7 @@ XRootDStatus BuildPath( std::string &newPath, Env *env,
     if( op )
       msg = std::string( op ) + " relative path '" + path + "' is disallowed.";
     else
-      msg = "relative path '" + path + "' is disallowed.";
+      msg = "Relative path '" + path + "' is disallowed.";
     log->Error( AppMsg, "%s", msg.c_str() );
     return XRootDStatus( stError, errInvalidArgs, 0, msg );
   }
@@ -108,7 +112,11 @@ XRootDStatus BuildPath( std::string &newPath, Env *env,
     if( *it == ".." )
     {
       if( it == pathComponents.begin() )
-        return XRootDStatus( stError, errInvalidArgs );
+      {
+        const std::string msg = "Path '" + path + "' escapes above root.";
+        log->Error( AppMsg, "%s", msg.c_str() );
+        return XRootDStatus( stError, errInvalidArgs, 0, msg );
+      }
       std::list<std::string>::iterator it1 = it;
       --it1;
       it = pathComponents.erase( it1 );

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -202,11 +202,9 @@ XRootDStatus DoCache( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[2] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid cache path." );
-    return XRootDStatus( stError, errInvalidArgs, 0, "Invalid cache path." );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[2], "Caching" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Create the command 
@@ -260,11 +258,9 @@ XRootDStatus DoCD( FileSystem                      *fs,
   env->PutInt( "NoCWD", 0 );
 
   std::string newPath;
-  if( !BuildPath( newPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( newPath, env, args[1], "Changing" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Check if the path exist and is not a directory
@@ -432,11 +428,9 @@ XRootDStatus DoLS( FileSystem                      *fs,
     env->GetString( "CWD", newPath );
   else
   {
-    if( !BuildPath( newPath, env, path ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid arguments. Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( newPath, env, path, "Listing" );
+    if( !pathSt.IsOK() )
+      return pathSt;
   }
 
   //----------------------------------------------------------------------------
@@ -654,18 +648,14 @@ XRootDStatus DoMv( FileSystem                      *fs,
   }
 
   std::string fullPath1;
-  if( !BuildPath( fullPath1, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid source path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath1, env, args[1], "Renaming" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   std::string fullPath2;
-  if( !BuildPath( fullPath2, env, args[2] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid destination path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  pathSt = BuildPath( fullPath2, env, args[2], "Renaming to" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   if( is_subdirectory(fullPath1, fullPath2) )
     return XRootDStatus( stError, errInvalidArgs, 0,
@@ -723,11 +713,9 @@ XRootDStatus DoRm( FileSystem                      *fs,
   for( size_t i = 1; i < argc; ++i )
   {
     std::string fullPath;
-    if( !BuildPath( fullPath, env, args[i] ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path: %s", fullPath.c_str() );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( fullPath, env, args[i], "Removing" );
+    if( !pathSt.IsOK() )
+      return pathSt;
     rms.emplace_back( Rm( fs, fullPath ) >>
                       [log, fullPath, print]( XRootDStatus &st )
                       {
@@ -777,11 +765,9 @@ XRootDStatus DoTruncate( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "Truncating" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   char *result;
   uint64_t size = ::strtoll( args[2].c_str(), &result, 0 );
@@ -826,11 +812,9 @@ XRootDStatus DoChMod( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "Modifying" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   Access::Mode mode = Access::None;
   XRootDStatus st = ConvertMode( mode, args[2] );
@@ -912,11 +896,9 @@ XRootDStatus DoLocate( FileSystem                      *fs,
     fullPath = path;
   else
   {
-    if( !BuildPath( fullPath, env, path ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( fullPath, env, path, "Locating" );
+    if( !pathSt.IsOK() )
+      return pathSt;
   }
 
   //----------------------------------------------------------------------------
@@ -1097,11 +1079,9 @@ XRootDStatus DoStat( FileSystem                      *fs,
   for( auto &path : paths )
   {
     std::string fullPath;
-    if( !BuildPath( fullPath, env, path ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( fullPath, env, path, "Stating" );
+    if( !pathSt.IsOK() )
+      return pathSt;
     std::future<XrdCl::StatInfo> ftr;
     stats.emplace_back( XrdCl::Stat( fs, fullPath ) >> ftr );
     results.emplace_back( std::move( ftr ), std::move( fullPath ) );
@@ -1207,11 +1187,9 @@ XRootDStatus DoStatVFS( FileSystem                      *fs,
   }
 
   std::string fullPath;
-  if( !BuildPath( fullPath, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( fullPath, env, args[1], "Stating" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Run the query
@@ -1307,11 +1285,9 @@ XRootDStatus DoQuery( FileSystem                      *fs,
     for( size_t i = 3; i < args.size(); ++i )
     {
       std::string path = args[i];
-      if( !BuildPath( path, env, path ).IsOK() )
-      {
-        log->Error( AppMsg, "Invalid path." );
-        return XRootDStatus( stError, errInvalidArgs );
-      }
+      XRootDStatus pathSt = BuildPath( path, env, path, "Preparing" );
+      if( !pathSt.IsOK() )
+        return pathSt;
       // we use new line character as delimiter
       strArg += '\n';
       strArg += path;
@@ -1324,11 +1300,9 @@ XRootDStatus DoQuery( FileSystem                      *fs,
         qCode == QueryCode::Checksum       ||
         qCode == QueryCode::XAttr )
     {
-      if( !BuildPath( strArg, env, args[2] ).IsOK() )
-      {
-        log->Error( AppMsg, "Invalid path." );
-        return XRootDStatus( stError, errInvalidArgs );
-      }
+      XRootDStatus pathSt = BuildPath( strArg, env, args[2], "Querying" );
+      if( !pathSt.IsOK() )
+        return pathSt;
     }
   }
 
@@ -1571,11 +1545,9 @@ XRootDStatus DoCat( FileSystem                      *fs,
   for( auto &remote : remotes )
   {
     std::string remoteFile;
-    if( !BuildPath( remoteFile, env, remote ).IsOK() )
-    {
-      log->Error( AppMsg, "Invalid path." );
-      return XRootDStatus( stError, errInvalidArgs );
-    }
+    XRootDStatus pathSt = BuildPath( remoteFile, env, remote, "Opening" );
+    if( !pathSt.IsOK() )
+      return pathSt;
 
     remoteUrls.emplace_back( server );
     remoteUrls.back().SetPath( remoteFile );
@@ -1686,11 +1658,9 @@ XRootDStatus DoTail( FileSystem                      *fs,
   }
 
   std::string remoteFile;
-  if( !BuildPath( remoteFile, env, remote ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( remoteFile, env, remote, "Opening" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   URL remoteUrl( server );
   remoteUrl.SetPath( remoteFile );
@@ -1833,11 +1803,9 @@ XRootDStatus DoXAttr( FileSystem                      *fs,
   }
 
   std::string path;
-  if( !BuildPath( path, env, args[1] ).IsOK() )
-  {
-    log->Error( AppMsg, "Invalid path." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+  XRootDStatus pathSt = BuildPath( path, env, args[1], "Accessing" );
+  if( !pathSt.IsOK() )
+    return pathSt;
 
   //----------------------------------------------------------------------------
   // Issue the xattr operation

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -29,7 +29,13 @@ function test_http() {
 	echo "server: XRootD $(xrdfs "${DAV_HOST}" query config version 2>&1)"
 	echo
 
-	# Non-interactive xrdfs sets NoCWD: relative paths must be rejected client-side
+	# BuildPath client-side checks (non-interactive xrdfs sets NoCWD)
+	if out=$(xrdfs "${DAV_HOST}" mkdir -p 2>&1); then
+		error "mkdir -p without a path should fail"
+	fi
+	echo "${out}" | grep -F "A path is required." \
+		|| error "unexpected empty-path error: ${out}"
+
 	if out=$(xrdfs "${DAV_HOST}" mkdir foo 2>&1); then
 		error "mkdir foo should fail"
 	fi
@@ -41,6 +47,30 @@ function test_http() {
 	fi
 	echo "${out}" | grep -F "Removing relative path 'foo' is disallowed." \
 		|| error "unexpected rmdir relative-path error: ${out}"
+
+	if out=$(xrdfs "${DAV_HOST}" rm foo 2>&1); then
+		error "rm foo should fail"
+	fi
+	echo "${out}" | grep -F "Removing relative path 'foo' is disallowed." \
+		|| error "unexpected rm relative-path error: ${out}"
+
+	if out=$(xrdfs "${DAV_HOST}" ls foo 2>&1); then
+		error "ls foo should fail"
+	fi
+	echo "${out}" | grep -F "Listing relative path 'foo' is disallowed." \
+		|| error "unexpected ls relative-path error: ${out}"
+
+	# Under NoCWD, ../path is rejected as relative before .. collapse
+	if out=$(xrdfs "${DAV_HOST}" mkdir ../foo 2>&1); then
+		error "mkdir ../foo should fail"
+	fi
+	echo "${out}" | grep -F "Creating relative path '../foo' is disallowed." \
+		|| error "unexpected mkdir ../ relative-path error: ${out}"
+
+	# Interactive mode leaves NoCWD unset: relative ../ from CWD=/ escapes root
+	out=$(printf 'mkdir ../foo\nexit\n' | xrdfs "${DAV_HOST}" 2>&1) || true
+	echo "${out}" | grep -F "Path '../foo' escapes above root." \
+		|| error "unexpected escape-above-root error: ${out}"
 
 	# create local temporary directory under LOCAL_DIR so common teardown removes it
 	TMPDIR=$(mktemp -d "${LOCAL_DIR}/test-XXXXXX")

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -29,6 +29,19 @@ function test_http() {
 	echo "server: XRootD $(xrdfs "${DAV_HOST}" query config version 2>&1)"
 	echo
 
+	# Non-interactive xrdfs sets NoCWD: relative paths must be rejected client-side
+	if out=$(xrdfs "${DAV_HOST}" mkdir foo 2>&1); then
+		error "mkdir foo should fail"
+	fi
+	echo "${out}" | grep -F "Creating relative path 'foo' is disallowed." \
+		|| error "unexpected mkdir relative-path error: ${out}"
+
+	if out=$(xrdfs "${DAV_HOST}" rmdir foo 2>&1); then
+		error "rmdir foo should fail"
+	fi
+	echo "${out}" | grep -F "Removing relative path 'foo' is disallowed." \
+		|| error "unexpected rmdir relative-path error: ${out}"
+
 	# create local temporary directory under LOCAL_DIR so common teardown removes it
 	TMPDIR=$(mktemp -d "${LOCAL_DIR}/test-XXXXXX")
 
@@ -37,6 +50,8 @@ function test_http() {
 	# this will get cleaned up by CMake upon fixture tear down
 	assert xrdfs "${DAV_HOST}" mkdir -p "${TMPDIR}"
 
+	assert xrdfs "${DAV_HOST}" mkdir -p "${TMPDIR}/nocwd-abs"
+	assert xrdfs "${DAV_HOST}" rmdir "${TMPDIR}/nocwd-abs"
 	# create local files with random contents using OpenSSL
 
 	FILES=$(seq -w 1 "${NFILES:-10}")

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -146,7 +146,7 @@ function test_http() {
   assert_eq "$expectedBody" "$receivedBody" "GET range-request test failed (second body)"
   ## Check the amount of boundary delimiters there is in the body
   expectedDelimiters=3
-  receivedDelimiters=$(grep -c '\-\-123456' "$outputFilePath")
+  receivedDelimiters=$(grep -cF -- '--123456' "$outputFilePath")
   assert_eq "$expectedDelimiters" "$receivedDelimiters" "GET range-request test failed (boundary delimiters)"
   ## GET with trailers
   curl -v -L --raw -H "X-Transfer-Status: true" -H "TE: trailers" "${HTTP_HOST}/$alphabetFilePath" --output - | tr -d '\r' > "$outputFilePath"

--- a/tests/XRootD/noauth.sh
+++ b/tests/XRootD/noauth.sh
@@ -147,5 +147,21 @@ function test_noauth() {
 	# remove 1 existing, 2 not existing should error
 	assert_failure xrdfs "${HOST}" rm "${TMPDIR}"/6.exists.ref "${TMPDIR}"/not_exists_{5,6}.ref
 
+	# Non-interactive xrdfs sets NoCWD: relative paths must be rejected client-side
+	if out=$(xrdfs "${HOST}" mkdir foo 2>&1); then
+		error "mkdir foo should fail"
+	fi
+	echo "${out}" | grep -F "Creating relative path 'foo' is disallowed." \
+		|| error "unexpected mkdir relative-path error: ${out}"
+
+	if out=$(xrdfs "${HOST}" rmdir foo 2>&1); then
+		error "rmdir foo should fail"
+	fi
+	echo "${out}" | grep -F "Removing relative path 'foo' is disallowed." \
+		|| error "unexpected rmdir relative-path error: ${out}"
+
+	assert xrdfs "${HOST}" mkdir -p "${TMPDIR}/nocwd-abs"
+	assert xrdfs "${HOST}" rmdir "${TMPDIR}/nocwd-abs"
+
 	assert xrdfs "${HOST}" rmdir "${TMPDIR}"
 }

--- a/tests/XRootD/noauth.sh
+++ b/tests/XRootD/noauth.sh
@@ -147,7 +147,13 @@ function test_noauth() {
 	# remove 1 existing, 2 not existing should error
 	assert_failure xrdfs "${HOST}" rm "${TMPDIR}"/6.exists.ref "${TMPDIR}"/not_exists_{5,6}.ref
 
-	# Non-interactive xrdfs sets NoCWD: relative paths must be rejected client-side
+	# BuildPath client-side checks (non-interactive xrdfs sets NoCWD)
+	if out=$(xrdfs "${HOST}" mkdir -p 2>&1); then
+		error "mkdir -p without a path should fail"
+	fi
+	echo "${out}" | grep -F "A path is required." \
+		|| error "unexpected empty-path error: ${out}"
+
 	if out=$(xrdfs "${HOST}" mkdir foo 2>&1); then
 		error "mkdir foo should fail"
 	fi
@@ -159,6 +165,30 @@ function test_noauth() {
 	fi
 	echo "${out}" | grep -F "Removing relative path 'foo' is disallowed." \
 		|| error "unexpected rmdir relative-path error: ${out}"
+
+	if out=$(xrdfs "${HOST}" rm foo 2>&1); then
+		error "rm foo should fail"
+	fi
+	echo "${out}" | grep -F "Removing relative path 'foo' is disallowed." \
+		|| error "unexpected rm relative-path error: ${out}"
+
+	if out=$(xrdfs "${HOST}" ls foo 2>&1); then
+		error "ls foo should fail"
+	fi
+	echo "${out}" | grep -F "Listing relative path 'foo' is disallowed." \
+		|| error "unexpected ls relative-path error: ${out}"
+
+	# Under NoCWD, ../path is rejected as relative before .. collapse
+	if out=$(xrdfs "${HOST}" mkdir ../foo 2>&1); then
+		error "mkdir ../foo should fail"
+	fi
+	echo "${out}" | grep -F "Creating relative path '../foo' is disallowed." \
+		|| error "unexpected mkdir ../ relative-path error: ${out}"
+
+	# Interactive mode leaves NoCWD unset: relative ../ from CWD=/ escapes root
+	out=$(printf 'mkdir ../foo\nexit\n' | xrdfs "${HOST}" 2>&1) || true
+	echo "${out}" | grep -F "Path '../foo' escapes above root." \
+		|| error "unexpected escape-above-root error: ${out}"
 
 	assert xrdfs "${HOST}" mkdir -p "${TMPDIR}/nocwd-abs"
 	assert xrdfs "${HOST}" rmdir "${TMPDIR}/nocwd-abs"

--- a/tests/XrdClHttp/setup.sh
+++ b/tests/XrdClHttp/setup.sh
@@ -393,11 +393,11 @@ echo "Origin PID: $ORIGIN_PID"
 
 echo "Origin logs are available at $BINARY_DIR/tests/$TEST_NAME/origin.log"
 
-ORIGIN_PORT=$(grep -E -a '\-\-\-\-\-\- xrootd origin@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/origin.log" | tr ':' ' ' | awk '{print $4}')
+ORIGIN_PORT=$(grep -E -a -e '------ xrootd origin@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/origin.log" | tr ':' ' ' | awk '{print $4}')
 IDX=0
 while [ -z "$ORIGIN_PORT" ]; do
   sleep 1
-  ORIGIN_PORT=$(grep -E -a '\-\-\-\-\-\- xrootd origin@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/origin.log" | tr ':' ' ' | awk '{print $4}')
+  ORIGIN_PORT=$(grep -E -a -e '------ xrootd origin@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/origin.log" | tr ':' ' ' | awk '{print $4}')
   IDX=$((IDX+1))
   if [ $IDX -gt 1 ]; then
     echo "Waiting for origin to start ($IDX seconds so far) ..."
@@ -422,11 +422,11 @@ echo "Cache PID: $ORIGIN_PID"
 
 echo "Cache logs are available at $BINARY_DIR/tests/$TEST_NAME/cache.log"
 
-CACHE_PORT=$(grep -E -a '\-\-\-\-\-\- xrootd cache@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/cache.log" | tr ':' ' ' | awk '{print $4}')
+CACHE_PORT=$(grep -E -a -e '------ xrootd cache@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/cache.log" | tr ':' ' ' | awk '{print $4}')
 IDX=0
 while [ -z "$CACHE_PORT" ]; do
   sleep 1
-  CACHE_PORT=$(grep -E -a '\-\-\-\-\-\- xrootd cache@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/cache.log" | tr ':' ' ' | awk '{print $4}')
+  CACHE_PORT=$(grep -E -a -e '------ xrootd cache@.*:[0-9]+ initialization completed' "$BINARY_DIR/tests/$TEST_NAME/cache.log" | tr ':' ' ' | awk '{print $4}')
   IDX=$((IDX+1))
   if [ $IDX -gt 1 ]; then
     echo "Waiting for cache to start ($IDX seconds so far) ..."

--- a/tests/XrdClHttp/test.sh
+++ b/tests/XrdClHttp/test.sh
@@ -175,7 +175,6 @@ fi
 
 ##
 # It's unfortunate but there's no good machine-readable output from the HTTP protocol.
-# Switch to using xrdfs which also isn't great formatting -- but at least workable with egrep.
 CACHE_ROOT_URL="$(echo "$CACHE_URL" | sed 's|https://|roots://|')"
 echo "Listing directory $CACHE_ROOT_URL via root protocol"
 #export XRD_LOGLEVEL=Debug
@@ -193,8 +192,8 @@ fi
 
 echo "Output from xrdfs:"
 cat "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
-assert egrep -q -e '-r-----r-- (.*) 0 (.*) /test-public/subdir/test1' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
-assert egrep -q -e '-r-----r-- (.*) 14 (.*) /test-public/subdir/test2' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
-assert egrep -q -e 'dr-x---r-x (.*) /test-public/subdir/test3' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
+assert grep -Eq -e '-r-----r-- (.*) 0 (.*) /test-public/subdir/test1' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
+assert grep -Eq -e '-r-----r-- (.*) 14 (.*) /test-public/subdir/test2' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
+assert grep -Eq -e 'dr-x---r-x (.*) /test-public/subdir/test3' "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out"
 assert_eq 3 "$(wc -l "$BINARY_DIR/tests/$TEST_NAME/xrdfs.out" | awk '{print $1}')"
 


### PR DESCRIPTION
Fixes https://github.com/xrootd/xrootd/issues/2792 

As part of refactoring BuildPath, I also took the the opportunity to add better error logging for other cases. 
Instead of returning InvalidArg, we now log the "operation" and "error".