### PR TITLE
[XrdHttpTPC] Fix TPC PULL curl's buffer exhaustion

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcStream.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcStream.cc
@@ -10,12 +10,6 @@ using namespace TPC;
 
 Stream::~Stream()
 {
-    for (std::vector<Entry*>::iterator buffer_iter = m_buffers.begin();
-        buffer_iter != m_buffers.end();
-        buffer_iter++) {
-        delete *buffer_iter;
-        *buffer_iter = NULL;
-    }
     m_fh->close();
 }
 
@@ -29,12 +23,10 @@ Stream::Finalize()
     }
     m_open_for_write = false;
 
-    for (std::vector<Entry*>::iterator buffer_iter = m_buffers.begin();
-        buffer_iter != m_buffers.end();
-        buffer_iter++) {
-        delete *buffer_iter;
-        *buffer_iter = NULL;
-    }
+    // If there are outstanding buffers to reorder, finalization failed; the
+    // check has to happen before the buffers are released.
+    bool all_buffers_returned = m_avail_count == m_buffers.size();
+    m_buffers.clear();
 
     if (m_fh->close() == SFS_ERROR) {
         std::stringstream ss;
@@ -45,8 +37,7 @@ Stream::Finalize()
         return false;
     }
 
-    // If there are outstanding buffers to reorder, finalization failed
-    return m_avail_count == m_buffers.size();
+    return all_buffers_returned;
 }
 
 
@@ -72,7 +63,7 @@ Stream::Write(off_t offset, const char *buf, size_t size, bool force)
         return SFS_ERROR;
     }
     size_t bytes_accepted = 0;
-    int retval = size;
+    ssize_t retval = size;
     if (offset < m_offset) {
         if (!m_error_buf.size()) {m_error_buf = "Logic error: writing to a prior offset";}
         return SFS_ERROR;
@@ -94,50 +85,24 @@ Stream::Write(off_t offset, const char *buf, size_t size, bool force)
             return retval;
         }
     }
-    // Even if we already accepted the current data, always
-    // iterate through available buffers and try to write as
-    // much out to disk as possible.
-    Entry *avail_entry;
-    bool buffer_was_written;
-    size_t avail_count = 0;
+    // Even if we already accepted the current data, always iterate through the
+    // buffers and try to write as much out to disk as possible.
+    //
+    // Accepting data can complete a buffer, and flushing a buffer advances
+    // m_offset, which can in turn let another buffer accept more data or become
+    // writable.  Alternate between the two until neither makes progress.  When
+    // size == 0 we force a flush even if things are not MB-aligned.
+    ssize_t buffers_flushed;
     do {
-        avail_count = 0;
-        avail_entry = NULL;
-        buffer_was_written = false;
-        for (std::vector<Entry*>::iterator entry_iter = m_buffers.begin();
-             entry_iter != m_buffers.end();
-             entry_iter++) {
-            // Always try to dump from memory; when size == 0, then we are
-            // going to force a flush even if things are not MB-aligned.
-            int retval2 = (*entry_iter)->Write(*this, size == 0);
-            if (retval2 == SFS_ERROR) {
-                if (!m_error_buf.size()) {m_error_buf = "Unknown filesystem write failure.";}
-                return retval2;
-            }
-            buffer_was_written |= retval2 > 0;
-            if ((*entry_iter)->Available()) { // Empty buffer
-                if (!avail_entry) {avail_entry = *entry_iter;}
-                avail_count ++;
-            }
-            else if (bytes_accepted != size && size) {
-                size_t new_accept = (*entry_iter)->Accept(offset + bytes_accepted, buf + bytes_accepted, size - bytes_accepted);
-                    // Partial accept; buffer should be writable which means we should free it up
-                    // for next iteration
-                if (new_accept && new_accept != size - bytes_accepted) {
-                    int retval3 = (*entry_iter)->Write(*this, false);
-                    if (retval3 == SFS_ERROR) {
-                        if (!m_error_buf.size()) {m_error_buf = "Unknown filesystem write failure.";}
-                        return SFS_ERROR;
-                    }
-                    buffer_was_written = true;
-                }
-                bytes_accepted += new_accept;
-            }
-        }
-    } while ((avail_count != m_buffers.size()) && buffer_was_written);
-    m_avail_count = avail_count;
+        bytes_accepted += AcceptIntoBuffers(offset + bytes_accepted,
+                                            buf + bytes_accepted,
+                                            size - bytes_accepted);
+        buffers_flushed = FlushBuffers(size == 0);
+        if (buffers_flushed == SFS_ERROR) {return SFS_ERROR;}
+    } while ((buffers_flushed > 0) && (bytes_accepted != size));
 
-    if (bytes_accepted != size && size) {  // No place for this data in allocated buffers
+    if (bytes_accepted != size && size) {  // No place for this data in the buffers currently in use
+        Entry *avail_entry = FirstAvailableBuffer();
         if (!avail_entry) {  // No available buffers to allocate; logic error, should not happen.
             DumpBuffers();
             m_error_buf = "No empty buffers available to place unordered data.";
@@ -147,19 +112,77 @@ Stream::Write(off_t offset, const char *buf, size_t size, bool force)
             m_error_buf = "Empty re-ordering buffer was unable to to accept data; internal logic error.";
             return SFS_ERROR;
         }
-        m_avail_count --;
+        // The buffer we just filled may already be complete and contiguous with
+        // m_offset; flush it now instead of waiting for a later callback to
+        // notice, as every curl handle may be idle by then.
+        if (FlushBuffers(false) == SFS_ERROR) {return SFS_ERROR;}
     }
 
     // If we have low buffer occupancy, then release memory.
     if ((m_buffers.size() > 2) && (m_avail_count * 2 > m_buffers.size())) {
-        for (std::vector<Entry*>::iterator entry_iter = m_buffers.begin();
-             entry_iter != m_buffers.end();
-             entry_iter++) {
-            (*entry_iter)->ShrinkIfUnused();
+        for (auto &entry : m_buffers) {
+            entry->ShrinkIfUnused();
         }
     }
 
     return retval;
+}
+
+
+size_t
+Stream::AcceptIntoBuffers(off_t offset, const char *buf, size_t size)
+{
+    size_t bytes_accepted = 0;
+    if (!size) {return 0;}
+    for (auto &entry : m_buffers) {
+        // Empty buffers are deliberately skipped here: they are only handed out
+        // as a last resort by Write() so that buffer occupancy keeps tracking
+        // the number of transfers in flight.
+        if (entry->Available()) {continue;}
+        bytes_accepted += entry->Accept(offset + bytes_accepted,
+                                        buf + bytes_accepted,
+                                        size - bytes_accepted);
+        if (bytes_accepted == size) {break;}
+    }
+    return bytes_accepted;
+}
+
+
+ssize_t
+Stream::FlushBuffers(bool force)
+{
+    ssize_t buffers_flushed = 0;
+    bool buffer_was_written;
+    do {
+        size_t avail_count = 0;
+        buffer_was_written = false;
+        for (auto &entry : m_buffers) {
+            ssize_t retval = entry->Write(*this, force);
+            if (retval == SFS_ERROR) {
+                if (!m_error_buf.size()) {m_error_buf = "Unknown filesystem write failure.";}
+                return SFS_ERROR;
+            }
+            if (retval > 0) {
+                buffer_was_written = true;
+                buffers_flushed ++;
+            }
+            if (entry->Available()) {avail_count ++;}
+        }
+        m_avail_count = avail_count;
+        // Writing a buffer advances m_offset, which may have made a buffer we
+        // already walked past contiguous with the stream; go around again.
+    } while (buffer_was_written && (m_avail_count != m_buffers.size()));
+    return buffers_flushed;
+}
+
+
+Stream::Entry *
+Stream::FirstAvailableBuffer()
+{
+    for (auto &entry : m_buffers) {
+        if (entry->Available()) {return entry.get();}
+    }
+    return nullptr;
 }
 
 
@@ -191,12 +214,10 @@ Stream::DumpBuffers() const
         m_log.Emsg("Stream::DumpBuffers", ss.str().c_str());
     }
     size_t idx = 0;
-    for (std::vector<Entry*>::const_iterator entry_iter = m_buffers.begin();
-         entry_iter!= m_buffers.end();
-         entry_iter++) {
+    for (const auto &entry : m_buffers) {
         std::stringstream ss;
-        ss << "Buffer " << idx << ": Offset=" << (*entry_iter)->GetOffset() << ", Size="
-           << (*entry_iter)->GetSize() << ", Capacity=" << (*entry_iter)->GetCapacity();
+        ss << "Buffer " << idx << ": Offset=" << entry->GetOffset() << ", Size="
+           << entry->GetSize() << ", Capacity=" << entry->GetCapacity();
         m_log.Emsg("Stream::DumpBuffers", ss.str().c_str());
         idx ++;
     }

--- a/src/XrdHttpTpc/XrdHttpTpcStream.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcStream.hh
@@ -31,7 +31,7 @@ public:
     {
         m_buffers.reserve(max_blocks);
         for (size_t idx=0; idx < max_blocks; idx++) {
-            m_buffers.push_back(new Entry(buffer_size));
+            m_buffers.push_back(std::make_unique<Entry>(buffer_size));
         }
         m_open_for_write = true;
     }
@@ -81,7 +81,11 @@ private:
 
         bool Available() const {return m_offset == -1;}
 
-        int Write(Stream &stream, bool force) {
+        // Writes the contents of this buffer out to the stream, returning the
+        // number of bytes written (0 if the buffer is not eligible for a write
+        // yet) or SFS_ERROR.  On success the buffer is emptied and becomes
+        // available again.
+        ssize_t Write(Stream &stream, bool force) {
             if (Available() || !CanWrite(stream)) {return 0;}
             // Only full buffer writes are accepted unless the stream forces a flush
             // (i.e., we are at EOF) because the multistream code uses buffer occupancy
@@ -131,15 +135,7 @@ private:
 
         void ShrinkIfUnused() {
            if (!Available()) {return;}
-#if __cplusplus > 199711L
            m_buffer.shrink_to_fit();
-#endif
-        }
-
-        void Move(Entry &other) {
-            m_buffer.swap(other.m_buffer);
-            m_offset = other.m_offset;
-            m_size = other.m_size;
         }
 
         off_t GetOffset() const {return m_offset;}
@@ -162,11 +158,31 @@ private:
 
     ssize_t WriteImpl(off_t offset, const char *buffer, size_t size);
 
+    // Copies as much of [buffer, buffer+size) as possible into the buffers that
+    // are already holding data and can be extended contiguously.  This is pure
+    // bookkeeping: it never touches the underlying filesystem.
+    //
+    // Returns the number of bytes consumed.
+    size_t AcceptIntoBuffers(off_t offset, const char *buffer, size_t size);
+
+    // Writes out every buffer that is contiguous with m_offset, repeating until
+    // no further progress is made: flushing one buffer advances m_offset, which
+    // can in turn make another buffer writable.  Only completely full buffers
+    // are written unless force is set (see Entry::Write).
+    //
+    // This is the only place where m_avail_count is computed.
+    //
+    // Returns the number of buffers written out, or SFS_ERROR.
+    ssize_t FlushBuffers(bool force);
+
+    // Returns the first empty buffer, or nullptr if all of them hold data.
+    Entry *FirstAvailableBuffer();
+
     bool m_open_for_write;
     size_t m_avail_count;
     std::unique_ptr<XrdSfsFile> m_fh;
     off_t m_offset;
-    std::vector<Entry*> m_buffers;
+    std::vector<std::unique_ptr<Entry>> m_buffers;
     XrdSysError &m_log;
     std::string m_error_buf;
 };

--- a/tests/XrdHttpTpc/CMakeLists.txt
+++ b/tests/XrdHttpTpc/CMakeLists.txt
@@ -7,3 +7,17 @@ add_library(XrdHttpTpcUtils
 target_link_libraries(xrdhttptpc-unit-tests XrdHttpTpcUtils GTest::GTest GTest::Main)
 
 gtest_discover_tests(xrdhttptpc-unit-tests PROPERTIES DISCOVERY_TIMEOUT 10)
+
+if(TARGET XrdServer)
+  add_executable(xrdhttptpc-stream-unit-tests
+          XrdHttpTpcStreamTests.cc
+          ${PROJECT_SOURCE_DIR}/src/XrdHttpTpc/XrdHttpTpcStream.cc)
+
+  target_link_libraries(xrdhttptpc-stream-unit-tests
+          XrdServer
+          XrdUtils
+          GTest::gtest
+          GTest::gtest_main)
+
+  gtest_discover_tests(xrdhttptpc-stream-unit-tests PROPERTIES DISCOVERY_TIMEOUT 10)
+endif()

--- a/tests/XrdHttpTpc/XrdHttpTpcStreamTests.cc
+++ b/tests/XrdHttpTpc/XrdHttpTpcStreamTests.cc
@@ -1,0 +1,312 @@
+#undef NDEBUG
+
+#include "XrdHttpTpc/XrdHttpTpcStream.hh"
+#include "XrdSfs/XrdSfsInterface.hh"
+#include "XrdSys/XrdSysError.hh"
+#include "XrdSys/XrdSysLogger.hh"
+
+#include <algorithm>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <memory>
+#include <utility>
+#include <vector>
+#include <unistd.h>
+
+using namespace testing;
+
+class XrdHttpTpcStreamTests : public Test {};
+
+// Minimal XrdSfsFile implementation used to observe which writes the Stream
+// reordering layer sends to the backing filesystem.
+class MemorySfsFile : public XrdSfsFile {
+public:
+  MemorySfsFile() : XrdSfsFile("test", 0) {}
+
+  int open(const char *, XrdSfsFileOpenMode, mode_t,
+           const XrdSecEntity * = 0, const char * = 0) override {
+    return SFS_OK;
+  }
+
+  int close() override {
+    return SFS_OK;
+  }
+
+  int fctl(const int, const char *, XrdOucErrInfo &) override {
+    return SFS_OK;
+  }
+
+  const char *FName() override {
+    return "memory";
+  }
+
+  int getMmap(void **addr, off_t &size) override {
+    *addr = nullptr;
+    size = 0;
+    return SFS_ERROR;
+  }
+
+  XrdSfsXferSize read(XrdSfsFileOffset, XrdSfsXferSize) override {
+    return 0;
+  }
+
+  XrdSfsXferSize read(XrdSfsFileOffset offset, char *buffer,
+                      XrdSfsXferSize size) override {
+    if (offset < 0 || static_cast<size_t>(offset) > m_data.size()) {
+      return SFS_ERROR;
+    }
+    size_t available = m_data.size() - static_cast<size_t>(offset);
+    size_t to_copy = std::min(static_cast<size_t>(size), available);
+    if (!to_copy) {
+      return 0;
+    }
+    memcpy(buffer, &m_data[static_cast<size_t>(offset)], to_copy);
+    return static_cast<XrdSfsXferSize>(to_copy);
+  }
+
+  int read(XrdSfsAio *) override {
+    return SFS_ERROR;
+  }
+
+  XrdSfsXferSize write(XrdSfsFileOffset offset, const char *buffer,
+                       XrdSfsXferSize size) override {
+    if (offset < 0 || m_fail_writes) {
+      return SFS_ERROR;
+    }
+    if (!size) {
+      return 0;
+    }
+    size_t begin = static_cast<size_t>(offset);
+    size_t end = begin + static_cast<size_t>(size);
+    if (m_data.size() < end) {
+      m_data.resize(end);
+    }
+    memcpy(&m_data[begin], buffer, static_cast<size_t>(size));
+    m_writes.emplace_back(offset, size);
+    return size;
+  }
+
+  int write(XrdSfsAio *) override {
+    return SFS_ERROR;
+  }
+
+  int stat(struct stat *buf) override {
+    memset(buf, 0, sizeof(*buf));
+    buf->st_size = m_data.size();
+    return SFS_OK;
+  }
+
+  int sync() override {
+    return SFS_OK;
+  }
+
+  int sync(XrdSfsAio *) override {
+    return SFS_OK;
+  }
+
+  int truncate(XrdSfsFileOffset size) override {
+    if (size < 0) {
+      return SFS_ERROR;
+    }
+    m_data.resize(static_cast<size_t>(size));
+    return SFS_OK;
+  }
+
+  int getCXinfo(char cxtype[4], int &cxrsz) override {
+    memset(cxtype, 0, 4);
+    cxrsz = 0;
+    return SFS_OK;
+  }
+
+  const std::vector<char> &Data() const {
+    return m_data;
+  }
+
+  const std::vector<std::pair<XrdSfsFileOffset, XrdSfsXferSize>> &Writes() const {
+    return m_writes;
+  }
+
+  // Makes every subsequent write() fail, to check error propagation.
+  void FailWrites() {
+    m_fail_writes = true;
+  }
+
+private:
+  std::vector<char> m_data;
+  std::vector<std::pair<XrdSfsFileOffset, XrdSfsXferSize>> m_writes;
+  bool m_fail_writes = false;
+};
+
+namespace {
+
+std::vector<char> AsBytes(const std::string &str) {
+  return std::vector<char>(str.begin(), str.end());
+}
+
+}
+
+TEST_F(XrdHttpTpcStreamTests, FlushesExactlyFullEmptyBuffer) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 1, 8, log);
+
+  // Reproduce the case where a single callback exactly fills an empty reorder
+  // buffer.  The buffer is contiguous with the stream offset, so it must be
+  // written immediately and returned to the available-buffer pool.
+  ASSERT_EQ(8, stream.Write(0, "abcdefgh", 8, false));
+  ASSERT_EQ(1u, stream.AvailableBuffers());
+  ASSERT_EQ(1u, raw_file->Writes().size());
+  EXPECT_EQ(0, raw_file->Writes()[0].first);
+  EXPECT_EQ(8, raw_file->Writes()[0].second);
+  EXPECT_EQ(AsBytes("abcdefgh"), raw_file->Data());
+}
+
+TEST_F(XrdHttpTpcStreamTests, FlushesExactlyFullCurrentBuffer) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 1, 8, log);
+
+  // Reproduce the multi-stream pull stall from xrootd/xrootd#2108 in miniature:
+  // a first callback partially fills the only reorder buffer, then a later
+  // callback exactly completes it.  If exact fills are not flushed immediately,
+  // the transfer has no active curl handles and no available buffers, so no new
+  // range requests can be started.
+  ASSERT_EQ(4, stream.Write(0, "abcd", 4, false));
+  ASSERT_EQ(0u, stream.AvailableBuffers());
+  ASSERT_TRUE(raw_file->Writes().empty());
+
+  // Completing the buffer should trigger a backing write and make the buffer
+  // available again without requiring another callback to enter Stream::Write().
+  ASSERT_EQ(4, stream.Write(4, "efgh", 4, false));
+  ASSERT_EQ(1u, stream.AvailableBuffers());
+  ASSERT_EQ(1u, raw_file->Writes().size());
+  EXPECT_EQ(0, raw_file->Writes()[0].first);
+  EXPECT_EQ(8, raw_file->Writes()[0].second);
+  EXPECT_EQ(AsBytes("abcdefgh"), raw_file->Data());
+}
+
+TEST_F(XrdHttpTpcStreamTests, FlushesCascadeAfterOutOfOrderArrival) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 4, 8, log);
+
+  // Four ranges arrive in reverse-ish order; none of them can be written until
+  // the one starting at offset 0 shows up.  Writing that one advances the stream
+  // offset and must in turn unblock the buffer holding offset 8, then 16, then
+  // 24 -- a single flush pass over the buffers is not enough.
+  ASSERT_EQ(8, stream.Write(24, "dddddddd", 8, false));
+  ASSERT_EQ(3u, stream.AvailableBuffers());
+  ASSERT_EQ(8, stream.Write(8, "bbbbbbbb", 8, false));
+  ASSERT_EQ(2u, stream.AvailableBuffers());
+  ASSERT_EQ(8, stream.Write(16, "cccccccc", 8, false));
+  ASSERT_EQ(1u, stream.AvailableBuffers());
+  ASSERT_TRUE(raw_file->Writes().empty());
+
+  ASSERT_EQ(8, stream.Write(0, "aaaaaaaa", 8, false));
+
+  // Every buffer must have been handed back, otherwise the multi-stream
+  // scheduler cannot start any further range request.
+  EXPECT_EQ(4u, stream.AvailableBuffers());
+  ASSERT_EQ(4u, raw_file->Writes().size());
+  for (size_t idx = 0; idx < 4; idx++) {
+    EXPECT_EQ(static_cast<XrdSfsFileOffset>(idx * 8), raw_file->Writes()[idx].first);
+    EXPECT_EQ(8, raw_file->Writes()[idx].second);
+  }
+  EXPECT_EQ(AsBytes("aaaaaaaabbbbbbbbccccccccdddddddd"), raw_file->Data());
+}
+
+TEST_F(XrdHttpTpcStreamTests, PartialAcceptSpansTwoBuffers) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 2, 8, log);
+
+  ASSERT_EQ(4, stream.Write(0, "abcd", 4, false));
+  ASSERT_EQ(1u, stream.AvailableBuffers());
+
+  // This one completes the first buffer and spills the rest into a second one:
+  // the first four bytes go to disk, the last four stay buffered.
+  ASSERT_EQ(8, stream.Write(4, "efghijkl", 8, false));
+  EXPECT_EQ(1u, stream.AvailableBuffers());
+  ASSERT_EQ(1u, raw_file->Writes().size());
+  EXPECT_EQ(0, raw_file->Writes()[0].first);
+  EXPECT_EQ(8, raw_file->Writes()[0].second);
+  EXPECT_EQ(AsBytes("abcdefgh"), raw_file->Data());
+
+  // Completing the spill-over buffer releases it too.
+  ASSERT_EQ(4, stream.Write(12, "mnop", 4, false));
+  EXPECT_EQ(2u, stream.AvailableBuffers());
+  ASSERT_EQ(2u, raw_file->Writes().size());
+  EXPECT_EQ(8, raw_file->Writes()[1].first);
+  EXPECT_EQ(8, raw_file->Writes()[1].second);
+  EXPECT_EQ(AsBytes("abcdefghijklmnop"), raw_file->Data());
+}
+
+TEST_F(XrdHttpTpcStreamTests, AvailableCountReflectsBufferOccupancy) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 3, 8, log);
+
+  // AvailableBuffers() is what gates new range requests, so it must match the
+  // number of empty buffers after every single call, not eventually.
+  ASSERT_EQ(3u, stream.AvailableBuffers());
+  ASSERT_EQ(8, stream.Write(16, "cccccccc", 8, false));
+  EXPECT_EQ(2u, stream.AvailableBuffers());
+  ASSERT_EQ(4, stream.Write(8, "bbbb", 4, false));
+  EXPECT_EQ(1u, stream.AvailableBuffers());
+
+  // Writes out the buffer holding offset 0 and hands it straight back; the
+  // half-filled buffer at offset 8 is not full yet, so it stays put and keeps
+  // blocking the one holding offset 16.
+  ASSERT_EQ(8, stream.Write(0, "aaaaaaaa", 8, false));
+  EXPECT_EQ(1u, stream.AvailableBuffers());
+  ASSERT_EQ(1u, raw_file->Writes().size());
+
+  // Completing the half-filled buffer cascades: offset 8, then offset 16.
+  ASSERT_EQ(4, stream.Write(12, "bbbb", 4, false));
+  EXPECT_EQ(3u, stream.AvailableBuffers());
+  EXPECT_EQ(3u, raw_file->Writes().size());
+  EXPECT_EQ(AsBytes("aaaaaaaabbbbbbbbcccccccc"), raw_file->Data());
+}
+
+TEST_F(XrdHttpTpcStreamTests, ZeroSizeWriteForcesFlushOfPartialBuffer) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 2, 8, log);
+
+  ASSERT_EQ(4, stream.Write(0, "abcd", 4, false));
+  ASSERT_TRUE(raw_file->Writes().empty());
+
+  // This is what TPC::State::Flush() does at the end of a transfer: a forced,
+  // zero-sized write that must push out buffers that never got filled.
+  ASSERT_EQ(0, stream.Write(4, nullptr, 0, true));
+  EXPECT_EQ(2u, stream.AvailableBuffers());
+  ASSERT_EQ(1u, raw_file->Writes().size());
+  EXPECT_EQ(0, raw_file->Writes()[0].first);
+  EXPECT_EQ(4, raw_file->Writes()[0].second);
+  EXPECT_EQ(AsBytes("abcd"), raw_file->Data());
+  EXPECT_TRUE(stream.Finalize());
+}
+
+TEST_F(XrdHttpTpcStreamTests, FilesystemWriteFailureIsPropagated) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 2, 8, log);
+
+  raw_file->FailWrites();
+  EXPECT_EQ(SFS_ERROR, stream.Write(0, "abcdefgh", 8, false));
+  EXPECT_FALSE(stream.GetErrorMessage().empty());
+}

--- a/tests/XrdHttpTpc/XrdHttpTpcTests.cc
+++ b/tests/XrdHttpTpc/XrdHttpTpcTests.cc
@@ -2,8 +2,11 @@
 
 #include "XrdHttpTpc/XrdHttpTpcUtils.hh"
 #include "XrdHttpTpc/XrdHttpTpcTPC.hh"
+
 #include <exception>
 #include <gtest/gtest.h>
+
+#include <map>
 #include <string>
 
 using namespace testing;


### PR DESCRIPTION
For multi-stream HTTP TPC pull, incoming ranges may arrive out of order. TPC::Stream buffers those chunks until they become contiguous with m_offset, then writes them to the local file and marks the buffer available again.

The fix makes Stream::Write() attempt to write a buffer whenever it accepts new bytes into it, not only when the accept was partial.
So an exactly-filled contiguous buffer is flushed immediately and returned to the available-buffer pool.

Fixes #2108