### PR TITLE
Use config in pluginconfdir to configure client plugins

### DIFF
--- a/src/XrdCl/XrdClEnv.cc
+++ b/src/XrdCl/XrdClEnv.cc
@@ -17,6 +17,7 @@
 //------------------------------------------------------------------------------
 
 #include <cstdlib>
+#include <algorithm>
 
 #include "XrdCl/XrdClEnv.hh"
 #include "XrdCl/XrdClDefaultEnv.hh"
@@ -25,6 +26,67 @@
 
 namespace XrdCl
 {
+  //----------------------------------------------------------------------------
+  // Normalize a configuration key
+  //----------------------------------------------------------------------------
+  std::string Env::UnifyKey( std::string key )
+  {
+    std::transform( key.begin(), key.end(), key.begin(), ::tolower );
+
+    static const char prefix[] = "xrd_";
+    if( key.compare( 0, sizeof( prefix ) - 1, prefix ) == 0 )
+      key = key.substr( sizeof( prefix ) - 1 );
+
+    return key;
+  }
+
+  //----------------------------------------------------------------------------
+  // Look up a value in a plug-in configuration map
+  //----------------------------------------------------------------------------
+  std::string Env::GetPluginConfigValue(
+      const std::map<std::string, std::string> &pluginConfig,
+      const std::string                         &key )
+  {
+    const auto unified = UnifyKey( key );
+    for( const auto &entry : pluginConfig )
+    {
+      if( UnifyKey( entry.first ) == unified )
+        return entry.second;
+    }
+    return "";
+  }
+
+  //----------------------------------------------------------------------------
+  // Resolve a string setting
+  //----------------------------------------------------------------------------
+  bool Env::ResolveString( const std::string                         &key,
+                           const std::string                         &shellKey,
+                           const std::map<std::string, std::string> *pluginConfig,
+                           std::string                               &value,
+                           const std::string                         &defaultValue )
+  {
+    value.clear();
+    PutString( key, "" );
+    if( !shellKey.empty() )
+      ImportString( key, shellKey );
+
+    if( GetString( key, value ) && !value.empty() )
+      return true;
+
+    if( pluginConfig )
+    {
+      value = GetPluginConfigValue( *pluginConfig, key );
+      if( !value.empty() )
+      {
+        PutString( key, value );
+        return true;
+      }
+    }
+
+    value = defaultValue;
+    return false;
+  }
+
   //----------------------------------------------------------------------------
   // Get string
   //----------------------------------------------------------------------------

--- a/src/XrdCl/XrdClEnv.cc
+++ b/src/XrdCl/XrdClEnv.cc
@@ -88,6 +88,48 @@ namespace XrdCl
   }
 
   //----------------------------------------------------------------------------
+  // Resolve an integer setting
+  //----------------------------------------------------------------------------
+  bool Env::ResolveInt( const std::string                         &key,
+                        const std::string                         &shellKey,
+                        const std::map<std::string, std::string> *pluginConfig,
+                        int                                       &value,
+                        int                                        defaultValue )
+  {
+    PutInt( key, defaultValue );
+    if( !shellKey.empty() && ImportInt( key, shellKey ) )
+    {
+      GetInt( key, value );
+      return true;
+    }
+
+    if( pluginConfig )
+    {
+      const auto strValue = GetPluginConfigValue( *pluginConfig, key );
+      if( !strValue.empty() )
+      {
+        char *endPtr = nullptr;
+        const int parsed = static_cast<int>( strtol( strValue.c_str(), &endPtr, 0 ) );
+        if( endPtr && *endPtr == '\0' )
+        {
+          PutInt( key, parsed );
+          value = parsed;
+          return true;
+        }
+
+        Log *log = DefaultEnv::GetLog();
+        log->Error( UtilityMsg,
+                    "Env: Unable to import %s as %s: %s is not a proper integer",
+                    strValue.c_str(), key.c_str(), strValue.c_str() );
+      }
+    }
+
+    value = defaultValue;
+    PutInt( key, defaultValue );
+    return false;
+  }
+
+  //----------------------------------------------------------------------------
   // Get string
   //----------------------------------------------------------------------------
   bool Env::GetString( const std::string &k, std::string &value )

--- a/src/XrdCl/XrdClEnv.hh
+++ b/src/XrdCl/XrdClEnv.hh
@@ -139,6 +139,76 @@ namespace XrdCl
       bool GetDefaultStringValue( const std::string &key, std::string &value );
 
       //------------------------------------------------------------------------
+      //! Normalize a configuration key for case-insensitive lookup.
+      //! The key is lowercased and a leading "xrd_" prefix is removed.
+      //! @param key : configuration key to normalize
+      //! @return    : normalized key suitable for map lookup
+      //------------------------------------------------------------------------
+      static std::string UnifyKey( std::string key );
+
+      //------------------------------------------------------------------------
+      //! Look up a value in a plug-in configuration map.
+      //! Keys are matched case-insensitively after applying UnifyKey().
+      //! @param pluginConfig : settings from a client.plugins.d entry
+      //! @param key          : configuration key to look up
+      //! @return             : value associated with @a key, or an empty
+      //!                       string if no matching entry exists
+      //------------------------------------------------------------------------
+      static std::string GetPluginConfigValue(
+          const std::map<std::string, std::string> &pluginConfig,
+          const std::string                         &key );
+
+      //------------------------------------------------------------------------
+      //! Resolve a string setting using shell environment, then plug-in
+      //! configuration, then @a defaultValue.
+      //!
+      //! The resolved value is stored in the environment under @a key.
+      //! @param key          : environment key to store the resolved value
+      //!                       under
+      //! @param shellKey     : shell environment variable to import from;
+      //!                       may be empty to skip shell lookup
+      //! @param pluginConfig : optional map of plug-in settings from
+      //!                       client.plugins.d; may be null
+      //! @param value        : output parameter, receives the resolved
+      //!                       value
+      //! @param defaultValue : fallback value when neither the shell nor
+      //!                       plug-in configuration provides a setting
+      //! @return             : true if @a value came from the shell or
+      //!                       plug-in configuration, false if
+      //!                       @a defaultValue was used
+      //------------------------------------------------------------------------
+      bool ResolveString( const std::string                         &key,
+                          const std::string                         &shellKey,
+                          const std::map<std::string, std::string> *pluginConfig,
+                          std::string                               &value,
+                          const std::string                         &defaultValue = "" );
+
+      //------------------------------------------------------------------------
+      //! Resolve an integer setting using shell environment, then plug-in
+      //! configuration, then @a defaultValue.
+      //!
+      //! The resolved value is stored in the environment under @a key.
+      //! @param key          : environment key to store the resolved value
+      //!                       under
+      //! @param shellKey     : shell environment variable to import from;
+      //!                       may be empty to skip shell lookup
+      //! @param pluginConfig : optional map of plug-in settings from
+      //!                       client.plugins.d; may be null
+      //! @param value        : output parameter, receives the resolved
+      //!                       value
+      //! @param defaultValue : fallback value when neither the shell nor
+      //!                       plug-in configuration provides a setting
+      //! @return             : true if @a value came from the shell or
+      //!                       plug-in configuration, false if
+      //!                       @a defaultValue was used
+      //------------------------------------------------------------------------
+      bool ResolveInt( const std::string                         &key,
+                       const std::string                         &shellKey,
+                       const std::map<std::string, std::string> *pluginConfig,
+                       int                                       &value,
+                       int                                        defaultValue = 0 );
+
+      //------------------------------------------------------------------------
       // Lock the environment for writing
       //------------------------------------------------------------------------
       void WriteLock()
@@ -174,27 +244,6 @@ namespace XrdCl
       }
 
     private:
-
-      //------------------------------------------------------------------------
-      // Unify the key, make sure it is not case sensitive and strip it of
-      // the XRD_ prefix if necessary
-      //------------------------------------------------------------------------
-      inline std::string UnifyKey( std::string key )
-      {
-        //----------------------------------------------------------------------
-        // Make the key lower case
-        //----------------------------------------------------------------------
-        std::transform( key.begin(), key.end(), key.begin(), ::tolower );
-
-        //----------------------------------------------------------------------
-        // Strip the `xrd_` prefix if necessary
-        //----------------------------------------------------------------------
-        static const char prefix[] = "xrd_";
-        if( key.compare( 0, sizeof( prefix ) - 1, prefix ) == 0 )
-          key = key.substr( sizeof( prefix ) - 1 );
-
-        return key;
-      }
 
       std::string GetEnv( const std::string &key );
       typedef std::map<std::string, std::pair<std::string, bool> > StringMap;

--- a/src/XrdCl/XrdClFileSystem.cc
+++ b/src/XrdCl/XrdClFileSystem.cc
@@ -1167,7 +1167,7 @@ namespace XrdCl
                                    time_t              timeout )
   {
     SyncResponseHandler handler;
-    Status st = Locate( path, flags, &handler, timeout );
+    XRootDStatus st = Locate( path, flags, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1195,7 +1195,7 @@ namespace XrdCl
                                        time_t              timeout )
   {
     SyncResponseHandler handler;
-    Status st = DeepLocate( path, flags, &handler, timeout );
+    XRootDStatus st = DeepLocate( path, flags, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1242,7 +1242,7 @@ namespace XrdCl
                                time_t             timeout )
   {
     SyncResponseHandler handler;
-    Status st = Mv( source, dest, &handler, timeout );
+    XRootDStatus st = Mv( source, dest, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1284,7 +1284,7 @@ namespace XrdCl
                                   time_t            timeout )
   {
     SyncResponseHandler handler;
-    Status st = Query( queryCode, arg, &handler, timeout );
+    XRootDStatus st = Query( queryCode, arg, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1327,7 +1327,7 @@ namespace XrdCl
                                      time_t             timeout )
   {
     SyncResponseHandler handler;
-    Status st = Truncate( path, size, &handler, timeout );
+    XRootDStatus st = Truncate( path, size, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1370,7 +1370,7 @@ namespace XrdCl
                                time_t             timeout )
   {
     SyncResponseHandler handler;
-    Status st = Rm( path, &handler, timeout );
+    XRootDStatus st = Rm( path, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1416,7 +1416,7 @@ namespace XrdCl
                                   time_t             timeout )
   {
     SyncResponseHandler handler;
-    Status st = MkDir( path, flags, mode, &handler, timeout );
+    XRootDStatus st = MkDir( path, flags, mode, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1456,7 +1456,7 @@ namespace XrdCl
                                   time_t             timeout )
   {
     SyncResponseHandler handler;
-    Status st = RmDir( path, &handler, timeout );
+    XRootDStatus st = RmDir( path, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1499,7 +1499,7 @@ namespace XrdCl
                                   time_t             timeout )
   {
     SyncResponseHandler handler;
-    Status st = ChMod( path, mode, &handler, timeout );
+    XRootDStatus st = ChMod( path, mode, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1533,7 +1533,7 @@ namespace XrdCl
   XRootDStatus FileSystem::Ping( time_t   timeout  )
   {
     SyncResponseHandler handler;
-    Status st = Ping( &handler, timeout );
+    XRootDStatus st = Ping( &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1578,7 +1578,7 @@ namespace XrdCl
                                  time_t              timeout )
   {
     SyncResponseHandler handler;
-    Status st = Stat( path, &handler, timeout );
+    XRootDStatus st = Stat( path, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1620,7 +1620,7 @@ namespace XrdCl
                                     time_t              timeout )
   {
     SyncResponseHandler handler;
-    Status st = StatVFS( path, &handler, timeout );
+    XRootDStatus st = StatVFS( path, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1656,7 +1656,7 @@ namespace XrdCl
                                      time_t         timeout )
   {
     SyncResponseHandler handler;
-    Status st = Protocol( &handler, timeout );
+    XRootDStatus st = Protocol( &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1913,7 +1913,7 @@ namespace XrdCl
                                       time_t              timeout )
   {
     SyncResponseHandler handler;
-    Status st = SendCache( info, &handler, timeout );
+    XRootDStatus st = SendCache( info, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -1940,7 +1940,7 @@ namespace XrdCl
                                      time_t              timeout )
   {
     SyncResponseHandler handler;
-    Status st = SendInfo( info, &handler, timeout );
+    XRootDStatus st = SendInfo( info, &handler, timeout );
     if( !st.IsOK() )
       return st;
 
@@ -2022,7 +2022,7 @@ namespace XrdCl
                                     time_t                           timeout )
   {
     SyncResponseHandler handler;
-    Status st = Prepare( fileList, flags, priority, &handler, timeout );
+    XRootDStatus st = Prepare( fileList, flags, priority, &handler, timeout );
     if( !st.IsOK() )
       return st;
 

--- a/src/XrdClHttp/XrdClHttpFactory.cc
+++ b/src/XrdClHttp/XrdClHttpFactory.cc
@@ -28,11 +28,10 @@
 
 #include "XrdCl/XrdClConstants.hh"
 #include "XrdCl/XrdClDefaultEnv.hh"
+#include "XrdCl/XrdClEnv.hh"
 #include "XrdCl/XrdClLog.hh"
-#include "XrdXrootd/XrdXrootdGStream.hh"
 #include "XrdVersion.hh"
 
-#include <stdio.h>
 #include <unistd.h>
 
 XrdVERSIONINFO(XrdClGetPlugIn, XrdClGetPlugIn)
@@ -54,6 +53,7 @@ Factory::GetHeaderTimeoutWithDefault(time_t oper_timeout)
 }
 
 bool Factory::m_initialized = false;
+std::map<std::string, std::string> Factory::m_plugin_config;
 std::shared_ptr<XrdClHttp::HandlerQueue> Factory::m_queue;
 XrdCl::Log *Factory::m_log = nullptr;
 std::once_flag Factory::m_init_once;
@@ -91,9 +91,8 @@ Factory::Initialize()
 
         // The location for the client to write the statistics file; this will be dropped
         // atomically every ~5 seconds and is meant to be complementary to the future g-stream.
-        env->PutString("HttpStatisticsLocation", "");
-        env->ImportString("HttpStatisticsLocation", "XRD_HTTPSTATISTICSLOCATION");
-        if (env->GetString("HttpStatisticsLocation", m_stats_location)) {
+        env->ResolveString("HttpStatisticsLocation", "XRD_HTTPSTATISTICSLOCATION", &m_plugin_config, m_stats_location, "");
+        if (!m_stats_location.empty()) {
             m_log->Debug(kLogXrdClHttp, "Will write client statistics to %s", m_stats_location.c_str());
         } else {
             m_log->Debug(kLogXrdClHttp, "Not writing client statistics to disk");
@@ -102,90 +101,77 @@ Factory::Initialize()
 
         // The minimum value we will accept from the request for a header timeout.
         // (i.e., the amount of time the plugin will wait to receive headers from the remote server)
-        env->PutString("HttpMinimumHeaderTimeout", "");
-        env->ImportString("HttpMinimumHeaderTimeout", "XRD_HTTPMINIMUMHEADERTIMEOUT");
+        std::string minimum_header_timeout;
+        env->ResolveString("HttpMinimumHeaderTimeout", "XRD_HTTPMINIMUMHEADERTIMEOUT", &m_plugin_config, minimum_header_timeout, "");
 
         // The default value of the header timeout (the amount of time the plugin will wait)
         // to receive headers from the remote server.
-        env->PutString("HttpDefaultHeaderTimeout", "");
-        env->ImportString("HttpDefaultHeaderTimeout", "XRD_HTTPDEFAULTHEADERTIMEOUT");
+        std::string default_header_timeout;
+        env->ResolveString("HttpDefaultHeaderTimeout", "XRD_HTTPDEFAULTHEADERTIMEOUT", &m_plugin_config, default_header_timeout, "");
 
         // The number of pending operations allowed in the global work queue.
-        env->PutInt("HttpMaxPendingOps", XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps());
-        env->ImportInt("HttpMaxPendingOps", "XRD_HTTPMAXPENDINGOPS");
         int max_pending = XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps();
-        if (env->GetInt("HttpMaxPendingOps", max_pending)) {
-            if (max_pending <= 0 || max_pending > 10'000'000) {
-                m_log->Error(kLogXrdClHttp,
-                    "Invalid value for the maximum number of pending operations in the global work queue (%d); using default value of %d",
-                    max_pending,
-                    XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps());
-                max_pending = XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps();
-                env->PutInt("HttpMaxPendingOps", max_pending);
-            }
-            m_log->Debug(kLogXrdClHttp, "Using %d pending operations in the global work queue", max_pending);
+        env->ResolveInt("HttpMaxPendingOps", "XRD_HTTPMAXPENDINGOPS", &m_plugin_config, max_pending, XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps());
+        if (max_pending <= 0 || max_pending > 10'000'000) {
+            m_log->Error(kLogXrdClHttp,
+                "Invalid value for the maximum number of pending operations in the global work queue (%d); using default value of %d",
+                max_pending,
+                XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps());
+            max_pending = XrdClHttp::HandlerQueue::GetDefaultMaxPendingOps();
+            env->PutInt("HttpMaxPendingOps", max_pending);
         }
+        m_log->Debug(kLogXrdClHttp, "Using %d pending operations in the global work queue", max_pending);
         m_queue.reset(new XrdClHttp::HandlerQueue(max_pending));
 
         // The number of threads to use for curl operations.
-        env->PutInt("HttpNumThreads", m_poll_threads);
-        env->ImportInt("HttpNumThreads", "XRD_HTTPNUMTHREADS");
         int num_threads = m_poll_threads;
-        if (env->GetInt("HttpNumThreads", num_threads)) {
-            if (num_threads <= 0 || num_threads > 1'000) {
-                m_log->Error(kLogXrdClHttp, "Invalid value for the number of threads to use for curl operations (%d); using default value of %d", num_threads, m_poll_threads);
-                num_threads = m_poll_threads;
-                env->PutInt("HttpNumThreads", num_threads);
-            }
-            m_log->Debug(kLogXrdClHttp, "Using %d threads for curl operations", num_threads);
+        env->ResolveInt("HttpNumThreads", "XRD_HTTPNUMTHREADS", &m_plugin_config, num_threads, m_poll_threads);
+        if (num_threads <= 0 || num_threads > 1'000) {
+            m_log->Error(kLogXrdClHttp, "Invalid value for the number of threads to use for curl operations (%d); using default value of %d", num_threads, m_poll_threads);
+            num_threads = m_poll_threads;
+            env->PutInt("HttpNumThreads", num_threads);
         }
+        m_log->Debug(kLogXrdClHttp, "Using %d threads for curl operations", num_threads);
 
         // The stall timeout to use for transfer operations.
-        env->PutInt("HttpStallTimeout", XrdClHttp::CurlOperation::GetDefaultStallTimeout());
-        env->ImportInt("HttpStallTimeout", "XRD_HTTPSTALLTIMEOUT");
         int stall_timeout = XrdClHttp::CurlOperation::GetDefaultStallTimeout();
-        if (env->GetInt("HttpStallTimeout", stall_timeout)) {
-            if (stall_timeout < 0 || stall_timeout > 86'400) {
-                m_log->Error(kLogXrdClHttp, "Invalid value for the stall timeout (%d); using default value of %d", stall_timeout, XrdClHttp::CurlOperation::GetDefaultStallTimeout());
-                stall_timeout = XrdClHttp::CurlOperation::GetDefaultStallTimeout();
-                env->PutInt("HttpStallTimeout", stall_timeout);
-            }
-            m_log->Debug(kLogXrdClHttp, "Using %d seconds for the stall timeout", stall_timeout);
+        env->ResolveInt("HttpStallTimeout", "XRD_HTTPSTALLTIMEOUT", &m_plugin_config, stall_timeout, XrdClHttp::CurlOperation::GetDefaultStallTimeout());
+        if (stall_timeout < 0 || stall_timeout > 86'400) {
+            m_log->Error(kLogXrdClHttp, "Invalid value for the stall timeout (%d); using default value of %d", stall_timeout, XrdClHttp::CurlOperation::GetDefaultStallTimeout());
+            stall_timeout = XrdClHttp::CurlOperation::GetDefaultStallTimeout();
+            env->PutInt("HttpStallTimeout", stall_timeout);
         }
+        m_log->Debug(kLogXrdClHttp, "Using %d seconds for the stall timeout", stall_timeout);
         XrdClHttp::CurlOperation::SetStallTimeout(stall_timeout);
 
         // The slow transfer rate, in bytes per second, for timing out slow uploads/downloads.
-        env->PutInt("HttpSlowRateBytesSec", XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec());
-        env->ImportInt("HttpSlowRateBytesSec", "XRD_HTTPSLOWRATEBYTESSEC");
         int slow_xfer_rate = XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec();
-        if (env->GetInt("HttpSlowRateBytesSec", slow_xfer_rate)) {
-            if (slow_xfer_rate < 0 || slow_xfer_rate > (1024 * 1024 * 1024)) {
-                m_log->Error(kLogXrdClHttp, "Invalid value for the slow transfer rate threshold (%d); using default value of %d", stall_timeout, XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec());
-                slow_xfer_rate = XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec();
-                env->PutInt("HttpSlowRateBytesSec", slow_xfer_rate);
-            }
-            m_log->Debug(kLogXrdClHttp, "Using %d bytes/sec for the slow transfer rate threshold", slow_xfer_rate);
+        env->ResolveInt("HttpSlowRateBytesSec", "XRD_HTTPSLOWRATEBYTESSEC", &m_plugin_config, slow_xfer_rate, XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec());
+        if (slow_xfer_rate < 0 || slow_xfer_rate > (1024 * 1024 * 1024)) {
+            m_log->Error(kLogXrdClHttp, "Invalid value for the slow transfer rate threshold (%d); using default value of %d", slow_xfer_rate, XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec());
+            slow_xfer_rate = XrdClHttp::CurlOperation::GetDefaultSlowRateBytesSec();
+            env->PutInt("HttpSlowRateBytesSec", slow_xfer_rate);
         }
+        m_log->Debug(kLogXrdClHttp, "Using %d bytes/sec for the slow transfer rate threshold", slow_xfer_rate);
         XrdClHttp::CurlOperation::SetSlowRateBytesSec(slow_xfer_rate);
 
         // Determine the minimum header timeout.  It's somewhat arbitrarily defaulted to 2s; below
         // that and timeouts could be caused by OS scheduling noise.  If the client has unreasonable
         // expectations of the origin, we don't want to cause it to generate lots of origin-side load.
-        std::string val;
         struct timespec mct{2, 0};
-        if (env->GetString("HttpMinimumHeaderTimeout", val) && !val.empty()) {
+        if (!minimum_header_timeout.empty()) {
             std::string errmsg;
-            if (!ParseTimeout(val, mct, errmsg)) {
-                m_log->Error(kLogXrdClHttp, "Failed to parse the minimum client timeout (%s): %s", val.c_str(), errmsg.c_str());
+            if (!ParseTimeout(minimum_header_timeout, mct, errmsg)) {
+                m_log->Error(kLogXrdClHttp, "Failed to parse the minimum client timeout (%s): %s", minimum_header_timeout.c_str(), errmsg.c_str());
             }
         }
         XrdClHttp::File::SetMinimumHeaderTimeout(mct);
 
         struct timespec dht{9, 500'000'000};
-        if (env->GetString("HttpDefaultHeaderTimeout", val) && !val.empty()) {
+        if (!default_header_timeout.empty()) {
             std::string errmsg;
-            if (!ParseTimeout(val, dht, errmsg)) {
-                m_log->Error(kLogXrdClHttp, "Failed to parse the default header timeout (%s): %s", val.c_str(), errmsg.c_str());
+            if (!ParseTimeout(default_header_timeout, dht, errmsg)) {
+                m_log->Error(kLogXrdClHttp, "Failed to parse the default header timeout (%s): %s", default_header_timeout.c_str(), errmsg.c_str());
             }
         }
         XrdClHttp::File::SetDefaultHeaderTimeout(dht);
@@ -269,15 +255,8 @@ Factory::Monitor()
 
 namespace {
 
-void SetIfEmpty(XrdCl::Env *env, XrdCl::Log &log, const std::string &optName, const std::string &envName) {
-    if (!env) return;
-
-    std::string val;
-    if (!env->GetString(optName, val) || val.empty()) {
-        env->PutString(optName, "");
-        env->ImportString(optName, envName);
-    }
-    if (env->GetString(optName, val) && !val.empty()) {
+void LogIfSet(XrdCl::Log &log, const std::string &optName, const std::string &val) {
+    if (!val.empty()) {
         log.Info(kLogXrdClHttp, "Setting %s to value '%s'", optName.c_str(), val.c_str());
     }
 }
@@ -285,17 +264,30 @@ void SetIfEmpty(XrdCl::Env *env, XrdCl::Log &log, const std::string &optName, co
 } // namespace
 
 void
+Factory::SetPluginConfig(const std::map<std::string, std::string> &config)
+{
+    m_plugin_config = config;
+}
+
+void
 Factory::SetupX509() {
 
     auto env = XrdCl::DefaultEnv::GetEnv();
-    SetIfEmpty(env, *m_log, "HttpCertFile", "XRD_HTTPCERTFILE");
-    SetIfEmpty(env, *m_log, "HttpCertDir", "XRD_HTTPCERTDIR");
-    SetIfEmpty(env, *m_log, "HttpClientCertFile", "XRD_HTTPCLIENTCERTFILE");
-    SetIfEmpty(env, *m_log, "HttpClientKeyFile", "XRD_HTTPCLIENTKEYFILE");
+    std::string cert_file;
+    env->ResolveString("HttpCertFile", "XRD_HTTPCERTFILE", &m_plugin_config, cert_file, "");
+    LogIfSet(*m_log, "HttpCertFile", cert_file);
+    std::string cert_dir;
+    env->ResolveString("HttpCertDir", "XRD_HTTPCERTDIR", &m_plugin_config, cert_dir, "");
+    LogIfSet(*m_log, "HttpCertDir", cert_dir);
+    std::string client_cert_file;
+    env->ResolveString("HttpClientCertFile", "XRD_HTTPCLIENTCERTFILE", &m_plugin_config, client_cert_file, "");
+    LogIfSet(*m_log, "HttpClientCertFile", client_cert_file);
+    std::string client_key_file;
+    env->ResolveString("HttpClientKeyFile", "XRD_HTTPCLIENTKEYFILE", &m_plugin_config, client_key_file, "");
+    LogIfSet(*m_log, "HttpClientKeyFile", client_key_file);
 
     int disable_proxy = 0;
-    env->PutInt("HttpDisableX509", 0);
-    env->ImportInt("HttpDisableX509", "XRD_HTTPDISABLEX509");
+    env->ResolveInt("HttpDisableX509", "XRD_HTTPDISABLEX509", &m_plugin_config, disable_proxy, 0);
 
     std::string filename;
     char *filename_char;
@@ -352,8 +344,12 @@ Factory::CreateFileSystem(const std::string & url) {
 
 extern "C"
 {
-    void *XrdClGetPlugIn(const void*)
+    void *XrdClGetPlugIn(const void *arg)
     {
+        if (arg) {
+            auto config = static_cast<const std::map<std::string, std::string> *>(arg);
+            Factory::SetPluginConfig(*config);
+        }
         return static_cast<void*>(new Factory());
     }
 }

--- a/src/XrdClHttp/XrdClHttpFactory.hh
+++ b/src/XrdClHttp/XrdClHttpFactory.hh
@@ -24,6 +24,7 @@
 #include "XrdCl/XrdClPlugInInterface.hh"
 
 #include <condition_variable>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -51,6 +52,9 @@ public:
     // Get the header timeout value, taking into consideration the provided command timeout, and XrdCl's default values
     static struct timespec GetHeaderTimeoutWithDefault(time_t oper_timeout);
 
+    // Store plug-in configuration from client.plugins.d for this library.
+    static void SetPluginConfig(const std::map<std::string, std::string> &config);
+
     // Hand off a given curl operation to the factory's worker pool.
     void Produce(std::unique_ptr<XrdClHttp::CurlOperation> operation);
 
@@ -70,6 +74,7 @@ private:
     static void Shutdown();
 
     static bool m_initialized;
+    static std::map<std::string, std::string> m_plugin_config;
     static std::shared_ptr<XrdClHttp::HandlerQueue> m_queue;
     static XrdCl::Log *m_log;
     const static unsigned m_poll_threads{8};

--- a/src/XrdClS3/XrdClS3Factory.cc
+++ b/src/XrdClS3/XrdClS3Factory.cc
@@ -25,8 +25,10 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 #include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClEnv.hh>
 #include <XrdCl/XrdClLog.hh>
 
+#include <algorithm>
 #include <fcntl.h>
 
 XrdVERSIONINFO(XrdClGetPlugIn, XrdClGetPlugIn)
@@ -41,6 +43,7 @@ std::string Factory::m_endpoint = "";
 std::string Factory::m_service = "s3";
 std::string Factory::m_region = "";
 std::string Factory::m_url_style = "path";
+std::map<std::string, std::string> Factory::m_plugin_config;
 std::string Factory::m_mkdir_sentinel;
 Factory::Credentials Factory::m_default_creds;
 std::unordered_map<std::string, Factory::Credentials> Factory::m_bucket_location_map;
@@ -180,19 +183,6 @@ Factory::CreateFileSystem(const std::string & url) {
 }
 
 namespace {
-
-void SetDefault(XrdCl::Env *env, const std::string &optName, const std::string &envName, std::string &location, const std::string &def) {
-    std::string val;
-    if (!env->GetString(optName, val) || val.empty()) {
-        env->PutString(optName, "");
-        env->ImportString(optName, envName);
-    }
-    if (env->GetString(optName, val) && !val.empty()) {
-        location = val;
-    } else {
-        location = def;
-    }
-}
 
 // Trim the left side of a string_view for space
 std::string_view ltrim_view(const std::string_view input_view) {
@@ -350,17 +340,23 @@ Factory::ExtractHostname(const std::string_view url) {
 }
 
 void
+Factory::SetPluginConfig(const std::map<std::string, std::string> &config)
+{
+    m_plugin_config = config;
+}
+
+void
 Factory::InitS3Config()
 {
     auto env = XrdCl::DefaultEnv::GetEnv();
-    SetDefault(env, "XrdClS3MkdirSentinel", "XRDCLS3_MKDIRSENTINEL", m_mkdir_sentinel, ".xrdcls3.dirsentinel");
-    SetDefault(env, "XrdClS3Endpoint", "XRDCLS3_ENDPOINT", m_endpoint, "");
-    SetDefault(env, "XrdClS3UrlStyle", "XRDCLS3_URLSTYLE", m_url_style, "path");
-    SetDefault(env, "XrdClS3Region", "XRDCLS3_REGION", m_region, "");
+    env->ResolveString("XrdClS3MkdirSentinel", "XRDCLS3_MKDIRSENTINEL", &m_plugin_config, m_mkdir_sentinel, ".xrdcls3.dirsentinel");
+    env->ResolveString("XrdClS3Endpoint", "XRDCLS3_ENDPOINT", &m_plugin_config, m_endpoint, "");
+    env->ResolveString("XrdClS3UrlStyle", "XRDCLS3_URLSTYLE", &m_plugin_config, m_url_style, "path");
+    env->ResolveString("XrdClS3Region", "XRDCLS3_REGION", &m_plugin_config, m_region, "");
     std::string access_key;
-    SetDefault(env, "XrdClS3AccessKeyLocation", "XRDCLS3_ACCESSKEYLOCATION", access_key, "");
+    env->ResolveString("XrdClS3AccessKeyLocation", "XRDCLS3_ACCESSKEYLOCATION", &m_plugin_config, access_key, "");
     std::string secret_key;
-    SetDefault(env, "XrdClS3SecretKeyLocation", "XRDCLS3_SECRETKEYLOCATION", secret_key, "");
+    env->ResolveString("XrdClS3SecretKeyLocation", "XRDCLS3_SECRETKEYLOCATION", &m_plugin_config, secret_key, "");
     if (!access_key.empty() && !secret_key.empty()) {
         m_default_creds = {access_key, secret_key};
     } else if (access_key.empty() && secret_key.empty()) {
@@ -373,7 +369,7 @@ Factory::InitS3Config()
 
     // Parse the per-bucket configuration of credentials.
     std::string bucket_configs;
-    SetDefault(env, "XrdClS3BucketConfigs", "XRDCLS3_BUCKETCONFIGS", bucket_configs, "");
+    env->ResolveString("XrdClS3BucketConfigs", "XRDCLS3_BUCKETCONFIGS", &m_plugin_config, bucket_configs, "");
     if (!bucket_configs.empty()) {
         std::stringstream ss(bucket_configs);
         std::string config_name;
@@ -381,17 +377,17 @@ Factory::InitS3Config()
             auto name = TrimView(config_name);
             auto bucket_name_key = std::string("XrdClS3") + std::string(name) + "BucketName";
             std::string bucket_name_val;
-            if (!env->GetString(bucket_name_key, bucket_name_val) || bucket_name_val.empty()) {
+            if (!env->ResolveString(bucket_name_key, "", &m_plugin_config, bucket_name_val, "") || bucket_name_val.empty()) {
                 m_log->Warning(kLogXrdClS3, "Per-bucket config includes entry '%s' but XrdClS3%sBucketName is not set", std::string(name).c_str(), std::string(name).c_str());
                 continue;
             }
             auto access_key_location_key = std::string("XrdClS3") + std::string(name) + "AccessKeyLocation";
             std::string access_key_location_val;
-            auto has_access_key = env->GetString(access_key_location_key, access_key_location_val) && !access_key_location_val.empty();
+            auto has_access_key = env->ResolveString(access_key_location_key, "", &m_plugin_config, access_key_location_val, "") && !access_key_location_val.empty();
 
             auto secret_key_location_key = std::string("XrdClS3") + std::string(name) + "SecretKeyLocation";
             std::string secret_key_location_val;
-            auto has_secret_key = env->GetString(secret_key_location_key, secret_key_location_val) && !secret_key_location_val.empty();
+            auto has_secret_key = env->ResolveString(secret_key_location_key, "", &m_plugin_config, secret_key_location_val, "") && !secret_key_location_val.empty();
 
             if (has_access_key && has_secret_key) {
                 m_bucket_location_map[bucket_name_val] = {access_key_location_val, secret_key_location_val};
@@ -851,8 +847,12 @@ Factory::TrimView(const std::string_view input_view) {
 
 extern "C"
 {
-    void *XrdClGetPlugIn(const void*)
+    void *XrdClGetPlugIn(const void *arg)
     {
+        if (arg) {
+            auto config = static_cast<const std::map<std::string, std::string> *>(arg);
+            Factory::SetPluginConfig(*config);
+        }
         return static_cast<void*>(new Factory());
     }
 }

--- a/src/XrdClS3/XrdClS3Factory.cc
+++ b/src/XrdClS3/XrdClS3Factory.cc
@@ -27,6 +27,7 @@
 #include <XrdCl/XrdClDefaultEnv.hh>
 #include <XrdCl/XrdClEnv.hh>
 #include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClXRootDResponses.hh>
 
 #include <algorithm>
 #include <fcntl.h>
@@ -403,11 +404,14 @@ Factory::InitS3Config()
     }
 }
 
-bool
-Factory::GenerateHttpUrl(const std::string &s3_url, std::string &https_url, std::string *obj_result, std::string &err_msg) {
+XrdCl::XRootDStatus
+Factory::GenerateHttpUrl(const std::string &s3_url,
+                         std::string &https_url,
+                         std::string *obj_result)
+{
     if (s3_url.substr(0, 5) != "s3://") {
-        err_msg = "Provided URL does not start with s3://";
-        return false;
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0,
+                                   "Provided URL does not start with s3://");
     }
     auto loc = s3_url.find('/', 5);
     auto bucket = s3_url.substr(5, loc - 5);
@@ -424,8 +428,8 @@ Factory::GenerateHttpUrl(const std::string &s3_url, std::string &https_url, std:
         auto old_loc = loc + 1;
         loc = s3_url.find('/', loc + 1);
         if (loc == std::string::npos) {
-            err_msg = "Provided S3 URL does not contain a bucket in path";
-            return false;
+            return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0,
+                                       "Provided S3 URL does not contain a bucket in path");
         }
         bucket = s3_url.substr(old_loc, loc - old_loc);
     } else {
@@ -459,17 +463,17 @@ Factory::GenerateHttpUrl(const std::string &s3_url, std::string &https_url, std:
     }
     if (m_url_style == "virtual" || m_url_style.empty()) {
         https_url = "https://" + bucket + "." + m_region + "." + endpoint + (obj_result ? "" : ("/" + obj));
-        return true;
+        return XrdCl::XRootDStatus();
     } else if (m_url_style == "path") {
         if (!m_region.empty()) {
             https_url = "https://" + m_region + "." + endpoint + "/" + bucket + (obj_result ? "" : ("/" + obj));
         } else {
             https_url = "https://" + endpoint + "/" + bucket + (obj_result ? "" : ("/" + obj));
         }
-        return true;
+        return XrdCl::XRootDStatus();
     } else {
-        err_msg = "Server configuration has invalid setting for URL style";
-        return false;
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errConfig, 0,
+                                   "Invalid S3 URL style '" + m_url_style + "'; expected 'path' or 'virtual'");
     }
 }
 

--- a/src/XrdClS3/XrdClS3Factory.hh
+++ b/src/XrdClS3/XrdClS3Factory.hh
@@ -23,10 +23,10 @@
 
 #include <XrdCl/XrdClPlugInInterface.hh>
 
+#include <map>
 #include <mutex>
 #include <shared_mutex>
 #include <string>
-#include <string_view>
 
 namespace XrdCl {
     class Log;
@@ -98,6 +98,9 @@ public:
         m_bucket_auth_map.clear();
     }
 
+    // Store the plug-in configuration map from client.plugins.d.
+    static void SetPluginConfig(const std::map<std::string, std::string> &config);
+
 private:
 
     // Iterate through the client configuration and determine the S3
@@ -116,6 +119,7 @@ private:
     static std::string m_service;
     static std::string m_region;
     static std::string m_url_style;
+    static std::map<std::string, std::string> m_plugin_config;
 
     // S3 doesn't have the concept of "directories"; if a given name
     // (some/path) has an object containing it as a prefix

--- a/src/XrdClS3/XrdClS3Factory.hh
+++ b/src/XrdClS3/XrdClS3Factory.hh
@@ -49,7 +49,10 @@ public:
     //
     // If "obj_result" is not nullptr, then it will be set to the object/key and the resulting HTTPS URL
     // will not include the key name.
-    static bool GenerateHttpUrl(const std::string &s3_url, std::string &https_url, std::string *obj_result, std::string &err_msg);
+    // On failure, returns an error status with a descriptive message.
+    static XrdCl::XRootDStatus GenerateHttpUrl(const std::string &s3_url,
+                                               std::string &https_url,
+                                               std::string *obj_result);
 
     // Convenience function to extract the hostname from a URL.
     static std::string_view ExtractHostname(const std::string_view url);

--- a/src/XrdClS3/XrdClS3File.cc
+++ b/src/XrdClS3/XrdClS3File.cc
@@ -134,9 +134,10 @@ File::GetFileHandle(const std::string &s3_url) {
         }
     }
 
-    std::string https_url, err_msg;
-    if (!Factory::GenerateHttpUrl(s3_noslash_url.empty() ? s3_url : s3_noslash_url, https_url, nullptr, err_msg)) {
-        return std::make_tuple(XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, err_msg), "", nullptr);
+    std::string https_url;
+    auto st = Factory::GenerateHttpUrl(s3_noslash_url.empty() ? s3_url : s3_noslash_url, https_url, nullptr);
+    if (!st.IsOK()) {
+        return std::make_tuple(st, "", nullptr);
     }
     auto loc = https_url.find('/', 8); // strlen("https://") -> 8
     if (loc == std::string::npos) {

--- a/src/XrdClS3/XrdClS3Filesystem.cc
+++ b/src/XrdClS3/XrdClS3Filesystem.cc
@@ -170,11 +170,12 @@ StatHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl::AnyObject *r
 
     // We got a "file not found" type of response.  In this case, we could interpret
     // this as a directory.
-    std::string https_url, err_msg;
+    std::string https_url;
     const auto s3_url = JoinUrl(m_s3_url, m_path);
     std::string obj;
-    if (!Factory::GenerateHttpUrl(s3_url, https_url, &obj, err_msg)) {
-        if (m_handler) return m_handler->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, err_msg), nullptr);
+    auto st = Factory::GenerateHttpUrl(s3_url, https_url, &obj);
+    if (!st.IsOK()) {
+        if (m_handler) return m_handler->HandleResponse(new XrdCl::XRootDStatus(st), nullptr);
         else return;
     }
     obj = obj.substr(0, obj.find('?'));
@@ -185,7 +186,7 @@ StatHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl::AnyObject *r
 
     auto expiry = time(NULL) + m_timeout;
 
-    auto st = DownloadUrl(
+    st = DownloadUrl(
         https_url,
         m_header_callout,
         new DirListResponseHandler(
@@ -472,11 +473,12 @@ Filesystem::DirList(const std::string          &path,
                     XrdCl::ResponseHandler     *handler,
                     time_t                      timeout)
 {
-    std::string https_url, err_msg;
+    std::string https_url;
     const auto s3_url = JoinUrl(m_url.GetURL(), path);
     std::string obj;
-    if (!Factory::GenerateHttpUrl(s3_url, https_url, &obj, err_msg)) {
-        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, err_msg);
+    auto st = Factory::GenerateHttpUrl(s3_url, https_url, &obj);
+    if (!st.IsOK()) {
+        return st;
     }
     obj = obj.substr(0, obj.find('?'));
     auto query_loc = https_url.find('?');
@@ -499,9 +501,10 @@ Filesystem::DirList(const std::string          &path,
 std::pair<XrdCl::XRootDStatus, XrdCl::FileSystem*>
 Filesystem::GetFSHandle(const std::string &path) {
     const auto s3_url = JoinUrl(m_url.GetURL(), path);
-    std::string https_url, err_msg;
-    if (!Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg)) {
-        return std::make_pair(XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, err_msg), nullptr);
+    std::string https_url;
+    auto st = Factory::GenerateHttpUrl(s3_url, https_url, nullptr);
+    if (!st.IsOK()) {
+        return std::make_pair(st, nullptr);
     }
     auto loc = https_url.find('/', 8); // strlen("https://") -> 8
     if (loc == std::string::npos) {
@@ -585,10 +588,11 @@ Filesystem::MkDir(const std::string        &input_path,
     }
 
     // Try creating a zero-sized sentinel.
-    std::string https_url, err_msg;
+    std::string https_url;
     const auto s3_url = JoinUrl(m_url.GetURL(), path);
-    if (!Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg)) {
-        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, err_msg);
+    auto st = Factory::GenerateHttpUrl(s3_url, https_url, nullptr);
+    if (!st.IsOK()) {
+        return st;
     }
 
     XrdCl::File *http_file(new XrdCl::File(https_url));

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(xrdcl-test
 add_executable(xrdcl-http-test
   CopyTest.cc
   ParseTimeoutTest.cc
+  PluginConfigTest.cc
   VectorReadTest.cc
 )
 

--- a/tests/XrdClHttp/PluginConfigTest.cc
+++ b/tests/XrdClHttp/PluginConfigTest.cc
@@ -1,0 +1,45 @@
+/******************************************************************************/
+/* Copyright (C) 2025, Pelican Project, Morgridge Institute for Research      */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpFactory.hh"
+
+#include "XrdCl/XrdClDefaultEnv.hh"
+#include "XrdCl/XrdClEnv.hh"
+
+#include <gtest/gtest.h>
+
+#include <map>
+
+using namespace XrdClHttp;
+
+extern "C" void *XrdClGetPlugIn(const void *arg);
+
+TEST(Factory, PluginConfig) {
+    std::map<std::string, std::string> config{
+        {"url", "https://*"},
+        {"lib", "libXrdClHttp.so"},
+        {"enable", "true"},
+        {"httpstalltimeout", "42"},
+        {"httpcertfile", "/etc/ssl/certs/ca-bundle.crt"},
+    };
+
+    auto factory = static_cast<Factory *>(XrdClGetPlugIn(&config));
+    ASSERT_NE(factory, nullptr);
+
+    auto fs = factory->CreateFileSystem("https://example.com/");
+    ASSERT_NE(fs, nullptr);
+    delete fs;
+
+    int stall_timeout = 0;
+    ASSERT_TRUE(XrdCl::DefaultEnv::GetEnv()->GetInt("HttpStallTimeout", stall_timeout));
+    ASSERT_EQ(stall_timeout, 42);
+
+    std::string cert_file;
+    ASSERT_TRUE(XrdCl::DefaultEnv::GetEnv()->GetString("HttpCertFile", cert_file));
+    ASSERT_EQ(cert_file, "/etc/ssl/certs/ca-bundle.crt");
+
+    delete factory;
+}

--- a/tests/XrdClS3/UrlParseTest.cc
+++ b/tests/XrdClS3/UrlParseTest.cc
@@ -21,6 +21,8 @@
 #include "gtest/gtest.h"
 #include "XrdClS3/XrdClS3Factory.hh"
 
+#include <XrdCl/XrdClStatus.hh>
+
 #include <filesystem>
 #include <map>
 
@@ -125,49 +127,40 @@ TEST(Factory, GenerateHttpUrl) {
     Factory::SetUrlStyle("virtual");
 
     std::string s3_url = "s3://bucket-name/path/to/object";
-    std::string err_msg;
     std::string https_url;
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path/to/object");
 
     Factory::SetEndpoint("");
     s3_url = "s3://p0@localhost:55708/bucket-name/object";
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.localhost:55708/object");
 
     Factory::SetEndpoint("s3.amazonaws.com");
     s3_url = "s3://bucket-name/path/to/object?versionId=12345";
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path/to/object?versionId=12345");
 
     s3_url = "s3://bucket-name.us-east-1.s3.amazonaws.com/path/to/object";
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path/to/object");
     
     s3_url = "s3://s3.amazonaws.com/bucket-name/path/to/object";
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path/to/object");
 
     Factory::SetEndpoint("");
     s3_url = "s3://s3.amazonaws.com/bucket-name/path";
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path");
 
     Factory::SetUrlStyle("path");
     s3_url = "s3://s3.amazonaws.com/bucket-name/path";
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://us-east-1.s3.amazonaws.com/bucket-name/path");
 
     Factory::SetRegion("");
-    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://s3.amazonaws.com/bucket-name/path");
 }
 
@@ -310,10 +303,22 @@ TEST(Factory, PluginConfigUrlStyle) {
     ASSERT_NE(factory, nullptr);
 
     std::string https_url;
-    std::string err_msg;
-    ASSERT_TRUE(Factory::GenerateHttpUrl("s3://bucket-name/path/to/object", https_url, nullptr, err_msg));
-    ASSERT_TRUE(err_msg.empty());
+    ASSERT_TRUE(Factory::GenerateHttpUrl("s3://bucket-name/path/to/object", https_url, nullptr).IsOK());
     ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path/to/object");
 
     delete factory;
+}
+
+TEST(Factory, InvalidUrlStyleError) {
+    Factory::SetUrlStyle("fooo");
+    Factory::SetEndpoint("s3.amazonaws.com");
+    Factory::SetRegion("us-east-1");
+
+    std::string https_url;
+    auto st = Factory::GenerateHttpUrl("s3://bucket/key", https_url, nullptr);
+    ASSERT_FALSE(st.IsOK());
+    ASSERT_EQ(st.code, XrdCl::errConfig);
+    ASSERT_EQ(st.GetErrorMessage(), "Invalid S3 URL style 'fooo'; expected 'path' or 'virtual'");
+    ASSERT_EQ(st.ToStr(),
+              "[ERROR] Configuration error: Invalid S3 URL style 'fooo'; expected 'path' or 'virtual'");
 }

--- a/tests/XrdClS3/UrlParseTest.cc
+++ b/tests/XrdClS3/UrlParseTest.cc
@@ -22,10 +22,13 @@
 #include "XrdClS3/XrdClS3Factory.hh"
 
 #include <filesystem>
+#include <map>
 
 #include <fcntl.h>
 
 using namespace XrdClS3;
+
+extern "C" void *XrdClGetPlugIn(const void *arg);
 
 class FactoryFixture : public testing::Test {
 public:
@@ -291,4 +294,26 @@ TEST(Factory, CleanObjectName) {
     ASSERT_EQ(Factory::CleanObjectName("test.txt?foo=bar&authz=foo&foo=bar"), "test.txt?foo=bar&foo=bar");
     ASSERT_EQ(Factory::CleanObjectName("test.txt?&foo=bar&authz=foo&foo=bar"), "test.txt?foo=bar&foo=bar");
     ASSERT_EQ(Factory::CleanObjectName("test.txt?&foo=bar&oss.asize&authz=foo&foo=bar"), "test.txt?foo=bar&oss.asize&foo=bar");
+}
+
+TEST(Factory, PluginConfigUrlStyle) {
+    std::map<std::string, std::string> config{
+        {"url", "s3://*"},
+        {"lib", "libXrdClS3.so"},
+        {"enable", "true"},
+        {"xrdcls3urlstyle", "virtual"},
+        {"xrdcls3endpoint", "s3.amazonaws.com"},
+        {"xrdcls3region", "us-east-1"},
+    };
+
+    auto factory = static_cast<Factory *>(XrdClGetPlugIn(&config));
+    ASSERT_NE(factory, nullptr);
+
+    std::string https_url;
+    std::string err_msg;
+    ASSERT_TRUE(Factory::GenerateHttpUrl("s3://bucket-name/path/to/object", https_url, nullptr, err_msg));
+    ASSERT_TRUE(err_msg.empty());
+    ASSERT_EQ(https_url, "https://bucket-name.us-east-1.s3.amazonaws.com/path/to/object");
+
+    delete factory;
 }

--- a/tests/XrdClS3/s3-setup.sh
+++ b/tests/XrdClS3/s3-setup.sh
@@ -128,7 +128,7 @@ if [ "$?" -ne 0 ]; then
   exit 1
 fi
 
-HOST="${HOSTNAME:-localhost}"
+HOST=localhost
 
 # Create the host certificate request
 openssl genrsa -out "$MINIO_CERTSDIR/private.key" 4096 >> "$BINARY_DIR/tests/$TEST_NAME/server.log"


### PR DESCRIPTION
Fixes #2787 

I was using environment variables for now, from comments in https://github.com/xrootd/xrootd/issues/2787 I understood with systemd managing xrootd process, one can only use Environment directive since `xrd` prefix is not accepted in env by xrootd.  https://github.com/xrootd/xrootd/issues/2787

I think its best to allow configuring client plugins through the same file (though one can argue it mixes up plugin config with lib loading config). It seems much more intuitive to do it this way. 

If we come to a consensus on the approach, we can also implement this for HTTP plugin configuration, too.
The second commit simply makes the errors more explicit, something I realised while testing the changes.