### PR TITLE
[XrdCl] Use new constructor

### DIFF
--- a/src/XrdClHttp/XrdClHttpFile.cc
+++ b/src/XrdClHttp/XrdClHttpFile.cc
@@ -309,26 +309,6 @@ File::Open(const std::string      &url,
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp);
     }
 
-    // Note: workaround for a design flaw of the XrdCl API.
-    //
-    // Any properties we set on the file *prior* to opening it are sent to the
-    // XrdCl base implementation, not the plugin object.  Hence, they are effectively
-    // ignored because the later `GetProperty` accesses a different object.  We want
-    // the SetProperty calls to take effect because they are needed for successfully
-    // `Open`ing the file.  There's no way to "setup the plugin", "set properties", and
-    // then "open file" because the first and third operations are part of the same API
-    // call.  We thus allow the caller to trigger the plugin loading by doing a special
-    // `Open` call (flags set to Compress, access mode None) that is a no-op.
-    //
-    // Contrast the XrdCl::File plugin loading style with XrdCl::Filesystem; the latter
-    // gets a target URL on construction, before any operations are done, allowing
-    // the `SetProperty` to work.
-    if ((flags == XrdCl::OpenFlags::Compress) && (mode == XrdCl::Access::None) &&
-        (handler == nullptr) && (timeout == 0))
-    {
-        return XrdCl::XRootDStatus();
-    }
-
     m_open_flags = flags;
 
     m_header_timeout.tv_nsec = m_default_header_timeout.tv_nsec;

--- a/src/XrdClS3/XrdClS3DownloadHandler.cc
+++ b/src/XrdClS3/XrdClS3DownloadHandler.cc
@@ -234,15 +234,7 @@ S3DownloadHandler::CloseHandler::HandleResponse(XrdCl::XRootDStatus *status_raw,
 XrdCl::XRootDStatus
 XrdClS3::DownloadUrl(const std::string &url, XrdClHttp::HeaderCallout *header_callout, XrdCl::ResponseHandler *handler, time_t timeout)
 {
-    std::unique_ptr<XrdCl::File> http_file(new XrdCl::File());
-    // Hack - we need to set a few properties on the file object before the open occurs.
-    // However, the "real" (plugin) file object is not created until the open call.
-    // This forces the plugin object to be created, so we can set the properties and Open later.
-    auto status = http_file->Open(url, XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, time_t(0));
-    if (!status.IsOK()) {
-        return status;
-    }
-
+    std::unique_ptr<XrdCl::File> http_file(new XrdCl::File(url));
 
     if (header_callout) {
         auto callout_loc = reinterpret_cast<long long>(header_callout);

--- a/src/XrdClS3/XrdClS3File.cc
+++ b/src/XrdClS3/XrdClS3File.cc
@@ -148,14 +148,7 @@ File::GetFileHandle(const std::string &s3_url) {
         return std::make_tuple(XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, "Invalid generated XrdCl URL"), "", nullptr);
     }
     m_url = https_url;
-    std::unique_ptr<XrdCl::File> wrapped_file(new XrdCl::File());
-    // Hack - we need to set a few properties on the file object before the open occurs.
-    // However, the "real" (plugin) file object is not created until the open call.
-    // This forces the plugin object to be created, so we can set the properties and Open later.
-    auto status = wrapped_file->Open(url.GetURL(), XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, time_t(0));
-    if (!status.IsOK()) {
-        return std::make_tuple(status, "", nullptr);
-    }
+    std::unique_ptr<XrdCl::File> wrapped_file(new XrdCl::File(https_url));
 
     std::stringstream ss;
     ss << std::hex << reinterpret_cast<long long>(&m_header_callout);

--- a/src/XrdClS3/XrdClS3Filesystem.cc
+++ b/src/XrdClS3/XrdClS3Filesystem.cc
@@ -591,12 +591,7 @@ Filesystem::MkDir(const std::string        &input_path,
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidAddr, 0, err_msg);
     }
 
-    XrdCl::File *http_file(new XrdCl::File());
-    auto status = http_file->Open(https_url, XrdCl::OpenFlags::Compress, XrdCl::Access::None, nullptr, time_t(0));
-    if (!status.IsOK()) {
-        delete http_file;
-        return status;
-    }
+    XrdCl::File *http_file(new XrdCl::File(https_url));
 
     auto callout_loc = reinterpret_cast<long long>(&m_header_callout);
     size_t buf_size = 16;


### PR DESCRIPTION
Commit 28adbb7a8 introduced a new constructor to initialise XrdCl::File without requiring a dummy open.
Refactor XrdClS3 code to use this new constructor, same as XrdClHttp