### PR TITLE
[XrdClS3] Fix use-after-move crash when synchronous read fails

### DIFF
--- a/src/XrdClHttp/XrdClHttpFile.cc
+++ b/src/XrdClHttp/XrdClHttpFile.cc
@@ -651,7 +651,9 @@ File::ReadPrefetch(uint64_t offset, uint64_t size, void *buffer, XrdCl::Response
         return std::make_tuple(XrdCl::XRootDStatus{}, false);
     }
     std::unique_lock lock(m_default_prefetch_handler->m_prefetch_mutex);
-    if (m_prefetch_size == -1) {
+    // In full-download mode the transfer is a single GET whose end is detected on transfer completion 
+    // This is similar to a red to end case
+    if (m_prefetch_size == -1 && !m_full_download.load(std::memory_order_relaxed)) {
         m_logger->Debug(kLogXrdClHttp, "%sRead prefetch skipping due to unknown file size", isPgRead ? "Pg": "");
         m_prefetch_reads_miss.fetch_add(1, std::memory_order_relaxed);
         m_default_prefetch_handler->m_prefetch_enabled = false;

--- a/src/XrdClHttp/XrdClHttpFile.cc
+++ b/src/XrdClHttp/XrdClHttpFile.cc
@@ -651,8 +651,8 @@ File::ReadPrefetch(uint64_t offset, uint64_t size, void *buffer, XrdCl::Response
         return std::make_tuple(XrdCl::XRootDStatus{}, false);
     }
     std::unique_lock lock(m_default_prefetch_handler->m_prefetch_mutex);
-    // In full-download mode the transfer is a single GET whose end is detected on transfer completion 
-    // This is similar to a red to end case
+    // In full-download mode the transfer is a single GET whose end is detected on transfer completion
+    // This is similar to a read to end case
     if (m_prefetch_size == -1 && !m_full_download.load(std::memory_order_relaxed)) {
         m_logger->Debug(kLogXrdClHttp, "%sRead prefetch skipping due to unknown file size", isPgRead ? "Pg": "");
         m_prefetch_reads_miss.fetch_add(1, std::memory_order_relaxed);

--- a/src/XrdClHttp/XrdClHttpFile.hh
+++ b/src/XrdClHttp/XrdClHttpFile.hh
@@ -337,7 +337,7 @@ private:
     // Last prefetch handler on the stack.
     PrefetchResponseHandler *m_last_prefetch_handler{nullptr};
 
-    // Size of prefetch operation
+    // Size of prefetch operation (-1 = unknown; INT64_MAX / off_t max = full object)
     off_t m_prefetch_size{-1};
 
     // Offset of the next write operation;

--- a/src/XrdClHttp/XrdClHttpOpRead.cc
+++ b/src/XrdClHttp/XrdClHttpOpRead.cc
@@ -123,9 +123,9 @@ CurlReadOp::Setup(CURL *curl, CurlWorker &worker)
     else if (m_op.second >= 128*1024) {
         curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, 32*1024);
     }
-    // If the requested read size is UINT64_MAX, it means read the entire object;
+    // If the requested read size is INT64_MAX, it means read the entire object;
     // in this case, we do not set the Range header.
-    if (m_op.second != UINT64_MAX) {
+    if (m_op.second != static_cast<uint64_t>(INT64_MAX)) {
         auto range_req = "bytes=" + std::to_string(m_op.first) + "-" + std::to_string(m_op.first + m_op.second - 1);
         m_headers_list.emplace_back("Range", range_req);
     }

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -119,6 +119,7 @@ std::pair<uint16_t, uint32_t> XrdClHttp::HTTPStatusConvert(unsigned status) {
         case 404:
             return std::make_pair(XrdCl::errErrorResponse, kXR_NotFound);
         case 405: // Method not allowed
+            return std::make_pair(XrdCl::errErrorResponse, kXR_Unsupported);
         case 406: // Not acceptable
             return std::make_pair(XrdCl::errErrorResponse, kXR_InvalidRequest);
         case 407: // Proxy Authentication Required
@@ -155,10 +156,13 @@ std::pair<uint16_t, uint32_t> XrdClHttp::HTTPStatusConvert(unsigned status) {
         case 451: // Unavailable For Legal Reasons
             return std::make_pair(XrdCl::errErrorResponse, kXR_Impossible);
         case 500: // Internal Server Error
-        case 501: // Not Implemented
-        case 502: // Bad Gateway
-        case 503: // Service Unavailable
             return std::make_pair(XrdCl::errErrorResponse, kXR_ServerError);
+        case 501: // Not Implemented
+            return std::make_pair(XrdCl::errErrorResponse, kXR_Unsupported);
+        case 502: // Bad Gateway
+            return std::make_pair(XrdCl::errErrorResponse, kXR_ServerError);
+        case 503: // Service Unavailable
+            return std::make_pair(XrdCl::errErrorResponse, kXR_Overloaded);
         case 504: // Gateway Timeout
             return std::make_pair(XrdCl::errErrorResponse, kXR_ReqTimedOut);
         case 507: // Insufficient Storage

--- a/src/XrdClS3/XrdClS3DownloadHandler.cc
+++ b/src/XrdClS3/XrdClS3DownloadHandler.cc
@@ -69,6 +69,9 @@ private:
         virtual ~ReadHandler() noexcept = default;
 
         virtual void HandleResponse(XrdCl::XRootDStatus *status, XrdCl::AnyObject *response) override;
+
+        // Release ownership of the parent handler back to the caller
+        std::unique_ptr<S3DownloadHandler> TakeParent() { return std::move(m_parent); }
     private:
         std::unique_ptr<S3DownloadHandler> m_parent; // Pointer to the parent handler to access its members
     };
@@ -108,9 +111,13 @@ S3DownloadHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl::AnyObj
     }
 
     // Open succeeded, so we can now read the file.
-    auto st = m_file->Read(0, S3DownloadHandler::kReadSize, m_buffer->GetBufferAtCursor(), new ReadHandler(std::move(self)), timeout);
+    std::unique_ptr<ReadHandler> readHandler(new ReadHandler(std::move(self)));
+    auto st = m_file->Read(0, S3DownloadHandler::kReadSize, m_buffer->GetBufferAtCursor(), readHandler.get(), timeout);
+
     if (!st.IsOK()) {
-        // If the read request failed, we close the file and return the error.
+        // The read request failed; take ownership of 'this' back
+        self = readHandler->TakeParent();
+        // We close the file and return the error
         std::unique_ptr<CloseHandler> closeHandler(new CloseHandler(std::move(self), std::unique_ptr<XrdCl::XRootDStatus>(new XrdCl::XRootDStatus(st))));
         auto close_st = m_file->Close(closeHandler.get(), timeout);
         if (close_st.IsOK()) {
@@ -122,6 +129,9 @@ S3DownloadHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl::AnyObj
         }
         return;
     }
+
+    // if read succeeds relinquish ownership
+    readHandler.release(); // Read now owns the handler
 }
 
 void
@@ -185,9 +195,11 @@ S3DownloadHandler::ReadHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, 
     // Read was successful; read additional data if available.
     m_parent->m_buffer->AdvanceCursor(chunkInfo->GetLength());
     m_parent->m_buffer->ReAllocate(m_parent->m_buffer->GetCursor() + S3DownloadHandler::kReadSize);
-    auto st = m_parent->m_file->Read(m_parent->m_buffer->GetCursor(), kReadSize, m_parent->m_buffer->GetBufferAtCursor(), self.release(), timeout);
+    // Pass to Read a non-owning pointer
+    auto st = m_parent->m_file->Read(m_parent->m_buffer->GetCursor(), kReadSize, m_parent->m_buffer->GetBufferAtCursor(), self.get(), timeout);
     if (!st.IsOK()) {
         // If the read request failed, close or delete the parent handler.
+        // We still own the handler, pass it to close handler
         auto parent = m_parent.get();
         std::unique_ptr<CloseHandler> closeHandler(new CloseHandler(std::move(m_parent), nullptr));
         auto close_st = parent->m_file->Close(closeHandler.get(), timeout);
@@ -196,7 +208,11 @@ S3DownloadHandler::ReadHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, 
         } else if (parent->m_handler) {
             parent->m_handler->HandleResponse(new XrdCl::XRootDStatus(close_st), nullptr);
         }
+        return;
     }
+
+    // Release ownership if Read returns successfully
+    self.release();
 }
 
 void

--- a/tests/XrdClHttp/ReadTest.cc
+++ b/tests/XrdClHttp/ReadTest.cc
@@ -20,6 +20,7 @@
 
 #include "XrdClHttp/XrdClHttpOps.hh"
 #include "XrdClHttp/XrdClHttpFile.hh"
+#include "XrdClHttp/XrdClHttpHeaderCallout.hh"
 #include "XrdClHttp/XrdClHttpWorker.hh"
 #include "../XrdClHttpCommon/TransferTest.hh"
 
@@ -28,6 +29,7 @@
 
 #include <gtest/gtest.h>
 
+#include <charconv>
 #include <memory>
 
 class CurlReadFixture : public TransferFixture {
@@ -216,4 +218,65 @@ TEST_F(CurlReadFixture, ConcurrentTest)
 
     rv = fh.Close();
     ASSERT_TRUE(rv.IsOK());
+}
+
+// Full-download against a chunked/unknown-size response must keep prefetch enabled.
+//
+// The origin returns Transfer-Encoding: chunked (no Content-Length) when the client
+// sends TE: trailers and X-Transfer-Status: true. Combined with the full-download
+// Range fix (no Range header), PrefetchSize becomes -1 and sequential reads still
+// hit the ongoing prefetch stream.
+TEST_F(CurlReadFixture, FullDownloadUnknownSizePrefetchTest)
+{
+    auto chunk_ctr = 10;
+    auto chunk_size = chunk_ctr * 10'000;
+    auto file_size = chunk_ctr * 100'000;
+    char starting_char = 'a';
+    auto url = GetOriginURL() + "/test/read_fulldownload_unknown_" + std::to_string(chunk_ctr);
+    ASSERT_NO_FATAL_FAILURE(WritePattern(url, file_size, starting_char, chunk_size));
+
+    class TrailersCallout : public XrdClHttp::HeaderCallout {
+    public:
+        TrailersCallout(const std::string &token) : m_token(token) {}
+        virtual ~TrailersCallout() = default;
+
+        virtual std::shared_ptr<HeaderList> GetHeaders(const std::string & /*verb*/,
+                                                       const std::string & /*url*/,
+                                                       const HeaderList &input_headers) override
+        {
+            auto headers = std::make_shared<HeaderList>(input_headers);
+            headers->emplace_back("Authorization", "Bearer " + m_token);
+            headers->emplace_back("TE", "trailers");
+            headers->emplace_back("X-Transfer-Status", "true");
+            return headers;
+        }
+
+    private:
+        std::string m_token;
+    };
+
+    TrailersCallout callout(GetReadToken());
+    // Construct with URL so the HTTP client plug-in is loaded before SetProperty.
+    XrdCl::File fh(url);
+
+    auto callout_loc = reinterpret_cast<long long>(&callout);
+    char callout_buf[16];
+    auto result = std::to_chars(callout_buf, callout_buf + sizeof(callout_buf) - 1, callout_loc, 16);
+    ASSERT_EQ(result.ec, std::errc{});
+    std::string callout_str(callout_buf, result.ptr - callout_buf);
+    ASSERT_TRUE(fh.SetProperty("XrdClHttpHeaderCallout", callout_str));
+    ASSERT_TRUE(fh.SetProperty("XrdClHttpFullDownload", "true"));
+
+    auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
+    ASSERT_TRUE(rv.IsOK()) << rv.ToString();
+
+    std::string prefetch_size;
+    ASSERT_TRUE(fh.GetProperty("XrdClHttpPrefetchSize", prefetch_size));
+    ASSERT_EQ(prefetch_size, "-1") << "Expected unknown size under chunked full-download";
+
+    std::string is_prefetching;
+    ASSERT_TRUE(fh.GetProperty("IsPrefetching", is_prefetching));
+    ASSERT_EQ(is_prefetching, "true");
+
+    ASSERT_NO_FATAL_FAILURE(VerifyContents(fh, file_size, starting_char, chunk_size));
 }

--- a/tests/XrdClS3/CMakeLists.txt
+++ b/tests/XrdClS3/CMakeLists.txt
@@ -66,6 +66,7 @@ add_executable(xrdcl-s3-test
 
 add_executable(xrdcl-s3-unittest
   UrlParseTest.cc
+  DownloadHandlerTest.cc
 )
 
 target_link_libraries(xrdcl-s3-test XrdClS3Obj XrdClHttpTransferTest GTest::gtest_main)

--- a/tests/XrdClS3/CMakeLists.txt
+++ b/tests/XrdClS3/CMakeLists.txt
@@ -83,6 +83,9 @@ set_tests_properties(${S3Tests}
     ENVIRONMENT "XRD_LOGLEVEL=Debug;ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/s3/client.plugins.d"
 )
 
+gtest_add_tests(TARGET xrdcl-s3-unittest TEST_LIST S3UnitTests)
+
+
 ######################################
 # Integration tests.
 ######################################

--- a/tests/XrdClS3/DownloadHandlerTest.cc
+++ b/tests/XrdClS3/DownloadHandlerTest.cc
@@ -1,0 +1,136 @@
+/******************************************************************************/
+/* Copyright (C) 2026, Pelican Project, Morgridge Institute for Research      */
+/*                                                                            */
+/* This file is part of the XrdClS3 client plugin for XRootD.                 */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClS3/XrdClS3DownloadHandler.hh"
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClMessageUtils.hh>
+#include <XrdCl/XrdClPlugInInterface.hh>
+#include <XrdCl/XrdClPlugInManager.hh>
+#include <XrdCl/XrdClXRootDResponses.hh>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+namespace {
+
+// File plug-in that opens successfully then fails the first Read()
+// synchronously (without invoking the response handler). That hits the
+// ownership path fixed for #2790 in S3DownloadHandler.
+class FailReadFile : public XrdCl::FilePlugIn {
+public:
+    FailReadFile() = default;
+    virtual ~FailReadFile() = default;
+
+    virtual XrdCl::XRootDStatus Open(const std::string & /*url*/,
+                                     XrdCl::OpenFlags::Flags /*flags*/,
+                                     XrdCl::Access::Mode /*mode*/,
+                                     XrdCl::ResponseHandler *handler,
+                                     time_t /*timeout*/) override
+    {
+        m_is_open = true;
+        if (handler) {
+            handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
+        }
+        return XrdCl::XRootDStatus();
+    }
+
+    virtual XrdCl::XRootDStatus Close(XrdCl::ResponseHandler *handler,
+                                      time_t /*timeout*/) override
+    {
+        m_is_open = false;
+        if (handler) {
+            handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
+        }
+        return XrdCl::XRootDStatus();
+    }
+
+    virtual XrdCl::XRootDStatus Read(uint64_t /*offset*/,
+                                     uint32_t /*size*/,
+                                     void * /*buffer*/,
+                                     XrdCl::ResponseHandler * /*handler*/,
+                                     time_t /*timeout*/) override
+    {
+        // Synchronous failure: do not call the handler.
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errErrorResponse, 0,
+                                   "injected sync read failure");
+    }
+
+    virtual bool IsOpen() const override { return m_is_open; }
+
+    virtual bool SetProperty(const std::string & /*name*/,
+                             const std::string & /*value*/) override
+    {
+        return true;
+    }
+
+private:
+    bool m_is_open{false};
+};
+
+class FailReadFactory : public XrdCl::PlugInFactory {
+public:
+    virtual ~FailReadFactory() = default;
+
+    virtual XrdCl::FilePlugIn *CreateFile(const std::string & /*url*/) override
+    {
+        return new FailReadFile();
+    }
+
+    virtual XrdCl::FileSystemPlugIn *CreateFileSystem(const std::string & /*url*/) override
+    {
+        return nullptr;
+    }
+};
+
+} // namespace
+
+class DownloadHandlerFixture : public testing::Test {
+protected:
+    void SetUp() override
+    {
+        auto *factory = new FailReadFactory();
+        XrdCl::DefaultEnv::GetPlugInManager()->RegisterDefaultFactory(factory);
+    }
+
+    void TearDown() override
+    {
+        XrdCl::DefaultEnv::GetPlugInManager()->RegisterDefaultFactory(nullptr);
+    }
+};
+
+// Ensure a synchronous Read failure after a successful Open does not crash
+// (use-after-move of the parent handler) and still reports an error to the
+// caller.
+TEST_F(DownloadHandlerFixture, SyncReadFailurePropagates)
+{
+    XrdCl::SyncResponseHandler handler;
+    auto st = XrdClS3::DownloadUrl("failread://localhost/obj", nullptr, &handler, time_t{10});
+    ASSERT_TRUE(st.IsOK()) << "Open should succeed: " << st.ToString();
+
+    handler.WaitForResponse();
+    auto *status = handler.GetStatus();
+    ASSERT_TRUE(status != nullptr);
+    ASSERT_FALSE(status->IsOK()) << "Expected read failure to reach the user handler";
+    EXPECT_NE(std::string::npos, status->GetErrorMessage().find("injected sync read failure"))
+        << status->ToString();
+}

--- a/tests/XrdClS3/UrlParseTest.cc
+++ b/tests/XrdClS3/UrlParseTest.cc
@@ -160,6 +160,11 @@ TEST(Factory, GenerateHttpUrl) {
     s3_url = "s3://s3.amazonaws.com/bucket-name/path";
     ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
     ASSERT_TRUE(err_msg.empty());
+    ASSERT_EQ(https_url, "https://us-east-1.s3.amazonaws.com/bucket-name/path");
+
+    Factory::SetRegion("");
+    ASSERT_TRUE(Factory::GenerateHttpUrl(s3_url, https_url, nullptr, err_msg));
+    ASSERT_TRUE(err_msg.empty());
     ASSERT_EQ(https_url, "https://s3.amazonaws.com/bucket-name/path");
 }
 


### PR DESCRIPTION

Fixes: #2790

This is a partial fix to the issue reported in #2790. 
We fix the branch leading to the crash from segfault, but the reason for the Read failure that lead to this path still needs investigation. 
 