### PR TITLE
[XrdClHttp] Read BEARER_TOKEN authorisation

### DIFF
--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -19,25 +19,27 @@
 /******************************************************************************/
 
 #include "XrdClHttpOps.hh"
+
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include <XrdCl/XrdClDefaultEnv.hh>
+#include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClURL.hh>
+#include <XrdCl/XrdClXRootDResponses.hh>
+#include <chrono>
+#include <cmath>
+#include <utility>
+
 #include "XrdClHttpResponses.hh"
 #include "XrdClHttpUtil.hh"
 #include "XrdClHttpWorker.hh"
 
-#include <XrdCl/XrdClDefaultEnv.hh>
-#include <XrdCl/XrdClLog.hh>
-#include <XrdCl/XrdClXRootDResponses.hh>
-
-#include <arpa/inet.h>
-#include <unistd.h>
-#include <chrono>
-#include <cmath>
 #ifdef __APPLE__
 #include <stdlib.h>
 #else
 #include <sys/random.h>
 #endif
-#include <utility>
-
 using namespace XrdClHttp;
 
 std::chrono::steady_clock::duration CurlOperation::m_stall_interval{CurlOperation::m_default_stall_interval};
@@ -215,6 +217,10 @@ CurlOperation::FailCallback(XErrorCode ecode, const std::string &emsg) {
 bool
 CurlOperation::FinishSetup(CURL *curl)
 {
+    if (m_parsed_url) {
+        XrdClHttp::InjectBearerToken(*m_parsed_url, m_headers_list, m_logger);
+    }
+
     if (!m_header_callout) {
         m_header_slist.reset();
         for (const auto &header : m_headers_list) {

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -18,40 +18,41 @@
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
 
-#include "XrdClHttpFile.hh"
-#include "XrdClHttpOps.hh"
-#include "XrdClHttpOptionsCache.hh"
 #include "XrdClHttpUtil.hh"
-#include "XrdClHttpWorker.hh"
+
+#include <curl/curl.h>
+#include <fcntl.h>
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <unistd.h>
 
 #include <XProtocol/XProtocol.hh>
 #include <XrdCl/XrdClDefaultEnv.hh>
 #include <XrdCl/XrdClLog.hh>
 #include <XrdCl/XrdClURL.hh>
 #include <XrdCl/XrdClXRootDResponses.hh>
+#include <XrdOuc/XrdOucBearerToken.hh>
 #include <XrdOuc/XrdOucCRC.hh>
 #include <XrdOuc/XrdOucPrivateUtils.hh>
 #include <XrdSys/XrdSysPageSize.hh>
 #include <XrdVersion.hh>
+#include <cerrno>
+#include <cstring>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
 
-#include <curl/curl.h>
-#include <openssl/bio.h>
-#include <openssl/evp.h>
+#include "XrdClHttpFile.hh"
+#include "XrdClHttpOps.hh"
+#include "XrdClHttpOptionsCache.hh"
+#include "XrdClHttpWorker.hh"
 
-#include <fcntl.h>
-#include <fstream>
 #ifdef __APPLE__
 #include <pthread.h>
 #else
 #include <sys/syscall.h>
 #include <sys/types.h>
 #endif
-#include <unistd.h>
-
-#include <charconv>
-#include <sstream>
-#include <stdexcept>
-#include <utility>
 
 using namespace XrdClHttp;
 
@@ -669,6 +670,50 @@ XrdClHttp::GetHandle(bool verbose) {
     curl_easy_setopt(result, CURLOPT_BUFFERSIZE, 32*1024);
 
     return result;
+}
+
+std::string XrdClHttp::GetBearerToken(XrdCl::Log* logger) {
+    auto result = XrdOucBearerToken::Discover();
+    if (result.status == XrdOucBearerToken::Status::Found) return result.token;
+
+    if (logger && result.status == XrdOucBearerToken::Status::Error) {
+        std::string emsg;
+        switch (result.errnum) {
+            case EPERM:
+                emsg = "token file must be readable only by its owner";
+                break;
+            case EMSGSIZE:
+                emsg = "token exceeds the maximum allowed size";
+                break;
+            case EIO:
+                emsg = "unable to read the complete token from file";
+                break;
+            default:
+                emsg = strerror(result.errnum);
+                break;
+        }
+
+        logger->Warning(kLogXrdClHttp, "Bearer token discovery failed at %s: %s",
+                        result.location.c_str(), emsg.c_str());
+    }
+
+    return {};
+}
+
+void XrdClHttp::InjectBearerToken(const XrdCl::URL& url, std::vector<std::pair<std::string, std::string>>& headers,
+                                  XrdCl::Log* logger) {
+    if (url.GetParams().count("authz")) return;
+    for (const auto& h : headers) {
+        if (h.first.compare("Authorization") == 0) return;
+    }
+
+    auto tok = GetBearerToken(logger);
+    if (tok.empty()) return;
+
+    if (logger) {
+        logger->Debug(kLogXrdClHttp, "Injecting bearer token from environment for %s", url.GetURL().c_str());
+    }
+    headers.emplace_back("Authorization", "Bearer " + tok);
 }
 
 CURL *

--- a/src/XrdClHttp/XrdClHttpUtil.hh
+++ b/src/XrdClHttp/XrdClHttpUtil.hh
@@ -21,18 +21,17 @@
 #ifndef XRDCLHTTPUTIL_HH
 #define XRDCLHTTPUTIL_HH
 
-#include "XrdClHttpChecksum.hh"
-#include "XrdClHttpOptionsCache.hh"
-#include "XrdClHttpResponseInfo.hh"
-
 #include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <vector>
+
+#include "XrdClHttpChecksum.hh"
+#include "XrdClHttpOptionsCache.hh"
+#include "XrdClHttpResponseInfo.hh"
 
 // Forward dec'ls
 typedef void CURL;
@@ -41,6 +40,13 @@ struct curl_slist;
 namespace XrdCl {
 
 class ResponseHandler;
+class Log;
+class URL;
+
+}  // namespace XrdCl
+
+namespace XrdCl {
+
 class Log;
 
 }
@@ -64,6 +70,14 @@ std::string_view trim_view(const std::string_view &input_view);
 // Returns a newly-created curl handle (no internal caching) with the
 // various configurations needed to be used by XrdClHttp
 CURL *GetHandle(bool verbose);
+
+// Locate a bearer token using the shared WLCG discovery rules
+std::string GetBearerToken(XrdCl::Log* logger = nullptr);
+
+// Add an Authorization header from discovered bearer token when the URL and
+// headers do not already carry credentials.
+void InjectBearerToken(const XrdCl::URL& url, std::vector<std::pair<std::string,
+                       std::string>>& headers, XrdCl::Log* logger = nullptr);
 
 // Parser for headers as emitted by libcurl.
 //

--- a/src/XrdOuc/CMakeLists.txt
+++ b/src/XrdOuc/CMakeLists.txt
@@ -59,6 +59,7 @@ target_sources(XrdUtils
     XrdOucTrace.cc       XrdOucTrace.hh
     XrdOucUri.cc         XrdOucUri.hh
     XrdOucUtils.cc       XrdOucUtils.hh
+    XrdOucBearerToken.cc XrdOucBearerToken.hh
     XrdOucVerName.cc     XrdOucVerName.hh
                          XrdOucChain.hh
                          XrdOucDLlist.hh

--- a/src/XrdOuc/XrdOucBearerToken.cc
+++ b/src/XrdOuc/XrdOucBearerToken.cc
@@ -1,0 +1,102 @@
+#include "XrdOuc/XrdOucBearerToken.hh"
+
+#include <fcntl.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <string>
+#include <utility>
+
+std::string XrdOucBearerToken::Strip(std::string_view token) {
+    constexpr std::string_view ws = " \t\n\r\f\v";
+    const auto start = token.find_first_not_of(ws);
+    if (start == std::string_view::npos) return {};
+    const auto end = token.find_last_not_of(ws);
+    return std::string(token.substr(start, end - start + 1));
+}
+
+XrdOucBearerToken::Result XrdOucBearerToken::FromEnvValue(const char* value, size_t maxSize) {
+    if (!value || !*value) return {};
+
+    auto token = Strip(value);
+    if (token.empty()) return {};
+
+    if (maxSize && token.size() > maxSize) return {Status::Error, {}, EMSGSIZE, value};
+
+    return {Status::Found, std::move(token), 0, {}};
+}
+
+XrdOucBearerToken::Result XrdOucBearerToken::ReadFile(const char* path, size_t maxSize) {
+    if (!path || !*path) return {};
+
+    struct stat st;
+    if (stat(path, &st) != 0) {
+        if (errno == ENOENT) return {};
+        return {Status::Error, {}, errno, path};
+    }
+
+    if (maxSize && static_cast<size_t>(st.st_size) > maxSize)
+        return {Status::Error, {}, EMSGSIZE, path};
+
+    // make sure the file is not accessible to anyone but the owner
+    if (st.st_mode & (S_IRWXG | S_IRWXO)) return {Status::Error, {}, EPERM, path};
+
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) return {Status::Error, {}, errno, path};
+
+    std::string token(static_cast<size_t>(st.st_size), '\0');
+    ssize_t nread = read(fd, &token[0], static_cast<size_t>(st.st_size));
+    int readErr = errno;
+    close(fd);
+
+    if (nread != st.st_size) return {Status::Error, {}, nread < 0 ? readErr : EIO, path};
+
+    token = Strip(token);
+    if (token.empty()) return {};
+
+    return {Status::Found, std::move(token), 0, path};
+}
+
+XrdOucBearerToken::Result XrdOucBearerToken::TryEntry(std::string_view entry, size_t maxSize) {
+    if (entry.empty()) return {};
+
+    // absolute path to the token file
+    if (entry.front() == '/') {
+        char path[MAXPATHLEN + 8];
+        const std::string fmt(entry);
+        snprintf(path, sizeof(path), fmt.c_str(), static_cast<int>(geteuid()));
+        return ReadFile(path, maxSize);
+    }
+
+    const std::string envName(entry);
+    const char* env = getenv(envName.c_str());
+    if (!env || !*env) return {};
+
+    if (entry.size() >= 4 && !entry.compare(entry.size() - 4, 4, "_DIR")) {
+        const std::string path = std::string(env) + "/bt_u" + std::to_string(geteuid());
+        return ReadFile(path.c_str(), maxSize);
+    }
+
+    if (entry.size() >= 5 && !entry.compare(entry.size() - 5, 5, "_FILE"))
+        return ReadFile(env, maxSize);
+
+    return FromEnvValue(env, maxSize);
+}
+
+XrdOucBearerToken::Result XrdOucBearerToken::Discover(size_t maxSize, const char* xrdZtnPath) {
+    static constexpr std::array<std::string_view, 4> dfltLoc = {"BEARER_TOKEN", "BEARER_TOKEN_FILE",
+                                                                "XDG_RUNTIME_DIR", "/tmp/bt_u%d"};
+
+    for (const auto loc : dfltLoc) {
+        auto result = TryEntry(loc, maxSize);
+        if (result.status != Status::NotFound) return result;
+    }
+
+    if (xrdZtnPath && *xrdZtnPath) return ReadFile(xrdZtnPath, maxSize);
+
+    return {};
+}

--- a/src/XrdOuc/XrdOucBearerToken.hh
+++ b/src/XrdOuc/XrdOucBearerToken.hh
@@ -1,0 +1,95 @@
+#ifndef __XRDOUCBEARERTOKEN_HH__
+#define __XRDOUCBEARERTOKEN_HH__
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+/**
+ * WLCG bearer-token discovery helpers shared by client components.
+ *
+ * Implements the discovery order defined by the WLCG Bearer Token Discovery
+ * specification and currently used by the ztn security protocol.
+ * https://github.com/WLCG-AuthZ-WG/bearer-token-discovery
+ */
+class XrdOucBearerToken {
+   public:
+    enum class Status { Found, NotFound, Error };
+
+    struct Result {
+        Status status{Status::NotFound};
+        std::string token;
+        int errnum{0};
+        std::string location;
+    };
+
+    /**
+     * Strip leading and trailing whitespace from a token string.
+     *
+     * @param token input token text
+     * @return the trimmed token, or an empty string if @p token is blank
+     */
+    static std::string Strip(std::string_view token);
+
+    /**
+     * Read a bearer token from a file.
+     *
+     * The file must be readable only by its owner. Group or world-accessible
+     * files are rejected with EPERM.
+     *
+     * @param path    path to the token file
+     * @param maxSize maximum allowed token size in bytes, or 0 for no limit
+     * @return a Result with status
+     *         Found and token set on success;
+     *         NotFound if path does not exist or contains only whitespace;
+     *         Error with errnum and location set on failure
+     */
+    static Result ReadFile(const char* path, size_t maxSize = 0);
+
+    /**
+     * Extract a bearer token from a raw environment value.
+     *
+     * @param value   token contents
+     * @param maxSize maximum allowed token size in bytes, or 0 for no limit
+     * @return a Result with status Found and token set on success;
+     *          NotFound if @p value is null, empty, or whitespace only;
+     *          Error with errnum set to EMSGSIZE if the token is too large
+     */
+    static Result FromEnvValue(const char* value, size_t maxSize = 0);
+
+    /**
+     * Try one WLCG bearer-token discovery entry.
+     *
+     * Supported forms match the ztn client lookup vector entries:
+     *   - BEARER_TOKEN : read the variable value directly
+     *   - BEARER_TOKEN_FILE : read the file named by the variable
+     *   - XDG_RUNTIME_DIR : read $XDG_RUNTIME_DIR/bt_u<uid>
+     *   - absolute paths containing %d : read the path with the effective user
+     *     id substituted (for example /tmp/bt_u%d)
+     *
+     * @param entry discovery entry name or path pattern
+     * @param maxSize maximum allowed token size in bytes, or 0 for no limit
+     * @return the Result from the resolved entry, or NotFound if @p entry is
+     *         unknown or the entry is unset
+     */
+    static Result TryEntry(std::string_view entry, size_t maxSize = 0);
+
+    /**
+     * Run the default WLCG bearer-token discovery sequence.
+     *
+     * Locations are tried in order until one returns Found or Error:
+     *   1. BEARER_TOKEN
+     *   2. BEARER_TOKEN_FILE
+     *   3. XDG_RUNTIME_DIR
+     *   4. /tmp/bt_u<uid>
+     *   5. @p xrdZtnPath, when provided
+     *
+     * @param maxSize    maximum allowed token size in bytes, or 0 for no limit
+     * @param xrdZtnPath optional path from the xrd.ztn opaque parameter
+     * @return the first non-NotFound Result from the sequence, or NotFound if no
+     * token is available
+     */
+    static Result Discover(size_t maxSize = 0, const char* xrdZtnPath = nullptr);
+};
+
+#endif

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -30,16 +30,16 @@
 
 #define __STDC_FORMAT_MACROS 1
 
-#include <cctype>
-#include <cerrno>
 #include <fcntl.h>
+
+#include <cerrno>
 #include <cinttypes>
-#include <iostream>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <iostream>
 #include <vector>
 
 #ifndef __FreeBSD__
@@ -47,24 +47,23 @@
 #endif
 
 #include <arpa/inet.h>
+#include <strings.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/uio.h>
-#include <strings.h>
 #include <unistd.h>
 
-#include "XrdVersion.hh"
-
 #include "XrdNet/XrdNetAddrInfo.hh"
+#include "XrdOuc/XrdOucBearerToken.hh"
 #include "XrdOuc/XrdOucEnv.hh"
 #include "XrdOuc/XrdOucErrInfo.hh"
 #include "XrdOuc/XrdOucPinLoader.hh"
 #include "XrdOuc/XrdOucString.hh"
 #include "XrdOuc/XrdOucTokenizer.hh"
 #include "XrdSciTokens/XrdSciTokensHelper.hh"
-#include "XrdSys/XrdSysE2T.hh"
-#include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSec/XrdSecInterface.hh"
+#include "XrdSys/XrdSysE2T.hh"
+#include "XrdVersion.hh"
 
 #ifndef EAUTH
 #define EAUTH EBADE
@@ -248,7 +247,6 @@ XrdSecCredentials *readFail(XrdOucErrInfo *erp, const char *path, int rc);
 XrdSecCredentials *readToken(XrdOucErrInfo *erp, const char *path, bool &isbad);
 XrdSecCredentials *retToken(XrdOucErrInfo *erp, const char *tkn, int tsz);
 int                SendAI(XrdOucErrInfo *erp, XrdSecParameters **parms);
-const char        *Strip(const char *bTok, int &sz);
 
 XrdSciTokensHelper *sthP;
 const char         *tokName;
@@ -319,38 +317,19 @@ XrdSecCredentials *XrdSecProtocolztn::findToken(XrdOucErrInfo *erp,
                                                 bool &isbad)
 {
    XrdSecCredentials *resp;
-   const char *aTok, *bTok;
-   int sz;
 
 // Look through all of the possible envars
 //
    for (int i = 0; i < (int)Vec.size(); i++)
        {tokName = Vec[i].c_str();
-
-        if (Vec[i].beginswith('/') == 1)
-           {char tokPath[MAXPATHLEN+8];
-            snprintf(tokPath, sizeof(tokPath), tokName, int(geteuid()));
-            resp = readToken(erp, tokPath, isbad);
-            if (resp || isbad) return resp;
-            continue;
+        auto result = XrdOucBearerToken::TryEntry(tokName, maxTSize);
+        if (result.status == XrdOucBearerToken::Status::Found)
+           return retToken(erp, result.token.c_str(),
+                           static_cast<int>(result.token.size()));
+        if (result.status == XrdOucBearerToken::Status::Error)
+           {isbad = true;
+            return readFail(erp, result.location.c_str(), result.errnum);
            }
-
-        if (!(aTok = getenv(Vec[i].c_str())) || !*(aTok)) continue;
-
-        if (Vec[i].endswith("_DIR"))
-           {char tokPath[MAXPATHLEN+8];
-            snprintf(tokPath,sizeof(tokPath),"%s/bt_u%d",aTok,int(geteuid()));
-            resp = readToken(erp, tokPath, isbad);
-            if (resp || isbad) return resp;
-            continue;
-           }
-
-        if (Vec[i].endswith("_FILE"))
-           {if ((resp = readToken(erp, aTok, isbad)) || isbad) return resp;
-            continue;
-           }
-
-        if ((bTok = Strip(aTok, sz))) return retToken(erp, bTok, sz);
        }
 
 // We support passing the credential cache path via Url parameter
@@ -452,60 +431,21 @@ XrdSecCredentials *XrdSecProtocolztn::readFail(XrdOucErrInfo *erp,
 XrdSecCredentials *XrdSecProtocolztn::readToken(XrdOucErrInfo *erp,
                                                 const char *path, bool &isbad)
 {
-   struct stat Stat;
-   const char *bTok;
-   char *buff;
-   int rdLen, sz, tokFD;
-
-// Be pessimistic
-//
    isbad = true;
 
-// Get the size of the file
-//
-   if (stat(path, &Stat))
-      {if (errno != ENOENT) return readFail(erp, path, errno);
-       isbad = false;
-       return 0;
+   auto result = XrdOucBearerToken::ReadFile(path, maxTSize);
+   if (result.status == XrdOucBearerToken::Status::Found)
+      {isbad = false;
+       return retToken(erp, result.token.c_str(),
+                       static_cast<int>(result.token.size()));
       }
 
-// Make sure token is not too big
-//
-   if (Stat.st_size > maxTSize) return readFail(erp, path, EMSGSIZE);
-   buff = (char *)alloca(Stat.st_size+1);
-
-// Open the token file
-//
-   if ((tokFD = open(path, O_RDONLY)) < 0)
-      return readFail(erp, path, errno);
-
-// Read in the token
-//
-   if ((rdLen = read(tokFD, buff, Stat.st_size)) != Stat.st_size)
-      {int rc = (rdLen < 0 ? errno : EIO);
-       close(tokFD);
-       return readFail(erp, path, rc);
-      }
-   close(tokFD);
-
-// Make sure the token ends with a null byte
-//
-   buff[Stat.st_size] = 0;
-
-// Strip the token
-//
-   if (!(bTok = Strip(buff, sz)))
+   if (result.status == XrdOucBearerToken::Status::NotFound)
       {isbad = false;
        return 0;
       }
 
-// Make sure the file is not accessible to anyone but the owner
-//
-   if (Stat.st_mode & (S_IRWXG | S_IRWXO)) return readFail(erp, path, EPERM);
-
-// Return response
-//
-   return retToken(erp, bTok, sz);
+   return readFail(erp, result.location.c_str(), result.errnum);
 }
   
 /******************************************************************************/
@@ -544,40 +484,6 @@ XrdSecCredentials *XrdSecProtocolztn::retToken(XrdOucErrInfo *erp,
 // Now return it
 //
    return new XrdSecCredentials((char *)tResp, rspLen);
-}
-  
-/******************************************************************************/
-/* Private:                        S t r i p                                  */
-/******************************************************************************/
-
-const char *XrdSecProtocolztn::Strip(const char *bTok, int &sz)
-{
-   int j, k, n = strlen(bTok);
-
-// Make sure we have at least one character here
-//
-   if (!n) return 0;
-
-// Find first non-whitespace character
-//
-   for (j = 0; j < n; j++) if (!isspace(static_cast<int>(bTok[j]))) break;
-
-// Make sure we have at least one character
-//
-   if (j >= n) return 0;
-
-// Find last non-whitespace character
-//
-   for (k = n-1; k > j; k--) if (!isspace(static_cast<int>(bTok[k]))) break;
-
-// Compute length and allocate enough storage to copy the token
-//
-   if (k <= j) return 0;
-
-// Compute length and return pointer to the token
-//
-   sz = k - j + 1;
-   return bTok + j;
 }
   
 /******************************************************************************/

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ add_subdirectory(XrdMacaroons)
 
 add_subdirectory(XrdOucTests)
 
+add_subdirectory(XrdSecztnTests)
+
 add_subdirectory(XrdThrottleTests)
 
 add_subdirectory( XrdSsiTests )

--- a/tests/XrdOucTests/CMakeLists.txt
+++ b/tests/XrdOucTests/CMakeLists.txt
@@ -1,6 +1,30 @@
-add_executable(xrdoucutils-unit-tests XrdOucUtilsTests.cc)
+add_executable(xrdoucutils-unit-tests
+  XrdOucBearerTokenTests.cc
+  XrdOucUtilsTests.cc
+)
 
 target_link_libraries(xrdoucutils-unit-tests XrdUtils GTest::gtest GTest::gtest_main)
 
 gtest_discover_tests(xrdoucutils-unit-tests
   PROPERTIES DISCOVERY_TIMEOUT 10)
+
+find_package(CURL QUIET)
+if(CURL_FOUND AND TARGET XrdClHttpObj)
+  add_executable(xrdclhttp-bearer-token-tests
+    XrdClHttpGetBearerTokenTests.cc
+  )
+
+  target_link_libraries(xrdclhttp-bearer-token-tests
+    XrdClHttpObj
+    XrdCl
+    GTest::gtest
+    GTest::gtest_main
+  )
+
+  target_include_directories(xrdclhttp-bearer-token-tests PRIVATE
+    "${CMAKE_SOURCE_DIR}/src"
+  )
+
+  gtest_discover_tests(xrdclhttp-bearer-token-tests
+    PROPERTIES DISCOVERY_TIMEOUT 10)
+endif()

--- a/tests/XrdOucTests/XrdClHttpGetBearerTokenTests.cc
+++ b/tests/XrdOucTests/XrdClHttpGetBearerTokenTests.cc
@@ -1,0 +1,140 @@
+#undef NDEBUG
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <XrdCl/XrdClLog.hh>
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+#include "XrdClHttp/XrdClHttpUtil.hh"
+
+namespace {
+
+class EnvGuard {
+   public:
+    EnvGuard(const char* name, const char* value) {
+        m_name = name;
+        if (const char* old = getenv(name)) {
+            m_hadOld = true;
+            m_oldValue = old;
+        }
+        if (value) {
+            setenv(name, value, 1);
+        } else {
+            unsetenv(name);
+        }
+    }
+
+    ~EnvGuard() {
+        if (m_hadOld) {
+            setenv(m_name.c_str(), m_oldValue.c_str(), 1);
+        } else {
+            unsetenv(m_name.c_str());
+        }
+    }
+
+   private:
+    std::string m_name;
+    bool m_hadOld{false};
+    std::string m_oldValue;
+};
+
+class StringLogOut : public XrdCl::LogOut {
+   public:
+    std::string messages;
+
+    void Write(const std::string& message) override { messages += message; }
+};
+
+struct TestLogger {
+    StringLogOut* out{nullptr};
+    XrdCl::Log logger;
+
+    TestLogger() {
+        out = new StringLogOut();
+        logger.SetOutput(out);
+        logger.SetLevel(XrdCl::Log::DebugMsg);
+        logger.SetMask("warning", XrdClHttp::kLogXrdClHttp);
+        logger.SetMask("debug", XrdClHttp::kLogXrdClHttp);
+    }
+
+    ~TestLogger() { logger.SetOutput(new XrdCl::LogOutCerr()); }
+};
+
+std::string TempTokenPath() {
+    char path[] = "/tmp/xrdclhttp-bearer-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        ADD_FAILURE() << "mkstemp failed: " << strerror(errno);
+        return {};
+    }
+    close(fd);
+    unlink(path);
+    return std::string(path);
+}
+
+bool WriteTokenFile(const std::string& path, const std::string& contents, mode_t mode) {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) return false;
+    out << contents;
+    out.close();
+    return chmod(path.c_str(), mode) == 0;
+}
+
+void ClearDiscoveryEnv() {
+    unsetenv("BEARER_TOKEN");
+    unsetenv("BEARER_TOKEN_FILE");
+    unsetenv("XDG_RUNTIME_DIR");
+}
+
+}  // anonymous namespace
+
+class XrdClHttpGetBearerTokenTests : public ::testing::Test {
+   protected:
+    void SetUp() override { ClearDiscoveryEnv(); }
+    void TearDown() override { ClearDiscoveryEnv(); }
+};
+
+TEST_F(XrdClHttpGetBearerTokenTests, ReturnsTokenFromEnvironment) {
+    EnvGuard env("BEARER_TOKEN", "http-jwt");
+
+    EXPECT_EQ("http-jwt", XrdClHttp::GetBearerToken());
+}
+
+TEST_F(XrdClHttpGetBearerTokenTests, NotFoundIsSilentWithoutLogger) {
+    TestLogger log;
+
+    EXPECT_TRUE(XrdClHttp::GetBearerToken(&log.logger).empty());
+    EXPECT_TRUE(log.out->messages.empty());
+}
+
+TEST_F(XrdClHttpGetBearerTokenTests, DiscoveryErrorIsLogged) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "secret-token", S_IRUSR | S_IRGRP));
+    EnvGuard tokenFile("BEARER_TOKEN_FILE", path.c_str());
+
+    TestLogger log;
+
+    EXPECT_TRUE(XrdClHttp::GetBearerToken(&log.logger).empty());
+    EXPECT_NE(std::string::npos, log.out->messages.find("Bearer token discovery failed"));
+    EXPECT_NE(std::string::npos, log.out->messages.find(path));
+    EXPECT_NE(std::string::npos, log.out->messages.find("readable only by its owner"));
+    unlink(path.c_str());
+}
+
+TEST_F(XrdClHttpGetBearerTokenTests, DiscoveryErrorWithoutLoggerReturnsEmpty) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "secret-token", S_IRUSR | S_IRGRP));
+    EnvGuard tokenFile("BEARER_TOKEN_FILE", path.c_str());
+
+    EXPECT_TRUE(XrdClHttp::GetBearerToken(nullptr).empty());
+
+    unlink(path.c_str());
+}

--- a/tests/XrdOucTests/XrdOucBearerTokenTests.cc
+++ b/tests/XrdOucTests/XrdOucBearerTokenTests.cc
@@ -1,0 +1,189 @@
+#undef NDEBUG
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+#include "XrdOuc/XrdOucBearerToken.hh"
+
+namespace {
+
+class EnvGuard {
+   public:
+    EnvGuard(const char* name, const char* value) {
+        m_name = name;
+        if (const char* old = getenv(name)) {
+            m_hadOld = true;
+            m_oldValue = old;
+        }
+        if (value) {
+            setenv(name, value, 1);
+        } else {
+            unsetenv(name);
+        }
+    }
+
+    ~EnvGuard() {
+        if (m_hadOld) {
+            setenv(m_name.c_str(), m_oldValue.c_str(), 1);
+        } else {
+            unsetenv(m_name.c_str());
+        }
+    }
+
+   private:
+    std::string m_name;
+    bool m_hadOld{false};
+    std::string m_oldValue;
+};
+
+std::string TempTokenPath() {
+    char path[] = "/tmp/xrdouc-bearer-XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) {
+        ADD_FAILURE() << "mkstemp failed: " << strerror(errno);
+        return {};
+    }
+    close(fd);
+    unlink(path);
+    return std::string(path);
+}
+
+bool WriteTokenFile(const std::string& path, const std::string& contents, mode_t mode) {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) return false;
+    out << contents;
+    out.close();
+    return chmod(path.c_str(), mode) == 0;
+}
+
+void ClearDiscoveryEnv() {
+    unsetenv("BEARER_TOKEN");
+    unsetenv("BEARER_TOKEN_FILE");
+    unsetenv("XDG_RUNTIME_DIR");
+}
+
+}  // anonymous namespace
+
+class XrdOucBearerTokenTests : public ::testing::Test {
+   protected:
+    void SetUp() override { ClearDiscoveryEnv(); }
+    void TearDown() override { ClearDiscoveryEnv(); }
+};
+
+TEST_F(XrdOucBearerTokenTests, StripTrimsWhitespace) {
+    EXPECT_EQ("token", XrdOucBearerToken::Strip("  token \n"));
+    EXPECT_EQ("token", XrdOucBearerToken::Strip("\ttoken\r"));
+    EXPECT_TRUE(XrdOucBearerToken::Strip("   ").empty());
+}
+
+TEST_F(XrdOucBearerTokenTests, FromEnvValue) {
+    auto found = XrdOucBearerToken::FromEnvValue("  jwt-value  ");
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, found.status);
+    EXPECT_EQ("jwt-value", found.token);
+
+    auto empty = XrdOucBearerToken::FromEnvValue("   ");
+    EXPECT_EQ(XrdOucBearerToken::Status::NotFound, empty.status);
+
+    auto tooLarge = XrdOucBearerToken::FromEnvValue("0123456789", 5);
+    ASSERT_EQ(XrdOucBearerToken::Status::Error, tooLarge.status);
+    EXPECT_EQ(EMSGSIZE, tooLarge.errnum);
+}
+
+TEST_F(XrdOucBearerTokenTests, ReadFileNotFound) {
+    auto result = XrdOucBearerToken::ReadFile("/tmp/xrdouc-bearer-missing-token");
+    EXPECT_EQ(XrdOucBearerToken::Status::NotFound, result.status);
+}
+
+TEST_F(XrdOucBearerTokenTests, ReadFileRejectsGroupReadable) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "secret-token", S_IRUSR | S_IRGRP));
+
+    auto result = XrdOucBearerToken::ReadFile(path.c_str());
+    ASSERT_EQ(XrdOucBearerToken::Status::Error, result.status);
+    EXPECT_EQ(EPERM, result.errnum);
+    EXPECT_EQ(path, result.location);
+
+    unlink(path.c_str());
+}
+
+TEST_F(XrdOucBearerTokenTests, ReadFileAcceptsOwnerOnlyToken) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "  bearer-jwt  \n", S_IRUSR | S_IWUSR));
+
+    auto result = XrdOucBearerToken::ReadFile(path.c_str());
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, result.status);
+    EXPECT_EQ("bearer-jwt", result.token);
+
+    unlink(path.c_str());
+}
+
+TEST_F(XrdOucBearerTokenTests, TryEntryBearerTokenEnv) {
+    EnvGuard env("BEARER_TOKEN", "env-token");
+
+    auto result = XrdOucBearerToken::TryEntry("BEARER_TOKEN");
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, result.status);
+    EXPECT_EQ("env-token", result.token);
+}
+
+TEST_F(XrdOucBearerTokenTests, TryEntryBearerTokenFile) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "file-token", S_IRUSR | S_IWUSR));
+    EnvGuard env("BEARER_TOKEN_FILE", path.c_str());
+
+    auto result = XrdOucBearerToken::TryEntry("BEARER_TOKEN_FILE");
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, result.status);
+    EXPECT_EQ("file-token", result.token);
+
+    unlink(path.c_str());
+}
+
+TEST_F(XrdOucBearerTokenTests, DiscoverPrefersBearerTokenOverFile) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "file-token", S_IRUSR | S_IWUSR));
+
+    EnvGuard token("BEARER_TOKEN", "env-token");
+    EnvGuard tokenFile("BEARER_TOKEN_FILE", path.c_str());
+
+    auto result = XrdOucBearerToken::Discover();
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, result.status);
+    EXPECT_EQ("env-token", result.token);
+
+    unlink(path.c_str());
+}
+
+TEST_F(XrdOucBearerTokenTests, DiscoverUsesBearerTokenFile) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "file-token", S_IRUSR | S_IWUSR));
+    EnvGuard tokenFile("BEARER_TOKEN_FILE", path.c_str());
+
+    auto result = XrdOucBearerToken::Discover();
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, result.status);
+    EXPECT_EQ("file-token", result.token);
+
+    unlink(path.c_str());
+}
+
+TEST_F(XrdOucBearerTokenTests, DiscoverHonorsXrdZtnPath) {
+    auto path = TempTokenPath();
+    ASSERT_FALSE(path.empty());
+    ASSERT_TRUE(WriteTokenFile(path, "ztn-token", S_IRUSR | S_IWUSR));
+
+    auto result = XrdOucBearerToken::Discover(0, path.c_str());
+    ASSERT_EQ(XrdOucBearerToken::Status::Found, result.status);
+    EXPECT_EQ("ztn-token", result.token);
+
+    unlink(path.c_str());
+}

--- a/tests/XrdSecztnTests/CMakeLists.txt
+++ b/tests/XrdSecztnTests/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(XrdSecztnLib XrdSecztn-${PLUGIN_VERSION})
+
+add_executable(xrdsecztn-token-tests XrdSecztnTokenTests.cc)
+
+target_link_libraries(xrdsecztn-token-tests
+  PRIVATE
+    XrdUtils
+    GTest::gtest
+    GTest::gtest_main
+    ${CMAKE_DL_LIBS}
+)
+
+target_compile_definitions(xrdsecztn-token-tests
+  PRIVATE
+    XRD_SECZTN_LIB="$<TARGET_FILE:${XrdSecztnLib}>"
+)
+
+add_dependencies(xrdsecztn-token-tests ${XrdSecztnLib})
+
+gtest_discover_tests(xrdsecztn-token-tests
+  PROPERTIES DISCOVERY_TIMEOUT 10)

--- a/tests/XrdSecztnTests/XrdSecztnTokenTests.cc
+++ b/tests/XrdSecztnTests/XrdSecztnTokenTests.cc
@@ -1,0 +1,541 @@
+/******************************************************************************/
+/* Black-box characterization of the ztn *client* bearer-token discovery path */
+/*                                                                            */
+/* These tests load libXrdSecztn and drive only the stable public ABI:        */
+/*                                                                            */
+/*   XrdSecProtocolztnObject('c', ...) -> getCredentials()                    */
+/*                                                                            */
+/* Client discovery order under test (WLCG bearer-token discovery):           */
+/*   1. BEARER_TOKEN                                                          */
+/*   2. BEARER_TOKEN_FILE                                                     */
+/*   3. $XDG_RUNTIME_DIR/bt_u<uid>                                            */
+/*   4. /tmp/bt_u<uid>                                                        */
+/*   5. opaque xrd.ztn=<path> (via XrdOucErrInfo env)                         */
+/******************************************************************************/
+
+#undef NDEBUG
+
+#include <arpa/inet.h>
+#include <dlfcn.h>
+#include <gtest/gtest.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <utility>
+
+#include "XrdNet/XrdNetAddr.hh"
+#include "XrdOuc/XrdOucEnv.hh"
+#include "XrdOuc/XrdOucErrInfo.hh"
+#include "XrdSec/XrdSecInterface.hh"
+
+#ifndef XRD_SECZTN_LIB
+#error "XRD_SECZTN_LIB must be defined to the built libXrdSecztn path"
+#endif
+
+namespace {
+
+using ZtnObjectFn = XrdSecProtocol *(*)(const char /*mode*/, const char * /*host*/,
+                                        XrdNetAddrInfo &, const char * /*parms*/,
+                                        XrdOucErrInfo *);
+
+// Server-advertised client parms: <opts>:<maxTokenBytes>:
+constexpr const char *kDefaultParms = "0:4096:";
+
+//------------------------------------------------------------------------------
+// Environment helpers
+//------------------------------------------------------------------------------
+
+class EnvVar {
+   public:
+    EnvVar(const char *name, const char *value) : m_name(name) {
+        if (const char *old = getenv(name)) {
+            m_had = true;
+            m_old = old;
+        }
+        if (value)
+            setenv(name, value, 1);
+        else
+            unsetenv(name);
+    }
+
+    ~EnvVar() {
+        if (m_had)
+            setenv(m_name.c_str(), m_old.c_str(), 1);
+        else
+            unsetenv(m_name.c_str());
+    }
+
+    EnvVar(const EnvVar &) = delete;
+    EnvVar &operator=(const EnvVar &) = delete;
+
+   private:
+    std::string m_name;
+    std::string m_old;
+    bool m_had{false};
+};
+
+// Saves BEARER_TOKEN / BEARER_TOKEN_FILE / XDG_RUNTIME_DIR, clears them for the
+// test, then restores the ambient values (so CI/local env is not permanently
+// unset across the process).
+class DiscoveryEnvGuard {
+   public:
+    DiscoveryEnvGuard() {
+        for (auto &slot : m_saved) {
+            if (const char *old = getenv(slot.name)) {
+                slot.had = true;
+                slot.value = old;
+            }
+            unsetenv(slot.name);
+        }
+    }
+
+    ~DiscoveryEnvGuard() {
+        for (auto &slot : m_saved) {
+            if (slot.had)
+                setenv(slot.name, slot.value.c_str(), 1);
+            else
+                unsetenv(slot.name);
+        }
+    }
+
+    DiscoveryEnvGuard(const DiscoveryEnvGuard &) = delete;
+    DiscoveryEnvGuard &operator=(const DiscoveryEnvGuard &) = delete;
+
+   private:
+    struct Saved {
+        const char *name;
+        bool had{false};
+        std::string value;
+    };
+
+    std::array<Saved, 3> m_saved{{{"BEARER_TOKEN", false, {}},
+                                  {"BEARER_TOKEN_FILE", false, {}},
+                                  {"XDG_RUNTIME_DIR", false, {}}}};
+};
+
+std::string DefaultTmpTokenPath() {
+    return "/tmp/bt_u" + std::to_string(static_cast<int>(geteuid()));
+}
+
+std::string XdgTokenFileName() {
+    return "bt_u" + std::to_string(static_cast<int>(geteuid()));
+}
+
+// Discovery always probes /tmp/bt_u<uid>. Move any ambient file aside for the
+// test duration and restore it afterwards so local/CI runs leave no residue.
+class IsolateDefaultTmpToken {
+   public:
+    IsolateDefaultTmpToken() {
+        m_path = DefaultTmpTokenPath();
+        if (access(m_path.c_str(), F_OK) != 0) return;
+
+        m_backup = m_path + ".xrdsecztn-test-bak";
+        unlink(m_backup.c_str());
+        if (rename(m_path.c_str(), m_backup.c_str()) != 0) {
+            m_blocked = true;
+            m_reason = strerror(errno);
+            return;
+        }
+        m_moved = true;
+    }
+
+    ~IsolateDefaultTmpToken() {
+        if (!m_moved) return;
+        unlink(m_path.c_str());
+        rename(m_backup.c_str(), m_path.c_str());
+    }
+
+    bool Blocked() const { return m_blocked; }
+    const std::string &Path() const { return m_path; }
+    const std::string &Reason() const { return m_reason; }
+
+    IsolateDefaultTmpToken(const IsolateDefaultTmpToken &) = delete;
+    IsolateDefaultTmpToken &operator=(const IsolateDefaultTmpToken &) = delete;
+
+   private:
+    std::string m_path;
+    std::string m_backup;
+    std::string m_reason;
+    bool m_moved{false};
+    bool m_blocked{false};
+};
+
+//------------------------------------------------------------------------------
+// Temporary dirs / token files
+//------------------------------------------------------------------------------
+
+class TempDir {
+   public:
+    static TempDir Create() {
+        char tmpl[] = "/tmp/xrdsecztn-xdg-XXXXXX";
+        if (!mkdtemp(tmpl)) return {};
+        TempDir dir;
+        dir.m_path = tmpl;
+        return dir;
+    }
+
+    TempDir() = default;
+    TempDir(TempDir &&other) noexcept : m_path(std::move(other.m_path)) {
+        other.m_path.clear();
+    }
+    TempDir &operator=(TempDir &&other) noexcept {
+        if (this != &other) {
+            Reset();
+            m_path = std::move(other.m_path);
+            other.m_path.clear();
+        }
+        return *this;
+    }
+
+    ~TempDir() { Reset(); }
+
+    bool Ok() const { return !m_path.empty(); }
+    const std::string &Path() const { return m_path; }
+
+    TempDir(const TempDir &) = delete;
+    TempDir &operator=(const TempDir &) = delete;
+
+   private:
+    void Reset() {
+        if (m_path.empty()) return;
+        // Best-effort: remove known token filename then the directory.
+        unlink((m_path + "/" + XdgTokenFileName()).c_str());
+        rmdir(m_path.c_str());
+        m_path.clear();
+    }
+
+    std::string m_path;
+};
+
+class TokenFile {
+   public:
+    static TokenFile Create(const std::string &contents, mode_t mode) {
+        char tmpl[] = "/tmp/xrdsecztn-token-XXXXXX";
+        int fd = mkstemp(tmpl);
+        if (fd < 0) return {};
+        close(fd);
+        return WriteAt(tmpl, contents, mode, /*owned=*/true);
+    }
+
+    // Write (or overwrite) a token at an exact path. If owned, unlink on destroy.
+    static TokenFile WriteAt(const std::string &path, const std::string &contents, mode_t mode,
+                             bool owned) {
+        TokenFile file;
+        file.m_path = path;
+        file.m_owned = owned;
+        std::ofstream out(file.m_path, std::ios::trunc);
+        if (!out) {
+            file.m_path.clear();
+            return file;
+        }
+        out << contents;
+        out.close();
+        if (chmod(file.m_path.c_str(), mode) != 0) {
+            if (owned) unlink(file.m_path.c_str());
+            file.m_path.clear();
+        }
+        return file;
+    }
+
+    TokenFile() = default;
+    TokenFile(TokenFile &&other) noexcept
+        : m_path(std::move(other.m_path)), m_owned(other.m_owned) {
+        other.m_path.clear();
+        other.m_owned = false;
+    }
+    TokenFile &operator=(TokenFile &&other) noexcept {
+        if (this != &other) {
+            Reset();
+            m_path = std::move(other.m_path);
+            m_owned = other.m_owned;
+            other.m_path.clear();
+            other.m_owned = false;
+        }
+        return *this;
+    }
+
+    ~TokenFile() { Reset(); }
+
+    bool Ok() const { return !m_path.empty(); }
+    const char *Path() const { return m_path.c_str(); }
+
+    TokenFile(const TokenFile &) = delete;
+    TokenFile &operator=(const TokenFile &) = delete;
+
+   private:
+    void Reset() {
+        if (m_owned && !m_path.empty()) unlink(m_path.c_str());
+        m_path.clear();
+        m_owned = false;
+    }
+
+    std::string m_path;
+    bool m_owned{false};
+};
+
+//------------------------------------------------------------------------------
+// Credential wire format (public on-the-wire contract of a ztn token reply)
+//------------------------------------------------------------------------------
+
+#pragma pack(push, 1)
+struct ZtnTokenCredHdr {
+    char id[4];    // "ztn\0"
+    char ver;      // 0
+    char opr;      // 'T' = token
+    char rsvd[2];
+    uint16_t len;  // htons(token_bytes + 1)  (includes trailing NUL)
+};
+#pragma pack(pop)
+
+std::string TokenFromCredentials(const XrdSecCredentials *cred) {
+    if (!cred || !cred->buffer) return {};
+    if (cred->size < static_cast<int>(sizeof(ZtnTokenCredHdr))) return {};
+
+    const auto *hdr = reinterpret_cast<const ZtnTokenCredHdr *>(cred->buffer);
+    if (std::strncmp(hdr->id, "ztn", 3) != 0 || hdr->opr != 'T') return {};
+
+    // Layout: TokenHdr(8) + htons(len) + token[len] where len includes trailing NUL.
+    const uint16_t n = ntohs(hdr->len);
+    if (n < 1) return {};
+    if (cred->size < static_cast<int>(sizeof(ZtnTokenCredHdr) + n)) return {};
+
+    const char *tkn = cred->buffer + sizeof(ZtnTokenCredHdr);
+    return std::string(tkn, n - 1);
+}
+
+//------------------------------------------------------------------------------
+// Plugin loader + thin protocol handle
+//------------------------------------------------------------------------------
+
+class ZtnPlugin {
+   public:
+    ZtnPlugin() {
+        m_lib = dlopen(XRD_SECZTN_LIB, RTLD_NOW);
+        if (!m_lib) {
+            m_error = dlerror() ? dlerror() : "dlopen(libXrdSecztn) failed";
+            return;
+        }
+        m_object = reinterpret_cast<ZtnObjectFn>(dlsym(m_lib, "XrdSecProtocolztnObject"));
+        if (!m_object)
+            m_error = dlerror() ? dlerror() : "dlsym(XrdSecProtocolztnObject) failed";
+    }
+
+    ~ZtnPlugin() {
+        if (m_lib) dlclose(m_lib);
+    }
+
+    bool Ok() const { return m_object != nullptr; }
+    const std::string &Error() const { return m_error; }
+
+    // Client mode requires a TLS endpoint; parms come from the server sectoken.
+    XrdSecProtocol *NewClient(const char *parms, XrdOucErrInfo *ei) {
+        m_ep.Set("localhost", 0);
+        m_ep.SetTLS(true);
+        return m_object('c', "localhost", m_ep, parms, ei);
+    }
+
+    ZtnPlugin(const ZtnPlugin &) = delete;
+    ZtnPlugin &operator=(const ZtnPlugin &) = delete;
+
+   private:
+    void *m_lib{nullptr};
+    ZtnObjectFn m_object{nullptr};
+    std::string m_error;
+    XrdNetAddr m_ep;
+};
+
+class Protocol {
+   public:
+    Protocol(ZtnPlugin &plugin, const char *parms, XrdOucErrInfo *ei)
+        : m_prot(plugin.NewClient(parms, ei)) {}
+
+    ~Protocol() {
+        if (m_prot) m_prot->Delete();
+    }
+
+    XrdSecProtocol *Get() const { return m_prot; }
+    explicit operator bool() const { return m_prot != nullptr; }
+
+    Protocol(const Protocol &) = delete;
+    Protocol &operator=(const Protocol &) = delete;
+
+   private:
+    XrdSecProtocol *m_prot{nullptr};
+};
+
+}  // namespace
+
+class XrdSecztnClientTokenTest : public ::testing::Test {
+   protected:
+    void SetUp() override { ASSERT_TRUE(m_plugin.Ok()) << m_plugin.Error(); }
+
+    // Declared first so ambient discovery env is cleared for the whole test and
+    // restored when the fixture is destroyed (after TearDown).
+    DiscoveryEnvGuard m_env;
+    ZtnPlugin m_plugin;
+};
+
+//--- success paths ------------------------------------------------------------
+
+TEST_F(XrdSecztnClientTokenTest, ReadsBearerTokenFromEnvironment) {
+    EnvVar token("BEARER_TOKEN", "  env-token  ");
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    ASSERT_NE(nullptr, cred) << ei.getErrText();
+    EXPECT_EQ("env-token", TokenFromCredentials(cred));
+    delete cred;
+}
+
+TEST_F(XrdSecztnClientTokenTest, ReadsBearerTokenFromOwnerOnlyFile) {
+    auto file = TokenFile::Create("file-token\n", S_IRUSR | S_IWUSR);
+    ASSERT_TRUE(file.Ok());
+    EnvVar tokenFile("BEARER_TOKEN_FILE", file.Path());
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    ASSERT_NE(nullptr, cred) << ei.getErrText();
+    EXPECT_EQ("file-token", TokenFromCredentials(cred));
+    delete cred;
+}
+
+TEST_F(XrdSecztnClientTokenTest, PrefersEnvironmentOverTokenFile) {
+    auto file = TokenFile::Create("file-token", S_IRUSR | S_IWUSR);
+    ASSERT_TRUE(file.Ok());
+    EnvVar token("BEARER_TOKEN", "env-token");
+    EnvVar tokenFile("BEARER_TOKEN_FILE", file.Path());
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    ASSERT_NE(nullptr, cred) << ei.getErrText();
+    EXPECT_EQ("env-token", TokenFromCredentials(cred));
+    delete cred;
+}
+
+TEST_F(XrdSecztnClientTokenTest, ReadsTokenFromXdgRuntimeDir) {
+    auto dir = TempDir::Create();
+    ASSERT_TRUE(dir.Ok());
+
+    const auto path = dir.Path() + "/" + XdgTokenFileName();
+    auto file = TokenFile::WriteAt(path, "xdg-token", S_IRUSR | S_IWUSR, /*owned=*/true);
+    ASSERT_TRUE(file.Ok());
+    EnvVar xdg("XDG_RUNTIME_DIR", dir.Path().c_str());
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    ASSERT_NE(nullptr, cred) << ei.getErrText();
+    EXPECT_EQ("xdg-token", TokenFromCredentials(cred));
+    delete cred;
+}
+
+TEST_F(XrdSecztnClientTokenTest, ReadsTokenFromDefaultTmpPath) {
+    IsolateDefaultTmpToken isolate;
+    if (isolate.Blocked()) {
+        GTEST_SKIP() << "cannot move aside " << isolate.Path() << ": " << isolate.Reason();
+    }
+
+    // owned=true: unlink our test file on scope exit. IsolateDefaultTmpToken is
+    // destroyed after this TokenFile, so any ambient original is restored next.
+    auto file = TokenFile::WriteAt(DefaultTmpTokenPath(), "tmp-token", S_IRUSR | S_IWUSR,
+                                   /*owned=*/true);
+    ASSERT_TRUE(file.Ok());
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    ASSERT_NE(nullptr, cred) << ei.getErrText();
+    EXPECT_EQ("tmp-token", TokenFromCredentials(cred));
+    delete cred;
+}
+
+TEST_F(XrdSecztnClientTokenTest, ReadsTokenFromXrdZtnOpaquePath) {
+    IsolateDefaultTmpToken isolate;
+    if (isolate.Blocked()) {
+        GTEST_SKIP() << "cannot move aside " << isolate.Path() << ": " << isolate.Reason();
+    }
+
+    auto file = TokenFile::Create("ztn-token", S_IRUSR | S_IWUSR);
+    ASSERT_TRUE(file.Ok());
+
+    XrdOucEnv opaque;
+    opaque.Put("xrd.ztn", file.Path());
+
+    XrdOucErrInfo ei;
+    ei.setEnv(&opaque);
+
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    ASSERT_NE(nullptr, cred) << ei.getErrText();
+    EXPECT_EQ("ztn-token", TokenFromCredentials(cred));
+    delete cred;
+
+    ei.setEnv(nullptr);
+}
+
+//--- failure paths ------------------------------------------------------------
+
+TEST_F(XrdSecztnClientTokenTest, RejectsGroupReadableTokenFile) {
+    auto file = TokenFile::Create("secret-token", S_IRUSR | S_IRGRP);
+    ASSERT_TRUE(file.Ok());
+    EnvVar tokenFile("BEARER_TOKEN_FILE", file.Path());
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    EXPECT_EQ(nullptr, cred);
+    EXPECT_EQ(EPERM, ei.getErrInfo());
+}
+
+TEST_F(XrdSecztnClientTokenTest, RejectsTokenFileLargerThanMaxSize) {
+    auto file = TokenFile::Create("0123456789", S_IRUSR | S_IWUSR);
+    ASSERT_TRUE(file.Ok());
+    EnvVar tokenFile("BEARER_TOKEN_FILE", file.Path());
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, "0:8:", &ei);  // max token size = 8 bytes
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    EXPECT_EQ(nullptr, cred);
+    EXPECT_EQ(EMSGSIZE, ei.getErrInfo());
+}
+
+TEST_F(XrdSecztnClientTokenTest, FailsWhenNoTokenIsAvailable) {
+    IsolateDefaultTmpToken isolate;
+    if (isolate.Blocked()) {
+        GTEST_SKIP() << "cannot move aside " << isolate.Path() << ": " << isolate.Reason();
+    }
+
+    XrdOucErrInfo ei;
+    Protocol prot(m_plugin, kDefaultParms, &ei);
+    ASSERT_TRUE(prot) << ei.getErrText();
+
+    XrdSecCredentials *cred = prot.Get()->getCredentials(nullptr, &ei);
+    EXPECT_EQ(nullptr, cred);
+    EXPECT_EQ(ENOPROTOOPT, ei.getErrInfo());
+}


### PR DESCRIPTION
Currently, there is no way to pass a bearer_token to xrdclhttp without an external header callout. For e.g. a client performing `xrdfs https://host:port stat /` has no way to set Authorisation header for the HTTP call.
This commit adds reading token files similar to XrdSecProtocolztn to maintain parity with the xrootd protocol.

The header callouts can override the token set in InjectBearerToken. We skip setting authorisation header if it is present in the url parameters via authz= or if a "Authorization" header is already present.

Fixes: #2740