### PR TITLE
XrdClHttp: fix processing of complex readv responses

### DIFF
--- a/src/XrdClHttp/XrdClHttpOpReadV.cc
+++ b/src/XrdClHttp/XrdClHttpOpReadV.cc
@@ -33,7 +33,11 @@ CurlVectorReadOp::CurlVectorReadOp(XrdCl::ResponseHandler *handler, const std::s
         CurlOperation(handler, url, timeout, logger, callout, header_callout),
         m_vr(new XrdCl::VectorReadInfo()),
         m_chunk_list(op_list)
-    {}
+    {
+        m_remainderbuflen = 0;
+        m_doublebuf = NULL;
+        m_doublebufsz = 0;
+    }
 
 bool
 CurlVectorReadOp::Setup(CURL *curl, CurlWorker &worker)
@@ -145,6 +149,23 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
 
     auto buffer = orig_buffer;
     auto length = orig_length;
+    
+    if (m_remainderbuflen) {
+        // Do we have unprocessed bytes from the previous chunk?
+        if (m_doublebufsz < length) {
+            if (!m_doublebufsz)
+                m_doublebuf = (char *)malloc(length+1024);
+            else
+                m_doublebuf = (char *)realloc(m_doublebuf, length+1024);
+            
+            m_doublebufsz = length;
+        }
+        memcpy(m_doublebuf, m_remainderbuf, m_remainderbuflen);
+        memcpy(m_doublebuf+m_remainderbuflen, buffer, orig_length);
+        buffer = m_doublebuf;
+        length += m_remainderbuflen;
+        m_remainderbuflen = 0;
+    }
 
     while (length) {
         // If we're in the middle of a response chunk, copy as much data as possible.
@@ -205,6 +226,17 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
         // We are at the boundary between chunks; we must parse header lines to understand the
         // next thing to do.
 
+        // Attention! We could be close to the end of the incoming chunk, hence the
+        // separator/header we are looking for might have been truncated.
+        // If we are less than 1KB form the end of the curl chunk, save this
+        // less-than-one-kb
+        // to a temporary buffer. The next chunk will have to be appended to it
+        if (length && (length < 1024)) {
+            memcpy(m_remainderbuf, buffer, length);
+            m_remainderbuflen = length;
+            length = 0;
+            return orig_length;
+        }
         // The following lambda function returns a string view to the next complete header line,
         // potentially partially from the previous buffer from curl.  If the second item in
         // the returned pair is false, then we ran out of buffer from curl before finding a

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -701,7 +701,10 @@ class CurlVectorReadOp : public CurlOperation {
         CurlVectorReadOp(XrdCl::ResponseHandler *handler, const std::string &url, struct timespec timeout,
             const XrdCl::ChunkList &op_list, XrdCl::Log *logger, CreateConnCalloutType callout, HeaderCallout *header_callout);
 
-        virtual ~CurlVectorReadOp() {}
+        virtual ~CurlVectorReadOp() {
+            if (m_doublebuf)
+                free(m_doublebuf);
+        }
 
         bool Setup(CURL *curl, CurlWorker &) override;
         void Fail(uint16_t errCode, uint32_t errNum, const std::string &msg) override;
@@ -736,6 +739,14 @@ class CurlVectorReadOp : public CurlOperation {
         off_t m_chunk_buffer_idx{0}; // Current offset in requested chunk where we are writing bytes.
         off_t m_bytes_consumed{0}; // Total number of bytes used for results serving the request.
         uint64_t m_skip_bytes{0}; // Count of bytes to skip in the next response (if response chunk contains unneeded bytes).
+        
+        // The number of bytes that have not been processed from the previous callback buffer
+        // and that have to be prepended to the incoming one
+        size_t m_remainderbuflen;
+        char m_remainderbuf[1024];
+        char *m_doublebuf;
+        size_t m_doublebufsz;
+        
         std::string m_response_headers; // Buffer of an incomplete response line from a prior curl write operation.
         std::pair<off_t, off_t> m_current_op{-1, -1}; // The (offset, length) of the current response chunk.
         std::unique_ptr<XrdCl::VectorReadInfo> m_vr; // The response buffers for the client.


### PR DESCRIPTION
Make the code able to correctly process readv responses where intermediate headers overlap the curl buffer