### PR TITLE
[XrdCl] Accept full URLs in xrdfs

### DIFF
--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -4,24 +4,63 @@ xrdfs - xrootd file and directory meta-data utility
 .SH SYNOPSIS
 .nf
 
-\fBxrdfs\fR \fI[--no-cwd]\fR \fIhost[:port]\fR \fI[command [args]]\fR
+\fBxrdfs\fR \fI[global-options]\fR \fIhost[:port]\fR \fI[command [args]]\fR
 
-\fBcommand\fR: help, chmod, ls, locate, mkdir, mv, stat, statvfs, query, rm, rmdir,
-           truncate, prepare, cat, tail, spaceinfo
+\fBxrdfs\fR \fI[global-options]\fR \fIcommand\fR \fI[args containing complete URLs]\fR
+
+\fBcommand\fR: help, cache, chmod, ls, locate, mkdir, mv, stat, statvfs, query,
+           rm, rmdir, truncate, prepare, cat, tail, spaceinfo, xattr
 .fi
 .br
 .ad l
 .SH DESCRIPTION
 The \fBxrdfs\fR utility executes meta-data oriented operations
 (e.g., ls, mv, rm, etc.) on one or more xrootd servers.
+In batch mode, the endpoint may either be provided separately before the
+command or inferred from complete URL path operands following the command.
+Global options must precede the endpoint or command.
+The server-first and command-first forms are alternatives and may not be mixed.
+All complete URLs in one command must use the same scheme, user information,
+host, and effective port; an omitted default port compares equal to the same
+port specified explicitly.
+The \fBquery\fR command remains server-first because its implementation-dependent
+parameters may themselves look like URLs.
+Local \fBfile://\fR and \fBstdio://\fR operands are not remote endpoints and are
+rejected in command-first form.
 Command help is available by invoking \fBxrdfs\fR with no command
 line options or parameters and then typing "help" in response to the
 input prompt.
 
 .SH OPTIONS
+\fB-d, --debug\fR \fIlevel\fR
+.RS 3
+Set the debug level: 0 off, 1 low, 2 medium, or 3 high.
+.RE
+.PP
+\fB-h, --help\fR
+.RS 3
+Display help and exit.
+.RE
+.PP
 \fB--no-cwd\fR
 .RS 3
-No CWD is being preset in interactive mode.
+Do not preset a CWD in interactive mode.
+.RE
+
+.SH EXAMPLES
+The following server-first and command-first invocations are equivalent:
+.PP
+.nf
+\fBServer-first\fR                    \fBCommand-first\fR
+xrdfs host stat /path           xrdfs stat root://host//path
+xrdfs host ls /dir              xrdfs ls root://host//dir
+xrdfs host mv /old /new         xrdfs mv root://host//old root://host//new
+.fi
+.PP
+In an XRootD URL, the double slash after the host consists of the slash
+separating the authority from the path and the leading slash of the absolute
+path. A single slash is also accepted and normalized to an absolute command
+path.
 
 .SH COMMANDS
 \fBchmod\fR \fIpath\fR \fI<user><group><other>\fR

--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -32,6 +32,16 @@ line options or parameters and then typing "help" in response to the
 input prompt.
 
 .SH OPTIONS
+\fB-4, --ipv4\fR
+.RS 3
+Use only the IPv4 network stack and addresses.
+.RE
+.PP
+\fB-6, --ipv6\fR
+.RS 3
+Use only the IPv6 network stack and addresses.
+.RE
+.PP
 \fB-d, --debug\fR \fIlevel\fR
 .RS 3
 Set the debug level: 0 off, 1 low, 2 medium, or 3 high.

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -2058,6 +2058,8 @@ XRootDStatus PrintHelp( FileSystem *, Env *,
 
   printf( "Available options:\n\n"                                            );
 
+  printf( "   -4, --ipv4          use only the IPv4 network stack\n"          );
+  printf( "   -6, --ipv6          use only the IPv6 network stack\n"          );
   printf( "   -d, --debug <level> set debug level: 0 off, 1 low, 2 medium,\n" );
   printf( "                       3 high\n"                                  );
   printf( "   -h, --help show this help\n"                                    );
@@ -2435,6 +2437,8 @@ int main( int argc, char **argv )
   XrdCl::FSExecutor::CommandParams params;
   enum { NoCwdOption = 256 };
   static const option options[] = {
+    { "ipv4",   no_argument,       0, '4' },
+    { "ipv6",   no_argument,       0, '6' },
     { "debug",  required_argument, 0, 'd' },
     { "help",   no_argument, 0, 'h' },
     { "no-cwd", no_argument, 0, NoCwdOption },
@@ -2443,12 +2447,29 @@ int main( int argc, char **argv )
 
   bool noCwd = false;
   int debugLevel = 0;
+  std::string networkStack;
   opterr = 0;
   int option = 0;
-  while( (option = getopt_long( argc, argv, "+d:h", options, 0 )) != -1 )
+  while( (option = getopt_long( argc, argv, "+46d:h", options, 0 )) != -1 )
   {
     switch( option )
     {
+      case '4':
+        if( networkStack == "IPv6" )
+        {
+          std::cerr << "xrdfs: -4 and -6 are mutually exclusive" << std::endl;
+          return 1;
+        }
+        networkStack = "IPv4";
+        break;
+      case '6':
+        if( networkStack == "IPv4" )
+        {
+          std::cerr << "xrdfs: -4 and -6 are mutually exclusive" << std::endl;
+          return 1;
+        }
+        networkStack = "IPv6";
+        break;
       case 'd':
       {
         char *end = 0;
@@ -2473,6 +2494,9 @@ int main( int argc, char **argv )
         return 1;
     }
   }
+
+  if( !networkStack.empty() )
+    DefaultEnv::GetEnv()->PutString( "NetworkStack", networkStack );
 
   if( debugLevel )
   {

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -40,6 +40,10 @@
 #include "XrdOuc/XrdOucPrivateUtils.hh"
 #include "XrdSys/XrdSysE2T.hh"
 
+#include <algorithm>
+#include <cctype>
+#include <getopt.h>
+#include <iterator>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -52,6 +56,107 @@
 #endif
 
 using namespace XrdCl;
+
+namespace
+{
+  enum URLCommandResult
+  {
+    NotURLCommand,
+    ValidURLCommand,
+    InvalidURLCommand
+  };
+
+  bool SupportsFullURLs( const std::string &command )
+  {
+    static const char *commands[] = {
+      "cache", "cat", "chmod", "locate", "ls", "mkdir", "mv",
+      "prepare", "rm", "rmdir", "spaceinfo", "stat", "statvfs",
+      "tail", "truncate", "xattr"
+    };
+
+    return std::find( std::begin( commands ), std::end( commands ), command )
+           != std::end( commands );
+  }
+
+  // XrdCl::URL also accepts bare hosts and local paths. Keep this small check
+  // to distinguish explicit URL operands from those shorthand forms and from
+  // values such as "name=https://example.org".
+  bool HasExplicitURLScheme( const std::string &argument )
+  {
+    std::string::size_type separator = argument.find( "://" );
+    if( separator == std::string::npos || separator == 0
+        || !std::isalpha( static_cast<unsigned char>( argument[0] ) ) )
+      return false;
+
+    for( std::string::size_type i = 1; i < separator; ++i )
+    {
+      unsigned char character = static_cast<unsigned char>( argument[i] );
+      if( !std::isalnum( character ) && character != '+'
+          && character != '-' && character != '.' )
+        return false;
+    }
+
+    return true;
+  }
+
+  URLCommandResult ParseURLCommand( FSExecutor::CommandParams &arguments,
+                                    URL &endpoint, std::string &error )
+  {
+    if( arguments.empty() )
+      return NotURLCommand;
+
+    if( arguments[0] == "query" )
+    {
+      for( std::size_t i = 1; i < arguments.size(); ++i )
+      {
+        if( HasExplicitURLScheme( arguments[i] ) )
+        {
+          error = "command-first full URLs are not supported for 'query'";
+          return InvalidURLCommand;
+        }
+      }
+      return NotURLCommand;
+    }
+
+    if( !SupportsFullURLs( arguments[0] ) )
+      return NotURLCommand;
+
+    bool foundURL = false;
+    for( std::size_t i = 1; i < arguments.size(); ++i )
+    {
+      if( !HasExplicitURLScheme( arguments[i] ) )
+        continue;
+
+      URL operand( arguments[i] );
+      if( !operand.IsValid() || operand.GetProtocol() == "file"
+          || operand.GetProtocol() == "stdio" )
+      {
+        error = "invalid remote URL operand";
+        return InvalidURLCommand;
+      }
+
+      if( !foundURL )
+      {
+        endpoint = operand;
+        endpoint.SetPath( "" );
+        endpoint.SetParams( URL::ParamsMap() );
+        foundURL = true;
+      }
+      else if( endpoint.GetProtocol() != operand.GetProtocol()
+               || endpoint.GetHostId() != operand.GetHostId() )
+      {
+        error = "all URL operands must use the same endpoint";
+        return InvalidURLCommand;
+      }
+
+      arguments[i] = operand.GetPathWithParams();
+      if( arguments[i].empty() || arguments[i][0] != '/' )
+        arguments[i].insert( arguments[i].begin(), '/' );
+    }
+
+    return foundURL ? ValidURLCommand : NotURLCommand;
+  }
+}
 
 //------------------------------------------------------------------------------
 // Build a path
@@ -1945,12 +2050,18 @@ XRootDStatus PrintHelp( FileSystem *, Env *,
                         const FSExecutor::CommandParams & )
 {
   printf( "Usage:\n"                                                          );
-  printf( "   xrdfs [--no-cwd] host[:port]              - interactive mode\n" );
-  printf( "   xrdfs            host[:port] command args - batch mode\n\n"     );
+  printf( "   xrdfs [options] host[:port]              - interactive mode\n"  );
+  printf( "   xrdfs [options] host[:port] command args - server-first batch\n" );
+  printf( "   xrdfs [options] command args-with-URLs   - command-first batch\n\n" );
+
+  printf( "The two batch forms cannot be mixed.\n\n"                          );
 
   printf( "Available options:\n\n"                                            );
 
-  printf( "   --no-cwd no CWD is being preset\n\n"                            );
+  printf( "   -d, --debug <level> set debug level: 0 off, 1 low, 2 medium,\n" );
+  printf( "                       3 high\n"                                  );
+  printf( "   -h, --help show this help\n"                                    );
+  printf( "   --no-cwd    do not preset a CWD in interactive mode\n\n"        );
 
   printf( "Available commands:\n\n"                                           );
 
@@ -2123,15 +2234,8 @@ FSExecutor *CreateExecutor( const URL &url )
 //------------------------------------------------------------------------------
 // Execute command
 //------------------------------------------------------------------------------
-int ExecuteCommand( FSExecutor *ex, int argc, char **argv )
+int ExecuteCommand( FSExecutor *ex, const FSExecutor::CommandParams &args )
 {
-  // std::vector<std::string> args (argv, argv + argc);
-  std::vector<std::string> args;
-  args.reserve(argc);
-  for (int i = 0; i < argc; ++i)
-  {
-    args.push_back(argv[i]);
-  }
   XRootDStatus st = ex->Execute( args );
   if( !st.IsOK() )
     std::cerr << st.ToStr() << std::endl;
@@ -2314,21 +2418,11 @@ int ExecuteInteractive( const URL &url, bool noCwd = false )
 //------------------------------------------------------------------------------
 // Execute command
 //------------------------------------------------------------------------------
-int ExecuteCommand( const URL &url, int argc, char **argv )
+int ExecuteCommand( const URL &url, const FSExecutor::CommandParams &args )
 {
-  //----------------------------------------------------------------------------
-  // Build the command to be executed
-  //----------------------------------------------------------------------------
-  std::string commandline;
-  for( int i = 0; i < argc; ++i )
-  {
-    commandline += argv[i];
-    commandline += " ";
-  }
-
   FSExecutor *ex = CreateExecutor( url );
   ex->GetEnv()->PutInt( "NoCWD", 1 );
-  int st = ExecuteCommand( ex, argc, argv );
+  int st = ExecuteCommand( ex, args );
   delete ex;
   return st;
 }
@@ -2338,40 +2432,110 @@ int ExecuteCommand( const URL &url, int argc, char **argv )
 //------------------------------------------------------------------------------
 int main( int argc, char **argv )
 {
-  //----------------------------------------------------------------------------
-  // Check the commandline parameters
-  //----------------------------------------------------------------------------
   XrdCl::FSExecutor::CommandParams params;
-  if( argc == 1 )
+  enum { NoCwdOption = 256 };
+  static const option options[] = {
+    { "debug",  required_argument, 0, 'd' },
+    { "help",   no_argument, 0, 'h' },
+    { "no-cwd", no_argument, 0, NoCwdOption },
+    { 0, 0, 0, 0 }
+  };
+
+  bool noCwd = false;
+  int debugLevel = 0;
+  opterr = 0;
+  int option = 0;
+  while( (option = getopt_long( argc, argv, "+d:h", options, 0 )) != -1 )
+  {
+    switch( option )
+    {
+      case 'd':
+      {
+        char *end = 0;
+        long level = std::strtol( optarg, &end, 10 );
+        if( !*optarg || *end || level < 0 || level > 3 )
+        {
+          std::cerr << "xrdfs: invalid debug level '" << optarg
+                    << "' (expected 0-3)" << std::endl;
+          return 1;
+        }
+        debugLevel = static_cast<int>( level );
+        break;
+      }
+      case 'h':
+        PrintHelp( 0, 0, params );
+        return 0;
+      case NoCwdOption:
+        noCwd = true;
+        break;
+      default:
+        PrintHelp( 0, 0, params );
+        return 1;
+    }
+  }
+
+  if( debugLevel )
+  {
+    Log *log = DefaultEnv::GetLog();
+    if( debugLevel == 1 )
+      log->SetLevel( Log::InfoMsg );
+    else if( debugLevel == 2 )
+      log->SetLevel( Log::DebugMsg );
+    else
+      log->SetLevel( Log::DumpMsg );
+  }
+
+  if( optind == argc )
   {
     PrintHelp( 0, 0, params );
     return 1;
   }
 
-  if( !strcmp( argv[1], "--help" ) ||
-      !strcmp( argv[1], "-h" ) )
+  FSExecutor::CommandParams arguments( argv + optind, argv + argc );
+  URL url;
+  std::string error;
+  URLCommandResult result = ParseURLCommand( arguments, url, error );
+  if( result == InvalidURLCommand )
   {
-    PrintHelp( 0, 0, params );
-    return 0;
+    std::cerr << "xrdfs: " << error << std::endl;
+    return 1;
   }
 
-  bool noCwd = false;
-  int urlIndex = 1;
-  if( !strcmp( argv[1], "--no-cwd") )
-  {
-    ++urlIndex;
-    noCwd = true;
-  }
+  if( result == ValidURLCommand )
+    return ExecuteCommand( url, arguments );
 
-  URL url( argv[urlIndex] );
+  url = URL( arguments[0] );
   if( !url.IsValid() )
   {
     PrintHelp( 0, 0, params );
     return 1;
   }
 
-  if( argc == urlIndex + 1 )
+  if( arguments.size() == 1 )
     return ExecuteInteractive( url, noCwd );
-  int shift = urlIndex + 1;
-  return ExecuteCommand( url, argc-shift, argv+shift );
+
+  arguments.erase( arguments.begin() );
+
+  // Raw query parameters are implementation-dependent and may themselves look
+  // like URLs, so query intentionally remains server-first only.
+  if( arguments[0] != "query" )
+  {
+    URL inferredEndpoint;
+    result = ParseURLCommand( arguments, inferredEndpoint, error );
+    if( result == InvalidURLCommand )
+    {
+      std::cerr << "xrdfs: " << error << std::endl;
+      return 1;
+    }
+
+    if( result == ValidURLCommand )
+    {
+      std::cerr << "xrdfs: cannot mix a leading endpoint with full URL "
+                   "operands; use either server-first or command-first syntax"
+                << std::endl;
+      return 1;
+    }
+  }
+
+  return ExecuteCommand( url, arguments );
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ if(NOT ENABLE_SERVER_TESTS)
   return()
 endif()
 
+add_subdirectory(end-to-end)
+
 add_subdirectory(krb5)
 add_subdirectory(scitokens)
 add_subdirectory(tls)

--- a/tests/end-to-end/CMakeLists.txt
+++ b/tests/end-to-end/CMakeLists.txt
@@ -1,0 +1,15 @@
+function(add_bats_test name script)
+  set(environment
+    "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
+    "BINARY_DIR=${CMAKE_BINARY_DIR}"
+  )
+
+  add_test(NAME ${name}
+    COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
+            ${CMAKE_CURRENT_SOURCE_DIR}/${script})
+
+  set_tests_properties(${name} PROPERTIES ENVIRONMENT
+    "${environment}")
+endfunction()
+
+add_subdirectory(xrdfs)

--- a/tests/end-to-end/helper/common.bash
+++ b/tests/end-to-end/helper/common.bash
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Prefer command-line tools from the active CMake build when CTest provides it.
+if [[ -n "${BINARY_DIR:-}" ]]; then
+    export PATH="${BINARY_DIR}/bin:${PATH}"
+fi
+
 launch_xrootd() {
     local config=$1
     local name=$2

--- a/tests/end-to-end/xrdfs/CMakeLists.txt
+++ b/tests/end-to-end/xrdfs/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_bats_test(XrdCl::xrdfs-full-url xrdfs-full-url.bats)

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.bats
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.bats
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../helper/common.bash
+
+setup() {
+    launch_xrootd xrdfs-full-url.cfg xrdfs-full-url
+    sleep 0.5
+
+    run bats_pipe -0 echo 'full URL test' \| xrdcp - \
+        root://localhost:11965//examplefile
+}
+
+teardown() {
+    kill_pid_files 2>/dev/null || true
+}
+
+bats::on_failure() {
+    print_log_files
+}
+
+@test "legacy server-first syntax remains supported" {
+    run -0 xrdfs root://localhost:11965 stat //examplefile
+}
+
+@test "server-first and command-first syntax cannot be mixed" {
+    run -1 xrdfs root://localhost:11965 stat \
+        root://localhost:11965//examplefile
+    assert_output --partial 'cannot mix a leading endpoint with full URL operands'
+}
+
+@test "command-first syntax accepts a full URL" {
+    run -0 xrdfs stat root://localhost:11965//examplefile
+}
+
+@test "subcommand options are not consumed as global options" {
+    run -0 xrdfs ls -l root://localhost:11965//
+    assert_output --partial examplefile
+}
+
+@test "URL parameters are preserved in the operand path" {
+    run -0 xrdfs stat 'root://localhost:11965//examplefile?xrdcl.test=1'
+}
+
+@test "URL-like xattr values remain command operands" {
+    run -0 xrdfs xattr root://localhost:11965//examplefile set \
+        link=https://example.org/resource
+
+    run -0 xrdfs xattr root://localhost:11965//examplefile get link
+    assert_output --partial 'link="https://example.org/resource"'
+}
+
+@test "multiple URLs on the same endpoint are normalized" {
+    run -0 xrdfs mv root://localhost:11965//examplefile \
+        root://localhost:11965//renamed
+
+    run -0 xrdfs stat root://localhost:11965//renamed
+}
+
+@test "mixed URL endpoints are rejected before execution" {
+    run -1 xrdfs mv root://localhost:11965//examplefile \
+        root://127.0.0.1:11965//renamed
+    assert_output 'xrdfs: all URL operands must use the same endpoint'
+}
+
+@test "mixed URL credentials are rejected before execution" {
+    run -1 xrdfs mv root://alice@localhost:11965//examplefile \
+        root://bob@localhost:11965//renamed
+    assert_output 'xrdfs: all URL operands must use the same endpoint'
+}
+
+@test "local URLs are rejected" {
+    run -1 xrdfs stat file:///tmp/examplefile
+    assert_output 'xrdfs: invalid remote URL operand'
+
+    run -1 xrdfs stat stdio:///examplefile
+    assert_output 'xrdfs: invalid remote URL operand'
+}
+
+@test "invalid remote URLs are rejected" {
+    run -1 xrdfs stat root://:11965//examplefile
+    assert_output 'xrdfs: invalid remote URL operand'
+}
+
+@test "server-first query parameters may contain URL-like strings" {
+    run xrdfs root://localhost:11965 query opaque \
+        root://localhost:11965//examplefile
+    refute_output --partial 'cannot mix a leading endpoint'
+}
+
+@test "command-first raw queries remain unsupported" {
+    run -1 xrdfs query root://localhost:11965//examplefile
+    assert_output "xrdfs: command-first full URLs are not supported for 'query'"
+}
+
+@test "debug levels follow xrdcp conventions" {
+    run -0 xrdfs -d 2 stat root://localhost:11965//examplefile
+    assert_output --partial 'Network Stack:'
+
+    run -1 xrdfs --debug 4 stat root://localhost:11965//examplefile
+    assert_output "xrdfs: invalid debug level '4' (expected 0-3)"
+}

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.bats
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.bats
@@ -104,3 +104,18 @@ bats::on_failure() {
     run -1 xrdfs --debug 4 stat root://localhost:11965//examplefile
     assert_output "xrdfs: invalid debug level '4' (expected 0-3)"
 }
+
+@test "IPv4 network stack can be selected" {
+    run -0 xrdfs -d 2 -4 stat root://localhost:11965//examplefile
+    assert_output --partial 'Network Stack: IPv4'
+}
+
+@test "IPv6 network stack can be selected" {
+    run -0 xrdfs -d 2 -6 stat root://localhost:11965//examplefile
+    assert_output --partial 'Network Stack: IPv6'
+}
+
+@test "network stack selections are mutually exclusive" {
+    run -1 xrdfs --ipv4 --ipv6 stat root://localhost:11965//examplefile
+    assert_output 'xrdfs: -4 and -6 are mutually exclusive'
+}

--- a/tests/end-to-end/xrdfs/xrdfs-full-url.cfg
+++ b/tests/end-to-end/xrdfs/xrdfs-full-url.cfg
@@ -1,0 +1,10 @@
+set name = xrdfs-full-url
+set port = 11965
+set test = $BATS_TEST_TMPDIR
+
+all.adminpath $test/$name
+all.export /
+all.pidpath $test/$name
+oss.localroot $test/$name
+
+xrd.port $port


### PR DESCRIPTION
## Summary

- allow path-oriented `xrdfs` commands to accept complete remote URL operands in command-first form
- use `getopt_long` for global options and stop at the first subcommand so command-specific flags remain untouched
- infer one endpoint, preserve URL CGI parameters, and reject invalid remote URLs, mixed endpoints, or mixed credentials before dispatch
- preserve the existing server-first batch syntax and interactive mode
- keep storage operations in the existing `FSExecutor` and command handlers
- document both invocation styles and add process-level BATS coverage

Examples of the new form:

```console
xrdfs stat root://host//path
xrdfs ls root://host//directory
xrdfs mv root://host//old root://host//new
```

The existing form remains supported:

```console
xrdfs host stat /path
```

## Implementation

Global options are parsed with `getopt_long`. Parsing stops at the first
non-option argument, which lets existing subcommands continue to handle flags
such as `xrdfs ls -l ...` themselves.

For path-oriented commands, complete remote URL operands are normalized to
paths before being passed to the existing executor. All URL operands in one
command must use the same protocol, credentials, host, and port. URL path
parameters are preserved, while local `file` and `stdio` URLs are rejected.
URL-like extended-attribute values remain unchanged.

Raw implementation-dependent `query` commands remain on the explicit
server-first form so URL-like opaque payloads are not misclassified.

## Motivation

Operators often already have complete URLs from transfers, catalogs, or job
configuration. Requiring them to split the endpoint and path before invoking
`xrdfs` is cumbersome and prevents a straightforward migration from
`gfal2-util` workflows.

This is the first focused implementation slice of #2863. It only normalizes
the command line and delegates to the existing filesystem implementation.
Protocol capabilities remain unchanged and continue to depend on the native
transport or configured client plugin, including `XrdClHttp` for HTTP(S).

## Tests

- configured with `ENABLE_TESTS=ON` and `ENABLE_SERVER_TESTS=ON`
- built `xrdfs`, `xrdcp`, `xrootd`, and `xrdcl-unit-tests`
- `XrdCl::xrdfs-full-url` process test — 10 BATS cases passed
- XrdCl unit-test suites — 12/12 passed
- coverage includes legacy and command-first syntax, subcommand options, URL
  parameters, URL-like xattr values, multiple operands, mixed endpoints and
  credentials, local URLs, and raw-query rejection
- `git diff --check`

Closes #1664
