### PR TITLE
[XrdCl] Refine xrdfs option parsing

### DIFF
--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -30,11 +30,11 @@ Modify permissions of the \fIpath\fR. Permission string example:
 \fIrwxr-x--x\fR
 
 .RE
-\fBls\fR \fI[-l]\fR \fI[-u]\fR \fI[-R]\fR \fI[-D]\fR \fI[-Z]\fR \fI[-C]\fR \fI[dirname]\fR
+\fBls\fR \fI[-l]\fR \fI[-u]\fR \fI[-R]\fR \fI[-D]\fR \fI[-Z]\fR \fI[-C]\fR \fI[-h|-H]\fR \fI[-d]\fR \fI[--]\fR \fI[dirname]\fR
 .RS 3
 Get directory listing.
 .br
-\fI-l\fR stat every entry and print long listing
+\fI-l\fR, \fI--long\fR stat every entry and print long listing
 .br
 \fI-u\fR print paths as URLs
 .br
@@ -45,6 +45,12 @@ Get directory listing.
 \fI-Z\fR check if file is a ZIP archive and if yes list its content
 .br
 \fI-C\fR checksum every entry
+.br
+\fI-h\fR, \fI-H\fR, \fI--human-readable\fR print human-readable sizes
+.br
+\fI-d\fR, \fI--directory\fR list the directory entry instead of its contents
+.br
+\fI--\fR stop option parsing, allowing a path beginning with a dash
 
 .RE
 \fBlocate\fR \fI[-n]\fR \fI[-r]\fR \fI[-d]\fR \fI[-m]\fR \fI[-i]\fR \fI[-p]\fR \fI<path>\fR
@@ -203,11 +209,15 @@ Prepare one or more files for access.
 \fI-e\fR evict the file from disk cache
 
 .RE
-\fBcat\fR \fI[-o localfile]\fR \fIfiles\fR
+\fBcat\fR \fI[-b|--bytes]\fR \fI[-o localfile]\fR \fI[--]\fR \fIfiles\fR
 .RS 3
 Print contents of one or mote files to stdout
 .br
+\fI-b\fR, \fI--bytes\fR accepted for gfal-cat compatibility; output is always byte-preserving
+.br
 \fI-o\fR print to the specified local file
+.br
+\fI--\fR stop option parsing, allowing a path beginning with a dash
 
 .RE
 \fBtail\fR \fI[-c bytes] [-f]\fR \fIfile\fR

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -353,54 +353,73 @@ XRootDStatus DoLS( FileSystem                      *fs,
   // Check up the args
   //----------------------------------------------------------------------------
   Log *log = DefaultEnv::GetLog();
-  uint32_t    argc     = args.size();
   bool        stats    = false;
   bool        showUrls = false;
   bool        hascks   = false;
   bool        human    = false;
+  bool        directory= false;
   uint64_t base        = 1024;
   std::string path;
   DirListFlags::Flags flags = DirListFlags::Locate | DirListFlags::Merge;
 
-  if( argc > 6 )
+  auto applyOption = [&]( char option )
   {
-    log->Error( AppMsg, "Too many arguments." );
-    return XRootDStatus( stError, errInvalidArgs );
-  }
+    switch( option )
+    {
+      case 'l':
+        stats = true;
+        flags |= DirListFlags::Stat;
+        break;
+      case 'u':
+        showUrls = true;
+        break;
+      case 'R':
+        flags |= DirListFlags::Recursive;
+        break;
+      case 'D':
+        flags &= ~DirListFlags::Merge;
+        break;
+      case 'Z':
+        flags |= DirListFlags::Zip;
+        break;
+      case 'C':
+        hascks = true;
+        stats = true;
+        flags |= DirListFlags::Cksm;
+        break;
+      case 'h':
+      case 'H':
+        human = true;
+        break;
+      case 'd':
+        directory = true;
+        break;
+    }
+  };
 
+  const std::string shortOptions = "luRDZChHd";
+  bool parseOptions = true;
   for( uint32_t i = 1; i < args.size(); ++i )
   {
-    if( args[i] == "-l" )
+    if( parseOptions && args[i] == "--" )
+    {
+      parseOptions = false;
+    }
+    else if( parseOptions && args[i] == "--long" )
     {
       stats = true;
       flags |= DirListFlags::Stat;
     }
-    else if( args[i] == "-u" )
-      showUrls = true;
-    else if( args[i] == "-R" )
-    {
-      flags |= DirListFlags::Recursive;
-    }
-    else if( args[i] == "-D" )
-    {
-      // show duplicates
-      flags &= ~DirListFlags::Merge;
-    }
-    else if( args[i] == "-Z" )
-    {
-      // check if file is a ZIP archive if yes list content
-      flags |= DirListFlags::Zip;
-    }
-    else if( args[i] == "-C" )
-    {
-      // query checksum for each entry in the directory
-      hascks = true;
-      stats  = true;
-      flags |= DirListFlags::Cksm;
-    }
-    else if ( args [i] == "-h" )
-    {
+    else if( parseOptions && args[i] == "--human-readable" )
       human = true;
+    else if( parseOptions && args[i] == "--directory" )
+      directory = true;
+    else if( parseOptions && args[i].size() > 1 && args[i][0] == '-' &&
+             args[i][1] != '-' &&
+             args[i].find_first_not_of( shortOptions, 1 ) == std::string::npos )
+    {
+      for( std::size_t j = 1; j < args[i].size(); ++j )
+        applyOption( args[i][j] );
     }
     else
       path = args[i];
@@ -437,8 +456,9 @@ XRootDStatus DoLS( FileSystem                      *fs,
     return st;
   }
 
-  if( !info->TestFlags( StatInfo::IsDir ) &&
-      !( flags & DirListFlags::Zip ) )
+  if( directory ||
+      (!info->TestFlags( StatInfo::IsDir ) &&
+       !( flags & DirListFlags::Zip )) )
   {
     if( stats )
       PrintDirListStatInfo( info, false, 0, 0, 0, human, base );
@@ -1528,10 +1548,22 @@ XRootDStatus DoCat( FileSystem                      *fs,
 
   std::vector<std::string> remotes;
   std::string local;
+  bool parseOptions = true;
 
   for( uint32_t i = 1; i < args.size(); ++i )
   {
-    if( args[i] == "-o" )
+    if( parseOptions && args[i] == "--" )
+    {
+      parseOptions = false;
+    }
+    else if( parseOptions &&
+             ( args[i] == "-b" || args[i] == "--bytes" ) )
+    {
+      // gfal-cat exposes this Python 3 compatibility flag. xrdfs always
+      // streams byte-preserving data, so no mode change is required.
+      continue;
+    }
+    else if( parseOptions && args[i] == "-o" )
     {
       if( i < args.size()-1 )
       {
@@ -1551,6 +1583,12 @@ XRootDStatus DoCat( FileSystem                      *fs,
   if( !local.empty() && remotes.size() > 1 )
   {
     log->Error( AppMsg, "If '-o' is used only can be used with only one remote file." );
+    return XRootDStatus( stError, errInvalidArgs );
+  }
+
+  if( remotes.empty() )
+  {
+    log->Error( AppMsg, "Missing remote file." );
     return XRootDStatus( stError, errInvalidArgs );
   }
 
@@ -1984,14 +2022,17 @@ XRootDStatus PrintHelp( FileSystem *, Env *,
   printf( "     Modify permissions. Permission string example:\n"             );
   printf( "     rwxr-x--x\n\n"                                                );
 
-  printf( "   ls [-l] [-u] [-R] [-D] [-Z] [-C] [dirname]\n"                   );
+  printf( "   ls [-l] [-u] [-R] [-D] [-Z] [-C] [-h|-H] [-d] [--] [dirname]\n" );
   printf( "     Get directory listing.\n"                                     );
-  printf( "     -l stat every entry and print long listing\n"                 );
+  printf( "     -l|--long stat every entry and print long listing\n"          );
   printf( "     -u print paths as URLs\n"                                     );
   printf( "     -R list subdirectories recursively\n"                         );
   printf( "     -D show duplicate entries\n"                                  );
   printf( "     -Z if a ZIP archive list its content\n"                       );
-  printf( "     -C checksum every entry\n\n"                                  );
+  printf( "     -C checksum every entry\n"                                    );
+  printf( "     -h|-H|--human-readable print human-readable sizes\n"          );
+  printf( "     -d|--directory list the entry instead of its contents\n"      );
+  printf( "     -- stop option parsing, allowing a dash-prefixed path\n\n"    );
 
   printf( "   locate [-n] [-r] [-d] [-m] [-i] [-p] <path>\n"                  );
   printf( "     Get the locations of the path.\n"                             );
@@ -2079,9 +2120,12 @@ XRootDStatus PrintHelp( FileSystem *, Env *,
   printf( "     -a abort stage request\n"                                   );
   printf( "     -e evict the file from disk cache\n\n"                      );
 
-  printf( "   cat [-o local file] files\n"                                  );
+  printf( "   cat [-b|--bytes] [-o local file] [--] files\n"                );
   printf( "     Print contents of one or more files to stdout.\n"           );
-  printf( "     -o print to the specified local file\n\n"                   );
+  printf( "     -b, --bytes accepted for gfal-cat compatibility; output\n"  );
+  printf( "                 is always byte-preserving\n"                    );
+  printf( "     -o print to the specified local file\n"                     );
+  printf( "     -- stop option parsing, allowing a dash-prefixed path\n\n"  );
 
   printf( "   tail [-c bytes] [-f] file\n"                                  );
   printf( "     Output last part of files to stdout.\n"                     );

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ if(NOT ENABLE_SERVER_TESTS)
   return()
 endif()
 
+add_subdirectory(end-to-end)
+
 add_subdirectory(krb5)
 add_subdirectory(scitokens)
 add_subdirectory(tls)

--- a/tests/end-to-end/CMakeLists.txt
+++ b/tests/end-to-end/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(xrdfs-options)

--- a/tests/end-to-end/xrdfs-options/CMakeLists.txt
+++ b/tests/end-to-end/xrdfs-options/CMakeLists.txt
@@ -1,0 +1,14 @@
+set(XRDFS_OPTIONS_BATS_ENV
+  "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
+  "DYLD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{DYLD_LIBRARY_PATH}"
+  "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib:$ENV{LD_LIBRARY_PATH}"
+  "PATH=${CMAKE_BINARY_DIR}/bin:$ENV{PATH}"
+  "XRDFS=$<TARGET_FILE:xrdfs>"
+)
+
+add_test(NAME XrdCl::xrdfs-options
+  COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
+          ${CMAKE_CURRENT_SOURCE_DIR}/xrdfs-options.bats)
+
+set_tests_properties(XrdCl::xrdfs-options
+  PROPERTIES ENVIRONMENT "${XRDFS_OPTIONS_BATS_ENV}")

--- a/tests/end-to-end/xrdfs-options/xrdfs-options.bats
+++ b/tests/end-to-end/xrdfs-options/xrdfs-options.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../helper/common.bash
+
+setup() {
+    mkdir -p "$BATS_TEST_TMPDIR/xrdfs-options/data/subdirectory"
+    printf 'first' > "$BATS_TEST_TMPDIR/xrdfs-options/data/first.txt"
+    printf 'nested' \
+        > "$BATS_TEST_TMPDIR/xrdfs-options/data/subdirectory/nested.txt"
+    printf 'dash' > "$BATS_TEST_TMPDIR/xrdfs-options/-dash.txt"
+    printf 'grouped-option' > "$BATS_TEST_TMPDIR/xrdfs-options/-lH"
+    printf 'bytes-option' > "$BATS_TEST_TMPDIR/xrdfs-options/-b"
+    printf '\000\001\177\200\377' \
+        > "$BATS_TEST_TMPDIR/xrdfs-options/data/binary.dat"
+
+    launch_xrootd xrdfs-options.cfg xrdfs-options
+
+    export TEST_ENDPOINT=root://localhost:12965
+
+    local ready=false
+    for _ in {1..50}; do
+        if "$XRDFS" "$TEST_ENDPOINT" stat /data/first.txt \
+            >/dev/null 2>&1; then
+            ready=true
+            break
+        fi
+        sleep 0.1
+    done
+    "$ready"
+}
+
+teardown() {
+    kill_pid_files 2>/dev/null || true
+}
+
+bats::on_failure() {
+    print_log_files
+}
+
+@test "ls accepts grouped short and gfal-compatible options" {
+    run "$XRDFS" "$TEST_ENDPOINT" ls -lH /data/first.txt
+    assert_success
+    assert_output --partial '/data/first.txt'
+    assert_output --partial '5'
+}
+
+@test "ls accepts long gfal-compatible options" {
+    run "$XRDFS" "$TEST_ENDPOINT" ls \
+        --long --human-readable --directory /data
+    assert_success
+    assert_output --partial '/data'
+    refute_output --partial 'first.txt'
+}
+
+@test "ls preserves legacy unknown dash-prefixed paths" {
+    run bash -c \
+        'printf "cd /\nls -dash.txt\nexit\n" | "$1" "$2"' \
+        _ "$XRDFS" "$TEST_ENDPOINT"
+    assert_success
+    assert_output --partial '/-dash.txt'
+}
+
+@test "ls delimiter addresses a path matching grouped options" {
+    run bash -c \
+        'printf "cd /\nls -- -lH\nexit\n" | "$1" "$2"' \
+        _ "$XRDFS" "$TEST_ENDPOINT"
+    assert_success
+    assert_output --partial '/-lH'
+}
+
+@test "ls delimiter does not impose the old argument limit" {
+    run "$XRDFS" "$TEST_ENDPOINT" ls -l -u -D -h -- /data/first.txt
+    assert_success
+    assert_output --partial '/data/first.txt'
+}
+
+@test "ls retains recursive listing" {
+    run "$XRDFS" "$TEST_ENDPOINT" ls -R /data
+    assert_success
+    assert_output --partial '/data/subdirectory/nested.txt'
+}
+
+@test "cat bytes option preserves binary output" {
+    local destination="$BATS_TEST_TMPDIR/binary-download.dat"
+    run bash -c '"$1" "$2" cat -b /data/binary.dat > "$3"' \
+        _ "$XRDFS" "$TEST_ENDPOINT" "$destination"
+    assert_success
+
+    run cmp "$BATS_TEST_TMPDIR/xrdfs-options/data/binary.dat" "$destination"
+    assert_success
+}
+
+@test "cat long bytes option is accepted" {
+    run "$XRDFS" "$TEST_ENDPOINT" cat --bytes /data/first.txt
+    assert_success
+    assert_output first
+}
+
+@test "cat delimiter addresses a file named like an option" {
+    run bash -c \
+        'printf "cd /\ncat -- -b\nexit\n" | "$1" "$2"' \
+        _ "$XRDFS" "$TEST_ENDPOINT"
+    assert_success
+    assert_output --partial 'bytes-option'
+}
+
+@test "cat retains output-to-file behavior" {
+    local destination="$BATS_TEST_TMPDIR/cat-output.dat"
+    run "$XRDFS" "$TEST_ENDPOINT" cat -o "$destination" /data/first.txt
+    assert_success
+
+    run cmp "$BATS_TEST_TMPDIR/xrdfs-options/data/first.txt" "$destination"
+    assert_success
+}
+
+@test "cat bytes option still requires a source" {
+    run "$XRDFS" "$TEST_ENDPOINT" cat -b
+    assert_failure
+    assert_output --partial 'Invalid arguments'
+}

--- a/tests/end-to-end/xrdfs-options/xrdfs-options.cfg
+++ b/tests/end-to-end/xrdfs-options/xrdfs-options.cfg
@@ -1,0 +1,10 @@
+set name = xrdfs-options
+set port = 12965
+set test = $BATS_TEST_TMPDIR
+
+all.adminpath $test/$name
+all.export /
+all.pidpath $test/$name
+oss.localroot $test/$name
+
+xrd.port $port


### PR DESCRIPTION
## Context

`xrdfs` currently uses a server-first command line and keeps the endpoint and remote path separate:

```console
xrdfs [--no-cwd] <server> <command> [command options] <remote path>
```

For example, this existing form remains the basis of the commands in this PR:

```console
xrdfs root://host.example ls -l /data/file
```

This PR improves the `ls` and `cat` option parsing inside that existing command structure. It is a focused part of the gfal2-utils migration work tracked in #2863 and is intentionally separate from the command-first/full-URL work in #2868.

## What changes

### `ls`

- accept grouped short options, such as `-lH`
- accept the gfal-familiar `-H`, `-d`, `--long`, `--human-readable`, and `--directory` spellings
- support the conventional `--` end-of-options delimiter
- preserve legacy unknown dash-prefixed paths, such as `-dash.txt`
- remove the fixed six-argument ceiling, which otherwise makes adding `--` break an invocation that was already at the limit

### `cat`

- accept `-b` and `--bytes` as compatibility options
- keep output byte-preserving; no new transfer implementation or mode is needed
- support `--` so files named `-b` or `--bytes` remain addressable
- preserve the existing `-o <local file>` behavior
- report an error when no remote source is supplied

The implementation continues to call the existing `xrdfs` command handlers and XrdCl operations. It does not duplicate filesystem or transfer behavior.

## Behavior comparison

| Invocation | Before this PR (`master`) | With this PR |
|---|---|---|
| `xrdfs root://host.example ls -l /data` | Long listing | Unchanged |
| `xrdfs root://host.example ls -lH /data` | `-lH` is treated as an operand and then overwritten by `/data`; its options are silently ignored | Grouped long and human-readable options are applied |
| `xrdfs root://host.example ls --long --human-readable --directory /data` | Long options are treated as operands; `/data` is listed normally | `/data` itself is printed with a long, human-readable entry |
| `xrdfs root://host.example ls -dash.txt` | `-dash.txt` is treated as a path | Preserved as a path |
| `xrdfs root://host.example ls -- -lH` | `--` has no delimiter semantics | Lists the remote path named `-lH` |
| `xrdfs root://host.example cat -b /data/file` | `-b` is treated as another remote path | `-b` is accepted and `/data/file` is streamed byte-for-byte |
| `xrdfs root://host.example cat -o local-copy /data/file` | Writes to `local-copy` | Unchanged |
| `xrdfs root://host.example cat -- -b` | `--` is treated as a remote path | Streams the remote file named `-b` |

## Example invocations added or covered

```console
# Grouped and long ls options
xrdfs root://host.example ls -lH /data
xrdfs root://host.example ls --long --human-readable /data

# Print the directory entry, rather than listing its contents
xrdfs root://host.example ls -ld /data
xrdfs root://host.example ls --directory /data

# Use -- for an option-shaped remote path
xrdfs root://host.example ls -- -lH

# Byte-preserving cat and the existing output-to-file mode
xrdfs root://host.example cat -b /data/file
xrdfs root://host.example cat --bytes /data/file
xrdfs root://host.example cat -o local-copy /data/file
xrdfs root://host.example cat -- -b

# The delimiter no longer exceeds an arbitrary ls argument ceiling
xrdfs root://host.example ls -l -u -D -h -- /data/file
```

## Explicit non-goal: command-first full URLs

This PR does **not** add the following syntax:

```console
xrdfs ls -lH root://host.example/data
xrdfs cat -b root://host.example/data/file
```

The endpoint and path remain split in this PR. Command-first full-URL normalization belongs to #2868. That broader PR currently contains overlapping option-parsing work and can be rebased onto this focused change so it only carries the full-URL portion.

## Compatibility details

Grouped short options are recognized only when every character in the token is a supported `ls` option. This preserves the historical behavior for unknown dash-prefixed operands:

```console
xrdfs root://host.example ls -dash.txt   # still a path
xrdfs root://host.example ls -lH         # supported option group
xrdfs root://host.example ls -- -lH      # path literally named -lH
```

`cat` necessarily reserves the exact tokens `-b` and `--bytes`; a remote file with either name can be selected after `--`.

## Tests

The PR adds an 11-case BATS suite backed by an ephemeral localhost XRootD server. No production storage is used. Coverage includes:

- grouped and long `ls` options
- human-readable and directory-entry behavior
- existing URL, duplicate, and recursive `ls` flags
- legacy unknown dash-prefixed paths
- option-shaped paths after `--`
- the former `ls` argument-limit edge
- byte-for-byte binary `cat -b`
- `cat --bytes`, `cat -- -b`, and existing `cat -o`
- missing-source failure handling

Validation performed locally:

```console
cmake -S . -B build-xrdfs-options \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DENABLE_TESTS=ON \
  -DENABLE_SERVER_TESTS=ON

cmake --build build-xrdfs-options --target xrdfs xrootd -j8

ctest --test-dir build-xrdfs-options \
  --output-on-failure \
  -R '^XrdCl::xrdfs-options$'
```

Result: `100% tests passed, 0 tests failed out of 1` (11 BATS cases).
