### PR TITLE
[XrdClHttp] Parse multipart headers split across chunks

### DIFF
--- a/src/XrdClHttp/XrdClHttpOpReadV.cc
+++ b/src/XrdClHttp/XrdClHttpOpReadV.cc
@@ -177,6 +177,7 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
                     m_response_idx++;
                     if (m_current_op.second == chunk.GetLength()) {
                         m_current_op.first = m_current_op.second = -1;
+                        m_multipart_boundary = true;
                     } else {
                         // We may need to skip the remaining bytes or, potentially, the server
                         // coalesced two adjacent requests into one larger response.
@@ -194,6 +195,7 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
                     m_bytes_consumed += m_chunk_buffer_idx;
                     m_chunk_buffer_idx = 0;
                     m_current_op.first = m_current_op.second = -1;
+                    m_multipart_boundary = true;
                     m_response_idx++;
                 }
             }
@@ -217,19 +219,22 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
                 length = 0;
                 return std::make_pair(std::string_view(), false);
             } else {
-                auto line = chunk_header.substr(0, pos);
+                auto line_part = chunk_header.substr(0, pos);
                 if (!m_response_headers.empty()) {
-                    m_response_headers += line;
-                    line = m_response_headers;
+                    m_response_headers += line_part;
+                    m_header_line = std::move(m_response_headers);
+                } else {
+                    m_header_line.assign(line_part);
                 }
                 buffer += pos + 2;
                 length -= pos + 2;
-                return std::make_pair(line, true);
+                return std::make_pair(std::string_view(m_header_line), true);
             }
         };
 
         // Consume the boundary line.
         bool last_segment = false;
+        if (m_multipart_boundary) {
         while (true) {
             auto [line, ok] = get_next_line();
             if (!ok) {
@@ -250,6 +255,7 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
             ss << "Server has responded with an invalid boundary line: '" << line << "' (expected '" << m_headers.MultipartSeparator() << "')";
             return FailCallback(kXR_ServerError, ss.str());
         }
+        }
         if (last_segment) {
             length = 0;
             break;
@@ -258,6 +264,7 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
         while (true) {
             auto [line, ok] = get_next_line();
             if (!ok) {
+                m_multipart_boundary = false;
                 return orig_length;
             }
             if (line.empty()) {
@@ -342,6 +349,8 @@ CurlVectorReadOp::Write(char *orig_buffer, size_t orig_length)
             // We now have a valid response range; locate a buffer where we will copy the bytes into.
             CalculateNextBuffer();
         }
+        m_multipart_boundary = true;
+
         // Check to see if the Content-Range was missing.
         if (!last_segment && (m_current_op.first == -1 || m_current_op.second == -1)) {
             return FailCallback(kXR_ServerError, "Response segment is missing a Content-Range header");

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -731,12 +731,15 @@ class CurlVectorReadOp : public CurlOperation {
         // Sets the m_response_idx and m_skip_bytes
         void CalculateNextBuffer();
 
+        bool m_multipart_boundary {true}; // 
+
     protected:
         size_t m_response_idx{0}; // The offset in the m_chunk_list which the current response chunk will write into.
         off_t m_chunk_buffer_idx{0}; // Current offset in requested chunk where we are writing bytes.
         off_t m_bytes_consumed{0}; // Total number of bytes used for results serving the request.
         uint64_t m_skip_bytes{0}; // Count of bytes to skip in the next response (if response chunk contains unneeded bytes).
         std::string m_response_headers; // Buffer of an incomplete response line from a prior curl write operation.
+        std::string m_header_line; // Storage for the last complete header line returned by get_next_line.
         std::pair<off_t, off_t> m_current_op{-1, -1}; // The (offset, length) of the current response chunk.
         std::unique_ptr<XrdCl::VectorReadInfo> m_vr; // The response buffers for the client.
         XrdCl::ChunkList m_chunk_list; // The requested chunks from the client.

--- a/tests/XrdClHttp/VectorReadTest.cc
+++ b/tests/XrdClHttp/VectorReadTest.cc
@@ -28,6 +28,9 @@
 
 #include <gtest/gtest.h>
 
+#include <cstring>
+#include <vector>
+
 class CurlVectorFixture : public TransferFixture {};
 
 TEST_F(CurlVectorFixture, Test)
@@ -148,4 +151,49 @@ TEST_F(CurlVectorFixture, WriteTest)
     ASSERT_EQ(b[1], 'b');
     ASSERT_EQ(d[0], 'd');
     ASSERT_EQ(d[1], 'd');
+}
+
+// Multipart header lines may be split across successive curl write callbacks.
+// CurlVectorReadOp::Write() must reassemble them via m_response_headers and then
+// clear that buffer.  Feed the first Content-Range across three writes so the
+// middle chunk never completes a header line (no '\r\n' in that piece).
+TEST_F(CurlVectorFixture, WriteTestSplitMultipartHeaderAcrossWrites)
+{
+    auto logger = XrdCl::DefaultEnv::GetLog();
+
+    std::vector<char> a(2);
+    std::vector<char> b(2);
+
+    XrdCl::ChunkList chunks;
+    chunks.emplace_back(0, 2, a.data());
+    chunks.emplace_back(2, 2, b.data());
+
+    XrdClHttp::CurlVectorReadOp vr(nullptr, "https://example.com", {10, 0}, chunks, logger, nullptr, nullptr);
+    vr.SetStatusCode(206);
+    vr.SetSeparator("123456");
+
+    const char *part1 =
+        "\r\n--123456\r\n"
+        "Content-type: text/plain; charset=UTF-8\r\n"
+        "Content-Range: by";
+    const char *part2 = "tes 0-";
+    const char *part3 =
+        "1/8\r\n"
+        "\r\n"
+        "aa"
+        "\r\n--123456\r\n"
+        "Content-type: text/plain; charset=UTF-8\r\n"
+        "Content-Range: bytes 2-3/8\r\n"
+        "\r\n"
+        "bb"
+        "\r\n--123456--\r\n";
+
+    ASSERT_EQ(strlen(part1), vr.Write(const_cast<char *>(part1), strlen(part1)));
+    ASSERT_EQ(strlen(part2), vr.Write(const_cast<char *>(part2), strlen(part2)));
+    ASSERT_EQ(strlen(part3), vr.Write(const_cast<char *>(part3), strlen(part3)));
+
+    ASSERT_EQ('a', a[0]);
+    ASSERT_EQ('a', a[1]);
+    ASSERT_EQ('b', b[0]);
+    ASSERT_EQ('b', b[1]);
 }


### PR DESCRIPTION
Fixes #2858 

@ffurano suggests that we try this fix in root.
Many thanks to fabrizio for explaning me the details of Range requests and multipart responses.

As fabrizio explained to me, 
the test in the PR incorrectly (unlike a valid response) starts the first chunk with a multipart boundary identifier `"\r\n--123456\r\n"`. Our code is still able to parse the response.

I intentionally divide the header in three parts instead of two, as originally reported, to have a much wider test case.