### PR TITLE
[XrdHttpTPC] Share one parsed CA/CRL store across transfers

### DIFF
--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -2532,12 +2532,16 @@ int XrdConfig::xtlsca(XrdSysError *eDest, XrdOucStream &Config)
       }
    tlsNoVer = false;
 
-
    do {if (!strcmp(val, "proxies") || !strcmp("noproxies", val))
           {if (*val == 'n') tlsOpts |=  XrdTlsContext::nopxy;
               else          tlsOpts &= ~XrdTlsContext::nopxy;
            continue;
           }
+
+         if (!strcmp(val,"allowmissingcrl")) {
+            tlsOpts |= XrdTlsContext::crlAM;
+            continue;
+         }
 
        if (strlen(val) >= (int)sizeof(kword))
           {eDest->Emsg("Config", "Invalid tlsca parameter -", val);
@@ -2590,8 +2594,7 @@ int XrdConfig::xtlsca(XrdSysError *eDest, XrdOucStream &Config)
                {if (XrdOuca2x::a2i(*eDest,"tlsca verdepth",val,&vd,1,255))
                    return 1;
                 tlsOpts = TLS_SET_VDEPTH(tlsOpts,vd);
-               }
-       else {eDest->Emsg("Config", "invalid tlsca option -",kword); return 1;}
+               } else {eDest->Emsg("Config", "invalid tlsca option -",kword); return 1;}
 
        } while((val = Config.GetWord()));
 

--- a/src/Xrd/XrdConfig.cc
+++ b/src/Xrd/XrdConfig.cc
@@ -2494,13 +2494,18 @@ do {     if (!strcmp(val,   "detail")) SSLmsgs = true;
 
              parms: {certdir | certfile} <path>
 
-             opts:  [crlcheck {all | external | last}] [log {failure | off}]
+             opts:  allow-missing-crl
+
+                    [crlcheck {all | external | last}] [log {failure | off}]
 
                     [[no]proxies] [refresh t[m|h|s]] [verdepth <n>]
 
              noverify client's cert need not be verified.
              <path>   is the the certificate path or file to be used.
                       Both a file and a directory path can be specified.
+             allow-missing-crl
+                      Ignores possible missing certificates crls which are
+                      presumed to be empty.
              crlcheck Controls internal crl checks:
                       all       applies crls to the full chain
                       external leaves crl checking to an external plug-in
@@ -2538,7 +2543,7 @@ int XrdConfig::xtlsca(XrdSysError *eDest, XrdOucStream &Config)
            continue;
           }
 
-         if (!strcmp(val,"allowmissingcrl")) {
+         if (!strcmp(val,"allow-missing-crl")) {
             tlsOpts |= XrdTlsContext::crlAM;
             continue;
          }

--- a/src/XrdHttp/XrdHttpProtocol.cc
+++ b/src/XrdHttp/XrdHttpProtocol.cc
@@ -82,6 +82,7 @@ char *XrdHttpProtocol::sslcert = 0;
 char *XrdHttpProtocol::sslkey = 0;
 char *XrdHttpProtocol::sslcadir = 0;
 int XrdHttpProtocol::crlRefIntervalSec = XrdTlsContext::DEFAULT_CRL_REF_INT_SEC;
+bool XrdHttpProtocol::allowMissingCRL = false;
 char *XrdHttpProtocol::sslcipherfilter = 0;
 char *XrdHttpProtocol::listredir = 0;
 bool XrdHttpProtocol::listdeny = false;
@@ -1226,6 +1227,10 @@ int XrdHttpProtocol::Config(const char *ConfigFN, XrdOucEnv *myEnv) {
        if (!httpsspec && what1) eDest.Say("Config Using ", what1);
        if (!httpsspec && what2) eDest.Say("Config Using ", what2);
        if (!httpsspec && what3) eDest.Say("Config Using ", what3);
+
+       if (cP->opts & XrdTlsContext::crlAM) {
+          allowMissingCRL = true;
+       }
       }
 
 // If a gridmap or secxtractor is present then we must be able to verify certs
@@ -1884,6 +1889,10 @@ bool XrdHttpProtocol::InitTLS() {
    std::string eMsg;
    uint64_t opts = XrdTlsContext::servr | XrdTlsContext::logVF |
                    XrdTlsContext::artON | XrdTlsContext::rfCRL;
+
+  if (allowMissingCRL) {
+    opts |= XrdTlsContext::crlAM;
+  }
 
 // Create a new TLS context
 //
@@ -3185,6 +3194,8 @@ int XrdHttpProtocol::LoadExtHandler(std::vector<extHInfo> &hiVec,
   if (sslcafile) myEnv.Put("http.cafile", sslcafile);
   if (sslcert)  myEnv.Put("http.cert",  sslcert);
   if (sslkey)   myEnv.Put("http.key"  , sslkey);
+  // Add the allowMissingCRL configuration to the environment
+  myEnv.PutInt("http.allowmissingcrl",allowMissingCRL ? 1 : 0);
 
   // Load all of the specified external handlers.
   //

--- a/src/XrdHttp/XrdHttpProtocol.hh
+++ b/src/XrdHttp/XrdHttpProtocol.hh
@@ -404,6 +404,9 @@ protected:
   /// CRL thread refresh interval
   static int crlRefIntervalSec;
 
+  // Allows missing CRL for CA verification
+  static bool allowMissingCRL;
+
   /// Gridmap file location. The same used by XrdSecGsi
   static char *gridmap;// [s] gridmap file [/etc/grid-security/gridmap]
   static bool isRequiredGridmap; // If true treat gridmap errors as fatal

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -34,6 +34,8 @@
  * 
  * 
  */
+#ifndef XRDHTTPUTILS_HH
+#define	XRDHTTPUTILS_HH
 
 #include "XProtocol/XPtypes.hh"
 #include "XProtocol/XProtocol.hh"
@@ -45,9 +47,6 @@
 #include <vector>
 #include <memory>
 #include <sstream>
-
-#ifndef XRDHTTPUTILS_HH
-#define	XRDHTTPUTILS_HH
 
 enum : int {
   HTTP_CONTINUE                        = 100,

--- a/src/XrdHttpTpc/CMakeLists.txt
+++ b/src/XrdHttpTpc/CMakeLists.txt
@@ -34,6 +34,8 @@ target_link_libraries(${XrdHttpTPC}
     XrdUtils
     XrdHttpUtils
     CURL::libcurl
+    OpenSSL::SSL
+    OpenSSL::Crypto
     ${CMAKE_THREAD_LIBS_INIT}
     ${CMAKE_DL_LIBS}
 )

--- a/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
@@ -24,7 +24,8 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
 
     // test if XrdEC is used
     usingEC = getenv("XRDCL_EC")? true : false;
-
+    // Test if the CRL checking is enabled
+    allowMissingCRL = (bool) myEnv->GetInt("http.allowmissingcrl");
     std::string authLib;
     std::string authLibParms;
     int cfgFD = open(configfn, O_RDONLY, 0);

--- a/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
@@ -138,11 +138,31 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
     auto env_cadir = getenv("XRDTPC_CADIR");
     if (env_cadir) m_cadir = env_cadir;
 
+    // Sharing a single pre-parsed CA/CRL store between transfers relies on
+    // CURLOPT_SSL_CTX_FUNCTION, which only libcurl's OpenSSL, mbedTLS and wolfSSL
+    // backends implement; the others reject it with CURLE_NOT_BUILT_IN.  libcurl
+    // checks this against the backend selected at run time rather than at build
+    // time, so probe an actual handle, and do it here so that an unsupported build
+    // is reported at startup instead of silently costing memory per transfer.
+    {
+        ManagedCurlHandle probe(curl_easy_init());
+        m_sslctx_supported = probe &&
+            curl_easy_setopt(probe.get(), CURLOPT_SSL_CTX_FUNCTION,
+                             ssl_ctx_callback) == CURLE_OK;
+        if (!m_sslctx_supported) {
+            m_log.Emsg("Config", "libcurl does not support CURLOPT_SSL_CTX_FUNCTION; "
+                       "each transfer will parse the CA and CRL bundles for itself, "
+                       "which costs significant memory per concurrent transfer.");
+        }
+    }
+
     const char *cadir = nullptr, *cafile = nullptr;
     if ((cadir = env_cadir ? env_cadir : myEnv->Get("http.cadir"))) {
         m_cadir = cadir;
         if (!env_cadir) {
-            m_ca_file.reset(new XrdTlsTempCA(&m_log, m_cadir));
+            // Only ask for the pre-parsed store when we can actually install it;
+            // maintaining one costs tens of MB that the fallback path never reads.
+            m_ca_file.reset(new XrdTlsTempCA(&m_log, m_cadir, m_sslctx_supported));
             if (!m_ca_file->IsValid()) {
                 m_log.Emsg("Config", "CAs / CRL generation for libcurl failed.");
                 return false;

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -185,10 +185,22 @@ int TPCHandler::closesocket_callback(void *clientp, curl_socket_t fd) {
  * https://curl.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html
  */
 int TPCHandler::ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *clientp) {
-    //TPCLogRecord * rec = (TPCLogRecord *)clientp;
+    TPCLogRecord * rec = (TPCLogRecord *)clientp;
     SSL_CTX* ctx = static_cast<SSL_CTX*>(ssl_ctx);
-    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
-    return CURL_SOCKOPT_OK;
+
+    if (rec && rec->ca_store) {
+        // Bumps the store's reference count instead of re-parsing the CA and CRL
+        // bundles for this connection.  libcurl runs this callback after it has
+        // applied its own TLS options, so this replaces whatever store it built.
+        SSL_CTX_set1_cert_store(ctx, rec->ca_store.get());
+    }
+    if (allowMissingCRL) {
+        // verify_callback only excuses X509_V_ERR_UNABLE_TO_GET_CRL, i.e. a CA in
+        // the chain for which no CRL could be found.  Every other verification rule
+        // still applies, including revocation itself whenever a CRL is present.
+        SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
+    }
+    return CURLE_OK;
 }
 
 int TPCHandler::verify_callback(int preverify_ok, X509_STORE_CTX* ctx) {
@@ -252,9 +264,33 @@ std::string encode_xrootd_opaque_to_uri(CURL *curl, const std::string &opaque)
 /*           T P C H a n d l e r : : C o n f i g u r e C u r l C A            */
 /******************************************************************************/
   
-void
-TPCHandler::ConfigureCurlCA(CURL *curl)
+bool
+TPCHandler::ConfigureCurlCA(CURL *curl, TPCLogRecord &rec)
 {
+    // Preferred path: hand libcurl the CA/CRL store that XrdTlsTempCA already
+    // parsed, rather than the bundle filenames.  Passing filenames makes libcurl
+    // build a private X509_STORE per connection, which costs tens of MB for a grid
+    // CA directory and is held for the whole transfer; sharing one store makes that
+    // a reference count.  See https://github.com/xrootd/xrootd/issues/2873
+    //
+    // Skipped when m_cafile is set, so that the http.cafile precedence established
+    // at the bottom of this function is preserved.
+    if (m_ca_file && m_sslctx_supported && m_cafile.empty()) {
+        rec.ca_store = m_ca_file->CAStore();
+        if (!rec.ca_store) {
+            m_log.Log(Error, "TpcHandler", "No CA store is available; refusing to "
+                      "fall back to libcurl's default CA bundle");
+            return false;
+        }
+        // Stop libcurl loading its build-time default bundle, which the callback
+        // below would only discard; the callback supplies the trust anchors.
+        curl_easy_setopt(curl, CURLOPT_CAINFO, static_cast<char *>(nullptr));
+        curl_easy_setopt(curl, CURLOPT_CAPATH, static_cast<char *>(nullptr));
+        curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, ssl_ctx_callback);
+        curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, &rec);
+        return true;
+    }
+
     auto ca_filename = m_ca_file ? m_ca_file->CAFilename() : "";
     auto crl_filename = m_ca_file ? m_ca_file->CRLFilename() : "";
     if (!ca_filename.empty() && !crl_filename.empty()) {
@@ -281,6 +317,7 @@ TPCHandler::ConfigureCurlCA(CURL *curl)
     if (!m_cafile.empty()) {
         curl_easy_setopt(curl, CURLOPT_CAINFO, m_cafile.c_str());
     }
+    return true;
 }
 
 
@@ -946,7 +983,15 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
         fh->close();
         return resp_result;
     }
-    ConfigureCurlCA(curl);
+    if (!ConfigureCurlCA(curl, rec)) {
+        std::stringstream ss;
+        ss << "Failed to configure the certificate authorities for the transfer";
+        rec.status = 500;
+        logTransferEvent(LogMask::Error, rec, "PUSH_FAIL", ss.str());
+        int resp_result = req.SendSimpleResp(rec.status, NULL, NULL, generateClientErr(ss, rec).c_str(), 0);
+        fh->close();
+        return resp_result;
+    }
     curl_easy_setopt(curl, CURLOPT_URL, resource.c_str());
 
     Stream stream(std::move(fh), 0, 0, m_log);
@@ -1075,7 +1120,13 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
     std::string full_url = prepareURL(req);
     std::string authz = GetAuthz(req);
     curl_easy_setopt(curl, CURLOPT_URL, resource.c_str());
-    ConfigureCurlCA(curl);
+    if (!ConfigureCurlCA(curl, rec)) {
+        std::stringstream ss;
+        ss << "Failed to configure the certificate authorities for the transfer";
+        rec.status = 500;
+        logTransferEvent(LogMask::Error, rec, "PULL_FAIL", ss.str());
+        return req.SendSimpleResp(rec.status, NULL, NULL, generateClientErr(ss, rec).c_str(), 0);
+    }
     uint64_t sourceFileContentLength = 0;
     {
         //Get the content-length of the source file and pass it to the OSS layer

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -38,6 +38,7 @@ int TPCHandler::m_marker_period = 5;
 size_t TPCHandler::m_block_size = 16*1024*1024;
 size_t TPCHandler::m_small_block_size = 1*1024*1024;
 XrdSysMutex TPCHandler::m_monid_mutex;
+bool TPCHandler::allowMissingCRL = false;
 
 XrdVERSIONINFO(XrdHttpGetExtHandler, HttpTPC);
 
@@ -174,6 +175,36 @@ int TPCHandler::closesocket_callback(void *clientp, curl_socket_t fd) {
 }
 
 /******************************************************************************/
+/*           s s l _ c t x _ c a l l b a c k                                  */
+/******************************************************************************/
+
+/**
+ * The callback that will be called by libcurl just before the initialization of an SSL connection
+ * after having processed all other SSL related options to give a last chance to an application to
+ * modify the behavior of the SSL initialization.
+ * https://curl.se/libcurl/c/CURLOPT_SSL_CTX_FUNCTION.html
+ */
+int TPCHandler::ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *clientp) {
+    //TPCLogRecord * rec = (TPCLogRecord *)clientp;
+    SSL_CTX* ctx = static_cast<SSL_CTX*>(ssl_ctx);
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, verify_callback);
+    return CURL_SOCKOPT_OK;
+}
+
+int TPCHandler::verify_callback(int preverify_ok, X509_STORE_CTX* ctx) {
+    if (preverify_ok == 1) return 1;
+
+    int err = X509_STORE_CTX_get_error(ctx);
+
+    if (err == X509_V_ERR_UNABLE_TO_GET_CRL) {
+        X509_STORE_CTX_set_error(ctx, X509_V_OK);
+        return 1;
+    }
+
+    return 0;
+}
+
+/******************************************************************************/
 /*                            p r e p a r e U R L                             */
 /******************************************************************************/
 
@@ -234,6 +265,10 @@ TPCHandler::ConfigureCurlCA(CURL *curl)
         std::ifstream in(crl_filename, std::ifstream::ate | std::ifstream::binary);
         if(in.tellg() > 0 && m_ca_file->atLeastOneValidCRLFound()){
             curl_easy_setopt(curl, CURLOPT_CRLFILE, crl_filename.c_str());
+            if (allowMissingCRL) {
+                // No need to set the callback if there is no need to do it
+                curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, ssl_ctx_callback);
+            }
         } else {
             std::ostringstream oss;
             oss << "No valid CRL file has been found in the file " << crl_filename << ". Disabling CRL checking.";

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.hh
@@ -82,6 +82,11 @@ private:
         std::string remote;
         std::string name;
         std::string clID;
+        // Keeps the shared CA/CRL store alive for the duration of the transfer.
+        // Declared here, rather than alongside the curl handle, so that it outlives
+        // every handle the request creates -- including the duplicates that
+        // multi-stream transfers make, which inherit the pointer to this record.
+        std::shared_ptr<X509_STORE> ca_store;
         static XrdXrootdTpcMon* tpcMonitor;
         timeval     begT;
         off_t bytes_transferred;
@@ -102,8 +107,13 @@ private:
     static std::string GetAuthz(XrdHttpExtReq &req);
 
     // Configure curl handle's CA settings.  The CA files present here should
-    // be valid for the lifetime of the process.
-    void ConfigureCurlCA(CURL *curl);
+    // be valid for the lifetime of the process.  The record takes a reference to
+    // the shared CA store, so it must outlive the curl handle.
+    //
+    // Returns false if no trust anchors could be configured, in which case the
+    // transfer must be failed: letting it proceed would leave libcurl verifying
+    // against its built-in default CA bundle instead of the configured one.
+    bool ConfigureCurlCA(CURL *curl, TPCLogRecord &rec);
 
     // Redirect the transfer according to the contents of an XrdOucErrInfo object.
     int RedirectTransfer(CURL *curl, const std::string &redirect_resource, XrdHttpExtReq &req,
@@ -181,6 +191,11 @@ private:
     bool usingEC; // indicate if XrdEC is used
 
     static bool allowMissingCRL;
+
+    // Whether the libcurl we are linked against supports CURLOPT_SSL_CTX_FUNCTION,
+    // which only its OpenSSL-family TLS backends do.  Probed once at configuration
+    // time because without it the shared CA store cannot be installed.
+    bool m_sslctx_supported{false};
 
     // Time to connect the curl socket to the remote server uses the linux's default value
     // of 60 seconds

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.hh
@@ -1,4 +1,5 @@
-
+#ifndef XRD_HTTP_TPC_TPC_HH
+#define XRD_HTTP_TPC_TPC_HH
 #include <memory>
 #include <string>
 #include <vector>
@@ -13,6 +14,7 @@
 #include "XrdHttpTpcPMarkManager.hh"
 
 #include <curl/curl.h>
+#include <openssl/ssl.h>
 
 class XrdOucErrInfo;
 class XrdOucStream;
@@ -61,6 +63,8 @@ private:
                                    struct curl_sockaddr *address);
 
     static int closesocket_callback(void *clientp, curl_socket_t fd);
+    static int ssl_ctx_callback(CURL *curl, void *ssl_ctx, void *clientp);
+    static int verify_callback(int preverify_ok, X509_STORE_CTX* ctx);
 
     struct TPCLogRecord {
 
@@ -176,6 +180,8 @@ private:
 
     bool usingEC; // indicate if XrdEC is used
 
+    static bool allowMissingCRL;
+
     // Time to connect the curl socket to the remote server uses the linux's default value
     // of 60 seconds
     static const long CONNECT_TIMEOUT = 60;
@@ -184,3 +190,4 @@ private:
     std::map<std::string,std::string> hdr2cgimap;
 };
 }
+#endif

--- a/src/XrdTls/XrdTlsContext.cc
+++ b/src/XrdTls/XrdTlsContext.cc
@@ -540,29 +540,46 @@ bool VerPaths(const char *cert, const char *pkey,
 
 extern "C"
 {
-int VerCB(int aOK, X509_STORE_CTX *x509P)
-{
-   if (!aOK)
-      {X509 *cert = X509_STORE_CTX_get_current_cert(x509P);
-       int depth  = X509_STORE_CTX_get_error_depth(x509P);
-       int err    = X509_STORE_CTX_get_error(x509P);
-       char name[512], info[1024];
-
-       X509_NAME_oneline(X509_get_subject_name(cert), name, sizeof(name));
-       snprintf(info,sizeof(info),"Cert verification failed for DN=%s",name);
-       XrdTls::Emsg("CertVerify:", info, false);
-
-       X509_NAME_oneline(X509_get_issuer_name(cert), name, sizeof(name));
-       snprintf(info,sizeof(info),"Failing cert issuer=%s", name);
-       XrdTls::Emsg("CertVerify:", info, false);
-
-       snprintf(info, sizeof(info), "Error %d at depth %d [%s]", err, depth,
-                                    X509_verify_cert_error_string(err));
-       XrdTls::Emsg("CertVerify:", info, true);
+/**
+ *
+ * OpenSSL peer-certificate verify callback
+ */
+int verifyPeerCB(int aOK, X509_STORE_CTX *x509P) {
+   if (!aOK) {
+      SSL *ssl = (SSL*)X509_STORE_CTX_get_ex_data(x509P, SSL_get_ex_data_X509_STORE_CTX_idx());
+      SSL_CTX *sslCtx = SSL_get_SSL_CTX(ssl);
+      XrdTlsContext *self = (XrdTlsContext*)SSL_CTX_get_ex_data(sslCtx, XrdTlsContext::ctxIndex);
+      bool LogVF = (self->GetParams()->opts & XrdTlsContext::logVF) != 0;
+      bool crlAllowMissingCA = (self->GetParams()->opts & XrdTlsContext::crlAM) != 0;
+      if (crlAllowMissingCA) {
+         int err = X509_STORE_CTX_get_error(x509P);
+         if (err == X509_V_ERR_UNABLE_TO_GET_CRL) {
+            X509_STORE_CTX_set_error(x509P, X509_V_OK);
+            return 1;
+         }
       }
+      if (LogVF) {
+         X509 *cert = X509_STORE_CTX_get_current_cert(x509P);
+         int depth  = X509_STORE_CTX_get_error_depth(x509P);
+         int err    = X509_STORE_CTX_get_error(x509P);
+         char name[512], info[1024];
 
+         X509_NAME_oneline(X509_get_subject_name(cert), name, sizeof(name));
+         snprintf(info,sizeof(info),"Cert verification failed for DN=%s",name);
+         XrdTls::Emsg("CertVerify:", info, false);
+
+         X509_NAME_oneline(X509_get_issuer_name(cert), name, sizeof(name));
+         snprintf(info,sizeof(info),"Failing cert issuer=%s", name);
+         XrdTls::Emsg("CertVerify:", info, false);
+
+         snprintf(info, sizeof(info), "Error %d at depth %d [%s]", err, depth,
+                                      X509_verify_cert_error_string(err));
+         XrdTls::Emsg("CertVerify:", info, true);
+      }
+   }
    return aOK;
 }
+
 }
   
 } // Anonymous namespace end
@@ -576,7 +593,9 @@ int VerCB(int aOK, X509_STORE_CTX *x509P)
 #define FATAL(msg) {Fatal(eMsg, msg); KILL_CTX(pImpl->ctx); return;}
 
 #define FATAL_SSL(msg) {Fatal(eMsg, msg, true); KILL_CTX(pImpl->ctx); return;}
-  
+
+int XrdTlsContext::ctxIndex = SSL_CTX_get_ex_new_index(0, NULL, NULL, NULL, NULL);
+
 XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
                              const char *caDir, const char *caFile,
                              uint64_t opts, std::string *eMsg)
@@ -690,6 +709,9 @@ XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
 //
    if (pImpl->ctx == 0) FATAL_SSL("Unable to allocate TLS context!");
 
+   //Add the XrdTlsContext object as extra information for OpenSSL callback re-use
+   SSL_CTX_set_ex_data(pImpl->ctx, ctxIndex, this);
+
 // Always prohibit SSLv2 & SSLv3 as these are not secure.
 //
    SSL_CTX_set_options(pImpl->ctx, sslOpts);
@@ -714,7 +736,13 @@ XrdTlsContext::XrdTlsContext(const char *cert,  const char *key,
       SSL_CTX_set_verify_depth(pImpl->ctx, (vDepth ? vDepth : 9));
 
       bool LogVF = (opts & logVF) != 0;
-      SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, (LogVF ? VerCB : 0));
+      bool crlAllowMissingCA = (opts & crlAM) != 0;
+
+      if (crlAllowMissingCA || LogVF) {
+         SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, verifyPeerCB);
+      } else {
+         SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, 0);
+      }
 
       unsigned long xFlags = (opts & nopxy ? 0 : X509_V_FLAG_ALLOW_PROXY_CERTS);
       if (opts & crlON)
@@ -945,6 +973,11 @@ void *XrdTlsContext::Session()
    //the reference counter of it. There is therefore no risk of double free...
    SSL_CTX_free(pImpl->ctx);
    pImpl->ctx = ctxnew->pImpl->ctx;
+
+   //Update ex_data to point to this (the surviving owner), not the
+   //cloned context which is about to be deleted.
+   SSL_CTX_set_ex_data(pImpl->ctx, ctxIndex, this);
+
    //In the destructor of XrdTlsContextImpl, SSL_CTX_Free() is
    //called if ctx is != 0. As this new ctx is used by the session
    //we just created, we don't want that to happen. We therefore set it to 0.
@@ -1142,10 +1175,15 @@ bool XrdTlsContext::newHostCertificateDetected() {
 }
 
 void XrdTlsContext::SetTlsClientAuth(bool setting) {
-    bool LogVF = (pImpl->Parm.opts & logVF) != 0;
     if (setting)
        {pImpl->Parm.opts &= ~clcOF;
-        SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, (LogVF ? VerCB : 0));
+       bool LogVF = (pImpl->Parm.opts & logVF) != 0;
+       bool crlAllowMissingCA = (pImpl->Parm.opts & crlAM) != 0;
+
+       if (LogVF || crlAllowMissingCA)
+          SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, verifyPeerCB);
+       else
+          SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_PEER, 0);
        } else
        {pImpl->Parm.opts |= clcOF;
         SSL_CTX_set_verify(pImpl->ctx, SSL_VERIFY_NONE, 0);

--- a/src/XrdTls/XrdTlsContext.hh
+++ b/src/XrdTls/XrdTlsContext.hh
@@ -252,9 +252,13 @@ static const uint64_t rfCRL = 0x0000004000000000; //!< Turn on the CRL refresh t
 static const uint64_t crlON = 0x0000008000000000; //!< Enables crl checking
 static const uint64_t crlFC = 0x000000C000000000; //!< Full crl chain checking
 static const uint64_t crlRF = 0x00000000ffff0000; //!< Mask to isolate crl refresh in min
+static const uint64_t crlAM = 0x0000001000000000; //!< Allow CA validation when CRL is missing (CRL soft-fail)
 static const int      crlRS = 16;                 //!< Bits to shift   vdept
 static const uint64_t artON = 0x0000002000000000; //!< Auto retry Handshake
 static const uint64_t clcOF = 0x0000010000000000; //!< Disable client certificate request
+
+
+static int ctxIndex;
 
        XrdTlsContext(const char *cert=0,  const char *key=0,
                      const char *cadir=0, const char *cafile=0,

--- a/src/XrdTls/XrdTlsTempCA.cc
+++ b/src/XrdTls/XrdTlsTempCA.cc
@@ -333,9 +333,10 @@ XrdTlsTempCA::TempCAGuard::TempCAGuard(int ca_fd, int crl_fd, const std::string 
     {}
 
 
-XrdTlsTempCA::XrdTlsTempCA(XrdSysError *err, std::string ca_dir)
+XrdTlsTempCA::XrdTlsTempCA(XrdSysError *err, std::string ca_dir, bool build_store)
     : m_log(*err),
-      m_ca_dir(ca_dir)
+      m_ca_dir(ca_dir),
+      m_build_store(build_store)
 {
     // Setup communication pipes; we write one byte to the child to tell it to shutdown;
     // it'll write one byte back to acknowledge before our destructor exits.
@@ -383,6 +384,63 @@ XrdTlsTempCA::~XrdTlsTempCA()
 }
 
 
+std::shared_ptr<X509_STORE>
+XrdTlsTempCA::BuildCAStore(const std::string &ca_fname, const std::string &crl_fname,
+                          bool use_crls)
+{
+    std::shared_ptr<X509_STORE> store(X509_STORE_new(), &X509_STORE_free);
+    if (!store) {
+        m_log.Emsg("TempCA", "Failed to allocate a certificate store");
+        return nullptr;
+    }
+
+    if (1 != X509_STORE_load_locations(store.get(), ca_fname.c_str(), nullptr)) {
+        m_log.Emsg("TempCA", "Failed to load the CA bundle into the certificate store",
+                   ca_fname.c_str());
+        return nullptr;
+    }
+
+    // The verification flags below mirror what libcurl applies when it is handed
+    // these same files through CURLOPT_CAINFO / CURLOPT_CRLFILE; see
+    // ossl_populate_x509_store() in its lib/vtls/openssl.c.  Consumers install this
+    // store in place of the one libcurl built, so any flag left out here is lost.
+    unsigned long x509flags;
+
+    if (use_crls) {
+        X509_LOOKUP *lookup = X509_STORE_add_lookup(store.get(), X509_LOOKUP_file());
+        if (!lookup) {
+            m_log.Emsg("TempCA", "Failed to add a file lookup to the certificate store");
+            return nullptr;
+        }
+        if (X509_load_crl_file(lookup, crl_fname.c_str(), X509_FILETYPE_PEM) <= 0) {
+            m_log.Emsg("TempCA", "Failed to load the CRL bundle into the certificate store",
+                       crl_fname.c_str());
+            return nullptr;
+        }
+        x509flags = X509_V_FLAG_CRL_CHECK | X509_V_FLAG_CRL_CHECK_ALL;
+    } else {
+        // Treat non-self-signed certificates in the store as trust anchors, so that
+        // a server can be verified from an intermediate alone.  This is not an
+        // OpenSSL default, but libcurl enables it unless asked not to, so leaving it
+        // out would reject chains that are accepted today.  It is deliberately not
+        // combined with CRL checking, which OpenSSL does not support:
+        // https://github.com/openssl/openssl/issues/5081
+        x509flags = X509_V_FLAG_PARTIAL_CHAIN;
+    }
+
+    X509_STORE_set_flags(store.get(), x509flags);
+
+    // Purely an optimization; OpenSSL sorts the store itself when it needs to.
+    // Adding objects to a store leaves its lookup stack unsorted, and OpenSSL
+    // sorts lazily on first use -- under a write lock, while every other thread
+    // verifying against this store waits.  Sorting here means the concurrent
+    // verifications that follow a reload only ever need the read lock.
+    sk_X509_OBJECT_sort(X509_STORE_get0_objects(store.get()));
+
+    return store;
+}
+
+
 bool
 XrdTlsTempCA::Maintenance()
 {
@@ -414,6 +472,7 @@ XrdTlsTempCA::Maintenance()
     }
 
     struct dirent *result;
+    bool atLeastOneCRLFound = false;
     errno = 0;
     {
       CASet ca_builder(new_file->getCAFD(), m_log);
@@ -459,7 +518,7 @@ XrdTlsTempCA::Maintenance()
       if (!crl_builder.processCRLWithCriticalExt()) {
         m_log.Emsg("Maintenance", "Failed to insert CRLs with critical extension for CRLs", result->d_name);
       }
-      m_atLeastOneCRLFound = crl_builder.atLeastOneValidCRLFound();
+      atLeastOneCRLFound = crl_builder.atLeastOneValidCRLFound();
     }
 
     if (!new_file->commit()) {
@@ -468,8 +527,47 @@ XrdTlsTempCA::Maintenance()
     }
     //m_log.Emsg("Maintenance", "Successfully created CA and CRL files", new_file->getCAFilename().c_str(),
     //    new_file->getCRLFilename().c_str());
-    m_ca_file.reset(new std::string(new_file->getCAFilename()));
-    m_crl_file.reset(new std::string(new_file->getCRLFilename()));
+    const std::string ca_fname = new_file->getCAFilename();
+    const std::string crl_fname = new_file->getCRLFilename();
+
+    std::shared_ptr<X509_STORE> new_store;
+    if (m_build_store) {
+        // An empty CRL bundle makes every verification fail, so CRL checking is only
+        // enabled once we know at least one CRL was written out.
+        // See https://github.com/xrootd/xrootd/issues/1543
+        struct stat crl_stat;
+        const bool use_crls = atLeastOneCRLFound
+                           && !stat(crl_fname.c_str(), &crl_stat)
+                           && crl_stat.st_size > 0;
+        if (!use_crls) {
+            std::stringstream ss;
+            ss << "No valid CRL file has been found in the file " << crl_fname
+               << ". Disabling CRL checking.";
+            m_log.Emsg("Maintenance", ss.str().c_str());
+        }
+
+        // Parse the bundles once here rather than once per consumer.  This is the
+        // expensive part of a reload, so it is deliberately done before taking the
+        // lock that publishes the result.
+        new_store = BuildCAStore(ca_fname, crl_fname, use_crls);
+        if (!new_store) {
+            // Deliberately publish nothing and let the maintenance thread retry on
+            // the short interval, leaving consumers on the previous store.  The
+            // tempting alternative -- carrying on and letting each consumer load the
+            // bundles for itself -- silently reinstates the per-transfer parsing that
+            // this store exists to avoid, turning a CA refresh problem into memory
+            // exhaustion.  See https://github.com/xrootd/xrootd/issues/2873
+            m_log.Emsg("Maintenance", "Failed to build the certificate store; "
+                                      "retaining the previously loaded CAs and CRLs");
+            return false;
+        }
+    }
+
+    XrdSysMutexHelper lock(m_mutex);
+    m_ca_file.reset(new std::string(ca_fname));
+    m_crl_file.reset(new std::string(crl_fname));
+    m_atLeastOneCRLFound = atLeastOneCRLFound;
+    m_ca_store = std::move(new_store);
 
     return true;
 }

--- a/src/XrdTls/XrdTlsTempCA.hh
+++ b/src/XrdTls/XrdTlsTempCA.hh
@@ -29,6 +29,10 @@
 #include <string>
 #include <memory>
 
+#include <openssl/x509.h>
+
+#include "XrdSys/XrdSysPthread.hh"
+
 // Forward dec'ls.
 class XrdSysError;
 
@@ -39,34 +43,66 @@ class XrdSysError;
  *
  * This will hand out the CA file directly, allowing external libraries (such
  * as libcurl) do the loading of CAs directly.
+ *
+ * Parsing those files is expensive -- a grid CA directory costs tens of MB of
+ * heap once parsed -- so a pre-parsed X509_STORE covering the same CAs and CRLs
+ * is maintained alongside them; see CAStore().
  */
 class XrdTlsTempCA {
 public:
     class TempCAGuard;
 
-    XrdTlsTempCA(XrdSysError *log, std::string ca_dir);
+    /**
+     * Set build_store when the caller intends to use CAStore().  Maintaining the
+     * store costs tens of MB of resident memory, so callers that only need the
+     * bundle filenames should leave it off.
+     */
+    XrdTlsTempCA(XrdSysError *log, std::string ca_dir, bool build_store = true);
     ~XrdTlsTempCA();
 
     /**
-     * Returns true if object is valid.
+     * Returns true if object is valid, i.e. the CA and CRL bundles were generated,
+     * and parsed into a store if one was asked for.  Failing to build a requested
+     * store is fatal rather than recoverable: falling back to having every consumer
+     * parse the bundles for itself is what the store exists to avoid.
      */
-    bool IsValid() const {return m_ca_file.get() && m_crl_file.get();}
+    bool IsValid() const {XrdSysMutexHelper lock(m_mutex);
+                          return m_ca_file.get() && m_crl_file.get()
+                              && (!m_build_store || m_ca_store.get());}
 
     /**
      * Returns the current location of the CA temp file.
      */
-    std::string CAFilename() const {auto file_ref = m_ca_file; return file_ref ? *file_ref : "";}
+    std::string CAFilename() const {XrdSysMutexHelper lock(m_mutex); return m_ca_file ? *m_ca_file : "";}
 
     /**
      * Returns the current location of the CA temp file.
      */
-    std::string CRLFilename() const {auto file_ref = m_crl_file; return file_ref ? *file_ref : "";}
+    std::string CRLFilename() const {XrdSysMutexHelper lock(m_mutex); return m_crl_file ? *m_crl_file : "";}
 
     /**
      * Returns true if a valid CRL file has been found during the Maintenance thread execution
      * false otherwise
      */
-    bool atLeastOneValidCRLFound() const { return m_atLeastOneCRLFound; }
+    bool atLeastOneValidCRLFound() const {XrdSysMutexHelper lock(m_mutex); return m_atLeastOneCRLFound;}
+
+    /**
+     * Returns the CA and CRL contents pre-parsed into a single X509_STORE, rebuilt
+     * once per maintenance cycle.  An X509_STORE is reference counted and internally
+     * locked by OpenSSL, so a single instance may be shared across any number of
+     * concurrent TLS handshakes -- e.g. via SSL_CTX_set1_cert_store() -- instead of
+     * having every connection parse the CA and CRL bundles for itself.
+     *
+     * The returned reference keeps the store alive for as long as the caller holds
+     * it, so a maintenance cycle may publish a replacement without disturbing the
+     * TLS sessions still using the previous one.
+     *
+     * Only ever null before the first successful maintenance run, which IsValid()
+     * reports on; a maintenance run that cannot build a store keeps the previous
+     * one rather than withdrawing it.  Callers should treat a null store as a hard
+     * error, not as a cue to load the bundles themselves.
+     */
+    std::shared_ptr<X509_STORE> CAStore() const {XrdSysMutexHelper lock(m_mutex); return m_ca_store;}
 
     /**
      * Manages the temporary file associated with the curl handle
@@ -111,6 +147,19 @@ private:
     bool Maintenance();
 
     /**
+     * Parse the freshly-generated CA and CRL bundles into a single X509_STORE.
+     * The CRL bundle is only added -- and CRL checking only enabled -- when it
+     * holds at least one valid CRL, mirroring the behaviour of the callers that
+     * hand these files to libcurl directly.
+     *
+     * Returns nullptr on failure, in which case the caller publishes nothing and
+     * leaves consumers on the previously loaded store.
+     */
+    std::shared_ptr<X509_STORE> BuildCAStore(const std::string &ca_fname,
+                                             const std::string &crl_fname,
+                                             bool use_crls);
+
+    /**
      * Thread managing the invocation of the CA maintenance routines
      */
     static void *MaintenanceThread(void *myself_raw);
@@ -125,8 +174,13 @@ private:
     int m_maintenance_thread_pipe_w{-1};
     XrdSysError &m_log;
     const std::string m_ca_dir;
+    const bool m_build_store;
+        // Guards the published state below; taken once per consumer request (not
+        // per I/O), so the critical sections are deliberately kept to a pointer copy.
+    mutable XrdSysMutex m_mutex;
     std::shared_ptr<std::string> m_ca_file;
     std::shared_ptr<std::string> m_crl_file;
+    std::shared_ptr<X509_STORE> m_ca_store;
     bool m_atLeastOneCRLFound = false;
 
         // After success, how long to wait until the next CA reload.

--- a/tests/XrdHttpTpc/CMakeLists.txt
+++ b/tests/XrdHttpTpc/CMakeLists.txt
@@ -4,6 +4,14 @@ add_library(XrdHttpTpcUtils
   ${PROJECT_SOURCE_DIR}/src/XrdHttpTpc/XrdHttpTpcUtils.cc
 )
 
-target_link_libraries(xrdhttptpc-unit-tests XrdHttpTpcUtils GTest::GTest GTest::Main)
+target_link_libraries(XrdHttpTpcUtils
+        PRIVATE
+        OpenSSL::SSL
+        OpenSSL::Crypto)
+
+target_link_libraries(xrdhttptpc-unit-tests
+        XrdHttpTpcUtils
+        GTest::GTest
+        GTest::Main)
 
 gtest_discover_tests(xrdhttptpc-unit-tests PROPERTIES DISCOVERY_TIMEOUT 10)


### PR DESCRIPTION
Every HTTP-TPC COPY was given the CA and CRL bundle paths through CURLOPT_CAINFO and CURLOPT_CRLFILE, so libcurl parsed both into a private X509_STORE for each connection and held it for the whole transfer. With a grid CA directory that costs tens of MB per in-flight transfer, and multi-stream pulls pay it once per stream. Memory therefore scaled with concurrency: on a busy server where thousands of transfers piled up this reached over 200 GB RSS and the process was OOM-killed.

libcurl's own CA store cache cannot help here, as it is keyed on the multi handle and every transfer creates a fresh one.

XrdTlsTempCA now parses the bundles into a single X509_STORE once per maintenance cycle and hands out reference counted copies. Transfers install it with SSL_CTX_set1_cert_store() from an SSL_CTX callback, so setting up a transfer costs a reference count instead of a full parse. In-flight transfers keep the previous store alive, so a reload never disturbs a running handshake.

The store is built with the same verification flags libcurl applies to these files, so chain building and CRL checking are unchanged: X509_V_FLAG_CRL_CHECK and X509_V_FLAG_CRL_CHECK_ALL when the CRL bundle holds at least one CRL, and X509_V_FLAG_PARTIAL_CHAIN when it does not.

A build of libcurl whose TLS backend does not implement CURLOPT_SSL_CTX_FUNCTION keeps the previous behaviour; this is detected once at configuration time and reported. A failure to build the store is instead treated as fatal, since silently letting each transfer load the bundles for itself would reintroduce the memory growth as soon as a reload went wrong.

Serialising the XrdTlsTempCA accessors also removes an unsynchronised read of the bundle filenames, which the maintenance thread can replace concurrently.

Fixes: #2873

Assisted-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Memory usage before the fix (100 transfers in parallel with the ca-policy-egi-core CAs installed:
<img width="1554" height="1042" alt="image" src="https://github.com/user-attachments/assets/f5937511-22ed-423f-9f69-8465c6fe4e7a" />

Memory usage after the fix:
<img width="1554" height="1042" alt="image" src="https://github.com/user-attachments/assets/ee8698db-6149-4b60-b02c-b507c20f5787" />