### PR TITLE
Implement pseudo unload functionality for plugins

### DIFF
--- a/src/XrdSys/XrdSysPlugin.cc
+++ b/src/XrdSys/XrdSysPlugin.cc
@@ -51,14 +51,14 @@
 #else
 #include "XrdSys/XrdWin32.hh"
 #endif
-  
+
 #include "XrdSys/XrdSysError.hh"
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysPlatform.hh"
 #include "XrdSys/XrdSysPlugin.hh"
 #include "XrdVersion.hh"
 #include "XrdVersionPlugin.hh"
- 
+
 /******************************************************************************/
 /*                        S t a t i c   M e m b e r s                         */
 /******************************************************************************/
@@ -68,7 +68,7 @@ struct XrdSysPlugin::PLlist *XrdSysPlugin::plList = 0;
 /******************************************************************************/
 /*                            D e s t r u c t o r                             */
 /******************************************************************************/
-  
+
 XrdSysPlugin::~XrdSysPlugin()
 {
    if (libHandle) dlclose(libHandle);
@@ -78,7 +78,7 @@ XrdSysPlugin::~XrdSysPlugin()
 /******************************************************************************/
 /* Private:                   b a d V e r s i o n                             */
 /******************************************************************************/
-  
+
 XrdSysPlugin::cvResult XrdSysPlugin::badVersion(XrdVersionInfo &urInfo,
                                                 char mmv, int majv, int minv)
 {
@@ -98,11 +98,11 @@ XrdSysPlugin::cvResult XrdSysPlugin::badVersion(XrdVersionInfo &urInfo,
 
    return cvBad;
 }
-  
+
 /******************************************************************************/
 /* Private:                   c h k V e r s i o n                             */
 /******************************************************************************/
-  
+
 XrdSysPlugin::cvResult XrdSysPlugin::chkVersion(XrdVersionInfo &urInfo,
                                                 const char     *pname,
                                                 void           *lHandle)
@@ -219,7 +219,7 @@ XrdSysPlugin::cvResult XrdSysPlugin::chkVersion(XrdVersionInfo &urInfo,
 /******************************************************************************/
 /* Private:                      D L F l a g s                                */
 /******************************************************************************/
-  
+
 int XrdSysPlugin::DLflags()
 {
 #if    defined(__APPLE__)
@@ -234,7 +234,7 @@ int XrdSysPlugin::DLflags()
 /******************************************************************************/
 /* Private:                         F i n d                                   */
 /******************************************************************************/
-  
+
 void *XrdSysPlugin::Find(const char *libpath)
 {
    struct PLlist *plP = plList;
@@ -251,7 +251,7 @@ void *XrdSysPlugin::Find(const char *libpath)
 /******************************************************************************/
 /*                            g e t L i b r a r y                             */
 /******************************************************************************/
-  
+
 void *XrdSysPlugin::getLibrary(bool allMsgs, bool global)
 {
    void *myHandle;
@@ -381,11 +381,11 @@ void XrdSysPlugin::Inform(const char *txt1, const char *txt2, const char *txt3,
             }
       }
 }
-  
+
 /******************************************************************************/
 /* Private:                       l i b M s g                                 */
 /******************************************************************************/
-  
+
 XrdSysPlugin::cvResult XrdSysPlugin::libMsg(const char *txt1, const char *txt2,
                                             const char *mSym)
 {
@@ -427,11 +427,11 @@ const char *XrdSysPlugin::msgSuffix(const char *Word, char *buff, int bsz)
       else      snprintf(buff, bsz,"%sexecutable image", Word);
    return (libPath ? libPath : "");
 }
-  
+
 /******************************************************************************/
 /*                               P r e l o a d                                */
 /******************************************************************************/
-  
+
 bool XrdSysPlugin::Preload(const char *path,  char *ebuff, int eblen)
 {
    struct PLlist *plP;
@@ -468,7 +468,7 @@ bool XrdSysPlugin::Preload(const char *path,  char *ebuff, int eblen)
 /******************************************************************************/
 /*                                V e r C m p                                 */
 /******************************************************************************/
-  
+
 bool XrdSysPlugin::VerCmp(XrdVersionInfo &vInfo1,
                           XrdVersionInfo &vInfo2, bool noMsg)
 {

--- a/src/XrdSys/XrdSysPlugin.cc
+++ b/src/XrdSys/XrdSysPlugin.cc
@@ -52,6 +52,8 @@
 #include "XrdSys/XrdWin32.hh"
 #endif
 
+#include <set>
+
 #include "XrdSys/XrdSysError.hh"
 #include "XrdSys/XrdSysHeaders.hh"
 #include "XrdSys/XrdSysPlatform.hh"
@@ -63,9 +65,12 @@
 /*                        S t a t i c   M e m b e r s                         */
 /******************************************************************************/
 
-struct XrdSysPlugin::PLlist *XrdSysPlugin::plList = 0;
+namespace
+{
+std::set<void (*)()> piUnload_Callbacks;
+}
 
-std::set<void (*)()> XrdSysPlugin::piSet;
+struct XrdSysPlugin::PLlist *XrdSysPlugin::plList = 0;
 
 /******************************************************************************/
 /*                            D e s t r u c t o r                             */
@@ -258,7 +263,7 @@ void XrdSysPlugin::Finish()
 {
 // Call Finish() for every plugin in our loaded plugin set
 //
-   for (auto it = piSet.begin(); it != piSet.end(); it++) (*it)();
+   for (auto& plugin : piUnload_Callbacks) plugin();
 }
 
 /******************************************************************************/
@@ -336,13 +341,12 @@ void *XrdSysPlugin::getPlugin(const char *pname, int optional, bool global)
 // it's psuedo unload handler, if any.
 //
    if ((cvRC = chkVersion(urInfo, pname, myHandle)) == cvBad) return 0;
-      else {void (*pUnLoad)(void);
-            char nUnLoad[512];
-            if (snprintf(nUnLoad, sizeof(nUnLoad), "%s%s", XrdVERSIONINFOSFX,
-                         pname) < (int)sizeof(nUnLoad)
-                && (pUnLoad = (void (*)())dlsym(myHandle, nUnLoad))
-               )  piSet.insert(pUnLoad);
-           }
+      {void (*pUnLoad)(void);
+       std::string unlSym = std::string(XrdVERSIONINFOSFX) + pname;
+       if ((pUnLoad = (void (*)())dlsym(myHandle, unlSym.c_str())))
+          piUnload_Callbacks.insert(pUnLoad);
+          else Inform("No virtual unload ", unlSym.c_str(), " in ", libPath);
+      }
 
 // Print the loaded version unless message is suppressed or not needed
 //

--- a/src/XrdSys/XrdSysPlugin.cc
+++ b/src/XrdSys/XrdSysPlugin.cc
@@ -65,6 +65,8 @@
 
 struct XrdSysPlugin::PLlist *XrdSysPlugin::plList = 0;
 
+std::set<void (*)()> XrdSysPlugin::piSet;
+
 /******************************************************************************/
 /*                            D e s t r u c t o r                             */
 /******************************************************************************/
@@ -249,6 +251,17 @@ void *XrdSysPlugin::Find(const char *libpath)
 }
 
 /******************************************************************************/
+/*                                F i n i s h                                 */
+/******************************************************************************/
+
+void XrdSysPlugin::Finish()
+{
+// Call Finish() for every plugin in our loaded plugin set
+//
+   for (auto it = piSet.begin(); it != piSet.end(); it++) (*it)();
+}
+
+/******************************************************************************/
 /*                            g e t L i b r a r y                             */
 /******************************************************************************/
 
@@ -319,9 +332,17 @@ void *XrdSysPlugin::getPlugin(const char *pname, int optional, bool global)
        return 0;
       }
 
-// Check if we need to verify version compatibility
+// Check if we need to verify version compatibility. If acceptable, record
+// it's psuedo unload handler, if any.
 //
    if ((cvRC = chkVersion(urInfo, pname, myHandle)) == cvBad) return 0;
+      else {void (*pUnLoad)(void);
+            char nUnLoad[512];
+            if (snprintf(nUnLoad, sizeof(nUnLoad), "%s%s", XrdVERSIONINFOSFX,
+                         pname) < (int)sizeof(nUnLoad)
+                && (pUnLoad = (void (*)())dlsym(myHandle, nUnLoad))
+               )  piSet.insert(pUnLoad);
+           }
 
 // Print the loaded version unless message is suppressed or not needed
 //

--- a/src/XrdSys/XrdSysPlugin.hh
+++ b/src/XrdSys/XrdSysPlugin.hh
@@ -29,8 +29,9 @@
 /* be used to endorse or promote products derived from this software without  */
 /* specific prior written permission of the institution or contributor.       */
 /******************************************************************************/
-  
+
 #include <cstring>
+#include <set>
 
 struct XrdVersionInfo;
 
@@ -52,6 +53,14 @@ class XrdSysError;
 class XrdSysPlugin
 {
 public:
+
+//------------------------------------------------------------------------------
+//! Invoke the pseudo-destructor for all loaded plugins. This should only
+//! be called at exit time since plugins are not automatically unloaded.
+//------------------------------------------------------------------------------
+
+static
+void  Finish();
 
 //------------------------------------------------------------------------------
 //! Prepare shared library for use (optional call).
@@ -246,5 +255,6 @@ struct PLlist {PLlist  *next;
               };
 
 static PLlist *plList;
+static std::set<void (*)()> piSet;
 };
 #endif

--- a/src/XrdSys/XrdSysPlugin.hh
+++ b/src/XrdSys/XrdSysPlugin.hh
@@ -31,7 +31,6 @@
 /******************************************************************************/
 
 #include <cstring>
-#include <set>
 
 struct XrdVersionInfo;
 
@@ -255,6 +254,5 @@ struct PLlist {PLlist  *next;
               };
 
 static PLlist *plList;
-static std::set<void (*)()> piSet;
 };
 #endif

--- a/src/XrdSys/XrdSysUtils.cc
+++ b/src/XrdSys/XrdSysUtils.cc
@@ -52,7 +52,7 @@
 #include <sys/utsname.h>
 #endif
 #include "XrdSysUtils.hh"
-  
+
 /******************************************************************************/
 /*                              E x e c N a m e                               */
 /******************************************************************************/
@@ -113,7 +113,7 @@ const char *XrdSysUtils::ExecName()
 /******************************************************************************/
 /*                              F m t U n a m e                               */
 /******************************************************************************/
-  
+
 int XrdSysUtils::FmtUname(char *buff, int blen)
 {
 #if defined(WINDOWS)
@@ -139,7 +139,7 @@ int XrdSysUtils::FmtUname(char *buff, int blen)
 #endif
 #endif
 }
-  
+
 /******************************************************************************/
 /*                             G e t S i g N u m                              */
 /******************************************************************************/
@@ -161,7 +161,7 @@ namespace
                         };
    static int snum = sizeof(sigtab)/sizeof(struct SigTab);
 };
-  
+
 int XrdSysUtils::GetSigNum(const char *sname)
 {
    int i;
@@ -184,7 +184,7 @@ extern "C" void __gcov_dump(void);
 /******************************************************************************/
 /*                              S i g B l o c k                               */
 /******************************************************************************/
-  
+
 bool XrdSysUtils::SigBlock()
 {
    sigset_t  myset;
@@ -217,7 +217,7 @@ bool XrdSysUtils::SigBlock()
 }
 
 /******************************************************************************/
-  
+
 bool XrdSysUtils::SigBlock(int numsig)
 {
    sigset_t  myset;

--- a/src/XrdSys/XrdSysUtils.cc
+++ b/src/XrdSys/XrdSysUtils.cc
@@ -51,6 +51,7 @@
 #include <sys/types.h>
 #include <sys/utsname.h>
 #endif
+#include "XrdSysPlugin.hh"
 #include "XrdSysUtils.hh"
 
 /******************************************************************************/

--- a/src/XrdSys/XrdSysUtils.cc
+++ b/src/XrdSys/XrdSysUtils.cc
@@ -195,10 +195,15 @@ bool XrdSysUtils::SigBlock()
    signal(SIGPIPE, SIG_IGN);  // Solaris optimization
 
 #ifdef ENABLE_COVERAGE
-   // Dump coverage information and exit upon receiving a TERM signal
-   signal(SIGTERM, [](int) { __gcov_dump(); XrdSysPlugin::Finish();
-                             _exit(EXIT_SUCCESS); });
+#define COVERAGE_CALL __gcov_dump();
+#else
+#define COVERAGE_CALL
 #endif
+
+// Perform a psuedo unload and then exit when receiving a SIGTERM signal
+//
+   signal(SIGTERM, [](int) { COVERAGE_CALL XrdSysPlugin::Finish();
+                             _exit(EXIT_SUCCESS); });
 
 // Add the standard signals we normally always block
 //

--- a/src/XrdSys/XrdSysUtils.cc
+++ b/src/XrdSys/XrdSysUtils.cc
@@ -195,7 +195,8 @@ bool XrdSysUtils::SigBlock()
 
 #ifdef ENABLE_COVERAGE
    // Dump coverage information and exit upon receiving a TERM signal
-   signal(SIGTERM, [](int) { __gcov_dump(); _exit(EXIT_SUCCESS); });
+   signal(SIGTERM, [](int) { __gcov_dump(); XrdSysPlugin::Finish();
+                             _exit(EXIT_SUCCESS); });
 #endif
 
 // Add the standard signals we normally always block

--- a/src/XrdVersion.hh.in
+++ b/src/XrdVersion.hh.in
@@ -75,7 +75,7 @@ extern "C" void __gcov_dump(void);
 #endif
 
 #ifndef FINISH_HANDLER
-#define FINISH_HANDLER
+#define FINISH_HANDLER(x)
 #endif
 
 // The following structure defines the standard way to record a version. You can
@@ -109,7 +109,7 @@ struct XrdVersionInfo {int vNum; const char vOpt; const char vPfx[3];\
 //
 #define XrdVERSIONINFO(x,y) \
         extern "C" {XrdVERSIONINFODEF(x##_,y,XrdVNUMBER,XrdVERSION);\
-                    void _##x () {COVERAGE_CALL ; FINISH_HANDLER ;}\
+                    void _##x () {COVERAGE_CALL ; FINISH_HANDLER(x) ;}\
                    }
 
 // The following macro is an easy way to declare externally defined version

--- a/src/XrdVersion.hh.in
+++ b/src/XrdVersion.hh.in
@@ -59,6 +59,25 @@
 #define XrdMinorVNUM(x) x/100%100
 #define XrdPatchVNUM(x) x%100
 
+// The following is used to define the contents of the pseudo unload function.
+// This is the function that is called right before the process exits to
+// complete any required final functions. This is necessary because plugin
+// libraries are never unloaded. The plugin system handles the call. The
+// possible code ceverage monitor is hanled by default. If an additional
+// monitor needs to be handled, then define the FINISH_HANDLER as a call
+// to any other function that should be called after the coverage call.
+//
+#ifdef ENABLE_COVERAGE
+extern "C" void __gcov_dump(void);
+#define COVERAGE_CALL __gcov_dump();
+#else
+#define COVERAGE_CALL
+#endif
+
+#ifndef FINISH_HANDLER
+#define FINISH_HANDLER
+#endif
+
 // The following structure defines the standard way to record a version. You can
 // determine component version numbers within an object file by simply executing
 // "strings <objectfile> | grep '@V:'".
@@ -69,6 +88,7 @@ struct XrdVersionInfo {int vNum; const char vOpt; const char vPfx[3];\
 // Macro to define the suffix to use when generating the extern version symbol.
 // This is used by SysPlugin. We cannot use it here as cpp does not expand the
 // macro when catenating tokens togther and we want to avoid yet another macro.
+// The suffix is also used as the prefix of the psuedo unload function.
 //
 #define XrdVERSIONINFOSFX "_"
 
@@ -88,7 +108,9 @@ struct XrdVersionInfo {int vNum; const char vOpt; const char vPfx[3];\
 // y -> An unquoted 1- to 15-character component name (e.g. cmsd, seckrb5, etc).
 //
 #define XrdVERSIONINFO(x,y) \
-        extern "C" {XrdVERSIONINFODEF(x##_,y,XrdVNUMBER,XrdVERSION);}
+        extern "C" {XrdVERSIONINFODEF(x##_,y,XrdVNUMBER,XrdVERSION);\
+                    void _##x () {COVERAGE_CALL ; FINISH_HANDLER ;}\
+                   }
 
 // The following macro is an easy way to declare externally defined version
 // information. This macro must be used at file level.


### PR DESCRIPTION
The purpose of this modification is to provide a hook for shared library plugins that can be called prior to the xrootd server exiting due to a SIGTERM signal. This hook can complete any necessary processing prior to the termination of the process. This is especially useful for code coverage analysis that requires a finalization in each shared library in order to produce statistics for the library (i.e. a clean exit). This is what the default implementation does when ENABLE_COVERAGE is defined. However, additional processing may be added in the future for specific plugins using the FINISH_HANDLER macro.

This update is compatible with all previous versions and can technically be considered for a patch release. However, since it adds new functionality it likely needs to be restricted to a feature release.