### PR TITLE
[CI] Tolerate transient CDash failures

### DIFF
--- a/test.cmake
+++ b/test.cmake
@@ -318,9 +318,20 @@ else()
 endif()
 
 if(CDASH OR (DEFINED ENV{CDASH} AND "$ENV{CDASH}"))
-  ctest_submit(BUILD_ID BUILDID QUIET)
-  message("CDash URL: https://my.cdash.org/index.php?project=XRootD")
-  if(BUILDID)
-    message("Build result URL: https://my.cdash.org/builds/${BUILDID}")
+  ctest_submit(
+    BUILD_ID BUILDID
+    RETRY_COUNT 3
+    RETRY_DELAY 5
+    RETURN_VALUE SUBMIT_RESULT
+    CAPTURE_CMAKE_ERROR SUBMIT_ERROR
+    QUIET)
+
+  if(NOT SUBMIT_RESULT EQUAL 0 OR NOT SUBMIT_ERROR EQUAL 0)
+    message(WARNING "CDash submission failed")
+  else()
+    message("CDash URL: https://my.cdash.org/index.php?project=XRootD")
+    if(BUILDID)
+      message("Build result URL: https://my.cdash.org/builds/${BUILDID}")
+    endif()
   endif()
 endif()


### PR DESCRIPTION
## Summary

- retry CDash submissions up to three times with a five-second delay
- capture an exhausted submission error and report it as a warning
- preserve configure, build, and test failures as CI-gating errors

## Root cause

This addresses an intermittent CI failure observed while testing xrootd/xrootd#2836.

In the [example Ubuntu 24.04 clang Release job](https://github.com/xrootd/xrootd/actions/runs/29263060208/job/86861115201?pr=2836), CTest completed all 350 tests successfully with zero failures. The job failed afterwards, while uploading `Test.xml` to my.cdash.org:

- CDash returned `SQLSTATE[40P01]`: a PostgreSQL deadlock
- the error came from `cdash-new.kitware.com` on PostgreSQL port `5432`
- CTest treated the failed dashboard submission as a fatal script error and exited with status 255

There is no Kerberos KDC bind failure in this job. The test KDC's configured port `50088` is unrelated, so changing that port would not address the linked failure.

CDash is a reporting service rather than part of the build or test itself. A transient or exhausted dashboard upload should therefore not override a successful configure, build, and test result.

## Validation

- verified with CTest 4.4 and a local mock CDash server that two transient application errors recover on the third attempt
- verified that an exhausted submission remains non-fatal
- `git diff --check`