### PR TITLE
[XrdHttpTPC] Make low-speed timeout configurable

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcConfigure.cc
@@ -1,6 +1,7 @@
 
 #include "XrdHttpTpcTPC.hh"
 
+#include <climits>
 #include <dlfcn.h>
 #include <fcntl.h>
 
@@ -115,7 +116,27 @@ bool TPCHandler::Configure(const char *configfn, XrdOucEnv *myEnv)
             if(authHdr != hdr2cgimap.end()) {
               hdr2cgimap.erase(authHdr);
             }
-        }  else if (!strcmp("tpc.timeout", val)) {
+        } else if (!strcmp("tpc.low_speed", val)) {
+            if (!(val = Config.GetWord())) {
+                Config.Close();
+                m_log.Emsg("Config", "tpc.low_speed rate not specified.");
+                return false;
+            }
+
+            long long low_speed_limit;
+            if (XrdOuca2x::a2sz(m_log, "low speed rate", val, &low_speed_limit, 0, LONG_MAX)) {
+                return false;
+            }
+            m_low_speed_limit = static_cast<long>(low_speed_limit);
+
+            if ((val = Config.GetWord())) {
+                int low_speed_time;
+                if (XrdOuca2x::a2tm(m_log, "low speed time", val, &low_speed_time, 1)) {
+                    return false;
+                }
+                m_low_speed_time = low_speed_time;
+            }
+        } else if (!strcmp("tpc.timeout", val)) {
             if (!(val = Config.GetWord())) {
                 Config.Close();
                 m_log.Emsg("Config","tpc.timeout value not specified.");  return false;

--- a/src/XrdHttpTpc/XrdHttpTpcState.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcState.cc
@@ -80,14 +80,6 @@ bool State::InstallHandlers(CURL *curl) {
       curl_easy_setopt(curl,CURLOPT_UNRESTRICTED_AUTH,1L);
     }
 
-    // Only use low-speed limits with libcurl v7.38 or later.
-    // Older versions have poor transfer performance, corrected in curl commit cacdc27f.
-    curl_version_info_data *curl_ver = curl_version_info(CURLVERSION_NOW);
-    if (curl_ver->age > 0 && curl_ver->version_num >= 0x072600) {
-        // Require a minimum speed from the transfer: 2 minute average must at least 10KB/s
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, 2*60);
-        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 10*1024);
-    }
     return true;
 }
 

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -320,6 +320,19 @@ TPCHandler::ConfigureCurlCA(CURL *curl, TPCLogRecord &rec)
     return true;
 }
 
+void
+TPCHandler::ConfigureCurlLowSpeed(CURL *curl)
+{
+    // Older versions have poor transfer performance when low-speed limits are
+    // enabled; this was corrected in curl commit cacdc27f for version 7.38.0.
+    curl_version_info_data *curl_ver = curl_version_info(CURLVERSION_NOW);
+    if (m_low_speed_limit > 0 && curl_ver && curl_ver->age > 0 &&
+        curl_ver->version_num >= 0x072600) {
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_TIME, m_low_speed_time);
+        curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, m_low_speed_limit);
+    }
+}
+
 
 bool TPCHandler::MatchesPath(const char *verb, const char *path) {
     return !strcmp(verb, "COPY") || !strcmp(verb, "OPTIONS");
@@ -407,6 +420,8 @@ TPCHandler::TPCHandler(XrdSysError *log, const char *config, XrdOucEnv *myEnv) :
         m_allow_private(true),
         m_desthttps(false),
         m_fixed_route(false),
+        m_low_speed_limit(10*1024),
+        m_low_speed_time(2*60),
         m_timeout(60),
         m_first_timeout(120),
         m_log(log->logger(), "TPC_"),
@@ -968,6 +983,7 @@ int TPCHandler::ProcessPushReq(const std::string & resource, XrdHttpExtReq &req)
         logTransferEvent(LogMask::Error, rec, "PUSH_FAIL", ss.str());
         return req.SendSimpleResp(rec.status, NULL, NULL, generateClientErr(ss, rec).c_str(), 0);
     }
+    ConfigureCurlLowSpeed(curl);
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
     curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1_2);
     curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long) CURL_HTTP_VERSION_1_1);
@@ -1069,6 +1085,7 @@ int TPCHandler::ProcessPullReq(const std::string &resource, XrdHttpExtReq &req) 
         logTransferEvent(LogMask::Error, rec, "PULL_FAIL", ss.str());
         return req.SendSimpleResp(rec.status, NULL, NULL, generateClientErr(ss, rec).c_str(), 0);
     }
+    ConfigureCurlLowSpeed(curl);
 
     // ddavila 2023-01-05:
     // The following change was required by the Rucio/SENSE project where

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.hh
@@ -115,6 +115,9 @@ private:
     // against its built-in default CA bundle instead of the configured one.
     bool ConfigureCurlCA(CURL *curl, TPCLogRecord &rec);
 
+    // Configure the minimum transfer rate and the permitted time below it.
+    void ConfigureCurlLowSpeed(CURL *curl);
+
     // Redirect the transfer according to the contents of an XrdOucErrInfo object.
     int RedirectTransfer(CURL *curl, const std::string &redirect_resource, XrdHttpExtReq &req,
         XrdOucErrInfo &error, TPCLogRecord &);
@@ -172,6 +175,8 @@ private:
     bool m_desthttps;
     bool m_fixed_route;  // If 'true' the Destination IP in an HTTP-TPC is forced to be the same as the IP used to contact the server
                            // when 'false' any IP available can be selected
+    long m_low_speed_limit; // Minimum transfer rate in bytes per second; zero disables the check.
+    long m_low_speed_time; // Time the transfer may remain below m_low_speed_limit before it is aborted.
     int m_timeout; // the 'timeout interval'; if no bytes have been received during this time period, abort the transfer.
     int m_first_timeout; // the 'first timeout interval'; the amount of time we're willing to wait to get the first byte.
                          // Unless explicitly specified, this is 2x the timeout interval.


### PR DESCRIPTION
## Summary

- add `tpc.low_speed <rate> [period]` configuration
- preserve the existing defaults of 10 KiB/s for two minutes
- allow `tpc.low_speed 0` to disable the low-speed check
- keep curl transfer policy in `TPCHandler`, separate from `State`

## Motivation

HTTP TPC transfers currently abort after remaining below 10 KiB/s for two minutes, with no operator-facing way to tune the policy. This may reject legitimate transfers over persistently slow links.

We needed a way to disable this feature for some tests but I thought it would be good to have this be a toggle instead of a hardcoded value.

## Validation

- built the `XrdHttpTPC-6` CMake target
- ran `xrdhttptpc-unit-tests` successfully
- ran `git diff --check`
