### PR TITLE
[XrdHttpTpc] Do not let a destination close failure mask the transfer…

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
@@ -124,16 +124,23 @@ public:
         return current_offset;
     }
 
-    int Flush() {
-        int last_error = 0;
+    // Flush every stream to the local filesystem.  Returns State::errNone and
+    // leaves error_msg untouched if all the streams could be flushed; otherwise
+    // returns the error code of the first failure encountered and sets error_msg
+    // to the corresponding error message.
+    int Flush(std::string &error_msg) {
+        int error_code = State::errNone;
         for (std::vector<State*>::iterator state_it = m_states.begin();
              state_it != m_states.end();
              state_it++)
         {
-            int error = (*state_it)->Flush();
-            if (error) {last_error = error;}
+            if (((*state_it)->Flush() == -1) && !error_code) {
+                error_code = State::errFlush;
+                error_msg = (*state_it)->GetFinalizeErrorMessage();
+                if (error_msg.empty()) {error_msg = "(no error message provided)";}
+            }
         }
-        return last_error;
+        return error_code;
     }
 
     off_t BytesTransferred() const {
@@ -324,7 +331,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
                 const char *log_prefix = rec.log_prefix.c_str();
                 bool tpc_pull = strncmp("Pull", log_prefix, 4) == 0;
 
-                mch.SetErrorCode(10);
+                mch.SetErrorCode(State::errTimeout);
                 std::stringstream ss;
                 ss << "Transfer failed because no bytes have been "
                    << (tpc_pull ? "received from the source (pull mode) in "
@@ -429,7 +436,18 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         throw std::runtime_error("Internal state error in libcurl");
     }
 
-    mch.Flush();
+    // A failure to flush the file to the local filesystem is always logged and is
+    // appended to the error reported to the client, but it never replaces the
+    // transfer failure itself: the flush failure is usually a consequence of it.
+    std::string flushErrorMsg;
+    const int flushErrorCode = mch.Flush(flushErrorMsg);
+    std::string flushErrorSuffix;
+    if (flushErrorCode) {
+        std::replace(flushErrorMsg.begin(), flushErrorMsg.end(), '\n', ' ');
+        flushErrorMsg = "Failed to flush the file to the local filesystem. " + flushErrorMsg;
+        logTransferEvent(LogMask::Error, rec, "FLUSH_FAIL", flushErrorMsg);
+        flushErrorSuffix = "; " + flushErrorMsg;
+    }
 
     rec.bytes_transferred = mch.BytesTransferred();
     rec.tpc_status = mch.GetStatusCode();
@@ -445,7 +463,16 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
             std::replace(err.begin(), err.end(), '\n', ' ');
             ss2 << "; error message: \"" << err << "\"";
         }
-        logTransferEvent(LogMask::Error, rec, "MULTISTREAM_FAIL", ss.str());
+        logTransferEvent(LogMask::Error, rec, "MULTISTREAM_FAIL", ss2.str());
+        ss2 << flushErrorSuffix;
+        ss << generateClientErr(ss2, rec);
+    } else if (mch.GetErrorCode() == State::errTimeout) {
+        // The stall detector fired; its message already describes precisely
+        // what happened, report it as-is.
+        std::stringstream ss2;
+        ss2 << mch.GetErrorMessage();
+        logTransferEvent(LogMask::Error, rec, "MULTISTREAM_FAIL", ss2.str());
+        ss2 << flushErrorSuffix;
         ss << generateClientErr(ss2, rec);
     } else if (mch.GetErrorCode()) {
         std::string err = mch.GetErrorMessage();
@@ -454,6 +481,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         std::stringstream ss2;
         ss2 << "Error when interacting with local filesystem: " << err;
         logTransferEvent(LogMask::Error, rec, "MULTISTREAM_FAIL", ss2.str());
+        ss2 << flushErrorSuffix;
         ss << generateClientErr(ss2, rec);
     } else if (res != CURLE_OK) {
         std::stringstream ss2;
@@ -461,17 +489,29 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         std::stringstream ss3;
         ss3 << ss2.str() << ":" << curl_easy_strerror(res);
         logTransferEvent(LogMask::Error, rec, "MULTISTREAM_FAIL", ss3.str());
+        ss2 << flushErrorSuffix;
         ss << generateClientErr(ss2, rec, res);
     } else if (current_offset != content_size) {
         std::stringstream ss2;
         ss2 << "Internal logic error led to early abort; current offset is " <<
               current_offset << " while full size is " << content_size;
         logTransferEvent(LogMask::Error, rec, "MULTISTREAM_FAIL", ss2.str());
+        ss2 << flushErrorSuffix;
+        ss << generateClientErr(ss2, rec);
+    } else if (flushErrorCode) {
+        // Nothing else went wrong: the flush failure is the reason of the failure.
+        std::stringstream ss2;
+        ss2 << flushErrorMsg;
         ss << generateClientErr(ss2, rec);
     } else {
         if (!handles[0]->Finalize()) {
             std::stringstream ss2;
             ss2 << "Failed to finalize and close file handle.";
+            std::string handleErrMsg = handles[0]->GetFinalizeErrorMessage();
+            if(handleErrMsg.size()) {
+              std::replace(handleErrMsg.begin(), handleErrMsg.end(), '\n', ' ');
+              ss2 << " " << handleErrMsg;
+            }
             ss << generateClientErr(ss2, rec);
             logTransferEvent(LogMask::Error, rec, "MULTISTREAM_ERROR",
                 ss2.str());

--- a/src/XrdHttpTpc/XrdHttpTpcState.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcState.cc
@@ -218,11 +218,19 @@ ssize_t State::Write(char *buffer, size_t size) {
     ssize_t retval = m_stream->Write(m_start_offset + m_offset, buffer, size, false);
     if (retval == SFS_ERROR) {
         m_error_buf = m_stream->GetErrorMessage();
-        m_error_code = 1;
+        m_error_code = errWrite;
         return -1;
     }
     m_offset += retval;
     return retval;
+}
+
+void State::RecordFinalizeError(int error_code, const std::string &error_msg) {
+    if (m_finalize_error_code) {
+        return;
+    }
+    m_finalize_error_code = error_code;
+    m_finalize_error_buf = error_msg;
 }
 
 int State::Flush() {
@@ -232,8 +240,7 @@ int State::Flush() {
 
     ssize_t retval = m_stream->Write(m_start_offset + m_offset, 0, 0, true);
     if (retval == SFS_ERROR) {
-        m_error_buf = m_stream->GetErrorMessage();
-        m_error_code = 2;
+        RecordFinalizeError(errFlush, m_stream->GetErrorMessage());
         return -1;
     }
     m_offset += retval;
@@ -302,8 +309,7 @@ void State::DumpBuffers() const
 bool State::Finalize()
 {
     if (!m_stream->Finalize()) {
-        m_error_buf = m_stream->GetErrorMessage();
-        m_error_code = 3;
+        RecordFinalizeError(errClose, m_stream->GetErrorMessage());
         return false;
     }
     return true;

--- a/src/XrdHttpTpc/XrdHttpTpcState.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcState.hh
@@ -21,6 +21,17 @@ class Stream;
 class State {
 public:
 
+    // Error codes recorded on a transfer state.  They are exposed so that the
+    // TPC handler is able to tell the various failure modes apart when it
+    // composes the error sent back to the client.
+    enum ErrorCode {
+        errNone    = 0,
+        errWrite   = 1,  // Failure while writing the received data to the local file.
+        errFlush   = 2,  // Failure while flushing the local file.
+        errClose   = 3,  // Failure while closing the local file.
+        errTimeout = 10  // The transfer did not make any progress within the timeout.
+    };
+
     State() :
         m_push(true),
         m_recv_status_line(false),
@@ -103,6 +114,15 @@ public:
 
     void SetErrorMessage(const std::string &error_msg) {m_error_buf = error_msg;}
 
+    // Error recorded while flushing and closing the local file at the end of the
+    // transfer (see Flush() and Finalize()).  It is deliberately kept apart from
+    // the transfer error above: a failure to flush or close the file must not
+    // hide the reason why the transfer itself failed, e.g. a libcurl error or a
+    // stalled transfer.
+    int GetFinalizeErrorCode() const {return m_finalize_error_code;}
+
+    std::string GetFinalizeErrorMessage() const {return m_finalize_error_buf;}
+
     void ResetAfterRequest();
 
     CURL *GetHandle() const {return m_curl;}
@@ -129,12 +149,16 @@ public:
     // system).
     //
     // Returns true on success; false otherwise.  Failures can happen, for example, if
-    // not all buffers have been reordered by the underlying stream.
+    // not all buffers have been reordered by the underlying stream.  A failure is
+    // recorded in the finalization error (GetFinalizeErrorCode()), not in the
+    // transfer error.
     bool Finalize();
 
     // Flush the data in memory to disk, even if it may cause unaligned or short
     // writes.  Typically, only done while shutting down the transfer (note some
     // backends may be unable to handle unaligned writes unless it's the last write).
+    // Returns -1 on failure, in which case the error is recorded in the
+    // finalization error (GetFinalizeErrorCode()), not in the transfer error.
     int Flush();
 
     // Retrieve the description of the remote connection; is of the form:
@@ -145,6 +169,11 @@ public:
 
 private:
     bool InstallHandlers(CURL *curl);
+
+    // Record a failure that happened while flushing or closing the local file.
+    // Only the first failure is kept: the ones that follow are almost always a
+    // consequence of it.
+    void RecordFinalizeError(int error_code, const std::string &error_msg);
 
     State(const State&);
     // Add back once C++11 is available
@@ -174,6 +203,8 @@ private:
     std::vector<std::string> m_headers_copy; // Copies of custom headers.
     std::string m_resp_protocol;  // Response protocol in the HTTP status line.
     std::string m_error_buf;  // Any error associated with a response.
+    int m_finalize_error_code = 0; // error code from flushing / closing the local file.
+    std::string m_finalize_error_buf; // error message from flushing / closing the local file.
     bool m_is_transfer_state; // If set to true, this state will be used to perform some transfers
     bool tpcForwardCreds = false; // if set to true, the redirection will send user credentials to the redirection host
 };

--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -678,7 +678,7 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
                 const char *log_prefix = rec.log_prefix.c_str();
                 bool tpc_pull = strncmp("Pull", log_prefix, 4) == 0;
 
-                state.SetErrorCode(10);
+                state.SetErrorCode(State::errTimeout);
                 std::stringstream ss;
                 ss << "Transfer failed because no bytes have been "
                    << (tpc_pull ? "received from the source (pull mode) in "
@@ -773,6 +773,14 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
     }
     curl_multi_cleanup(multi_handle);
 
+    // The transfer is over at this point: any error recorded so far - a failed
+    // write to the local filesystem or the stall detector having fired - is the
+    // reason why the transfer failed.  Flushing and closing the destination file
+    // below may fail as well but, as such a failure is usually a consequence of
+    // the transfer failure, it must not be reported instead of it.
+    const int transferErrorCode = state.GetErrorCode();
+    std::string transferErrorMsg = state.GetErrorMessage();
+
     state.Flush();
 
     rec.bytes_transferred = state.BytesTransferred();
@@ -783,6 +791,25 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
     // requests can occur before the filesystem is done closing the handle -
     // and those requests may occur against partial data.
     state.Finalize();
+
+    // A failure to flush or to close the destination file is always logged and is
+    // appended to the error reported to the client, but it never replaces the
+    // transfer failure itself: it is usually a consequence of it.
+    std::string finalizeErrorMsg, finalizeErrorSuffix;
+    if (state.GetFinalizeErrorCode()) {
+        std::stringstream ss2;
+        ss2 << (state.GetFinalizeErrorCode() == State::errFlush
+                    ? "Failed to flush the file to the local filesystem."
+                    : "Failed to finalize and close file handle.");
+        std::string err = state.GetFinalizeErrorMessage();
+        if (!err.empty()) {
+            std::replace(err.begin(), err.end(), '\n', ' ');
+            ss2 << " " << err;
+        }
+        finalizeErrorMsg = ss2.str();
+        logTransferEvent(LogMask::Error, rec, "CLOSE_FAIL", finalizeErrorMsg);
+        finalizeErrorSuffix = "; " + finalizeErrorMsg;
+    }
 
     // Generate the final response back to the client.
     std::stringstream ss;
@@ -796,14 +823,23 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
             ss2 << "; error message: \"" << err << "\"";
         }
         logTransferEvent(LogMask::Error, rec, "TRANSFER_FAIL", ss2.str());
+        ss2 << finalizeErrorSuffix;
         ss << generateClientErr(ss2, rec);
-    } else if (state.GetErrorCode()) {
-        std::string err = state.GetErrorMessage();
-        if (err.empty()) {err = "(no error message provided)";}
-        else {std::replace(err.begin(), err.end(), '\n', ' ');}
+    } else if (transferErrorCode == State::errTimeout) {
+        // The stall detector fired; its message already describes precisely
+        // what happened, report it as-is.
         std::stringstream ss2;
-        ss2 << "Error when interacting with local filesystem: " << err;
+        ss2 << transferErrorMsg;
         logTransferEvent(LogMask::Error, rec, "TRANSFER_FAIL", ss2.str());
+        ss2 << finalizeErrorSuffix;
+        ss << generateClientErr(ss2, rec);
+    } else if (transferErrorCode) {
+        if (transferErrorMsg.empty()) {transferErrorMsg = "(no error message provided)";}
+        else {std::replace(transferErrorMsg.begin(), transferErrorMsg.end(), '\n', ' ');}
+        std::stringstream ss2;
+        ss2 << "Error when interacting with local filesystem: " << transferErrorMsg;
+        logTransferEvent(LogMask::Error, rec, "TRANSFER_FAIL", ss2.str());
+        ss2 << finalizeErrorSuffix;
         ss << generateClientErr(ss2, rec);
     } else if (res != CURLE_OK) {
         std::stringstream ss2;
@@ -811,7 +847,13 @@ int TPCHandler::RunCurlWithUpdates(CURL *curl, XrdHttpExtReq &req, State &state,
         std::stringstream ss3;
         ss3 << ss2.str() << ": " << curl_easy_strerror(res);
         logTransferEvent(LogMask::Error, rec, "TRANSFER_FAIL", ss3.str());
+        ss2 << finalizeErrorSuffix;
         ss << generateClientErr(ss2, rec, res);
+    } else if (!finalizeErrorMsg.empty()) {
+        // Nothing else went wrong: the flush/close failure is the reason of the failure.
+        std::stringstream ss2;
+        ss2 << finalizeErrorMsg;
+        ss << generateClientErr(ss2, rec);
     } else {
         ss << "success: Created";
         success = true;


### PR DESCRIPTION
… error

In the single-stream path, State::Flush() and State::Finalize() recorded their failures in the same error code and message as the transfer itself, and both ran before the final error was composed.  A failing close of the destination file therefore overwrote the reason why the transfer actually failed.  Since the reporting chain tested the state error code before the libcurl result, the libcurl branch became unreachable as well: timeouts, partial files and receive errors were all reported as "Error when interacting with local filesystem: <close error>".  This is typically hit with storage backends that validate the expected file size and reject the close of a pull that was aborted mid-transfer.

Flush() and Finalize() now record their failures separately, so they can no longer overwrite the transfer error.  Both the single-stream and the multistream paths now report, in order: the remote status code, the transfer error (stall detector or local write failure), the libcurl result, and finally the flush/close failure.  The flush/close failure is always logged, and is appended to the message sent to the client, so that neither error is lost.

The stall detector message is no longer prefixed with "Error when interacting with local filesystem", which did not describe it.

Two related problems are fixed in the multistream path: the result of MultiCurlHandler::Flush() was discarded, so a failure to flush the file was reported to the client as a success, and the remote status code failure was logged with an empty message.

The 1, 2, 3 and 10 error codes are now named in a State::ErrorCode enum; their values are unchanged.

Fixes: #2878

Assisted-By: Claude Opus 5 (1M context) <noreply@anthropic.com>