### PR TITLE
[XrdHttpTpc] Report transferred bytes in multistream performance markers

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
@@ -147,6 +147,24 @@ public:
         return m_bytes_transferred;
     }
 
+    // Number of bytes that have actually been transferred so far: the bytes of
+    // the requests that already completed plus the bytes of the requests that
+    // are still in flight.  The two are disjoint: FinishCurlXfer() accumulates
+    // the counter of a state into m_bytes_transferred and then zeroes it via
+    // State::ResetAfterRequest(), so no byte is counted twice.
+    // Note this is not the same quantity as the scheduling offset maintained by
+    // StartTransfers(), which is advanced as soon as a range request is handed
+    // over to libcurl, hence before any byte of that range has been received.
+    off_t BytesInFlightAndTransferred() const {
+        off_t bytes = m_bytes_transferred;
+        for (std::vector<State*>::const_iterator state_iter = m_states.begin();
+             state_iter != m_states.end();
+             state_iter++) {
+            bytes += (*state_iter)->BytesTransferred();
+        }
+        return bytes;
+    }
+
     int GetStatusCode() const {
         return m_status_code;
     }
@@ -317,11 +335,16 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
         time_t now = time(NULL);
         time_t next_marker = last_marker + m_marker_period;
         if (now >= next_marker) {
-            if (current_offset > last_advance_bytes) {
-                last_advance_bytes = current_offset;
+            // Report - and watch for progress on - the bytes that have really
+            // been transferred, not the offset up to which the range requests
+            // have been scheduled: the latter runs ahead of the transfer by up
+            // to concurrency * m_block_size bytes.
+            const off_t bytes_transferred = mch.BytesInFlightAndTransferred();
+            if (bytes_transferred > last_advance_bytes) {
+                last_advance_bytes = bytes_transferred;
                 last_advance_time = now;
             }
-            if (SendPerfMarker(req, rec, handles, current_offset)) {
+            if (SendPerfMarker(req, rec, handles, bytes_transferred)) {
                 logTransferEvent(LogMask::Error, rec, "PERFMARKER_FAIL",
                     "Failed to send a perf marker to the TPC client");
                 return -1;
@@ -392,7 +415,7 @@ int TPCHandler::RunCurlWithStreamsImpl(XrdHttpExtReq &req, State &state,
                 }
             } else if (running_handles == 0) {
                 logTransferEvent(LogMask::Debug, rec, "MULTISTREAM_IDLE",
-                    "Unable to start new transfers; breaking loop.");
+                    "All the ranges have been scheduled and all the handles are done; ending the transfer loop.");
                 break;
             }
         }


### PR DESCRIPTION
The performance markers of a multi-stream transfer reported the scheduling cursor, i.e. the offset up to which range requests had been handed over to libcurl, instead of the number of bytes actually transferred.  The cursor runs ahead of the transfer by up to concurrency * block_size bytes, 768 MiB with the default block size and three streams, so progress was over-reported by that amount.  For any file smaller than that the very first marker announced the full file size before a single body byte had arrived, and the TPC client displayed 100% for the whole duration of the real transfer.  The final TRANSFER_SUCCESS record was unaffected, as it is computed from MultiCurlHandler::BytesTransferred().

The stall detector shared the same signal, while the error it produces states that no bytes have been received from the source, or transmitted to the destination in push mode.  Those are not the same quantity: the cursor stays frozen while all the handles are busy in the middle of their block, even though data is flowing.

MultiCurlHandler now exposes the bytes that have really been transferred, adding the bytes of the requests still in flight to those of the requests that already completed.  The two are disjoint, since FinishCurlXfer() accumulates the counter of a state before State::ResetAfterRequest() zeroes it.  Both the marker and the stall detector use that value.  The scheduling cursor keeps its role of deciding what is left to request and of checking, at the end, that the whole file was covered.

The single-stream path already reported State::BytesTransferred() in both places and is unchanged.

The MULTISTREAM_IDLE message logged when all the ranges have been scheduled and all the handles are done read as a failure, although it marks the normal end of the transfer loop, right before TRANSFER_SUCCESS.  It is reworded; the event name is kept.

Fixes: #2874

Assisted-By: Claude Opus 5 (1M context) <noreply@anthropic.com>