### PR TITLE
[XrdCl] [XrdClHttp] Param --header -H to inject http headers

### DIFF
--- a/docs/man/xrdcp.1
+++ b/docs/man/xrdcp.1
@@ -18,6 +18,7 @@ xrdcp - copy files
 [\fB--notlsok\fR] [\fB--tlsnodata\fR] [\fB--tlsmetalink\fR]
 [\fB--zip-mtln-cksum\fR] [\fB--rm-bad-cksum\fR] [\fB--continue\fR]
 [\fB--xrate-threshold\fR] [\fB--retry-policy\fR]
+[\fB--header\fR \fIname: value\fR]
 
 \fIlegacy options\fR: [\fB-adler\fR] [\fB-DS\fR\fIparm string\fR] [\fB-DI\fR\fIparm number\fR]
 [\fB-md5\fR] [\fB-np\fR] [\fB-OD\fR\fIcgi\fR] [\fB-OS\fR\fIcgi\fR] [\fB-x\fR]
@@ -58,12 +59,44 @@ file corruption if not properly used.
 re-creates a file if it is already present.
 
 .RE
+\fB-H\fR | \fB--header\fR \fIname: value\fR
+.RS 5
+adds the given header to the requests sent to an http or https endpoint. May be
+repeated to add more than one header. Requires that the source or the destination
+is an http or https URL. The \fBConnection\fR,
+\fBContent-Length\fR, \fBExpect\fR, \fBHost\fR, \fBKeep-Alive\fR,
+\fBProxy-Authenticate\fR, \fBProxy-Authorization\fR, \fBProxy-Connection\fR,
+\fBTE\fR, \fBTrailer\fR, \fBTransfer-Encoding\fR and \fBUpgrade\fR headers are
+reserved and cannot be overridden. Each of these names prepended with
+\fBTransferHeader\fR is reserved as well.
+.PP
+In a third party copy (\fB--tpc\fR), the headers go to the server the client
+connects to: the destination server in \fBpull\fR mode, or the source server in
+\fBpush\fR mode. To send a header to the other server, the one the client does not
+connect to, prepend \fBTransferHeader\fR to the header name. For example, in
+\fBpull\fR mode:
+.PP
+.RS 3
+\fB-H\fR "X-Request-Id: <destination-id>"
+.br
+\fB-H\fR "TransferHeaderX-Request-Id: <source-id>"
+.RE
+.PP
+The destination server gets the \fBX-Request-Id\fR header, and sends the value of
+\fBTransferHeaderX-Request-Id\fR as the \fBX-Request-Id\fR header of its request
+to the source server.
+.PP
+If the option is not specified, the \fBXRD_HTTPHEADERS\fR environment variable is
+used instead. It holds the headers as a newline separated list of
+"\fIname: value\fR" entries.
+
+.RE
 \fB-h\fR | \fB--help\fR
 .RS 5
 displays usage information.
 
 .RE
-\fB-H\fR | \fB--license\fR
+\fB--license\fR
 .RS 5
 displays license terms and conditions.
 

--- a/src/XrdApps/XrdCpConfig.cc
+++ b/src/XrdApps/XrdCpConfig.cc
@@ -76,11 +76,21 @@ namespace XrdCpConfiguration
 {
 static XrdSysLogger Logger;
 static XrdSysError  eDest(&Logger, "");
+
+// Returns true if the protocol is one that carries HTTP requests.
+//
+static bool isHttpProt(XrdCpFile::PType pType)
+                      {return pType == XrdCpFile::isHttp
+                           || pType == XrdCpFile::isHttps
+                           || pType == XrdCpFile::isS3;
+                      }
 };
+
+using XrdCpConfiguration::isHttpProt;
 
 XrdSysError  *XrdCpConfig::Log = &XrdCpConfiguration::eDest;
 
-const char   *XrdCpConfig::opLetters = ":C:d:D:EfFhHI:NpPrRsS:t:T:vVX:y:z:ZA";
+const char   *XrdCpConfig::opLetters = ":C:d:D:EfFhH:I:NpPrRsS:t:T:vVX:y:z:ZA";
 
 struct option XrdCpConfig::opVec[] =         // For getopt_long()
      {
@@ -90,6 +100,7 @@ struct option XrdCpConfig::opVec[] =         // For getopt_long()
       {OPT_TYPE "debug",          1, 0, XrdCpConfig::OpDebug},
       {OPT_TYPE "dynamic-src",    0, 0, XrdCpConfig::OpDynaSrc},
       {OPT_TYPE "force",          0, 0, XrdCpConfig::OpForce},
+      {OPT_TYPE "header",         1, 0, XrdCpConfig::OpHttpHeader},
       {OPT_TYPE "help",           0, 0, XrdCpConfig::OpHelp},
       {OPT_TYPE "infiles",        1, 0, XrdCpConfig::OpIfile},
       {OPT_TYPE "license",        0, 0, XrdCpConfig::OpLicense},
@@ -241,6 +252,9 @@ do{while(optind < Argc && Legacy(optind)) {}
           case OpZip:           OpSpec |= DoZip;
                                 if (zipFile) free(zipFile);
                                 zipFile = strdup(optarg);
+                                break;
+          case OpHttpHeader:    OpSpec |= DoHttpHeader;
+                                HttpHeaders.push_back(optarg);
                                 break;
           case OpHelp:          Usage(0);
                                 break;
@@ -430,6 +444,13 @@ do{while(optind < Argc && Legacy(optind)) {}
    if (isLcl && Opts & optNoLclCp)
       FMSG("All files are local; use 'cp' instead!", 1);
 
+// Injected headers only apply to http and https endpoints
+//
+   if (OpSpec & DoHttpHeader)
+      {if (!isHttpProt(srcFile->Protocol) && !isHttpProt(dstFile->Protocol))
+          UMSG("'--header' requires an http or https source or destination.");
+      }
+
 // Check for checksum spec conflicts
 //
    if (OpSpec & DoCksum)
@@ -465,7 +486,7 @@ do{while(optind < Argc && Legacy(optind)) {}
                          <<(numFiles != 1 ? " files." : " file."));
       }
 }
-  
+
 /******************************************************************************/
 /*                       P r i v a t e   M e t h o d s                        */
 /******************************************************************************/
@@ -930,8 +951,8 @@ void XrdCpConfig::Usage(int rc)
 
    static const char *Options= "\n"
    "Options: [--cksum <args>] [--coerce] [--continue]\n"
-   "         [--debug <lvl>] [--dynamic-src] [--force] [--help]\n"
-   "         [--infiles <fn>] [--license] [--nopbar] [--notlsok]\n"
+   "         [--debug <lvl>] [--dynamic-src] [--force] [--header <name: value>]\n"
+   "         [--help] [--infiles <fn>] [--license] [--nopbar] [--notlsok]\n"
    "         [--parallel <n>] [--posc] [--proxy <host>:<port>]\n"
    "         [--recursive] [--retry <n>] [--retry-policy <force|continue>]\n"
    "         [--rm-bad-cksum] [--server] [--silent] [--sources <n>]\n"
@@ -969,9 +990,28 @@ void XrdCpConfig::Usage(int rc)
    "-d | --debug <lvl>            sets the debug level: 0 off, 1 low, 2 medium, 3 high\n"
    "-Z | --dynamic-src            file size may change during the copy\n"
    "-f | --force                  replaces any existing output file\n"
+   "-H | --header <name: value>   adds the given header to the requests sent to an\n"
+   "                              http or https endpoint. May be repeated to add more\n"
+   "                              than one header. Requires an http or https source or\n"
+   "                              destination. The hop-by-hop and message framing\n"
+   "                              headers are reserved and cannot be overridden.\n"
+   "                              With --tpc, the headers go to the server the client\n"
+   "                              connects to: the destination server in 'pull' mode,\n"
+   "                              or the source server in 'push' mode. To send a header\n"
+   "                              to the other server, prepend 'TransferHeader' to the\n"
+   "                              header name. Example, in 'pull' mode:\n"
+   "                                -H \"X-Request-Id: <destination-id>\"\n"
+   "                                -H \"TransferHeaderX-Request-Id: <source-id>\"\n"
+   "                              The destination server gets the X-Request-Id header,\n"
+   "                              and sends the value of TransferHeaderX-Request-Id as\n"
+   "                              the X-Request-Id header of its request to the source.\n"
+   "                              If the option is not specified, the XRD_HTTPHEADERS\n"
+   "                              environment variable is used instead. It holds the\n"
+   "                              headers as a newline separated list of\n"
+   "                              '<name>: <value>' entries.\n"
    "-h | --help                   prints this information\n"
    "-I | --infiles <fname>        specifies the file that contains a list of input files\n"
-   "-H | --license                prints license terms and conditions\n"
+   "     --license                prints license terms and conditions\n"
    "-N | --nopbar                 does not print the progress bar\n"
    "     --notlsok                if server is too old to support TLS encryption fallback\n"
    "                              to unencrypted communication\n"

--- a/src/XrdApps/XrdCpConfig.hh
+++ b/src/XrdApps/XrdCpConfig.hh
@@ -96,6 +96,11 @@ static XrdSysError *Log;            // -> Error message object
 
 std::vector<std::string> AddCksVal; // -> Additional checksum argument
 
+std::vector<std::string> HttpHeaders; // -> -H | --header settings, as given.
+                                      //    These are passed through verbatim;
+                                      //    XrdClHttp does all the parsing and
+                                      //    validation of their contents.
+
 static const uint64_t    OpCksum        =  'C';  // -adler -MD5 legacy -> DoCksrc
 static const uint64_t    DoCksrc        =  0x0000000000000001LL; // --cksum <type>:source
 static const uint64_t    DoCksum        =  0x0000000000000002LL; // --cksum <type>
@@ -116,7 +121,7 @@ static const uint64_t    DoHelp         =  0x0000000000000040LL; // -h | --help
 static const uint64_t    OpIfile        =  'I';
 static const uint64_t    DoIfile        =  0x0000000000000080LL; // -I | --infiles
 
-static const uint64_t    OpLicense      =  'H';                  // -H | --license
+static const uint64_t    OpLicense      = 0x14;                  //      --license
 
 static const uint64_t    OpNoPbar       =  'N';        // -N | --nopbar | -np {legacy}
 static const uint64_t    DoNoPbar       =  0x0000000000000100LL;
@@ -202,6 +207,9 @@ static const uint64_t    DoRetryPolicy     = 0x0000000400000000LL; // --retry-po
 
 static const uint64_t    OpZipAppend       = 0x13;
 static const uint64_t    DoZipAppend       = 0x0000000800000000LL; // --zip-append
+
+static const uint64_t    OpHttpHeader      =  'H';
+static const uint64_t    DoHttpHeader      = 0x0000001000000000LL; // -H | --header
 
 // Call Config with the parameters passed to main() to fill out this object. If
 // the method returns then no errors have been found. Otherwise, it exits.

--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -646,6 +646,22 @@ int main( int argc, char **argv )
   if( config.Want( XrdCpConfig::DoZipMtlnCksum ) )
     env->PutInt( "ZipMtlnCksum", 1 );
 
+  //----------------------------------------------------------------------------
+  // Headers to inject into the HTTP requests. These are handed to the XrdClHttp
+  // plug-in verbatim, as a newline separated list; that plug-in owns all of the
+  // parsing and validation of their contents.
+  //----------------------------------------------------------------------------
+  if( !config.HttpHeaders.empty() )
+  {
+    std::string headers;
+    for( auto &header : config.HttpHeaders )
+    {
+      if( !headers.empty() ) headers += '\n';
+      headers += header;
+    }
+    env->PutString( "HttpHeaders", headers );
+  }
+
   int chunkSize = DefaultCPChunkSize;
   env->GetInt( "CPChunkSize", chunkSize );
 

--- a/src/XrdClHttp/CMakeLists.txt
+++ b/src/XrdClHttp/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(XrdClHttpObj OBJECT
   XrdClHttpFactory.cc        XrdClHttpFactory.hh
   XrdClHttpFile.cc           XrdClHttpFile.hh
   XrdClHttpFilesystem.cc     XrdClHttpFilesystem.hh
+  XrdClHttpHeaderBuilder.cc  XrdClHttpHeaderBuilder.hh
   XrdClHttpOpChecksum.cc
   XrdClHttpOpCopy.cc
   XrdClHttpOpDelete.cc

--- a/src/XrdClHttp/XrdClHttpFactory.cc
+++ b/src/XrdClHttp/XrdClHttpFactory.cc
@@ -190,6 +190,19 @@ Factory::Initialize()
         }
         XrdClHttp::File::SetDefaultHeaderTimeout(dht);
 
+        // Headers to inject into outgoing requests, given as a newline separated
+        // list of "<name>: <value>" entries.  Set programmatically by xrdcp for
+        // its --header option, so only fall back to the environment variable when
+        // no value was provided.  HeaderBuilder::Build is what interprets it, once
+        // per request.
+        //
+        // Note this deliberately does not use SetIfEmpty: header values routinely
+        // carry credentials and must not be written to the log.
+        if (!env->GetString("HttpHeaders", val) || val.empty()) {
+            env->PutString("HttpHeaders", "");
+            env->ImportString("HttpHeaders", "XRD_HTTPHEADERS");
+        }
+
         // Start up the cache for the OPTIONS response
         auto &cache = XrdClHttp::VerbsCache::Instance();
 

--- a/src/XrdClHttp/XrdClHttpHeaderBuilder.cc
+++ b/src/XrdClHttp/XrdClHttpHeaderBuilder.cc
@@ -1,0 +1,208 @@
+#include "XrdClHttpHeaderBuilder.hh"
+#include "XrdClHttpUtil.hh"
+
+#include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClDefaultEnv.hh>
+
+#include <algorithm>
+#include <array>
+#include <iterator>
+
+namespace {
+
+using namespace std::string_view_literals;
+
+// Headers the client must not inject: the RFC 7230 hop-by-hop and message
+// framing headers, and Host.  Overriding one permits request smuggling, cache
+// poisoning, or corrupt framing.
+//
+// Held in lower case and without the TransferHeader prefix, the form
+// IsForbiddenHeader reduces a name to before it looks the name up.
+constexpr std::array forbidden_headers{
+    "connection"sv,
+    "content-length"sv,
+    "expect"sv,
+    "host"sv,
+    "keep-alive"sv,
+    "proxy-authenticate"sv,
+    "proxy-authorization"sv,
+    "proxy-connection"sv,
+    "te"sv,
+    "trailer"sv,
+    "transfer-encoding"sv,
+    "upgrade"sv
+};
+
+// The prefix that aims a header at the far server of a third party copy.
+constexpr std::string_view transfer_header_prefix{"transferheader"};
+
+// The characters RFC 7230 permits in a header name.
+constexpr std::string_view tchar{
+    "!#$%&'*+-.^_`|~"
+    "0123456789"
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+};
+
+// The whitespace that may surround a header name or value.
+constexpr std::string_view ows{" \t"};
+
+// Returns `text` with any leading and trailing characters of `strip` removed.
+std::string_view trim(const std::string_view text, const std::string_view strip)
+{
+    const auto discard = [strip](const char c) {
+        return strip.find(c) != std::string_view::npos;
+    };
+
+    const auto first = std::find_if_not(text.begin(), text.end(), discard);
+    const auto last = std::find_if_not(text.rbegin(),
+        std::make_reverse_iterator(first), discard).base();
+
+    return text.substr(first - text.begin(), last - first);
+}
+
+} // namespace
+
+namespace XrdClHttp {
+namespace HeaderBuilder {
+
+bool
+IsForbiddenHeader(const std::string_view name)
+{
+    // A forbidden header stays forbidden when the TransferHeader prefix aims it
+    // at the far server of a third party copy, however often the prefix repeats.
+    std::string_view bare(name);
+    while (CompareIgnoreCase(bare.substr(0, transfer_header_prefix.size()), transfer_header_prefix)) {
+        bare.remove_prefix(transfer_header_prefix.size());
+    }
+
+    return std::find_if(forbidden_headers.begin(), forbidden_headers.end(), [bare](auto _sv) {
+        return CompareIgnoreCase(bare, _sv);
+    })
+        != forbidden_headers.end();
+}
+
+bool
+CompareIgnoreCase(const std::string_view lhs, const std::string_view rhs)
+{
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(),
+        [](const unsigned char a, const unsigned char b) {
+            return std::tolower(a) == std::tolower(b);
+        });
+}
+
+void
+AppendMissing(const HeaderList &extra, HeaderList &headers)
+{
+    for (const auto &header : extra) {
+        const auto present = std::any_of(headers.cbegin(), headers.cend(),
+            [&header](const auto &existing) {
+                return CompareIgnoreCase(existing.first, header.first);
+            });
+        if (!present) {
+            headers.emplace_back(header);
+        }
+    }
+}
+
+bool
+Build(const std::string_view spec, HeaderList &headers)
+{
+    XrdCl::Log *const log = XrdCl::DefaultEnv::GetLog();
+
+    // Walk the newline separated entries, reporting every unusable one so a user
+    // who wrote several mistakes sees them all at once.
+    // An empty specification simply yields no headers.
+    HeaderList requested;
+    bool usable = true;
+    for (auto pos = spec.begin(); pos != spec.end(); ) {
+        const auto eol = std::find(pos, spec.end(), '\n');
+
+        // A CRLF separator leaves the CR behind; drop it along with any padding.
+        const auto entry = trim(spec.substr(pos - spec.begin(), eol - pos), " \t\r");
+        pos = (eol == spec.end() ? eol : std::next(eol));
+
+        // Tolerate blank entries so a trailing newline is not an error.
+        if (entry.empty()) {
+            continue;
+        }
+
+        // The value may itself contain colons, so split on the first one only.
+        // Without a colon the entry carries no value, so the log can show the
+        // whole entry without showing a value the user keeps private.
+        const auto colon = entry.find(':');
+        if (colon == std::string_view::npos) {
+            log->Error(kLogXrdClHttp, "Requested header %s holds no colon;"
+                " each header must read \"<name>: <value>\"",
+                std::string(entry).c_str());
+            usable = false;
+            continue;
+        }
+
+        // The name must be a non-empty RFC 7230 token.
+        const std::string name(trim(entry.substr(0, colon), ows));
+        if (name.empty()) {
+            log->Error(kLogXrdClHttp, "Requested header holds no name before"
+                " its colon");
+            usable = false;
+            continue;
+        }
+        if (!std::all_of(name.begin(), name.end(), [](const char c) {
+                return tchar.find(c) != std::string_view::npos;
+            }))
+        {
+            log->Error(kLogXrdClHttp, "Requested header %s holds a name that"
+                " is not an HTTP token", name.c_str());
+            usable = false;
+            continue;
+        }
+        if (IsForbiddenHeader(name)) {
+            log->Error(kLogXrdClHttp, "Requested header %s must not be set by"
+                " the client", name.c_str());
+            usable = false;
+            continue;
+        }
+
+        // A newline separates entries and so cannot occur in a value, but an
+        // embedded carriage return would let one forge part of the request.
+        const auto value = trim(entry.substr(colon + 1), ows);
+        if (value.empty()) {
+            log->Error(kLogXrdClHttp, "Requested header %s holds no value",
+                name.c_str());
+            usable = false;
+            continue;
+        }
+        if (value.find('\r') != std::string_view::npos) {
+            log->Error(kLogXrdClHttp, "Requested header %s holds a carriage"
+                " return in its value", name.c_str());
+            usable = false;
+            continue;
+        }
+
+        requested.emplace_back(name, value);
+    }
+
+    if (!usable) {
+        return false;
+    }
+
+    if (requested.empty()) {
+        return true;
+    }
+
+    // Name the headers but never their values, which the user fills with whatever
+    // the endpoint understands.
+    std::string names;
+    for (const auto &header : requested) {
+        if (!names.empty()) names += ", ";
+        names += header.first;
+    }
+    log->Debug(kLogXrdClHttp, "Requested headers %s", names.c_str());
+
+    headers = std::move(requested);
+    return true;
+}
+
+} // namespace HeaderBuilder
+
+} // namespace XrdClHttp

--- a/src/XrdClHttp/XrdClHttpHeaderBuilder.hh
+++ b/src/XrdClHttp/XrdClHttpHeaderBuilder.hh
@@ -1,0 +1,44 @@
+#ifndef XRDCLHTTP_HEADERBUILDER_HH
+#define XRDCLHTTP_HEADERBUILDER_HH
+
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace XrdClHttp {
+
+// Builds the headers a client asks a request to carry.  The request is
+// described by the HttpHeaders environment setting, which xrdcp fills in from
+// its --header option.  These functions are the only place it is interpreted.
+namespace HeaderBuilder {
+
+using HeaderList = std::vector<std::pair<std::string, std::string>>;
+
+// Returns true if the named header must not be injected by the client.  A
+// forbidden name stays forbidden under the TransferHeader prefix, which aims a
+// header at the far server of a third party copy.
+[[nodiscard]] bool IsForbiddenHeader(std::string_view name);
+
+// Returns true if the two strings are the same, ignoring case.
+[[nodiscard]] bool CompareIgnoreCase(std::string_view lhs, std::string_view rhs);
+
+// Build into `headers` the headers `spec` asks for, replacing its contents.
+// `spec` is a newline separated list of "<name>: <value>" entries; callers pass
+// the user's input through verbatim.
+//
+// Returns false if any entry is malformed or names a forbidden header, in which
+// case the request must not be sent -- a dropped header changes what the
+// request asks for.  A rejected specification leaves `headers` empty.
+[[nodiscard]] bool Build(std::string_view spec, HeaderList &headers);
+
+// Append to `headers` each entry of `extra` whose name `headers` does not
+// already carry.  A request keeps the headers it built for itself: a requested
+// Range, Depth or Want-Digest would corrupt it.
+void AppendMissing(const HeaderList &extra, HeaderList &headers);
+
+} // namespace HeaderBuilder
+
+} // namespace XrdClHttp
+
+#endif // XRDCLHTTP_HEADERBUILDER_HH

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -19,6 +19,7 @@
 /******************************************************************************/
 
 #include "XrdClHttpOps.hh"
+#include "XrdClHttpHeaderBuilder.hh"
 #include "XrdClHttpResponses.hh"
 #include "XrdClHttpUtil.hh"
 #include "XrdClHttpWorker.hh"
@@ -232,6 +233,29 @@ CurlOperation::FinishSetup(CURL *curl)
     {
         InjectBearerToken(*m_parsed_url, m_headers_list, m_logger);
     }
+    
+    // The client asks every request to carry the headers given by the HttpHeaders
+    // environment setting.  HeaderBuilder interprets the contents.
+    std::string spec;
+    if (auto env = XrdCl::DefaultEnv::GetEnv()) {
+        env->GetString("HttpHeaders", spec);
+    }
+
+    if (!spec.empty()) {
+        // Refuse to send anything when the requested headers could not be understood;
+        // quietly omitting them changes what the request asks for.
+        //
+        // Fail here rather than leaving it to the caller, whose failure message for a
+        // setup error would suggest the wrong cause entirely.
+        HeaderList requested;
+        if (!HeaderBuilder::Build(spec, requested)) {
+            m_logger->Error(kLogXrdClHttp, "Not sending request to %s: the requested"
+                " headers could not be used", m_url.c_str());
+            Fail(XrdCl::errInvalidArgs, EINVAL, "Invalid header requested");
+            return false;
+        }
+        HeaderBuilder::AppendMissing(requested, m_headers_list);
+    }
 
     if (!m_header_callout) {
         m_header_slist.reset();
@@ -253,7 +277,7 @@ CurlOperation::FinishSetup(CURL *curl)
     }
     m_header_slist.reset();
     for (const auto &header : *extra_headers) {
-        if (!strcasecmp(header.first.c_str(), "Content-Length")) {
+        if (HeaderBuilder::CompareIgnoreCase(header.first, "Content-Length")) {
             auto upload_size = std::stoull(header.second);
             curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, upload_size);
             continue;

--- a/tests/end-to-end/CMakeLists.txt
+++ b/tests/end-to-end/CMakeLists.txt
@@ -13,4 +13,5 @@ function(add_bats_test name script)
 endfunction()
 
 add_subdirectory(cks)
+add_subdirectory(http)
 add_subdirectory(xrdfs)

--- a/tests/end-to-end/http/CMakeLists.txt
+++ b/tests/end-to-end/http/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(header)

--- a/tests/end-to-end/http/header/CMakeLists.txt
+++ b/tests/end-to-end/http/header/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_bats_test(XrdHttp::header-option option.bats)
+add_bats_test(XrdHttp::header-protocol protocol.bats)
+add_bats_test(XrdHttp::header-inject inject.bats)
+add_bats_test(XrdHttp::header-reject reject.bats)
+add_bats_test(XrdHttp::header-log log.bats)
+add_bats_test(XrdHttp::header-env env.bats)

--- a/tests/end-to-end/http/header/env.bats
+++ b/tests/end-to-end/http/header/env.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# $XRD_HTTPHEADERS is a second entry path that never passes through the xrdcp
+# command line, so the plug-in has to apply the same rules by itself
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../../helper/common.bash
+
+export XRD_PLUGINCONFDIR="$BATS_TEST_DIRNAME"
+
+HOST=http://localhost:9876
+ROOT=root://localhost:9876
+
+setup() {
+	# workdir as test tmp dir (all files are removed after execution)
+	cd $BATS_TEST_TMPDIR
+
+	PORT=9876 launch_xrootd header.cfg header
+
+	sleep 0.5
+
+	echo 'example file!' | xrdcp - $ROOT//examplefile
+}
+
+teardown() {
+    kill_pid_files
+}
+
+@test "XRD_HTTPHEADERS should succeed" {
+	XRD_HTTPHEADERS='X-Test-Header: env-value' run -0 xrdcp $HOST//examplefile -
+}
+
+@test "XRD_HTTPHEADERS should return the file contents" {
+	XRD_HTTPHEADERS='X-Test-Header: env-value' run xrdcp $HOST//examplefile -
+	assert_output 'example file!'
+}
+
+@test "XRD_HTTPHEADERS should be honoured" {
+	XRD_HTTPHEADERS='X-Test-Header: env-value' run xrdcp $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: X-Test-Header: env-value' header.log
+}
+
+@test "XRD_HTTPHEADERS naming a reserved header fails" {
+	XRD_HTTPHEADERS='Host: evil.example.com' run ! xrdcp $HOST//examplefile -
+}
+
+@test "XRD_HTTPHEADERS naming a reserved header should not send it" {
+	XRD_HTTPHEADERS='Host: evil.example.com' run xrdcp $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: Host: evil.example.com' header.log
+}
+
+@test "XRD_HTTPHEADERS that cannot be parsed fails" {
+	XRD_HTTPHEADERS='nocolon' run ! xrdcp $HOST//examplefile -
+}

--- a/tests/end-to-end/http/header/header.cfg
+++ b/tests/end-to-end/http/header/header.cfg
@@ -1,0 +1,31 @@
+set name = header
+set port = $PORT
+
+# temporary directory where all the tests in a file run
+set file = $BATS_FILE_TMPDIR
+
+# temporary directory where the test run
+set test = $BATS_TEST_TMPDIR
+
+# directory where the file.bats is located
+set dir  = $BATS_TEST_DIRNAME
+
+all.export /
+all.adminpath $test/$name
+all.pidpath   $test/$name
+oss.localroot $test/$name
+
+xrd.protocol XrdHttp:$port libXrdHttp.so
+
+all.sitename $name
+
+xrd.port $port
+
+# the request header lines are logged at debug level, which is what the tests
+# assert the injected headers against
+http.trace all
+
+all.trace    all
+ofs.trace    all
+oss.trace    all
+xrootd.trace all

--- a/tests/end-to-end/http/header/http_plugin.conf
+++ b/tests/end-to-end/http/header/http_plugin.conf
@@ -1,0 +1,3 @@
+url = http://*;https://*;dav://*;davs://*
+lib = libXrdClHttp.so
+enable = true

--- a/tests/end-to-end/http/header/inject.bats
+++ b/tests/end-to-end/http/header/inject.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+# a header given on the command line reaches the server
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../../helper/common.bash
+
+export XRD_PLUGINCONFDIR="$BATS_TEST_DIRNAME"
+
+HOST=http://localhost:9877
+ROOT=root://localhost:9877
+
+setup() {
+	# workdir as test tmp dir (all files are removed after execution)
+	cd $BATS_TEST_TMPDIR
+
+	PORT=9877 launch_xrootd header.cfg header
+
+	sleep 0.5
+
+	echo 'example file!' | xrdcp - $ROOT//examplefile
+}
+
+teardown() {
+    kill_pid_files
+}
+
+#
+# injecting a header on download
+#
+
+@test "download with an injected header should succeed" {
+	run -0 xrdcp -H 'X-Test-Header: e2e-value' $HOST//examplefile -
+}
+
+@test "download with an injected header should return the file contents" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $HOST//examplefile -
+	assert_output 'example file!'
+}
+
+@test "download with an injected header should send the header" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: X-Test-Header: e2e-value' header.log
+}
+
+@test "long form --header should succeed" {
+	run -0 xrdcp --header 'X-Test-Header: e2e-value' $HOST//examplefile -
+}
+
+@test "long form --header should send the header" {
+	run xrdcp --header 'X-Test-Header: e2e-value' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: X-Test-Header: e2e-value' header.log
+}
+
+@test "repeating --header should send the first header" {
+	run xrdcp --header 'X-First: one' --header 'X-Second: two' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: X-First: one' header.log
+}
+
+@test "repeating --header should send the second header" {
+	run xrdcp --header 'X-First: one' --header 'X-Second: two' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: X-Second: two' header.log
+}
+
+@test "a header value containing spaces and colons should be sent verbatim" {
+	run xrdcp -H 'X-Test-Header: a:b c:d' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: X-Test-Header: a:b c:d' header.log
+}
+
+# A user who holds a token has to be able to present it, so Authorization is the
+# caller's to set. The server log holds the name but redacts the credential, so
+# the tests below assert the name alone.
+
+@test "download with an injected Authorization header should succeed" {
+	run -0 xrdcp -H 'Authorization: Bearer e2e-token' $HOST//examplefile -
+}
+
+@test "download with an injected Authorization header should send the header" {
+	run xrdcp -H 'Authorization: Bearer e2e-token' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: Authorization:' header.log
+}
+
+@test "download with an injected TransferHeaderAuthorization header should succeed" {
+	run -0 xrdcp -H 'TransferHeaderAuthorization: Bearer e2e-token' $HOST//examplefile -
+}
+
+@test "download with an injected TransferHeaderAuthorization header should send the header" {
+	run xrdcp -H 'TransferHeaderAuthorization: Bearer e2e-token' $HOST//examplefile -
+	run -0 grep -F -- 'got hdr line: TransferHeaderAuthorization:' header.log
+}
+
+#
+# injecting a header on upload
+#
+
+@test "upload with an injected header should succeed" {
+	echo 'uploaded!' > localfile
+	run -0 xrdcp -H 'X-Test-Header: e2e-value' localfile $HOST//uploadedfile
+}
+
+@test "upload with an injected header should send the header" {
+	echo 'uploaded!' > localfile
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $HOST//uploadedfile
+	run -0 grep -F -- 'got hdr line: X-Test-Header: e2e-value' header.log
+}
+
+@test "upload with an injected header should store the file contents" {
+	echo 'uploaded!' > localfile
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $HOST//uploadedfile
+	assert_equal "$(cat header/uploadedfile)" 'uploaded!'
+}
+
+#
+# a transfer without --header, as the baseline the tests above are read against
+#
+
+@test "download without --header should return the file contents" {
+	run xrdcp $HOST//examplefile -
+	assert_output 'example file!'
+}
+
+@test "download without --header should not send the header" {
+	# the download has to succeed, otherwise the header is missing from the log
+	# only because no request was ever made
+	run -0 xrdcp $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: X-Test-Header' header.log
+}

--- a/tests/end-to-end/http/header/log.bats
+++ b/tests/end-to-end/http/header/log.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+# what the client log is allowed to say about a header, one message per fault
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../../helper/common.bash
+
+export XRD_PLUGINCONFDIR="$BATS_TEST_DIRNAME"
+
+HOST=http://localhost:9878
+
+setup() {
+	# workdir as test tmp dir (all files are removed after execution)
+	cd $BATS_TEST_TMPDIR
+}
+
+#
+# a header name reaches the log, a header value never does
+#
+
+# A reserved header is refused before any request is built, so neither its name
+# nor its value can reach the log.
+@test "a rejected credential should not be written to the client log" {
+	XRD_LOGLEVEL=Dump XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'Proxy-Authorization: Basic SUPERSECRETTOKEN' $HOST//examplefile -
+	run ! grep -F -- 'SUPERSECRETTOKEN' client.log
+}
+
+# An accepted credential is put in the request, and its value stays out of the
+# log even at the highest level.
+@test "an accepted credential should not be written to the client log" {
+	XRD_LOGLEVEL=Dump XRD_LOGFILE=client.log \
+		run xrdcp -H 'Authorization: Bearer SUPERSECRETTOKEN' $HOST//examplefile -
+	run ! grep -F -- 'SUPERSECRETTOKEN' client.log
+}
+
+# The name is reported so that a transfer can be told apart from one that sent
+# no header at all.
+@test "a header name should be written to the client log" {
+	XRD_LOGLEVEL=Dump XRD_LOGFILE=client.log \
+		run xrdcp -H 'X-Test-Header: e2e-value' $HOST//examplefile -
+	run -0 grep -F -- 'X-Test-Header' client.log
+}
+
+# The name of a refused header reaches the log, but its value never does.
+@test "a refused header should not write its value to the client log" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'Host: evil.example.com' $HOST//examplefile -
+	run ! grep -F -- 'evil.example.com' client.log
+}
+
+#
+# the message the client log holds for each fault
+#
+
+@test "a header without a separator should say the colon is missing" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'nocolon' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header nocolon holds no colon' client.log
+}
+
+@test "a header without a name should say the name is missing" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H ': novalue' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header holds no name before its colon' client.log
+}
+
+@test "a header with a space in the name should say the name is not a token" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'X Test: value' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header X Test holds a name that is not an HTTP token' client.log
+}
+
+@test "a header with a parenthesis in the name should say the name is not a token" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'X(Test): value' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header X(Test) holds a name that is not an HTTP token' client.log
+}
+
+@test "a reserved header should say the client must not set it" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'Host: evil.example.com' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header Host must not be set by the client' client.log
+}
+
+@test "a header without a value should say the value is missing" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'X-Test-Header:' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header X-Test-Header holds no value' client.log
+}
+
+@test "a header with a carriage return should say the value holds one" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H $'X-Test-Header: a\rEvil: b' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header X-Test-Header holds a carriage return in its value' client.log
+}
+
+# Every header is examined, so a command line with several mistakes reports each
+# of them instead of only the first.
+@test "two unusable headers should report the first one" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'nocolon' -H 'X-Test-Header:' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header nocolon holds no colon' client.log
+}
+
+@test "two unusable headers should report the second one" {
+	XRD_LOGLEVEL=Error XRD_LOGFILE=client.log \
+		run ! xrdcp -H 'nocolon' -H 'X-Test-Header:' $HOST//examplefile -
+	run -0 grep -F -- 'Requested header X-Test-Header holds no value' client.log
+}

--- a/tests/end-to-end/http/header/option.bats
+++ b/tests/end-to-end/http/header/option.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# the xrdcp option table, which the header argument never reaches
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../../helper/common.bash
+
+export XRD_PLUGINCONFDIR="$BATS_TEST_DIRNAME"
+
+#
+# the option takes a mandatory argument
+#
+
+@test "-H with no argument fails" {
+	run ! xrdcp -H
+}
+
+@test "--header with no argument fails" {
+	run ! xrdcp --header
+}
+
+#
+# options -H took over
+#
+
+@test "--license is still available after -H was reassigned" {
+	run xrdcp --license
+	assert_output --partial 'GNU Lesser General Public License'
+}

--- a/tests/end-to-end/http/header/protocol.bats
+++ b/tests/end-to-end/http/header/protocol.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+
+# the endpoints --header applies to: one side of the transfer must speak http
+# or https, in either direction
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../../helper/common.bash
+
+export XRD_PLUGINCONFDIR="$BATS_TEST_DIRNAME"
+
+HOST=http://localhost:9879
+HOSTS=https://localhost:9879
+ROOT=root://localhost:9879
+S3=s3://localhost:9879
+DAV=dav://localhost:9879
+DAVS=davs://localhost:9879
+
+# The endpoints are examined before any connection is made, so these tests need
+# no server. This is the message the command line check writes.
+REFUSAL="'--header' requires an http or https source or destination."
+
+setup() {
+	# workdir as test tmp dir (all files are removed after execution)
+	cd $BATS_TEST_TMPDIR
+
+	echo 'local file!' > localfile
+}
+
+#
+# a transfer that reaches no http or https endpoint
+#
+
+@test "--header on a root download fails" {
+	run ! xrdcp -H 'X-Test-Header: e2e-value' $ROOT//examplefile -
+}
+
+@test "--header on a root download should say an http endpoint is required" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $ROOT//examplefile -
+	assert_output --partial "$REFUSAL"
+}
+
+@test "--header on a root upload fails" {
+	run ! xrdcp -H 'X-Test-Header: e2e-value' localfile $ROOT//uploadedfile
+}
+
+@test "--header on a root upload should say an http endpoint is required" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $ROOT//uploadedfile
+	assert_output --partial "$REFUSAL"
+}
+
+@test "--header with a root source and a root destination fails" {
+	run ! xrdcp -H 'X-Test-Header: e2e-value' $ROOT//examplefile $ROOT//copiedfile
+}
+
+@test "--header with a root source and a root destination should say an http endpoint is required" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $ROOT//examplefile $ROOT//copiedfile
+	assert_output --partial "$REFUSAL"
+}
+
+@test "--header with a local source and destination fails" {
+	run ! xrdcp -H 'X-Test-Header: e2e-value' localfile localcopy
+}
+
+@test "--header with a local source and destination should say an http endpoint is required" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile localcopy
+	assert_output --partial "$REFUSAL"
+}
+
+#
+# a transfer that reaches an http or https endpoint. No server runs here, so
+# each transfer fails on the connection instead. What the tests assert is that
+# the endpoints themselves were accepted.
+#
+
+@test "--header on an http download should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $HOST//examplefile -
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on an http upload should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $HOST//uploadedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on an https download should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $HOSTS//examplefile -
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on an https upload should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $HOSTS//uploadedfile
+	refute_output --partial "$REFUSAL"
+}
+
+#
+# S3 speaks http under the hood, so it must be accepted like http and https.
+# No server runs here, so each transfer fails on the connection instead. What
+# the tests assert is that the endpoints themselves were accepted.
+#
+
+@test "--header on an s3 download should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $S3//examplefile -
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on an s3 upload should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $S3//uploadedfile
+	refute_output --partial "$REFUSAL"
+}
+
+#
+# dav and davs are the WebDAV aliases for http and https, so they must be
+# accepted the same way. No server runs here, so each transfer fails on the
+# connection instead. What the tests assert is that the endpoints themselves
+# were accepted.
+#
+
+@test "--header on a dav download should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $DAV//examplefile -
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a dav upload should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $DAV//uploadedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a davs download should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' $DAVS//examplefile -
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a davs upload should not be refused for its endpoints" {
+	run xrdcp -H 'X-Test-Header: e2e-value' localfile $DAVS//uploadedfile
+	refute_output --partial "$REFUSAL"
+}
+
+#
+# a third party copy, which the command line examines the same way. Both
+# endpoints are remote, so a local file takes no part here. The copy itself is
+# refused later, for a reason of its own, so each accepted case asserts the
+# endpoint check alone.
+#
+
+@test "--header on a root third party copy should say an http endpoint is required" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$ROOT//examplefile $ROOT//copiedfile
+	assert_output --partial "$REFUSAL"
+}
+
+@test "--header on an http third party copy should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$HOST//examplefile $HOST//copiedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on an https third party copy should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$HOSTS//examplefile $HOSTS//copiedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a third party copy from http to https should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$HOST//examplefile $HOSTS//copiedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a third party copy from https to http should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$HOSTS//examplefile $HOST//copiedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on an s3 third party copy should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$S3//examplefile $S3//copiedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a dav third party copy should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$DAV//examplefile $DAV//copiedfile
+	refute_output --partial "$REFUSAL"
+}
+
+@test "--header on a davs third party copy should not be refused for its endpoints" {
+	run xrdcp --tpc only -H 'X-Test-Header: e2e-value' \
+		$DAVS//examplefile $DAVS//copiedfile
+	refute_output --partial "$REFUSAL"
+}

--- a/tests/end-to-end/http/header/reject.bats
+++ b/tests/end-to-end/http/header/reject.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+
+# a header the client refuses fails the transfer and never reaches the server
+
+bats_require_minimum_version 1.5.0
+
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+
+load ../../helper/common.bash
+
+export XRD_PLUGINCONFDIR="$BATS_TEST_DIRNAME"
+
+HOST=http://localhost:9880
+
+setup() {
+	# workdir as test tmp dir (all files are removed after execution)
+	cd $BATS_TEST_TMPDIR
+}
+
+#
+# arguments that cannot be parsed as a header
+#
+
+@test "--header without a name and value separator fails" {
+	run ! xrdcp -H 'nocolon' $HOST//examplefile -
+}
+
+@test "--header without a name fails" {
+	run ! xrdcp -H ': novalue' $HOST//examplefile -
+}
+
+@test "--header without a value fails" {
+	run ! xrdcp -H 'X-Test-Header:' $HOST//examplefile -
+}
+
+@test "--header with a space in the name fails" {
+	run ! xrdcp -H 'X Test: value' $HOST//examplefile -
+}
+
+@test "--header with a parenthesis in the name fails" {
+	run ! xrdcp -H 'X(Test): value' $HOST//examplefile -
+}
+
+# A header that cannot be honoured must fail the transfer rather than quietly
+# sending a request without it, which for a credential would look like a denial.
+@test "an unusable header should not be silently dropped" {
+	run xrdcp -H 'nocolon' $HOST//examplefile -
+	assert_output --partial 'Invalid header requested'
+}
+
+#
+# arguments that try to forge a request
+#
+
+@test "--header with a carriage return in the value fails" {
+	run ! xrdcp -H $'X-Test-Header: a\rEvil: b' $HOST//examplefile -
+}
+
+@test "--header with a carriage return should not send the forged header" {
+	run xrdcp -H $'X-Test-Header: a\rEvil: b' $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: Evil: b' header.log
+}
+
+# A newline in the argument separates headers rather than forging one, and each
+# resulting header is validated in its own right.
+@test "--header with a newline cannot smuggle a reserved header" {
+	run ! xrdcp -H $'X-Test-Header: a\r\nHost: evil.example.com' $HOST//examplefile -
+}
+
+@test "--header with a newline should not send the smuggled header" {
+	run xrdcp -H $'X-Test-Header: a\r\nHost: evil.example.com' $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: Host: evil.example.com' header.log
+}
+
+@test "--header with a newline should not send the header preceding it" {
+	run xrdcp -H $'X-Test-Header: a\r\nHost: evil.example.com' $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: X-Test-Header: a' header.log
+}
+
+#
+# headers the request builds for itself and cannot have overridden
+#
+
+@test "--header naming Host fails" {
+	run ! xrdcp -H 'Host: evil.example.com' $HOST//examplefile -
+}
+
+@test "--header naming Transfer-Encoding fails" {
+	run ! xrdcp -H 'Transfer-Encoding: chunked' $HOST//examplefile -
+}
+
+@test "--header naming Content-Length fails" {
+	run ! xrdcp -H 'Content-Length: 0' $HOST//examplefile -
+}
+
+@test "--header naming Connection fails" {
+	run ! xrdcp -H 'Connection: close' $HOST//examplefile -
+}
+
+@test "a reserved header should reject the whole command line" {
+	run ! xrdcp -H 'X-Test-Header: e2e-value' -H 'Host: evil.example.com' \
+		$HOST//examplefile -
+}
+
+@test "a rejected command line should not send the reserved header" {
+	run xrdcp -H 'X-Test-Header: e2e-value' -H 'Host: evil.example.com' \
+		$HOST//examplefile -
+	run ! grep -F -- 'got hdr line: Host: evil.example.com' header.log
+}
+
+@test "a rejected command line should not send the accepted header either" {
+	run xrdcp -H 'X-Test-Header: e2e-value' -H 'Host: evil.example.com' \
+		$HOST//examplefile -
+	run ! grep -F -- 'got hdr line: X-Test-Header: e2e-value' header.log
+}
+
+#
+# the same headers aimed at the far server of a third party copy, which the
+# TransferHeader prefix must not let through
+#
+
+@test "--header naming TransferHeaderHost fails" {
+	run ! xrdcp -H 'TransferHeaderHost: evil.example.com' $HOST//examplefile -
+}
+
+@test "--header naming TransferHeaderTransfer-Encoding fails" {
+	run ! xrdcp -H 'TransferHeaderTransfer-Encoding: chunked' $HOST//examplefile -
+}
+
+@test "--header naming TransferHeaderContent-Length fails" {
+	run ! xrdcp -H 'TransferHeaderContent-Length: 0' $HOST//examplefile -
+}
+
+@test "--header naming TransferHeaderConnection fails" {
+	run ! xrdcp -H 'TransferHeaderConnection: close' $HOST//examplefile -
+}
+
+@test "a reserved TransferHeader should reject the whole command line" {
+	run ! xrdcp -H 'X-Test-Header: e2e-value' \
+		-H 'TransferHeaderHost: evil.example.com' $HOST//examplefile -
+}
+
+@test "a rejected command line should not send the reserved TransferHeader" {
+	run xrdcp -H 'X-Test-Header: e2e-value' \
+		-H 'TransferHeaderHost: evil.example.com' $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: TransferHeaderHost: evil.example.com' header.log
+}
+
+@test "a command line rejected for a TransferHeader should not send the accepted header either" {
+	run xrdcp -H 'X-Test-Header: e2e-value' \
+		-H 'TransferHeaderHost: evil.example.com' $HOST//examplefile -
+	run ! grep -F -- 'got hdr line: X-Test-Header: e2e-value' header.log
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -2,3 +2,4 @@ add_subdirectory(example)
 
 add_subdirectory(XrdCks)
 add_subdirectory(XrdOuc)
+add_subdirectory(XrdClHttp)

--- a/tests/unit/XrdClHttp/CMakeLists.txt
+++ b/tests/unit/XrdClHttp/CMakeLists.txt
@@ -1,0 +1,24 @@
+# XrdClHttpObj only exists when libcurl was found
+if(NOT TARGET XrdClHttpObj)
+  return()
+endif()
+
+add_executable(xrdclhttp-tests-unit
+        HeaderBuilderAppendMissingTest.cc
+        HeaderBuilderEntrySeparationTest.cc
+        HeaderBuilderForbiddenEntryTest.cc
+        HeaderBuilderForbiddenHeaderTest.cc
+        HeaderBuilderParsingTest.cc
+        )
+
+target_include_directories(xrdclhttp-tests-unit PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(xrdclhttp-tests-unit
+        XrdClHttpObj
+        GTest::gmock
+        GTest::gtest
+        GTest::gtest_main
+        )
+
+gtest_discover_tests(xrdclhttp-tests-unit
+        PROPERTIES DISCOVERY_TIMEOUT 10)

--- a/tests/unit/XrdClHttp/HeaderBuilderAppendMissingTest.cc
+++ b/tests/unit/XrdClHttp/HeaderBuilderAppendMissingTest.cc
@@ -1,0 +1,82 @@
+#include "HeaderBuilderFixture.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace XrdClHttp;
+
+using testing::Contains;
+using testing::ElementsAre;
+using testing::Pair;
+using testing::SizeIs;
+
+namespace {
+
+class AppendMissing : public HeaderBuilderFixture {};
+
+} // namespace
+
+/******************************************************************************/
+/*                          A p p e n d M i s s i n g                         */
+/******************************************************************************/
+
+// A requested header must never displace one the request set for itself; a
+// requested Range would otherwise corrupt a read.
+TEST_F(AppendMissing, ARequestHeaderIsNotDisplaced)
+{
+    headers.emplace_back("Range", "bytes=0-1023");
+
+    HeaderBuilder::AppendMissing({{"Range", "bytes=999-"}}, headers);
+    EXPECT_THAT(headers, Contains(Pair("Range", "bytes=0-1023")));
+}
+
+// Only one Range must be present, or curl would send both.
+TEST_F(AppendMissing, ARequestHeaderIsNotDuplicated)
+{
+    headers.emplace_back("Range", "bytes=0-1023");
+
+    HeaderBuilder::AppendMissing({{"Range", "bytes=999-"}}, headers);
+    EXPECT_THAT(headers, SizeIs(1));
+}
+
+// Dropping the duplicate must not cost the other entries their place.
+TEST_F(AppendMissing, ADroppedDuplicateStillLeavesTheOtherEntries)
+{
+    headers.emplace_back("Range", "bytes=0-1023");
+
+    HeaderBuilder::AppendMissing({{"Range", "bytes=999-"}, {"X-Test-Header", "value"}}, headers);
+    EXPECT_THAT(headers, Contains(Pair("X-Test-Header", "value")));
+}
+
+TEST_F(AppendMissing, ADuplicateDifferingInCaseIsNotAdded)
+{
+    headers.emplace_back("X-Test", "original");
+
+    HeaderBuilder::AppendMissing({{"x-TEST", "replacement"}}, headers);
+    EXPECT_THAT(headers, SizeIs(1));
+}
+
+TEST_F(AppendMissing, ADuplicateDifferingInCaseKeepsTheRequestValue)
+{
+    headers.emplace_back("X-Test", "original");
+
+    HeaderBuilder::AppendMissing({{"x-TEST", "replacement"}}, headers);
+    EXPECT_THAT(headers, Contains(Pair("X-Test", "original")));
+}
+
+TEST_F(AppendMissing, AnUnrelatedNameIsAppended)
+{
+    headers.emplace_back("Range", "bytes=0-1023");
+
+    HeaderBuilder::AppendMissing({{"X-Test-Header", "value"}}, headers);
+    EXPECT_THAT(headers, ElementsAre(Pair("Range", "bytes=0-1023"),
+                                     Pair("X-Test-Header", "value")));
+}
+
+TEST_F(AppendMissing, NothingToAppendLeavesTheHeadersUnchanged)
+{
+    headers.emplace_back("Range", "bytes=0-1023");
+
+    HeaderBuilder::AppendMissing({}, headers);
+    EXPECT_THAT(headers, ElementsAre(Pair("Range", "bytes=0-1023")));
+}

--- a/tests/unit/XrdClHttp/HeaderBuilderEntrySeparationTest.cc
+++ b/tests/unit/XrdClHttp/HeaderBuilderEntrySeparationTest.cc
@@ -1,0 +1,108 @@
+#include "HeaderBuilderFixture.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace XrdClHttp;
+
+using testing::Contains;
+using testing::ElementsAre;
+using testing::Pair;
+
+namespace {
+
+class EntrySeparation : public HeaderBuilderFixture {};
+
+} // namespace
+
+/******************************************************************************/
+/*                B u i l d :  e n t r y  s e p a r a t i o n                 */
+/******************************************************************************/
+
+TEST_F(EntrySeparation, TheFirstOfSeveralEntriesIsAdded)
+{
+    const std::string spec{"X-First: one\nX-Second: two\nX-Third: three"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, Contains(Pair("X-First", "one")));
+}
+
+TEST_F(EntrySeparation, AMiddleEntryIsAdded)
+{
+    const std::string spec{"X-First: one\nX-Second: two\nX-Third: three"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, Contains(Pair("X-Second", "two")));
+}
+
+TEST_F(EntrySeparation, TheLastOfSeveralEntriesIsAdded)
+{
+    const std::string spec{"X-First: one\nX-Second: two\nX-Third: three"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, Contains(Pair("X-Third", "three")));
+}
+
+// Blank entries are tolerated so that padding a specification is not an error.
+
+TEST_F(EntrySeparation, ALeadingBlankEntryIsSkipped)
+{
+    const std::string spec{"\nX-Test: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+TEST_F(EntrySeparation, AnEmbeddedBlankEntryIsSkipped)
+{
+    const std::string spec{"X-First: one\n\nX-Second: two"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-First", "one"), Pair("X-Second", "two")));
+}
+
+TEST_F(EntrySeparation, ATrailingBlankEntryIsSkipped)
+{
+    const std::string spec{"X-Test: value\n"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+// A newline separates entries, so it cannot appear inside a value; a bare
+// carriage return could otherwise forge part of the request.
+TEST_F(EntrySeparation, ACarriageReturnInAValueIsRejected)
+{
+    const std::string spec{"X-Test: a\rEvil: b"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+// A CRLF is the wire form of the separator, so it yields two entries.
+
+TEST_F(EntrySeparation, ACrlfEndsTheEntryBeforeIt)
+{
+    const std::string spec{"X-Test: a\r\nX-Other: b"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, Contains(Pair("X-Test", "a")));
+}
+
+TEST_F(EntrySeparation, ACrlfStartsTheEntryAfterIt)
+{
+    const std::string spec{"X-Test: a\r\nX-Other: b"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, Contains(Pair("X-Other", "b")));
+}
+
+// Each entry a CRLF yields is validated in its own right, which is what stops a
+// reserved header sneaking in behind one.
+TEST_F(EntrySeparation, AForbiddenEntryAfterACrlfIsRejected)
+{
+    const std::string spec{"X-Test: a\r\nHost: evil"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}

--- a/tests/unit/XrdClHttp/HeaderBuilderFixture.hh
+++ b/tests/unit/XrdClHttp/HeaderBuilderFixture.hh
@@ -1,0 +1,15 @@
+#ifndef XRDCLHTTP_HEADERBUILDERFIXTURE_HH
+#define XRDCLHTTP_HEADERBUILDERFIXTURE_HH
+
+#include "XrdClHttp/XrdClHttpHeaderBuilder.hh"
+
+#include <gtest/gtest.h>
+
+// Each test states the headers it asks for the way xrdcp does for its --header
+// option: a newline separated specification, handed to the builder verbatim.
+class HeaderBuilderFixture : public testing::Test {
+protected:
+    XrdClHttp::HeaderBuilder::HeaderList headers;
+};
+
+#endif

--- a/tests/unit/XrdClHttp/HeaderBuilderForbiddenEntryTest.cc
+++ b/tests/unit/XrdClHttp/HeaderBuilderForbiddenEntryTest.cc
@@ -1,0 +1,194 @@
+#include "HeaderBuilderFixture.hh"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace XrdClHttp;
+
+namespace {
+
+class ForbiddenEntry : public HeaderBuilderFixture {};
+
+} // namespace
+
+/******************************************************************************/
+/*                 B u i l d :  f o r b i d d e n  e n t r y                  */
+/******************************************************************************/
+
+TEST_F(ForbiddenEntry, AConnectionEntryIsRejected)
+{
+    const std::string spec{"connection: close"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AConnectionEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Connection: close"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AContentLengthEntryIsRejected)
+{
+    const std::string spec{"content-length: 0"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AContentLengthEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Content-Length: 0"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AnExpectEntryIsRejected)
+{
+    const std::string spec{"expect: 100-continue"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AnExpectEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Expect: 100-continue"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AHostEntryIsRejected)
+{
+    const std::string spec{"host: evil.example.com"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AHostEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Host: evil.example.com"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AKeepAliveEntryIsRejected)
+{
+    const std::string spec{"keep-alive: timeout=5"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AKeepAliveEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Keep-Alive: timeout=5"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AProxyAuthenticateEntryIsRejected)
+{
+    const std::string spec{"proxy-authenticate: Basic"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AProxyAuthenticateEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Proxy-Authenticate: Basic"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AProxyAuthorizationEntryIsRejected)
+{
+    const std::string spec{"proxy-authorization: Basic dXNlcg=="};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AProxyAuthorizationEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Proxy-Authorization: Basic dXNlcg=="};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AProxyConnectionEntryIsRejected)
+{
+    const std::string spec{"proxy-connection: close"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AProxyConnectionEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Proxy-Connection: close"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, ATeEntryIsRejected)
+{
+    const std::string spec{"te: trailers"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, ATeEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"TE: trailers"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, ATrailerEntryIsRejected)
+{
+    const std::string spec{"trailer: Expires"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, ATrailerEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Trailer: Expires"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, ATransferEncodingEntryIsRejected)
+{
+    const std::string spec{"transfer-encoding: chunked"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, ATransferEncodingEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Transfer-Encoding: chunked"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AnUpgradeEntryIsRejected)
+{
+    const std::string spec{"upgrade: websocket"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(ForbiddenEntry, AnUpgradeEntryIsRejectedWhenCapitalized)
+{
+    const std::string spec{"Upgrade: websocket"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+// A forbidden entry must reject the whole request rather than silently dropping
+// the offending header and sending the rest.
+TEST_F(ForbiddenEntry, AForbiddenEntryRejectsTheWholeRequest)
+{
+    const std::string spec{"X-Good: value\nHost: evil.example.com\nX-Also-Good: value"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}

--- a/tests/unit/XrdClHttp/HeaderBuilderForbiddenHeaderTest.cc
+++ b/tests/unit/XrdClHttp/HeaderBuilderForbiddenHeaderTest.cc
@@ -1,0 +1,273 @@
+#include "XrdClHttp/XrdClHttpHeaderBuilder.hh"
+
+#include <gtest/gtest.h>
+
+using namespace XrdClHttp;
+
+/******************************************************************************/
+/*                     I s F o r b i d d e n H e a d e r                      */
+/******************************************************************************/
+
+TEST(IsForbiddenHeader, ConnectionIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("connection"));
+}
+
+TEST(IsForbiddenHeader, ConnectionIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Connection"));
+}
+
+TEST(IsForbiddenHeader, ContentLengthIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("content-length"));
+}
+
+TEST(IsForbiddenHeader, ContentLengthIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Content-Length"));
+}
+
+TEST(IsForbiddenHeader, ExpectIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("expect"));
+}
+
+TEST(IsForbiddenHeader, ExpectIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Expect"));
+}
+
+TEST(IsForbiddenHeader, HostIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("host"));
+}
+
+TEST(IsForbiddenHeader, HostIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Host"));
+}
+
+TEST(IsForbiddenHeader, KeepAliveIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("keep-alive"));
+}
+
+TEST(IsForbiddenHeader, KeepAliveIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Keep-Alive"));
+}
+
+TEST(IsForbiddenHeader, ProxyAuthenticateIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("proxy-authenticate"));
+}
+
+TEST(IsForbiddenHeader, ProxyAuthenticateIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Proxy-Authenticate"));
+}
+
+TEST(IsForbiddenHeader, ProxyAuthorizationIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("proxy-authorization"));
+}
+
+TEST(IsForbiddenHeader, ProxyAuthorizationIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Proxy-Authorization"));
+}
+
+TEST(IsForbiddenHeader, ProxyConnectionIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("proxy-connection"));
+}
+
+TEST(IsForbiddenHeader, ProxyConnectionIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Proxy-Connection"));
+}
+
+TEST(IsForbiddenHeader, TeIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("te"));
+}
+
+TEST(IsForbiddenHeader, TeIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TE"));
+}
+
+TEST(IsForbiddenHeader, TrailerIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("trailer"));
+}
+
+TEST(IsForbiddenHeader, TrailerIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Trailer"));
+}
+
+TEST(IsForbiddenHeader, TransferEncodingIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("transfer-encoding"));
+}
+
+TEST(IsForbiddenHeader, TransferEncodingIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Transfer-Encoding"));
+}
+
+TEST(IsForbiddenHeader, UpgradeIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("upgrade"));
+}
+
+TEST(IsForbiddenHeader, UpgradeIsForbiddenWhenCapitalized)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("Upgrade"));
+}
+
+TEST(IsForbiddenHeader, ACustomHeaderIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("X-Test-Header"));
+}
+
+// A user who holds a token has to be able to present it, so Authorization is
+// the caller's to set, on the near server and on the far one alike.
+
+TEST(IsForbiddenHeader, AuthorizationIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("authorization"));
+}
+
+TEST(IsForbiddenHeader, AuthorizationIsAllowedWhenCapitalized)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("Authorization"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderAuthorizationIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("transferheaderauthorization"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderAuthorizationIsAllowedWhenCapitalized)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("TransferHeaderAuthorization"));
+}
+
+// The TransferHeader prefix aims a header at the far server of a third party
+// copy, and so must not let a forbidden header through.
+
+TEST(IsForbiddenHeader, TransferHeaderConnectionIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderConnection"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderContentLengthIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderContent-Length"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderExpectIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderExpect"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderHostIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderHost"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderKeepAliveIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderKeep-Alive"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderProxyAuthenticateIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderProxy-Authenticate"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderProxyAuthorizationIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderProxy-Authorization"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderProxyConnectionIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderProxy-Connection"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderTeIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderTE"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderTrailerIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderTrailer"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderTransferEncodingIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderTransfer-Encoding"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderUpgradeIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderUpgrade"));
+}
+
+TEST(IsForbiddenHeader, ARepeatedTransferHeaderPrefixOnAForbiddenNameIsForbidden)
+{
+    EXPECT_TRUE(HeaderBuilder::IsForbiddenHeader("TransferHeaderTransferHeaderHost"));
+}
+
+TEST(IsForbiddenHeader, TransferHeaderOnACustomHeaderIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("TransferHeaderX-Test-Header"));
+}
+
+TEST(IsForbiddenHeader, TheTransferHeaderPrefixAloneIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("TransferHeader"));
+}
+
+TEST(IsForbiddenHeader, RangeIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("Range"));
+}
+
+TEST(IsForbiddenHeader, WantDigestIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("Want-Digest"));
+}
+
+// The match must be on the whole name; a header that merely contains a
+// forbidden one is perfectly legitimate.
+
+TEST(IsForbiddenHeader, ANameEndingInAForbiddenOneIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("X-Host"));
+}
+
+TEST(IsForbiddenHeader, ANameStartingWithAForbiddenOneIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("Hostname"));
+}
+
+TEST(IsForbiddenHeader, ANameExtendingAForbiddenOneIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("Content-Length-Hint"));
+}
+
+TEST(IsForbiddenHeader, ANamePrefixingAForbiddenOneIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader("Not-Connection"));
+}
+
+TEST(IsForbiddenHeader, AnEmptyNameIsAllowed)
+{
+    EXPECT_FALSE(HeaderBuilder::IsForbiddenHeader(""));
+}

--- a/tests/unit/XrdClHttp/HeaderBuilderParsingTest.cc
+++ b/tests/unit/XrdClHttp/HeaderBuilderParsingTest.cc
@@ -1,0 +1,317 @@
+#include "HeaderBuilderFixture.hh"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace XrdClHttp;
+
+using testing::ElementsAre;
+using testing::IsEmpty;
+using testing::Pair;
+
+namespace {
+
+class HeaderParsing : public HeaderBuilderFixture {};
+
+} // namespace
+
+/******************************************************************************/
+/*                      B u i l d :  p a r s i n g                            */
+/******************************************************************************/
+
+TEST_F(HeaderParsing, ARequestedHeaderIsAdded)
+{
+    const std::string spec{"X-Test-Header: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test-Header", "value")));
+}
+
+// A user who holds a token has to be able to present it, so an Authorization
+// entry is built like any other, for the near server and for the far one.
+
+TEST_F(HeaderParsing, AnAuthorizationEntryIsAdded)
+{
+    const std::string spec{"Authorization: Bearer token"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("Authorization", "Bearer token")));
+}
+
+TEST_F(HeaderParsing, ATransferHeaderAuthorizationEntryIsAdded)
+{
+    const std::string spec{"TransferHeaderAuthorization: Bearer token"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers,
+        ElementsAre(Pair("TransferHeaderAuthorization", "Bearer token")));
+}
+
+TEST_F(HeaderParsing, TheColonNeedNotBeFollowedByASpace)
+{
+    const std::string spec{"X-Test:value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+TEST_F(HeaderParsing, WhitespaceBeforeTheNameIsTrimmed)
+{
+    const std::string spec{" \t X-Test: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+TEST_F(HeaderParsing, WhitespaceAfterTheNameIsTrimmed)
+{
+    const std::string spec{"X-Test \t : value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+TEST_F(HeaderParsing, WhitespaceBeforeTheValueIsTrimmed)
+{
+    const std::string spec{"X-Test: \t value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+TEST_F(HeaderParsing, WhitespaceAfterTheValueIsTrimmed)
+{
+    const std::string spec{"X-Test: value \t "};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "value")));
+}
+
+// Only the first colon separates, so the rest of the entry is the value.
+TEST_F(HeaderParsing, AValueMayContainAColon)
+{
+    const std::string spec{"X-Test: a:b"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "a:b")));
+}
+
+TEST_F(HeaderParsing, AValueMayContainASpace)
+{
+    const std::string spec{"X-Test: a b"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Test", "a b")));
+}
+
+// A name is an RFC 7230 token, so each of the characters below belongs in one.
+
+TEST_F(HeaderParsing, ADigitIsAcceptedInAName)
+{
+    const std::string spec{"X1Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X1Y", "value")));
+}
+
+TEST_F(HeaderParsing, AnExclamationMarkIsAcceptedInAName)
+{
+    const std::string spec{"X!Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X!Y", "value")));
+}
+
+TEST_F(HeaderParsing, AHashIsAcceptedInAName)
+{
+    const std::string spec{"X#Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X#Y", "value")));
+}
+
+TEST_F(HeaderParsing, ADollarSignIsAcceptedInAName)
+{
+    const std::string spec{"X$Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X$Y", "value")));
+}
+
+TEST_F(HeaderParsing, APercentSignIsAcceptedInAName)
+{
+    const std::string spec{"X%Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X%Y", "value")));
+}
+
+TEST_F(HeaderParsing, AnAmpersandIsAcceptedInAName)
+{
+    const std::string spec{"X&Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X&Y", "value")));
+}
+
+TEST_F(HeaderParsing, AnApostropheIsAcceptedInAName)
+{
+    const std::string spec{"X'Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X'Y", "value")));
+}
+
+TEST_F(HeaderParsing, AnAsteriskIsAcceptedInAName)
+{
+    const std::string spec{"X*Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X*Y", "value")));
+}
+
+TEST_F(HeaderParsing, APlusSignIsAcceptedInAName)
+{
+    const std::string spec{"X+Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X+Y", "value")));
+}
+
+TEST_F(HeaderParsing, AHyphenIsAcceptedInAName)
+{
+    const std::string spec{"X-Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X-Y", "value")));
+}
+
+TEST_F(HeaderParsing, APeriodIsAcceptedInAName)
+{
+    const std::string spec{"X.Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X.Y", "value")));
+}
+
+TEST_F(HeaderParsing, ACaretIsAcceptedInAName)
+{
+    const std::string spec{"X^Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X^Y", "value")));
+}
+
+TEST_F(HeaderParsing, AnUnderscoreIsAcceptedInAName)
+{
+    const std::string spec{"X_Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X_Y", "value")));
+}
+
+TEST_F(HeaderParsing, ABackquoteIsAcceptedInAName)
+{
+    const std::string spec{"X`Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X`Y", "value")));
+}
+
+TEST_F(HeaderParsing, AVerticalBarIsAcceptedInAName)
+{
+    const std::string spec{"X|Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X|Y", "value")));
+}
+
+TEST_F(HeaderParsing, ATildeIsAcceptedInAName)
+{
+    const std::string spec{"X~Y: value"};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, ElementsAre(Pair("X~Y", "value")));
+}
+
+TEST_F(HeaderParsing, AnEmptySpecificationYieldsNoHeaders)
+{
+    const std::string spec{""};
+
+    ASSERT_TRUE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, IsEmpty());
+}
+
+/******************************************************************************/
+/*                B u i l d :  m a l f o r m e d  e n t r y                   */
+/******************************************************************************/
+
+TEST_F(HeaderParsing, AnEntryWithoutAColonIsRejected)
+{
+    const std::string spec{"nocolon"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(HeaderParsing, AnEntryWithoutANameIsRejected)
+{
+    const std::string spec{": value"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(HeaderParsing, AnEntryWithoutAValueIsRejected)
+{
+    const std::string spec{"X-Test:"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(HeaderParsing, AnEntryWithABlankValueIsRejected)
+{
+    const std::string spec{"X-Test:   "};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+// A name is an RFC 7230 token, so none of the characters below belongs in one.
+
+TEST_F(HeaderParsing, ASpaceIsRejectedInAName)
+{
+    const std::string spec{"X Y: value"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(HeaderParsing, ATabIsRejectedInAName)
+{
+    const std::string spec{"X\tY: value"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(HeaderParsing, AParenthesisIsRejectedInAName)
+{
+    const std::string spec{"X(Y: value"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+TEST_F(HeaderParsing, AQuoteIsRejectedInAName)
+{
+    const std::string spec{"X\"Y: value"};
+
+    EXPECT_FALSE(HeaderBuilder::Build(spec, headers));
+}
+
+// Rejection must not leave a half-built list behind for a caller that ignores
+// the return value.
+TEST_F(HeaderParsing, RejectionYieldsNoRequestedHeaders)
+{
+    const std::string spec{"X-Good: value\nnocolon"};
+
+    ASSERT_FALSE(HeaderBuilder::Build(spec, headers));
+    EXPECT_THAT(headers, IsEmpty());
+}


### PR DESCRIPTION
This PR adds `--header` functionality, allowing HTTP(S) headers to be injected into HTTP(S) transfers. Injected headers are supported only for HTTP(S) connections.

A blacklist filter is also implemented to prevent the injection of specific sensitive headers. All injected headers are appended to the end of the existing header list, ensuring that they do not replace headers added through other mechanisms.

This PR also repurposes the `-H` option, which was previously used to display the license, to maintain compatibility with `curl`.

Assisted-By: Claude Sonnet 5 <noreply@anthropic.com>