### PR TITLE
[XrdHttpTpc] Fix the flush of the destination file in multistream mode

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcMultistream.cc
@@ -124,23 +124,18 @@ public:
         return current_offset;
     }
 
-    // Flush every stream to the local filesystem.  Returns State::errNone and
-    // leaves error_msg untouched if all the streams could be flushed; otherwise
-    // returns the error code of the first failure encountered and sets error_msg
-    // to the corresponding error message.
+    // Flush the file to the local filesystem.  All the states share the same
+    // underlying stream, hence a single flush is enough -- and required: a
+    // second one would be a no-op at best.  Returns State::errNone and leaves
+    // error_msg untouched on success; otherwise returns State::errFlush and sets
+    // error_msg to the corresponding error message.
     int Flush(std::string &error_msg) {
-        int error_code = State::errNone;
-        for (std::vector<State*>::iterator state_it = m_states.begin();
-             state_it != m_states.end();
-             state_it++)
-        {
-            if (((*state_it)->Flush() == -1) && !error_code) {
-                error_code = State::errFlush;
-                error_msg = (*state_it)->GetFinalizeErrorMessage();
-                if (error_msg.empty()) {error_msg = "(no error message provided)";}
-            }
+        if (m_states.empty() || (m_states[0]->Flush() != -1)) {
+            return State::errNone;
         }
-        return error_code;
+        error_msg = m_states[0]->GetFinalizeErrorMessage();
+        if (error_msg.empty()) {error_msg = "(no error message provided)";}
+        return State::errFlush;
     }
 
     off_t BytesTransferred() const {

--- a/src/XrdHttpTpc/XrdHttpTpcState.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcState.cc
@@ -230,13 +230,11 @@ int State::Flush() {
         return 0;
     }
 
-    ssize_t retval = m_stream->Write(m_start_offset + m_offset, 0, 0, true);
-    if (retval == SFS_ERROR) {
+    if (m_stream->Flush() == SFS_ERROR) {
         RecordFinalizeError(errFlush, m_stream->GetErrorMessage());
         return -1;
     }
-    m_offset += retval;
-    return retval;
+    return 0;
 }
 
 size_t State::ReadCB(void *buffer, size_t size, size_t nitems, void *userdata) {

--- a/src/XrdHttpTpc/XrdHttpTpcStream.hh
+++ b/src/XrdHttpTpc/XrdHttpTpcStream.hh
@@ -54,6 +54,20 @@ public:
     // the error code and error message for the stream
     ssize_t Write(off_t offset, const char *buffer, size_t size, bool force);
 
+    // Force the data still held in the re-ordering buffers out to the underlying
+    // file handle, even if it results in unaligned or short writes.  Typically
+    // only done while shutting down the transfer.
+    //
+    // The flush is deliberately issued at the current offset of the stream: the
+    // offset a given transfer state stopped at is not necessarily the offset the
+    // stream has been written up to.  In the multistream case, all the states
+    // share this stream, and all but the one that happened to serve the last
+    // range end up before it -- flushing at their offset would be rejected as a
+    // write to a prior offset.
+    //
+    // Returns 0 on success; SFS_ERROR on failure.
+    ssize_t Flush() {return Write(m_offset, nullptr, 0, true);}
+
     size_t AvailableBuffers() const {return m_avail_count;}
 
     void DumpBuffers() const;

--- a/tests/TPCTests/test.sh
+++ b/tests/TPCTests/test.sh
@@ -41,6 +41,16 @@ function assert_eq() {
   [[ "$1" == "$2" ]] || error "$3: expected $1 but received $2"
 }
 
+# Assert that the last COPY performed by perform_http_tpc() reported a success.
+# The HTTP status code is not enough: the destination server answers 201 as soon
+# as it starts the transfer, and reports the outcome in the last chunk of the
+# response body, as "success: ..." or "failure: ...".
+# $1 is the error message
+function assert_tpc_success() {
+  grep -q "^success" "${TPC_RESPONSE_BODY}" ||
+    error "$1: $(tr '\n' ' ' < "${TPC_RESPONSE_BODY}")"
+}
+
 # shellcheck disable=SC2317
 function assert_failure() {
 	echo "$@"; "$@" && error "command \"$*\" did not fail";
@@ -64,6 +74,25 @@ declare -a hosts_abbrev=(
     "srv2"
 )
 
+# Files used by the multistream HTTP TPC tests.  Both sizes are transferred on
+# purpose: one below the 16 MB block size of the multistream code, so that data
+# is still held in the re-ordering buffers when the transfer ends, and one that
+# is an exact multiple of it, in which case everything has already been written
+# out by the time the last range completes.
+declare -a multistream_suffixes=(
+    "_multistream_small"
+    "_multistream_aligned"
+)
+
+declare -a multistream_sizes=(
+    $((1024 * 1024))
+    $((32 * 1024 * 1024))
+)
+
+# Number of streams requested from the destination server.  Anything above 1
+# makes it take the multistream code path.
+MULTISTREAM_STREAMS=4
+
 setup_scitokens() {
 	if ! ${XRDSCITOKENS_CREATE_TOKEN} "${XRDSCITOKENS_ISSUER_DIR}"/issuer_pub_1.pem "${XRDSCITOKENS_ISSUER_DIR}"/issuer_key_1.pem test_1 \
 		"https://localhost:7095/issuer/one" "storage.modify:/ storage.create:/ storage.read:/" 1800 > "${PWD}/generated_tokens/token"; then
@@ -76,11 +105,19 @@ setup_scitokens() {
 # Cleanup function
 # shellcheck disable=SC2317
 cleanup() {
-    ## Cleanup empty files
+    ## Cleanup multistream files
     src_idx=0
     dst_idx=1
     src=${hosts_abbrev[${src_idx}]}
     dst=${hosts_abbrev[${dst_idx}]}
+    for suffix in "${multistream_suffixes[@]}"; do
+        rm "${LCLDATADIR}/${src}${suffix}.ref" || :
+        rm "${LCLDATADIR}/${src}_to_${dst}${suffix}.dat_http_pull" || :
+        ${XRDFS} "${hosts[$src_idx]}" rm "${RMTDATADIR}/${src}${suffix}.ref" || :
+        ${XRDFS} "${hosts[$dst_idx]}" rm "${RMTDATADIR}/${src}_to_${dst}${suffix}.ref_http_pull" || :
+    done
+
+    ## Cleanup empty files
     rm "${LCLDATADIR}/${src}_empty.dat" || :
     rm "${LCLDATADIR}/${src}_empty.ref" || :
     ${XRDFS} "${hosts[$src_idx]}" rm "${RMTDATADIR}/${src}_empty.ref" || :
@@ -112,6 +149,7 @@ cleanup() {
     done
 
     rmdir "${LCLDATADIR}" || :
+    rm "${TPC_RESPONSE_BODY}" || :
 }
 trap "cleanup" ERR
 
@@ -120,6 +158,8 @@ trap "cleanup" ERR
 # Set up directories
 RMTDATADIR="/srvdata/tpc"
 LCLDATADIR="${PWD}/localdata/tpc"
+# File the body of the COPY responses is saved to, see assert_tpc_success()
+TPC_RESPONSE_BODY="${PWD}/tpc_response_body.txt"
 mkdir -p "${LCLDATADIR}"
 mkdir -p "${PWD}/generated_tokens"
 mkdir -p "$XDG_CACHE_HOME/scitokens" && rm -rf "$XDG_CACHE_HOME/scitokens"/*
@@ -133,6 +173,12 @@ export BEARER_TOKEN
 generate_file() {
     local local_file=$1
     ${OPENSSL} rand -out "${local_file}" $((1024 * (RANDOM + 1)))
+}
+
+generate_file_of_size() {
+    local local_file=$1
+    local size=$2
+    ${OPENSSL} rand -out "${local_file}" "${size}"
 }
 
 generate_empty_file() {
@@ -187,9 +233,17 @@ perform_http_tpc() {
     local token_src=$4
     local token_dst=$5
     local file_suffix=$6
+    local streams=$7
 
     if [[ -z "${file_suffix}" ]]; then
         file_suffix=""
+    fi
+
+    # The number of streams is only honoured by the destination server, i.e. in
+    # the pull mode; it is what makes it take the multistream code path.
+    local -a streams_header=()
+    if [[ -n "${streams}" ]]; then
+        streams_header=(-H "X-Number-Of-Streams: ${streams}")
     fi
 
     local src_file_http="${hosts_http[$src_idx]}/${RMTDATADIR}/${src}${file_suffix}.ref"
@@ -198,18 +252,20 @@ perform_http_tpc() {
 
     if [[ "$mode" == "push" ]]; then
         dst_file_http="${dst_file_http}_push"
-        http_code=$(${CURL} -X COPY -L -s -o >(cat >&2) -w "%{http_code}" \
+        http_code=$(${CURL} -X COPY -L -s -o "${TPC_RESPONSE_BODY}" -w "%{http_code}" \
             -H "Destination: ${dst_file_http}" \
             -H "Authorization: Bearer ${token_dst}" \
             -H "TransferHeaderAuthorization: Bearer ${token_src}" \
+            "${streams_header[@]}" \
             --cacert "${BINARY_DIR}/tests/issuer/tlsca.pem" \
             "${src_file_http}")
     elif [[ "$mode" == "pull" ]]; then
         dst_file_http="${dst_file_http}_pull"
-        http_code=$(${CURL} -X COPY -L -s -o >(cat >&2) -w "%{http_code}" \
+        http_code=$(${CURL} -X COPY -L -s -o "${TPC_RESPONSE_BODY}" -w "%{http_code}" \
             -H "Source: ${src_file_http}" \
             -H "Authorization: Bearer ${token_src}" \
             -H "TransferHeaderAuthorization: Bearer ${token_dst}" \
+            "${streams_header[@]}" \
             --cacert "${BINARY_DIR}/tests/issuer/tlsca.pem" \
             "${dst_file_http}")
     else
@@ -217,6 +273,7 @@ perform_http_tpc() {
         return 1
     fi
 
+    cat "${TPC_RESPONSE_BODY}" >&2
     echo "$http_code"
     return 0
 }
@@ -337,7 +394,9 @@ for src_idx in {0..1}; do
     for dst_idx in {0..1}; do
        perform_tpc "${src_idx}" "${dst_idx}"
        assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN")" "HTTP TPC pull failed"
+       assert_tpc_success "HTTP TPC pull failed"
        assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "push" "$BEARER_TOKEN" "$BEARER_TOKEN")" "HTTP TPC push failed"
+       assert_tpc_success "HTTP TPC push failed"
     done
 done
 
@@ -399,7 +458,9 @@ verify_checksum "adler32" "${LCLDATADIR}/${src}_empty.ref" "${LCLDATADIR}/${src}
 
 perform_tpc "${src_idx}" "${dst_idx}" "_empty"
 assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN" "_empty")" "HTTP TPC pull failed"
+assert_tpc_success "HTTP TPC pull of an empty file failed"
 assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "push" "$BEARER_TOKEN" "$BEARER_TOKEN" "_empty")" "HTTP TPC push failed"
+assert_tpc_success "HTTP TPC push of an empty file failed"
 
 remote_file="${hosts_http[$dst_idx]}/${RMTDATADIR}/${src}_to_${dst}_empty.ref"
 local_file="${LCLDATADIR}/${src}_to_${dst}_empty.dat"
@@ -416,6 +477,44 @@ verify_checksum "adler32" "${LCLDATADIR}/${src}_empty.ref" "${LCLDATADIR}/${src}
 download_file "${remote_file_http}_push" "${local_file_http}_push" "http"
 verify_checksum "crc32c" "${LCLDATADIR}/${src}_empty.ref" "${LCLDATADIR}/${src}_to_${dst}_empty.dat_http_push" "${hosts[$dst_idx]}" "${RMTDATADIR}/${src}_to_${dst}_empty.ref_http_push"
 verify_checksum "adler32" "${LCLDATADIR}/${src}_empty.ref" "${LCLDATADIR}/${src}_to_${dst}_empty.dat_http_push" "${hosts[$dst_idx]}" "${RMTDATADIR}/${src}_to_${dst}_empty.ref_http_push"
+
+## Multistream HTTP TPC pull test
+#
+# A pull for which the client asks for more than one stream is served by a
+# completely different code path than the single stream one: the destination
+# splits the file into range requests it runs in parallel, and re-orders the
+# data in memory before writing it out to the local filesystem.
+src_idx=0
+dst_idx=1
+src="${hosts_abbrev[$src_idx]}"
+dst="${hosts_abbrev[$dst_idx]}"
+
+# The number of streams is validated by the destination; make sure a bogus
+# value is rejected, which also tells us the header is looked at at all.
+assert_eq "400" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN" "" "101")" \
+    "Did not reject an invalid number of streams"
+
+for idx in "${!multistream_suffixes[@]}"; do
+    suffix="${multistream_suffixes[$idx]}"
+    size="${multistream_sizes[$idx]}"
+
+    generate_file_of_size "${LCLDATADIR}/${src}${suffix}.ref" "${size}"
+    upload_file "${LCLDATADIR}/${src}${suffix}.ref" "${hosts[$src_idx]}/${RMTDATADIR}/${src}${suffix}.ref"
+
+    assert_eq "201" "$(perform_http_tpc "$src_idx" "$dst_idx" "pull" "$BEARER_TOKEN" "$BEARER_TOKEN" "${suffix}" "${MULTISTREAM_STREAMS}")" \
+        "HTTP TPC multistream pull of a ${size} bytes file failed"
+    assert_tpc_success "HTTP TPC multistream pull of a ${size} bytes file failed"
+
+    download_file "${hosts[$dst_idx]}/${RMTDATADIR}/${src}_to_${dst}${suffix}.ref_http_pull" \
+                  "${LCLDATADIR}/${src}_to_${dst}${suffix}.dat_http_pull"
+
+    verify_checksum "crc32c" "${LCLDATADIR}/${src}${suffix}.ref" \
+        "${LCLDATADIR}/${src}_to_${dst}${suffix}.dat_http_pull" \
+        "${hosts[$dst_idx]}" "${RMTDATADIR}/${src}_to_${dst}${suffix}.ref_http_pull"
+    verify_checksum "adler32" "${LCLDATADIR}/${src}${suffix}.ref" \
+        "${LCLDATADIR}/${src}_to_${dst}${suffix}.dat_http_pull" \
+        "${hosts[$dst_idx]}" "${RMTDATADIR}/${src}_to_${dst}${suffix}.ref_http_pull"
+done
 
 cleanup
 

--- a/tests/XrdHttpTpc/XrdHttpTpcStreamTests.cc
+++ b/tests/XrdHttpTpc/XrdHttpTpcStreamTests.cc
@@ -299,6 +299,50 @@ TEST_F(XrdHttpTpcStreamTests, ZeroSizeWriteForcesFlushOfPartialBuffer) {
   EXPECT_TRUE(stream.Finalize());
 }
 
+TEST_F(XrdHttpTpcStreamTests, RepeatedFlushesPushOutBufferedDataOnce) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 2, 8, log);
+
+  ASSERT_EQ(4, stream.Write(0, "abcd", 4, false));
+  ASSERT_TRUE(raw_file->Writes().empty());
+
+  // TPC::State::Flush() ends up here.  In the multistream case every transfer
+  // state shares this stream and each of them flushes it, hence the repeated
+  // calls; none of them may fail, whatever offset the states stopped at.
+  EXPECT_EQ(0, stream.Flush());
+  EXPECT_EQ(0, stream.Flush());
+  ASSERT_EQ(1u, raw_file->Writes().size());
+  EXPECT_EQ(0, raw_file->Writes()[0].first);
+  EXPECT_EQ(4, raw_file->Writes()[0].second);
+  EXPECT_EQ(AsBytes("abcd"), raw_file->Data());
+  EXPECT_TRUE(stream.GetErrorMessage().empty());
+  EXPECT_TRUE(stream.Finalize());
+}
+
+TEST_F(XrdHttpTpcStreamTests, FlushSucceedsWhenNothingIsBuffered) {
+  XrdSysLogger logger(STDERR_FILENO, 0);
+  XrdSysError log(&logger, "StreamTest");
+  auto file = std::make_unique<MemorySfsFile>();
+  auto raw_file = file.get();
+  TPC::Stream stream(std::move(file), 2, 8, log);
+
+  // A buffer that gets exactly filled is written out straight away, so nothing
+  // is left in memory.  This is what the end of a transfer looks like when the
+  // size of the file is a multiple of the block size.
+  ASSERT_EQ(8, stream.Write(0, "abcdefgh", 8, false));
+  ASSERT_EQ(1u, raw_file->Writes().size());
+
+  EXPECT_EQ(0, stream.Flush());
+  EXPECT_EQ(0, stream.Flush());
+  EXPECT_EQ(1u, raw_file->Writes().size());
+  EXPECT_EQ(AsBytes("abcdefgh"), raw_file->Data());
+  EXPECT_TRUE(stream.GetErrorMessage().empty());
+  EXPECT_TRUE(stream.Finalize());
+}
+
 TEST_F(XrdHttpTpcStreamTests, FilesystemWriteFailureIsPropagated) {
   XrdSysLogger logger(STDERR_FILENO, 0);
   XrdSysError log(&logger, "StreamTest");


### PR DESCRIPTION
State::Flush() issued the final flush at m_start_offset + m_offset, the position of the last range request served by that particular state.  In multistream mode every state shares the same Stream, so all the states but the one that happened to serve the tail of the file sit before the offset the stream has been written up to, and Stream::Write() rejects them with "Logic error: writing to a prior offset".

Those spurious errors have always been there, but they were harmless: a state that is behind the stream has nothing left to flush, and the return value of MultiCurlHandler::Flush() was discarded. Since commit 2ce9791, the flush failure is reported, so it now aborts transfers that were otherwise complete -- systematically when the file size is a multiple of the buffer size, as in that case nothing remains buffered and no state is left at the stream offset:

  TPC_PullRequest: event=FLUSH_FAIL, streams=11, bytes_transferred=0;
  Failed to flush the file to the local filesystem. Logic error:
  writing to a prior offset

Stream::Flush() is added and always flushes at the current offset of the stream, which is the only offset that is meaningful for the operation: the flush merely forces the re-ordering buffers out to the file handle, and it can never be a write to a prior offset.  This also removes the dependency on which state happened to serve the last range.

MultiCurlHandler::Flush() now flushes once instead of once per state, since a single stream is shared by all of them.

Assisted-By: Claude Opus 5 (1M context) <noreply@anthropic.com>