### PR TITLE
Http fullurl redirect

### DIFF
--- a/src/XrdCms/XrdCmsRedirLocal.cc
+++ b/src/XrdCms/XrdCmsRedirLocal.cc
@@ -197,16 +197,9 @@ int XrdCmsRedirLocal::Locate(XrdOucErrInfo &Resp, const char *path, int flags,
     // passed all checks, now to actual business
     // prepend manually configured localroot
     std::string ppath = "file://" + localroot + path;
-    if (strncmp(dialect.c_str(), "http", 4) == 0)
-    {
-      // set info which will be sent to client
-      // eliminate the resource name so it is not doubled in XrdHttpReq::Redir.
-      Resp.setErrInfo(-1, ppath.substr(0, ppath.find(path)).c_str());
-    }
-    else{
-      // set info which will be sent to client
-      Resp.setErrInfo(-1, ppath.c_str());
-    }
+    // A negative port tells the client the error text is a complete URL
+    // the path must be included for every dialect.
+    Resp.setErrInfo(-1, ppath.c_str());
     return SFS_REDIRECT;
   }
   return rcode;

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -852,18 +852,9 @@ void XrdHttpReq::parseResource(char *res) {
     // to the resource string. Here we choose to ignore it as a protection measure
     sanitizeResourcePfx();
 
-    std::string resourceDecoded = decode_str(resource.c_str());
-    resource = resourceDecoded.c_str();
+    const std::string resourceDecoded = decode_str(resource.c_str());
     resourceplusopaque = resourceDecoded.c_str();
-
-
-    // Sanitize the resource string, removing double slashes
-    int pos = 0;
-    do {
-      pos = resource.find("//", pos);
-      if (pos != STR_NPOS)
-        resource.erase(pos, 1);
-    } while (pos != STR_NPOS);
+    resource = httpCollapseSlashes(resourceDecoded).c_str();
 
     return;
   }
@@ -877,15 +868,7 @@ void XrdHttpReq::parseResource(char *res) {
   // to the resource string. Here we choose to ignore it as a protection measure
   sanitizeResourcePfx();
 
-  resource = decode_str(resource.c_str()).c_str();
-
-  // Sanitize the resource string, removing double slashes
-  int pos = 0;
-  do {
-    pos = resource.find("//", pos);
-    if (pos != STR_NPOS)
-      resource.erase(pos, 1);
-  } while (pos != STR_NPOS);
+  resource = httpCollapseSlashes(decode_str(resource.c_str())).c_str();
 
   resourceplusopaque = resource;
   // Whatever comes after is opaque data to be parsed

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -603,7 +603,6 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
 
 
 
-  char buf[512];
   char hash[512];
   hash[0] = '\0';
 
@@ -622,20 +621,15 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
     return keepalive;
   }
 
-  if (prot->isdesthttps)
-    redirdest = "Location: https://";
-  else
-    redirdest = "Location: http://";
-
-  // port < 0 signals switch to full URL
-  if (port < 0)
-  {
-    if (strncmp(hname, "file://", 7) == 0)
-    {
-      TRACE(REQ, " XrdHttpReq::Redir Switching to file:// ");
-      redirdest = "Location: "; // "file://" already contained in hname
-    }
+  // port < 0 means XRootD URL-form redirect: hname is a full scheme://… URL
+  // (host+port+path).
+  // Do not prefix http(s):// and do not append the original resource
+  // otherwise, that would produce https://https://…/pfn/lfn.
+  const bool fullUrl = (port < 0);
+  if (fullUrl) {
+    TRACE(REQ, " XrdHttpReq::Redir using absolute URL: " << hname);
   }
+
   // Beware, certain Ofs implementations (e.g. EOS) add opaque data directly to the host name
   // This must be correctly treated here and appended to the opaque info
   // that we may already have
@@ -643,25 +637,36 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
   char *vardata = 0;
   if (pp) {
     *pp = '\0';
-    redirdest += hname;
     vardata = pp+1;
     int varlen = strlen(vardata);
 
     //Now extract the remaining, vardata points to it
     while(*vardata == '&' && varlen) {vardata++; varlen--;}
+  }
 
-    // Put the question mark back where it was
+  // If the destination speaks cleartext HTTP, it needs the
+  // secret hash to reconstruct authorization info.
+  const bool destHttpCleartext =
+      fullUrl ? (strncmp(hname, "http://", 7) == 0) : (!prot->isdesthttps);
+
+  std::string urlHashPath;
+  {
+    const std::string encodedResource =
+        fullUrl ? std::string() : encode_str(resource.c_str());
+    redirdest = httpBuildRedirectLocation(prot->isdesthttps, port, hname,
+                                          encodedResource.c_str()).c_str();
+
+    // Derive the token path while hname is still truncated at '?', so the CGI
+    // stays out of the hash and both ends digest the same string.
+    if (fullUrl && destHttpCleartext) {
+      if (const char *urlPath = httpPathFromAbsoluteUrl(hname))
+        urlHashPath = httpCollapseSlashes(decode_str(urlPath));
+    }
+  }
+
+  // Restore '?' so later uses of hname see the original string.
+  if (pp)
     *pp = '?';
-  }
-  else
-    redirdest += hname;
-
-  if (port > 0) {
-    sprintf(buf, ":%d", port);
-    redirdest += buf;
-  }
-
-  redirdest += encode_str(resource.c_str()).c_str();
 
   // Here we put back the opaque info, if any
   if (vardata) {
@@ -676,11 +681,12 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
 
 
   time_t timenow = 0;
-  if (!prot->isdesthttps && prot->ishttps) {
+  if (destHttpCleartext && prot->ishttps) {
+    const char *hashPath = urlHashPath.empty() ? resource.c_str() : urlHashPath.c_str();
     // If the destination is not https, then we suppose that it
     // will need this token to fill its authorization info
     timenow = time(0);
-    calcHashes(hash, this->resource.c_str(), (kXR_int16) request,
+    calcHashes(hash, hashPath, (kXR_int16) request,
             &prot->SecEntity,
             timenow,
             prot->secretkey);

--- a/src/XrdHttp/XrdHttpReq.cc
+++ b/src/XrdHttp/XrdHttpReq.cc
@@ -658,10 +658,8 @@ bool XrdHttpReq::Redir(XrdXrootd::Bridge::Context &info, //!< the result context
 
     // Derive the token path while hname is still truncated at '?', so the CGI
     // stays out of the hash and both ends digest the same string.
-    if (fullUrl && destHttpCleartext) {
-      if (const char *urlPath = httpPathFromAbsoluteUrl(hname))
-        urlHashPath = httpCollapseSlashes(decode_str(urlPath));
-    }
+    if (fullUrl && destHttpCleartext)
+      urlHashPath = httpCollapseSlashes(decode_str(httpPathFromAbsoluteUrl(hname)));
   }
 
   // Restore '?' so later uses of hname see the original string.

--- a/src/XrdHttp/XrdHttpReq.hh
+++ b/src/XrdHttp/XrdHttpReq.hh
@@ -481,15 +481,18 @@ public:
   );
 
   //-----------------------------------------------------------------------------
-  //! Redirect the client to another host:port.
+  //! Redirect the client to another host:port (or absolute URL).
   //!
   //! The Redir() method is called when the client must be redirected to another
   //! host.
   //!
   //! @param  info    the context associated with the result.
-  //! @param  port    the port number in host byte format.
-  //! @param  hname   the DNS name of the host or IP address is IPV4 or IPV6
-  //!                 format (i.e. "n.n.n.n" or "[ipv6_addr]").
+  //! @param  port    destination port in host byte order; when port < 0 and
+  //!                 hname is an absolute URL (`scheme://…`), Location is that
+  //!                 URL as-is (path included) and the original resource is
+  //!                 not appended. Otherwise Location is built as
+  //!                 http(s)://hname[:port]<resource>.
+  //! @param  hname   DNS name / IP, or absolute URL when port < 0.
   //!
   //! @return true    continue normal processing.
   //!         false   terminate the bridge and close the link.

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -685,3 +685,43 @@ std::string httpStatusToString(int status) {
       }
   }
 }
+
+const char *httpPathFromAbsoluteUrl(const char *hname) {
+  if (!hname) return nullptr;
+  const char *scheme = strstr(hname, "://");
+  if (!scheme) return nullptr;
+  return strchr(scheme + 3, '/');
+}
+
+std::string httpCollapseSlashes(std::string path) {
+  // Erase one character at a time without advancing, so "///a" becomes "/a".
+  for (size_t pos = 0; (pos = path.find("//", pos)) != std::string::npos; )
+    path.erase(pos, 1);
+  return path;
+}
+
+std::string httpBuildRedirectLocation(bool destHttps, int port, const char *hname,
+                                      const char *encodedResource) {
+  std::string out;
+  // Same rule as XRootD: port < 0 => hname is a full scheme://… URL.
+  const bool fullUrl = (port < 0);
+  if (fullUrl)
+    out = "Location: ";
+  else if (destHttps)
+    out = "Location: https://";
+  else
+    out = "Location: http://";
+
+  if (hname)
+    out += hname;
+
+  if (port > 0) {
+    out += ':';
+    out += std::to_string(port);
+  }
+
+  if (!fullUrl && encodedResource)
+    out += encodedResource;
+
+  return out;
+}

--- a/src/XrdHttp/XrdHttpUtils.cc
+++ b/src/XrdHttp/XrdHttpUtils.cc
@@ -686,11 +686,15 @@ std::string httpStatusToString(int status) {
   }
 }
 
-const char *httpPathFromAbsoluteUrl(const char *hname) {
-  if (!hname) return nullptr;
-  const char *scheme = strstr(hname, "://");
-  if (!scheme) return nullptr;
-  return strchr(scheme + 3, '/');
+std::string httpPathFromAbsoluteUrl(const char *hname) {
+  std::string path = "/";
+  if (hname) {
+    if (const char *scheme = strstr(hname, "://")) {
+      if (const char *urlPath = strchr(scheme + 3, '/'))
+        path = urlPath;
+    }
+  }
+  return path;
 }
 
 std::string httpCollapseSlashes(std::string path) {

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -252,6 +252,22 @@ int mapErrNoToHttp(int err);
 
 std::string httpStatusToString(int status);
 
+//! Path starting at the first `/` after the authority, or nullptr.
+const char *httpPathFromAbsoluteUrl(const char *hname);
+
+//! Collapse duplicate slashes in a path. Applied to an already-decoded path,
+//! `decode_str()` then this yields the canonical request path. Shared by
+//! XrdHttpReq::parseResource() and the redirect token path so that the two
+//! ends of a redirect always hash an identical string.
+std::string httpCollapseSlashes(std::string path);
+
+//! Build the `Location:` header for an HTTP redirect (without auth opaque).
+//! When port < 0, hname is a full URL (XRootD URL-form redirect): emit as-is
+//! and ignore encodedResource. Otherwise:
+//! `Location: http(s)://hname[:port]<encodedResource>`.
+std::string httpBuildRedirectLocation(bool destHttps, int port, const char *hname,
+                                      const char *encodedResource);
+
 typedef std::vector<XrdOucIOVec2> XrdHttpIOList;
 
 

--- a/src/XrdHttp/XrdHttpUtils.hh
+++ b/src/XrdHttp/XrdHttpUtils.hh
@@ -252,8 +252,8 @@ int mapErrNoToHttp(int err);
 
 std::string httpStatusToString(int status);
 
-//! Path starting at the first `/` after the authority, or nullptr.
-const char *httpPathFromAbsoluteUrl(const char *hname);
+//! Path starting at the first `/` after the authority. An absent path is `/`.
+std::string httpPathFromAbsoluteUrl(const char *hname);
 
 //! Collapse duplicate slashes in a path. Applied to an already-decoded path,
 //! `decode_str()` then this yields the canonical request path. Shared by

--- a/tests/XrdHttpTests/XrdHttpTests.cc
+++ b/tests/XrdHttpTests/XrdHttpTests.cc
@@ -5,6 +5,7 @@
 #include "XrdHttp/XrdHttpChecksumHandler.hh"
 #include "XrdHttp/XrdHttpReadRangeHandler.hh"
 #include "XrdHttp/XrdHttpHeaderUtils.hh"
+#include "XrdHttp/XrdHttpUtils.hh"
 #include "XrdHttpCors/XrdHttpCorsHandler.hh"
 #include <exception>
 #include <gtest/gtest.h>
@@ -632,6 +633,51 @@ TEST(XrdHttpTests,encodeOpaqueTest) {
   for(auto [decoded,encoded]: decodedEncodedOpaque) {
     ASSERT_EQ(encoded,encode_opaque(decoded));
   }
+}
+
+TEST(XrdHttpTests, pathFromAbsoluteUrl) {
+  EXPECT_STREQ("/store/a", httpPathFromAbsoluteUrl("https://site.example:1094/store/a"));
+  EXPECT_STREQ("//pfn/path", httpPathFromAbsoluteUrl("root://host:1094//pfn/path"));
+  EXPECT_EQ(nullptr, httpPathFromAbsoluteUrl("https://site.example"));
+  EXPECT_EQ(nullptr, httpPathFromAbsoluteUrl("site.example"));
+  EXPECT_EQ(nullptr, httpPathFromAbsoluteUrl(nullptr));
+}
+
+TEST(XrdHttpTests, buildRedirectLocationHostPort) {
+  EXPECT_EQ("Location: https://site.example:1094/store/lfn",
+            httpBuildRedirectLocation(true, 1094, "site.example", "/store/lfn"));
+  EXPECT_EQ("Location: http://site.example:1094/store/lfn",
+            httpBuildRedirectLocation(false, 1094, "site.example", "/store/lfn"));
+}
+
+TEST(XrdHttpTests, buildRedirectLocationAbsoluteUrl) {
+  // port < 0 => URL-form: do not double the scheme or append the original LFN.
+  EXPECT_EQ("Location: https://site.example:443//dcache/store/file.root",
+            httpBuildRedirectLocation(
+                true, -1, "https://site.example:443//dcache/store/file.root", "/store/lfn"));
+  // No explicit port, and a '//' in the PFN path, are both preserved verbatim.
+  EXPECT_EQ("Location: https://site.example//pfn/file.root",
+            httpBuildRedirectLocation(true, -1, "https://site.example//pfn/file.root",
+                                      "/store/lfn"));
+  // XrdCmsRedirLocal sends localroot + path, so the LFN is already in the URL.
+  EXPECT_EQ("Location: file:///data/localroot/store/lfn",
+            httpBuildRedirectLocation(false, -1, "file:///data/localroot/store/lfn",
+                                      "/store/lfn"));
+}
+
+TEST(XrdHttpTests, collapseSlashes) {
+  EXPECT_EQ("/pfn/path", httpCollapseSlashes("//pfn/path"));
+  EXPECT_EQ("/a/b", httpCollapseSlashes("///a////b"));
+  EXPECT_EQ("/store/plain", httpCollapseSlashes("/store/plain"));
+  EXPECT_EQ("/", httpCollapseSlashes("//"));
+  EXPECT_EQ("", httpCollapseSlashes(""));
+
+  // decode_str() then collapse is the canonical request path: both ends of a
+  // redirect must produce the same string or the token hash will not validate.
+  EXPECT_EQ("/store/a b", httpCollapseSlashes(decode_str("/store//a%20b")));
+  EXPECT_EQ("/store/a+b", httpCollapseSlashes(decode_str("/store/a%2Bb")));
+  // Collapsing does not decode, so it cannot decode a second time.
+  EXPECT_EQ("/store/a%20b", httpCollapseSlashes(decode_str("/store/a%2520b")));
 }
 
 static inline const std::pair<std::string, std::map<std::string,std::string>> reprDigest[] {

--- a/tests/XrdHttpTests/XrdHttpTests.cc
+++ b/tests/XrdHttpTests/XrdHttpTests.cc
@@ -636,11 +636,16 @@ TEST(XrdHttpTests,encodeOpaqueTest) {
 }
 
 TEST(XrdHttpTests, pathFromAbsoluteUrl) {
-  EXPECT_STREQ("/store/a", httpPathFromAbsoluteUrl("https://site.example:1094/store/a"));
-  EXPECT_STREQ("//pfn/path", httpPathFromAbsoluteUrl("root://host:1094//pfn/path"));
-  EXPECT_EQ(nullptr, httpPathFromAbsoluteUrl("https://site.example"));
-  EXPECT_EQ(nullptr, httpPathFromAbsoluteUrl("site.example"));
-  EXPECT_EQ(nullptr, httpPathFromAbsoluteUrl(nullptr));
+  EXPECT_EQ("/store/a", httpPathFromAbsoluteUrl("https://site.example:1094/store/a"));
+  EXPECT_EQ("//pfn/path", httpPathFromAbsoluteUrl("root://host:1094//pfn/path"));
+  // HTTP clients request "/" when the URL has no path.
+  EXPECT_EQ("/", httpPathFromAbsoluteUrl("https://site.example"));
+  EXPECT_EQ("/", httpPathFromAbsoluteUrl("http://site.example:1094"));
+  EXPECT_EQ("/", httpPathFromAbsoluteUrl("site.example"));
+  EXPECT_EQ("/", httpPathFromAbsoluteUrl(nullptr));
+  // Redir hashes decode_str() then collapse, matching parseResource().
+  EXPECT_EQ("/store/a b", httpCollapseSlashes(decode_str(
+      httpPathFromAbsoluteUrl("http://host/store//a%20b"))));
 }
 
 TEST(XrdHttpTests, buildRedirectLocationHostPort) {


### PR DESCRIPTION
`XrdHttpReq::Redir()` mishandles XRootD URL-form redirects (`port < 0`, host field is a full `scheme://host[:port]/path URL`).

It always prefixes http(s):// and appends the original resource (special-casing only file://), so other schemes get a doubled scheme and a duplicated path, e.g.:
```
https://ds.example:443//pfn/f.root
 ->  Location: https://https://ds.example:443//pfn/f.root/store/lfn
```

It worked internally, since `XrdCmsRedirLocal` stripped the prefix; this PR removes the bug and the workaround.
Additionally, the same block also picks xrdhttptk from http. desthttps instead of the destination URL scheme, and hashes the wrong path for the token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTTP redirects to correctly handle absolute destination URLs, including their schemes, ports, paths, and query strings.
  - Prevented duplicated URL schemes and resource paths in redirect locations.
  - Corrected redirects for local resources and cleartext destinations.
  - Normalized repeated slashes in redirected resource paths while preserving encoded content.
  - Improved handling of file URLs, root paths, explicit ports, and destinations with empty or invalid paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->