### PR TITLE
[Tests] Make the cluster test re-runnable

### DIFF
--- a/tests/cluster/setup.sh
+++ b/tests/cluster/setup.sh
@@ -61,11 +61,16 @@ formatfiles() {
 
 generate(){
 
-       # check if files are in the data directory already...
-       if [[ -e ${DATAFOLDER}/${i} ]]; then
+       # The fixtures below cost a 2GB openssl rand, 4x1000 uuidgen calls and
+       # ten 16MB files, so they are generated once and cached for the life of
+       # the build tree. The sentinel is written last, which is the point: an
+       # interrupted generation leaves no sentinel and is redone, where testing
+       # for the data directory itself would treat a half-built tree as done.
+       if [[ -e ${DATAFOLDER}/.generated ]]; then
               return
        fi
 
+       rm -rf ${DATAFOLDER}
        mkdir -p ${TMPDATAFOLDER}
 
        for i in ${filenames[@]}; do
@@ -144,9 +149,14 @@ generate(){
        done
 
        rm -rf ${TMPDATAFOLDER}
+
+       touch ${DATAFOLDER}/.generated
 }
 
 start(){
+       # A previous run killed part way through leaves its servers holding the
+       # ports and its instance directories on disk.
+       stop
        generate
        set -x
        # start for each component
@@ -162,11 +172,20 @@ start(){
        sleep 1
 }
 
+# Signal only pids that are still alive. A crashed or SIGKILLed instance leaves
+# a stale pidfile behind, and killing it blindly under `set -e` would abort the
+# script -- which, since this is the fixture *cleanup*, reports the whole
+# cluster teardown as failed and leaves the instance directories in place.
 stop() {
 	for i in "${servernames[@]}"; do
 		if [[ -d "${i}" ]]; then
-			kill -s TERM $(cat ${i}/cmsd.pid)
-			kill -s TERM $(cat ${i}/xrootd.pid)
+			for pidfile in "${i}"/cmsd.pid "${i}"/xrootd.pid; do
+				test -s "${pidfile}" || continue
+				pid="$(ps -o pid= "$(cat "${pidfile}")" || true)"
+				if test -n "${pid}"; then
+					kill -s TERM "${pid}"
+				fi
+			done
 			rm -rf "${i}"
 		fi
 	done

--- a/tests/cluster/test.sh
+++ b/tests/cluster/test.sh
@@ -43,6 +43,121 @@ done
 
 set -e
 
+# The host tables have to be declared before anything iterates them: bash
+# expands an unset array to nothing, so a loop placed above these silently does
+# not run at all (which is what happened to the query-config checks below).
+
+# hostname-address pair, so that we can keep track of files more easily
+declare -A hosts
+hosts["metaman"]="${HOST_METAMAN}"
+hosts["man1"]="${HOST_MAN1}"
+hosts["man2"]="${HOST_MAN2}"
+hosts["srv1"]="${HOST_SRV1}"
+hosts["srv2"]="${HOST_SRV2}"
+hosts["srv3"]="${HOST_SRV3}"
+hosts["srv4"]="${HOST_SRV4}"
+
+declare -A hosts_http
+hosts_http["metaman"]="${HOST_HTTP_METAMAN}"
+hosts_http["man1"]="${HOST_HTTP_MAN1}"
+hosts_http["man2"]="${HOST_HTTP_MAN2}"
+hosts_http["srv1"]="${HOST_HTTP_SRV1}"
+hosts_http["srv2"]="${HOST_HTTP_SRV2}"
+hosts_http["srv3"]="${HOST_HTTP_SRV3}"
+hosts_http["srv4"]="${HOST_HTTP_SRV4}"
+
+RMTDATADIR="/srvdata"
+LCLDATADIR="${PWD}/localdata"  # client folder
+
+mkdir -p ${LCLDATADIR}
+
+# Every file each host is uploaded under. Declared here rather than next to the
+# upload loop so cleanup() below can name them however early the script dies.
+HTTP_SUFFIX=(".ref_http" ".ref_%23_http")
+declare -A MAP_HTTP_XRD_SUFFIX=( [".ref_http"]=".ref_http" [".ref_%23_http"]=".ref_#_http" )
+
+# Hosts the MOVE test uploads to, and the HTTP status each must answer with.
+declare -A srcs=(
+    [metaman]=501
+    [man1]=201
+    [srv1]=201
+)
+
+# The redirect tests below write these into the export root rather than into
+# ${RMTDATADIR}, so they need naming separately for the cleanup.
+declare -A redirfiles
+redirfiles["cluster_redirfile1"]="${HOST_SRV1}"
+redirfiles["cluster_redirfile2"]="${HOST_SRV1}"
+redirfiles["cluster_redirfile3"]="${HOST_SRV3}"
+
+# Captured stderr for the redirect assertions. A fixed path (this used to be
+# /tmp/err.txt) is shared with tests/badredir/test.sh, which sits behind a
+# different CTest fixture and therefore runs concurrently under ctest -j: each
+# clobbered the other's capture before grep read it.
+ERRFILE=$(mktemp)
+
+assert_xrdmapc_json() {
+       expected_json='{"name":"localhost:10940","type":"manager","managers":[{"name":"localhost:10941","type":"manager","servers":[{"name":"localhost:10943"},{"name":"localhost:10944"}]},{"name":"localhost:10942","type":"manager","servers":[{"name":"localhost:10945"},{"name":"localhost:10946"}]}]}'
+       actual_json="$(${XRDMAPC} --format json localhost:10940)"
+
+       if [[ "${actual_json}" != "${expected_json}" ]]; then
+               echo 1>&2 "$(basename $0): error: xrdmapc JSON output does not match expected topology"
+               echo "Expected: ${expected_json}"
+               echo "Actual:   ${actual_json}"
+               exit 1
+       fi
+
+       # Print cluster topology in string format
+       ${XRDMAPC} localhost:10940
+
+}
+
+# Remove everything this test creates, on the failure path as well as the happy
+# one. Anything left behind is not merely untidy: the uploads below would find
+# it on the next run, so a single failure used to wedge every later run in the
+# same build tree. Nothing here may fail -- hence the trailing "|| :" on every
+# command -- because the trap must not change the script's exit status, and it
+# runs on the successful path too.
+#
+# The generated fixtures under data/<srv>/data are deliberately NOT touched:
+# setup.sh spends a 2GB openssl rand and 4000 uuidgen calls on them and caches
+# them for the life of the build tree.
+cleanup() {
+       rm -rf ${LCLDATADIR} || :
+       rm -f ${ERRFILE} || :
+
+       for host in "${!hosts[@]}"; do
+              ${XRDFS} ${HOST_METAMAN} rm ${RMTDATADIR}/${host}.ref 2>/dev/null || :
+              for suffix in "${HTTP_SUFFIX[@]}"; do
+                     ${XRDFS} ${HOST_METAMAN} rm \
+                            "${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[$suffix]}" \
+                            2>/dev/null || :
+              done
+       done
+
+       for src in "${!srcs[@]}"; do
+              ${XRDFS} ${HOST_METAMAN} rm ${RMTDATADIR}/old_file_${src} 2>/dev/null || :
+              ${XRDFS} ${HOST_METAMAN} rm ${RMTDATADIR}/new_file_${src} 2>/dev/null || :
+       done
+
+       for file in "${!redirfiles[@]}"; do
+              ${XRDFS} ${redirfiles[$file]} rm /${file} 2>/dev/null || :
+       done
+
+       ${XRDFS} ${HOST_METAMAN} rmdir ${RMTDATADIR} 2>/dev/null || :
+}
+# Only EXIT runs cleanup. A signal trap that called cleanup directly would
+# replace bash's default terminating behaviour: after the handler returns, the
+# script would carry on past the interrupted command, now with its state
+# removed. Exiting explicitly keeps the conventional 128+signal status and
+# fires the EXIT trap exactly once.
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 131' QUIT
+
+assert_xrdmapc_json
+
 ${XRDCP} --version
 
 for host in "${!hosts[@]}"; do
@@ -64,57 +179,6 @@ ${XRDFS} ${HOST_METAMAN} stat /
 ${XRDFS} ${HOST_METAMAN} statvfs /
 ${XRDFS} ${HOST_METAMAN} spaceinfo /
 
-RMTDATADIR="/srvdata"
-LCLDATADIR="${PWD}/localdata"  # client folder
-
-mkdir -p ${LCLDATADIR}
-
-# hostname-address pair, so that we can keep track of files more easily
-declare -A hosts
-hosts["metaman"]="${HOST_METAMAN}"
-hosts["man1"]="${HOST_MAN1}"
-hosts["man2"]="${HOST_MAN2}"
-hosts["srv1"]="${HOST_SRV1}"
-hosts["srv2"]="${HOST_SRV2}"
-hosts["srv3"]="${HOST_SRV3}"
-hosts["srv4"]="${HOST_SRV4}"
-
-declare -A hosts_http
-hosts_http["metaman"]="${HOST_HTTP_METAMAN}"
-hosts_http["man1"]="${HOST_HTTP_MAN1}"
-hosts_http["man2"]="${HOST_HTTP_MAN2}"
-hosts_http["srv1"]="${HOST_HTTP_SRV1}"
-hosts_http["srv2"]="${HOST_HTTP_SRV2}"
-hosts_http["srv3"]="${HOST_HTTP_SRV3}"
-hosts_http["srv4"]="${HOST_HTTP_SRV4}"
-
-assert_xrdmapc_json() {
-       expected_json='{"name":"localhost:10940","type":"manager","managers":[{"name":"localhost:10941","type":"manager","servers":[{"name":"localhost:10943"},{"name":"localhost:10944"}]},{"name":"localhost:10942","type":"manager","servers":[{"name":"localhost:10945"},{"name":"localhost:10946"}]}]}'
-       actual_json="$(${XRDMAPC} --format json localhost:10940)"
-
-       if [[ "${actual_json}" != "${expected_json}" ]]; then
-               echo 1>&2 "$(basename $0): error: xrdmapc JSON output does not match expected topology"
-               echo "Expected: ${expected_json}"
-               echo "Actual:   ${actual_json}"
-               exit 1
-       fi
-
-       # Print cluster topology in string format
-       ${XRDMAPC} localhost:10940
-
-}
-
-cleanup() {
-       echo "Error occurred. Cleaning up..."
-       for host in "${!hosts[@]}"; do
-              rm -rf ${LCLDATADIR}/${host}.dat
-              rm -rf ${LCLDATADIR}/${host}.ref
-       done
-}
-trap "cleanup; exit 1" ABRT
-
-assert_xrdmapc_json
-
 # create local files with random contents using OpenSSL
 
 for host in "${!hosts[@]}"; do
@@ -122,11 +186,8 @@ for host in "${!hosts[@]}"; do
 done
 
 # upload local files to the servers in parallel
-HTTP_SUFFIX=(".ref_http" ".ref_%23_http")
-declare -A MAP_HTTP_XRD_SUFFIX=( [".ref_http"]=".ref_http" [".ref_%23_http"]=".ref_#_http" )
-
 for host in "${!hosts[@]}"; do
-       ${XRDCP} ${LCLDATADIR}/${host}.ref ${hosts[$host]}/${RMTDATADIR}/${host}.ref
+       ${XRDCP} -f ${LCLDATADIR}/${host}.ref ${hosts[$host]}/${RMTDATADIR}/${host}.ref
 
        for suffix in "${HTTP_SUFFIX[@]}"; do
               ${CURL} -v -L ${hosts_http[$host]}/${RMTDATADIR}/${host}${suffix} -T ${LCLDATADIR}/${host}.ref
@@ -141,7 +202,7 @@ for host in "${!hosts[@]}"; do
 done
 
 for host in "${!hosts[@]}"; do
-       ${XRDCP} ${hosts[$host]}/${RMTDATADIR}/${host}.ref ${LCLDATADIR}/${host}.dat
+       ${XRDCP} -f ${hosts[$host]}/${RMTDATADIR}/${host}.ref ${LCLDATADIR}/${host}.dat
        count=0
 
        for suffix in "${HTTP_SUFFIX[@]}"; do
@@ -213,12 +274,6 @@ done
 # Not sure why this is the expected behaviour
 # https://github.com/xrootd/xrootd/blob/8ac19b1d2b74521acff9ed0200052a2e373092cc/src/XrdHttp/XrdHttpReq.cc#L1746-L1752
 
-declare -A srcs=(
-    [metaman]=501
-    [man1]=201
-    [srv1]=201
-)
-
 # Upload files
 for src in "${!srcs[@]}"; do
     curl -s -S -L -v -T "${LCLDATADIR}/srv1.ref" \
@@ -240,37 +295,18 @@ for src in "${!srcs[@]}"; do
     fi
 done
 
-for host in "${!hosts[@]}"; do
-       ${XRDFS} ${HOST_METAMAN} rm ${RMTDATADIR}/${host}.ref &
-       rm ${LCLDATADIR}/${host}.dat &
-       count=0
-
-       for suffix in "${HTTP_SUFFIX[@]}"; do
-               ${XRDFS} ${HOST_METAMAN} rm "${RMTDATADIR}/${host}${MAP_HTTP_XRD_SUFFIX[$suffix]}" &
-               rm ${LCLDATADIR}/${host}.dat_http${count} &
-               count=$((count + 1))
-       done
-done
-wait
-
-# Additional cleanup for move operation files
-for src in "${!srcs[@]}"; do
-    if [[ "$src" == "man1" || "$src" == "srv1" ]]; then
-        ${XRDFS} "${HOST_METAMAN}" rm "${RMTDATADIR}/new_file_${src}" &
-    else
-        ${XRDFS} "${HOST_METAMAN}" rm "${RMTDATADIR}/old_file_${src}" &
-    fi
-done
+# Everything uploaded so far, and the local copies of it, are removed by
+# cleanup() on the way out -- on this path and on every failing one.
 
 # test redirects
-${XRDCP} "${LCLDATADIR}/srv1.ref" "${HOST_SRV1}//cluster_redirfile1"
-${XRDCP} "${LCLDATADIR}/srv1.ref" "${HOST_SRV1}//cluster_redirfile2"
-${XRDCP} "${LCLDATADIR}/srv3.ref" "${HOST_SRV3}//cluster_redirfile3"
+${XRDCP} -f "${LCLDATADIR}/srv1.ref" "${HOST_SRV1}//cluster_redirfile1"
+${XRDCP} -f "${LCLDATADIR}/srv1.ref" "${HOST_SRV1}//cluster_redirfile2"
+${XRDCP} -f "${LCLDATADIR}/srv3.ref" "${HOST_SRV3}//cluster_redirfile3"
 
 set +e
-${XRDCP} -f "${HOST_SRV1}//cluster_redirfile1" /dev/null 2> /tmp/err.txt
+${XRDCP} -f "${HOST_SRV1}//cluster_redirfile1" /dev/null 2> ${ERRFILE}
 ret1=$?
-grep -q "\[ERROR\] Local error: no such file or directory" /tmp/err.txt
+grep -q "\[ERROR\] Local error: no such file or directory" ${ERRFILE}
 ret2=$?
 if [ $ret1 -ne 54 -o $ret2 -ne 0 ]; then
   echo "cluster test with cluster_redirfile1 directly from srv1 did not fail as expected"
@@ -278,9 +314,9 @@ if [ $ret1 -ne 54 -o $ret2 -ne 0 ]; then
   exit 1
 fi
 
-XRD_LOGLEVEL=Dump ${XRDCP} -f "${HOST_METAMAN}//cluster_redirfile1" /dev/null 2> /tmp/err.txt
+XRD_LOGLEVEL=Dump ${XRDCP} -f "${HOST_METAMAN}//cluster_redirfile1" /dev/null 2> ${ERRFILE}
 ret1=$?
-grep -q ":10940\] Got notification that outgoing message kXR_open (file: /cluster_redirfile1?tried=" /tmp/err.txt
+grep -q ":10940\] Got notification that outgoing message kXR_open (file: /cluster_redirfile1?tried=" ${ERRFILE}
 ret2=$?
 if [ $ret1 -eq 0 -o $ret2 -ne 0 ]; then
   echo "cluster test with cluster_redirfile1 via meta-manager did not fail as expected"
@@ -288,9 +324,9 @@ if [ $ret1 -eq 0 -o $ret2 -ne 0 ]; then
   exit 1
 fi
 
-XRD_LOGLEVEL=Dump ${XRDCP} -f "${HOST_METAMAN}//cluster_redirfile2" /dev/null 2> /tmp/err.txt
+XRD_LOGLEVEL=Dump ${XRDCP} -f "${HOST_METAMAN}//cluster_redirfile2" /dev/null 2> ${ERRFILE}
 ret1=$?
-grep -q ":10940\] Got notification that outgoing message kXR_open (file: /cluster_redirfile2?tried=" /tmp/err.txt
+grep -q ":10940\] Got notification that outgoing message kXR_open (file: /cluster_redirfile2?tried=" ${ERRFILE}
 ret2=$?
 if [ $ret1 -eq 0 -o $ret2 -ne 0 ]; then
   echo "cluster test with cluster_redirfile2 via meta-manager did not fail as expected"
@@ -298,12 +334,6 @@ if [ $ret1 -eq 0 -o $ret2 -ne 0 ]; then
   exit 1
 fi
 set -e
-
-# Remove local file once after the loop
-rm -f "${LCLDATADIR}/srv1.ref" &
-wait
-
-${XRDFS} ${HOST_METAMAN} rmdir ${RMTDATADIR}
 
 echo "ALL TESTS PASSED"
 exit 0


### PR DESCRIPTION
XRootD::cluster::test failed on every run after the first against the same build tree, deterministically. CI never saw it: test.cmake wipes build/ with ctest_empty_binary_directory() before every configure and calls ctest_test() once, so the suite only ever runs on a virgin tree. It bites a developer running ctest --test-dir build twice, which is the normal inner loop.

Three separate reasons, all in the same file.

The redirect test uploaded cluster_redirfile{1,2,3} with no -f and nothing ever removed them, so a successful run guaranteed the next one died at set -e with "Invalid operation: file exists". Everything else was cleaned inline at the end of the happy path only: cleanup() was wired as `trap "cleanup; exit 1" ABRT`, and ABRT is not what set -e, an explicit exit 1 from a failed assertion, a ctest timeout or Ctrl-C sends, so one failure left both localdata/ and the servers dirty and every later run failed at the first upload or download -- neither of which passed -f either. It could not recover on its own.

Move the cleanup into a trap on EXIT INT TERM QUIT (EXIT rather than ERR because the assertions here exit explicitly), widen it to cover every path the test writes, and pass -f to the uploads and downloads. The -f is what actually guarantees re-runnability: a SIGKILLed or timed-out run executes no trap at all, so tolerating leftovers matters more than not leaving them. The generated fixtures under data/<srv>/data are deliberately untouched -- setup.sh spends a 2GB openssl rand and 4000 uuidgen calls on them and caches them for the life of the build tree.

/tmp/err.txt, where the redirect assertions captured stderr, is also written by tests/badredir/test.sh. The two sit behind different CTest fixtures with no RUN_SERIAL, so ctest runs them concurrently under -j and each clobbered the other's capture before grep read it. That was the one genuinely random failure in here; it is now an mktemp.

Both `query config` loops iterated "${!hosts[@]}" twenty-five lines above `declare -A hosts`. Bash expands an unset array to nothing, so all 28 version, role and sitename assertions across the seven hosts have silently not run since the file was added in 2fd4e6773b. Declaring the tables first revives them; they pass.

setup.sh gets the matching treatment: generate() keyed its "already built" check on ${DATAFOLDER}/${i} with ${i} unset, i.e. on ./data existing, so a generation interrupted part way was cached as complete forever -- it now writes a sentinel last and rebuilds when it is missing. stop() killed pids from pidfiles blindly under set -e, so a crashed instance made the fixture cleanup itself fail; it now checks liveness the way tests/XRootD/test.sh does. And start() calls stop() first, as tests/authenticated_cluster/setup.sh already did, so a half-killed cluster does not collide on the ports.

Verified: three consecutive XRootD::cluster runs pass; a run planted with the exact wedging leftovers (cluster_redirfile*, srvdata/*.ref, localdata/*.dat) passes and leaves nothing behind; a run SIGKILLed part way leaves state that the next run recovers from; and the full suite passes 679/679 twice in a row, which it did not before. tests/authenticated_cluster and tests/TPCTests were checked for the same defect and pass twice in a row unmodified.

Assisted-by: Claude:Opus 5