### PR TITLE
[XrdClHttp] Rebase PUT deadline on each client write

### DIFF
--- a/src/XrdClHttp/XrdClHttpFile.cc
+++ b/src/XrdClHttp/XrdClHttpFile.cc
@@ -195,7 +195,7 @@ private:
 // Note: these values are typically overwritten by `CurlFactory::CurlFactory`;
 // they are set here just to avoid uninitialized globals.
 struct timespec XrdClHttp::File::m_min_client_timeout = {2, 0};
-struct timespec XrdClHttp::File::m_default_header_timeout = {9, 5};
+struct timespec XrdClHttp::File::m_default_header_timeout = {9, 500'000'000};
 struct timespec XrdClHttp::File::m_fed_timeout = {5, 0};
 
 
@@ -412,7 +412,7 @@ File::Close(XrdCl::ResponseHandler *handler,
             m_logger->Debug(kLogXrdClHttp, "Flushing final write buffer on close");
             auto put_handler = m_put_handler.load(std::memory_order_acquire);
             if (put_handler) {
-                return put_handler->QueueWrite(std::make_pair(nullptr, 0), handler);
+                return put_handler->QueueWrite(std::make_pair(nullptr, 0), handler, GetHeaderTimeout(timeout));
             } else {
                 m_logger->Error(kLogXrdClHttp, "Internal state error - put operation ongoing without handle");
                 return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
@@ -819,7 +819,7 @@ File::Write(uint64_t                offset,
         PutResponseHandler *expected_value = nullptr;
         if (!m_put_handler.compare_exchange_strong(expected_value, handler_wrapper, std::memory_order_acq_rel)) {
             delete handler_wrapper;
-            return expected_value->QueueWrite(std::make_pair(buffer, size), handler);
+            return expected_value->QueueWrite(std::make_pair(buffer, size), handler, ts);
         }
 
         if (offset != 0) {
@@ -852,7 +852,7 @@ File::Write(uint64_t                offset,
             static_cast<long long>(offset), static_cast<long long>(old_offset));
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, 0, "Requested write offset does not match current offset");
     }
-    return handler_wrapper->QueueWrite(std::make_pair(buffer, size), handler);
+    return handler_wrapper->QueueWrite(std::make_pair(buffer, size), handler, ts);
 }
 
 XrdCl::XRootDStatus
@@ -877,7 +877,7 @@ File::Write(uint64_t                offset,
         PutResponseHandler *expected_value = nullptr;
         if (!m_put_handler.compare_exchange_strong(expected_value, handler_wrapper, std::memory_order_acq_rel)) {
             delete handler_wrapper;
-            return expected_value->QueueWrite(std::move(buffer), handler);
+            return expected_value->QueueWrite(std::move(buffer), handler, ts);
         }
 
         if (offset != 0) {
@@ -909,7 +909,7 @@ File::Write(uint64_t                offset,
             static_cast<long long>(offset), static_cast<long long>(old_offset));
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, 0, "Requested write offset does not match current offset");
     }
-    return handler_wrapper->QueueWrite(std::move(buffer), handler);
+    return handler_wrapper->QueueWrite(std::move(buffer), handler, ts);
 }
 
 XrdCl::XRootDStatus
@@ -1309,7 +1309,7 @@ File::PutResponseHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl:
         {
             std::lock_guard<std::mutex> lg(m_mutex);
             current_handler = m_active_handler;
-            for (auto &[_, h] : m_pending_writes) {
+            for (auto &[buf, h, ts] : m_pending_writes) {
                 if (h) pending_handlers.push_back(h);
             }
 
@@ -1337,7 +1337,7 @@ File::PutResponseHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl:
 }
 
 XrdCl::XRootDStatus
-File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer, XrdCl::ResponseHandler *handler)
+File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer, XrdCl::ResponseHandler *handler, struct timespec timeout)
 {
     if (m_op->HasFailed()) {
         auto sc = m_op->GetStatusCode();
@@ -1351,6 +1351,14 @@ File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t
         }
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp, 0, "Cannot continue writing to open file after error");
     }
+    // The PUT is one curl operation spanning every write the client makes, but
+    // the origin sends no response header until the body is complete.  Without
+    // pushing the deadline out per write, the header timeout derived from the
+    // first write would cap the whole upload regardless of how much data is
+    // still flowing.  A wedged transfer is still caught by the stall and
+    // slow-transfer detectors.
+    m_op->ExtendDeadline(timeout);
+
     std::lock_guard<std::mutex> lg(m_mutex);
     if (!m_active) {
         m_active = true;
@@ -1370,7 +1378,7 @@ File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t
             }
         }
     } else {
-        m_pending_writes.emplace_back(std::move(buffer), handler);
+        m_pending_writes.emplace_back(std::move(buffer), handler, timeout);
     }
     return XrdCl::XRootDStatus{};
 }
@@ -1388,9 +1396,13 @@ File::PutResponseHandler::ProcessQueue() {
     }
 
     // Start the next pending write.
-    auto & [buffer, handler] = m_pending_writes.front();
+    auto & [buffer, handler, timeout] = m_pending_writes.front();
     bool rv;
     m_active_handler = handler;
+    // The deadline was extended when this write was queued, but the wait
+    // behind the writes ahead of it may have consumed that budget; re-base
+    // it so the write starts with the timeout its caller asked for.
+    m_op->ExtendDeadline(timeout);
     if (std::holds_alternative<XrdCl::Buffer>(buffer)) {
         rv = m_op->Continue(m_op, this, std::move(std::get<XrdCl::Buffer>(buffer)));
     } else {
@@ -1404,7 +1416,7 @@ File::PutResponseHandler::ProcessQueue() {
         if (m_active_handler) {
             m_active_handler->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError, ENOSPC, "Cannot continue PUT operation"), nullptr);
         }
-        for (auto& [_, h] : m_pending_writes) {
+        for (auto& [buf, h, ts] : m_pending_writes) {
             if (h) {
                 h->HandleResponse(new XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError, ENOSPC, "Cannot continue PUT operation"), nullptr);
             }

--- a/src/XrdClHttp/XrdClHttpFile.hh
+++ b/src/XrdClHttp/XrdClHttpFile.hh
@@ -214,7 +214,15 @@ private:
 
         virtual void HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl::AnyObject *response_raw) override;
 
-        XrdCl::XRootDStatus QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer, XrdCl::ResponseHandler *handler);
+        // Queue another chunk of the in-progress PUT.
+        //
+        // `timeout` is the caller's timeout for this particular write; it
+        // extends the deadline of the underlying curl operation so that a
+        // multi-write upload is not bound by the first write's timeout.
+        // It is retained alongside queued writes so the deadline can be
+        // re-extended when each queued write actually starts.
+        XrdCl::XRootDStatus QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer,
+                                       XrdCl::ResponseHandler *handler, struct timespec timeout);
 
         void SetOp(std::shared_ptr<XrdClHttp::CurlPutOp> op) {m_op = op;}
 
@@ -227,7 +235,7 @@ private:
         XrdCl::ResponseHandler *m_active_handler;
         std::condition_variable m_cv;
         std::mutex m_mutex;
-        std::deque<std::tuple<std::variant<std::pair<const void *, size_t>, XrdCl::Buffer>, XrdCl::ResponseHandler*>> m_pending_writes;
+        std::deque<std::tuple<std::variant<std::pair<const void *, size_t>, XrdCl::Buffer>, XrdCl::ResponseHandler*, struct timespec>> m_pending_writes;
 
         // Start the next pending write operation.
         // Returns false if the active handler was invoked due to an error.

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -190,6 +190,17 @@ CurlOperation::CurlOperation(XrdCl::ResponseHandler *handler, const std::string 
 CurlOperation::~CurlOperation() {}
 
 void
+CurlOperation::ExtendDeadline(struct timespec timeout)
+{
+    auto expiry = CalculateExpiry(timeout);
+    auto current = m_header_expiry.load(std::memory_order_relaxed);
+    while (expiry > current &&
+           !m_header_expiry.compare_exchange_weak(current, expiry,
+                                                  std::memory_order_relaxed))
+        ;
+}
+
+void
 CurlOperation::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 {
     SetDone(true);
@@ -379,7 +390,10 @@ CurlOperation::Redirect(std::string &target)
             m_callout.reset(conn_callout);
             std::string err;
             SetTriedBoker();
-            if ((m_conn_callout_listener = m_callout->BeginCallout(err, m_header_expiry)) == -1) {
+            // BeginCallout takes the expiration by non-const reference; hand it
+            // a copy rather than the atomic's storage.
+            auto expiry = GetHeaderExpiry();
+            if ((m_conn_callout_listener = m_callout->BeginCallout(err, expiry)) == -1) {
                 auto errMsg = "Failed to start a connection callout request: " + err;
                 Fail(XrdCl::errInternal, 0, errMsg.c_str());
                 return RedirectAction::Fail;
@@ -423,7 +437,8 @@ CurlOperation::SetPaused(bool paused) {
 bool
 CurlOperation::StartConnectionCallout(std::string &err)
 {
-    if ((m_conn_callout_listener = m_callout->BeginCallout(err, m_header_expiry)) == -1) {
+    auto expiry = GetHeaderExpiry();
+    if ((m_conn_callout_listener = m_callout->BeginCallout(err, expiry)) == -1) {
         err = "Failed to start a callout for a socket connection: " + err;
         Fail(XrdCl::errInternal, 1, err.c_str());
         return false;
@@ -463,7 +478,7 @@ bool
 CurlOperation::HeaderTimeoutExpired(const std::chrono::steady_clock::time_point &now) {
     if (m_received_header) return false;
 
-    if (now > m_header_expiry) {
+    if (now > GetHeaderExpiry()) {
         if (m_error == OpError::ErrNone) m_error = OpError::ErrHeaderTimeout;
         return true;
     }
@@ -676,7 +691,8 @@ CurlOperation::OpenSocketCallback(void *clientp, curlsocktype purpose, struct cu
     me->m_conn_callout_result = -1;
     if (fd == -1) {
         std::string err;
-        if ((me->m_conn_callout_listener = me->m_callout->BeginCallout(err, me->m_header_expiry)) == -1) {
+        auto expiry = me->GetHeaderExpiry();
+        if ((me->m_conn_callout_listener = me->m_callout->BeginCallout(err, expiry)) == -1) {
             me->m_logger->Debug(kLogXrdClHttp, "Failed to start a connection callout request: %s", err.c_str());
         }
         return CURL_SOCKET_BAD;

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -99,14 +99,31 @@ public:
     // Returns when the curl header timeout expires.
     //
     // The first byte of the header must be received before this time.
-    std::chrono::steady_clock::time_point GetHeaderExpiry() const {return m_header_expiry;}
+    std::chrono::steady_clock::time_point GetHeaderExpiry() const {
+        return m_header_expiry.load(std::memory_order_relaxed);
+    }
+
+    // Push the header deadline out to `timeout` from now, if that is later than
+    // the current deadline; never brings it forward.
+    //
+    // A chunked PUT is a single curl operation that spans many client writes,
+    // each carrying its own timeout.  Without this, the whole upload would stay
+    // bound by the deadline derived from the very first write.
+    void ExtendDeadline(struct timespec timeout);
 
     // Returns when the curl operation expires
     std::chrono::steady_clock::time_point GetOperationExpiry() {
-        if (m_last_xfer == std::chrono::steady_clock::time_point()) {
-            return GetHeaderExpiry();
+        if (m_last_xfer != std::chrono::steady_clock::time_point()) {
+            return m_last_xfer + m_stall_interval;
         }
-        return m_last_xfer + m_stall_interval;
+        // Headers have arrived but no payload byte has been accounted for yet.
+        // The header deadline no longer applies (HeaderTimeoutExpired stops
+        // enforcing it at the same point), so anchor the stall clock on the
+        // last header activity instead of reviving a deadline that is moot.
+        if (m_received_header) {
+            return m_header_lastop + m_stall_interval;
+        }
+        return GetHeaderExpiry();
     }
 
     // Clean up the thread-local DNS cache for fake lookups associated with the
@@ -312,7 +329,10 @@ protected:
     std::chrono::steady_clock::time_point m_operation_expiry;
 
     // The expiration time for receiving the first header.
-    std::chrono::steady_clock::time_point m_header_expiry;
+    //
+    // Atomic because ExtendDeadline() is invoked from the client thread that
+    // submits writes while the curl worker thread evaluates the deadline.
+    std::atomic<std::chrono::steady_clock::time_point> m_header_expiry;
 
     // Any additional headers to send with the request.
     HeaderCallout *m_header_callout;
@@ -413,7 +433,7 @@ public:
         m_parent(op),
         m_parent_curl(curl)
     {
-        m_operation_expiry = m_header_expiry;
+        m_operation_expiry = GetHeaderExpiry();
     }
 
     virtual ~CurlOptionsOp() {}
@@ -449,7 +469,7 @@ public:
     CurlOperation(handler, url, timeout, log, callout, header_callout),
     m_response_info(response_info)
     {
-        m_operation_expiry = m_header_expiry;
+        m_operation_expiry = GetHeaderExpiry();
     }
 
     virtual ~CurlStatOp() {}

--- a/tests/XrdClHttp/WriteTest.cc
+++ b/tests/XrdClHttp/WriteTest.cc
@@ -26,6 +26,8 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <chrono>
 #include <thread>
 
 class CurlWriteFixture : public TransferFixture {
@@ -66,6 +68,92 @@ TEST_F(CurlWriteFixture, ParallelTest)
     for (unsigned ctr=0; ctr<10; ctr++) {
         threads[ctr].join();
     }
+}
+
+// A PUT is one curl operation that spans all Write()s made by the client, and the
+// origin only sends a response at the end, when the body is complete. Ensure the
+// upload is not capped by the header timeout derived from the first write, but that
+// each individual write is within the timeout.
+//
+// `xrdclhttp.timeout` is reduced by a second when parsed, so the header timeout
+// here is 2s while the writes span about 4s.  Every individual gap is well
+// inside both that and the 10s timeout each Write() asks for.
+TEST_F(CurlWriteFixture, SlowClientWriteTest)
+{
+    constexpr uint32_t chunkSize = 10'000;
+    constexpr unsigned chunkCount = 5;
+
+    XrdCl::File fh;
+    auto name = GetOriginURL() + "/test/write_slow_client";
+    auto url = name + "?authz=" + GetWriteToken()
+             + "&oss.asize=" + std::to_string(chunkCount * chunkSize)
+             + "&xrdclhttp.timeout=3s";
+    auto rv = fh.Open(url, XrdCl::OpenFlags::Write, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToStr();
+
+    unsigned char chunkByte = 'a';
+    uint64_t offset = 0;
+    for (unsigned ctr = 0; ctr < chunkCount; ctr++) {
+        if (ctr) std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::string writeBuffer(chunkSize, chunkByte);
+        rv = fh.Write(offset, chunkSize, writeBuffer.data(), static_cast<time_t>(10));
+        ASSERT_TRUE(rv.IsOK()) << "Failed to write chunk " << ctr << " of " << name << ": " << rv.ToStr();
+        offset += chunkSize;
+        chunkByte += 1;
+    }
+
+    rv = fh.Close();
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close " << name << ": " << rv.ToStr();
+
+    VerifyContents(name, chunkCount * chunkSize, 'a', chunkSize);
+}
+
+// Issue a burst of async writes so that writes 2..N land in the PUT handler's
+// pending queue while the first chunk is still in flight, then close and verify.
+// This is the only test that drives the queued-write path (m_pending_writes and
+// ProcessQueue), including the deadline re-base when each queued write starts.
+// It does not reproduce the queued-deadline timing defect deterministically:
+// that would need the queue drain to outlast the header timeout, which requires
+// a throttled origin the localhost fixture cannot provide.
+TEST_F(CurlWriteFixture, QueuedWriteTest)
+{
+    constexpr uint32_t chunkSize = 10'000;
+    constexpr unsigned chunkCount = 5;
+
+    // Buffers and handlers outlive the file handle so an early ASSERT return
+    // destroys the file (which waits on in-flight writes) before the memory
+    // those writes reference.
+    std::vector<std::string> buffers;
+    buffers.reserve(chunkCount);
+    std::array<SyncResponseHandler, chunkCount> handlers;
+
+    XrdCl::File fh;
+    auto name = GetOriginURL() + "/test/write_queued";
+    auto url = name + "?authz=" + GetWriteToken()
+             + "&oss.asize=" + std::to_string(chunkCount * chunkSize);
+    auto rv = fh.Open(url, XrdCl::OpenFlags::Write, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToStr();
+
+    unsigned char chunkByte = 'a';
+    uint64_t offset = 0;
+    for (unsigned ctr = 0; ctr < chunkCount; ctr++) {
+        buffers.emplace_back(chunkSize, chunkByte);
+        rv = fh.Write(offset, chunkSize, buffers.back().data(), &handlers[ctr], static_cast<time_t>(10));
+        ASSERT_TRUE(rv.IsOK()) << "Failed to submit chunk " << ctr << " of " << name << ": " << rv.ToStr();
+        offset += chunkSize;
+        chunkByte += 1;
+    }
+
+    for (unsigned ctr = 0; ctr < chunkCount; ctr++) {
+        handlers[ctr].Wait();
+        auto [status, obj] = handlers[ctr].Status();
+        ASSERT_TRUE(status->IsOK()) << "Chunk " << ctr << " of " << name << " failed: " << status->ToStr();
+    }
+
+    rv = fh.Close();
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close " << name << ": " << rv.ToStr();
+
+    VerifyContents(name, chunkCount * chunkSize, 'a', chunkSize);
 }
 
 // Ensure that writes fail after the PUT times out.

--- a/tests/XrdClHttpCommon/TransferTest.cc
+++ b/tests/XrdClHttpCommon/TransferTest.cc
@@ -105,7 +105,7 @@ TransferFixture::WritePattern(const std::string &name, const off_t writeSize,
 
     auto url = name + "?authz=" + GetWriteToken() + "&oss.asize=" + std::to_string(writeSize);
     auto rv = fh.Open(url, XrdCl::OpenFlags::Write, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
-    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToString();
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToStr();
 
     size_t sizeToWrite = (static_cast<off_t>(chunkSize) >= writeSize)
                                                         ? static_cast<size_t>(writeSize)
@@ -117,7 +117,8 @@ TransferFixture::WritePattern(const std::string &name, const off_t writeSize,
         std::string writeBuffer(sizeToWrite, curChunkByte);
 
         rv = fh.Write(offset, sizeToWrite, writeBuffer.data(), static_cast<time_t>(10));
-        ASSERT_TRUE(rv.IsOK()) << "Failed to write " << name << ": " << rv.ToString();
+        ASSERT_TRUE(rv.IsOK()) << "Failed to write " << name << " at offset " << offset
+                               << " (" << sizeToWrite << " bytes): " << rv.ToStr();
         
         curWriteSize -= sizeToWrite;
         offset += sizeToWrite;
@@ -128,7 +129,7 @@ TransferFixture::WritePattern(const std::string &name, const off_t writeSize,
     }
 
     rv = fh.Close();
-    ASSERT_TRUE(rv.IsOK());
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close " << name << " after write: " << rv.ToStr();
     m_log->Debug(XrdCl::UtilityMsg, "Finished writing transfer pattern to %s", name.c_str());
 
     VerifyContents(name, writeSize, chunkByte, chunkSize);
@@ -141,7 +142,7 @@ TransferFixture::VerifyContents(const std::string &obj,
     XrdCl::File fh;
     auto url = obj + "?authz=" + GetReadToken();
     auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
-    ASSERT_TRUE(rv.IsOK());
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << obj << " for read: " << rv.ToStr();
 
     return VerifyContents(fh, expectedSize, chunkByte, chunkSize);
 }
@@ -160,7 +161,8 @@ TransferFixture::VerifyContents(XrdCl::File &fh,
         std::string readBuffer(sizeToRead, curChunkByte - 1);
         uint32_t bytesRead;
         auto rv = fh.Read(offset, sizeToRead, readBuffer.data(), bytesRead, static_cast<time_t>(0));
-        ASSERT_TRUE(rv.IsOK());
+        ASSERT_TRUE(rv.IsOK()) << "Failed to read at offset " << offset
+                               << " (" << sizeToRead << " bytes): " << rv.ToStr();
         ASSERT_EQ(bytesRead, sizeToRead);
         readBuffer.resize(sizeToRead);
 
@@ -176,7 +178,7 @@ TransferFixture::VerifyContents(XrdCl::File &fh,
     }
 
     auto rv = fh.Close();
-    ASSERT_TRUE(rv.IsOK());
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close after read: " << rv.ToStr();
 }
 
 void


### PR DESCRIPTION
`CurlWriteFixture.ParallelTest` [failed intermittently in CI](https://my.cdash.org/tests/460170329) with `"[ERROR] Operation expired"`.

A chunked `PUT` is one curl operation that spans all `Write()`s the client issues. However, it was given a single absolute deadline computed at the first write and never re-based. `File::Write derives ts = GetHeaderTimeout(timeout)`, which is `min(header timeout, caller's timeout)` -- 9.5s by default -- and the `CurlPutOp` constructor turns that into an absolute deadline assigned only once. `Setup()` re-bases every other clock but not that one, and `ContinueHandle()` does no re-bases. Writes 2..N reached `QueueWrite()`, where ts was computed, but not used.

The origin sends no response header until the full body is complete, and m_received_header is never set for these uploads, so `HeaderTimeoutExpired()` stays armed from the first write to the final response. The whole upload of one file was therefore capped at 9.5s of wall clock however much data was still flowing. Ten 40KB writes 1.5s apart -- every gap far inside its own 10s timeout -- die at 10.5s with "Origin did not respond within timeout", and move to 3s exactly when `XRD_HTTPDEFAULTHEADERTIMEOUT=3s` is set.

Thread each write's own timeout through `QueueWrite()` to a new `CurlOperation::ExtendDeadline()`, which moves the deadline forward for each new `Write()`. All five call sites now pass it, including `Close()`'s final flush -- which is what makes the header timeout mean what it says: the time from the last body byte to the response headers. A wedged transfer is still bounded, by the stall and slow-rate detectors, which this doesn't change.

`GetOperationExpiry()` had the same defect one level down: it fell back to the header deadline whenever `m_last_xfer` was unset, without checking `m_received_header` the way `HeaderTimeoutExpired()` does, so the queue sweeper and `Produce()` could fail an operation on a deadline already known to be moot. It now anchors on `m_header_lastop + m_stall_interval` in that case.

`m_header_expiry` becomes atomic: it was write-once-before-publish, and `ExtendDeadline()` adds a client-thread writer against a worker-thread reader. The `BeginCallout()` sites take the expiration by non-const reference and now pass a local copy.

TransferTest printed `rv.ToString()`, which gives only the error-code name and drops the detail message -- seven distinct sites in the plugin raise `errOperationExpired` with seven distinct messages, so the CI log could not say which one fired. Use `rv.ToStr()`, and give the assertions that carried no message at all one.

`CurlWriteFixture.SlowClientWriteTest` is the regression guard: five writes a second apart against a per-file xrdclhttp.timeout of 3s (parsed as 2s), so the writes span twice the header timeout while every gap stays well inside it.

Also correct `m_default_header_timeout from {9, 5}` -- nine seconds and five nanoseconds -- to `{9, 500'000'000}`, matching what `Factory::Initialize` sets. It was harmless only because the factory overwrites it.

Assisted-by: Claude:Opus 5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected HTTP header timeout handling.
  - Improved timeout behavior for delayed and queued PUT writes, helping prevent premature failures.
  - Preserved each queued write’s timeout settings and extended deadlines when additional data is pending.

- **Tests**
  - Added coverage for slow sequential writes and queued asynchronous writes.
  - Improved transfer-test failure messages with operation and file details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->