### PR TITLE
[Tests] Prefer bundled GoogleTest headers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -101,6 +101,7 @@ jobs:
         dnf install -y dnf-plugins-core epel-release git rpmdevtools sudo
         dnf install -y epel-rpm-macros
         dnf config-manager --set-enabled powertools
+        dnf install -y gtest-devel
 
     - name: Clone repository
       uses: actions/checkout@v6
@@ -303,7 +304,7 @@ jobs:
       run: sudo sed -i -e "s/localhost/localhost $(hostname)/g" /etc/hosts
 
     - name: Install dependencies with Homebrew
-      run: brew install libzip nlohmann-json python-setuptools
+      run: brew install googletest libzip nlohmann-json python-setuptools
 
     - name: Clone repository
       uses: actions/checkout@v6

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -43,7 +43,7 @@ jobs:
       run: sudo sed -i -e "s/localhost/localhost $(hostname)/g" /etc/hosts
 
     - name: Install dependencies with Homebrew
-      run: brew install libzip nlohmann-json python-setuptools
+      run: brew install googletest libzip nlohmann-json python-setuptools
 
     - name: Clone repository
       uses: actions/checkout@v6

--- a/vendor/googletest/googlemock/CMakeLists.txt
+++ b/vendor/googletest/googlemock/CMakeLists.txt
@@ -103,12 +103,27 @@ else()
 endif()
 
 string(REPLACE ";" "$<SEMICOLON>" dirs "${gmock_build_include_dirs}")
-target_include_directories(gmock SYSTEM INTERFACE
-  "$<BUILD_INTERFACE:${dirs}>"
-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-target_include_directories(gmock_main SYSTEM INTERFACE
-  "$<BUILD_INTERFACE:${dirs}>"
-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+if(NOT MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # Keep the build-tree headers ahead of unrelated system prefixes while
+  # retaining system-header diagnostics behavior for Google Mock itself.
+  target_include_directories(gmock BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>")
+  target_include_directories(gmock SYSTEM BEFORE INTERFACE
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_include_directories(gmock_main BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>")
+  target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_compile_options(gmock INTERFACE
+    "$<BUILD_INTERFACE:--system-header-prefix=gmock/>")
+else()
+  target_include_directories(gmock SYSTEM BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_include_directories(gmock_main SYSTEM BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+endif()
 
 ########################################################################
 #

--- a/vendor/googletest/googletest/CMakeLists.txt
+++ b/vendor/googletest/googletest/CMakeLists.txt
@@ -141,12 +141,27 @@ endif()
 cxx_library(gtest_main "${cxx_strict}" src/gtest_main.cc)
 set_target_properties(gtest_main PROPERTIES VERSION ${GOOGLETEST_VERSION})
 string(REPLACE ";" "$<SEMICOLON>" dirs "${gtest_build_include_dirs}")
-target_include_directories(gtest SYSTEM INTERFACE
-  "$<BUILD_INTERFACE:${dirs}>"
-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
-target_include_directories(gtest_main SYSTEM INTERFACE
-  "$<BUILD_INTERFACE:${dirs}>"
-  "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+if(NOT MSVC AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # Keep the build-tree headers ahead of unrelated system prefixes while
+  # retaining system-header diagnostics behavior for Google Test itself.
+  target_include_directories(gtest BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>")
+  target_include_directories(gtest SYSTEM BEFORE INTERFACE
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_include_directories(gtest_main BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>")
+  target_include_directories(gtest_main SYSTEM BEFORE INTERFACE
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_compile_options(gtest INTERFACE
+    "$<BUILD_INTERFACE:--system-header-prefix=gtest/>")
+else()
+  target_include_directories(gtest SYSTEM BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+  target_include_directories(gtest_main SYSTEM BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${dirs}>"
+    "$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_INCLUDEDIR}>")
+endif()
 if(CMAKE_SYSTEM_NAME MATCHES "QNX" AND CMAKE_SYSTEM_VERSION VERSION_GREATER_EQUAL 7.1)
   target_link_libraries(gtest PUBLIC regex)
 endif()


### PR DESCRIPTION
Keep the bundled GoogleTest headers ahead of include paths exported by other dependencies. On Homebrew systems, nlohmann_json exposes the common package prefix and may otherwise select incompatible system GoogleTest headers while linking the bundled libraries.

Make the ordering apply centrally to every test target so individual test directories do not need their own workaround.