### PR TITLE
[CMake] Ignore local build and IDE artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,19 @@
-# CMake build directory
+# CMake build directories and local configuration
 build/
+build-*/
+cmake-build-*/
+CMakeUserPresets.json
+/compile_commands.json
+
+# IDE metadata
+.idea/
+
+# macOS metadata
+.DS_Store
+
 # docker builds
 docker/xrootd.tar.gz
+
 # Python build artifacts
 dist/
 *.egg-info


### PR DESCRIPTION
Ignore common out-of-tree CMake build directories, user presets, and root compile command databases. These generated files otherwise make local development directories appear as untracked content.

Also exclude CLion and macOS metadata while leaving project-specific nested repositories and patch files visible.