### PR TITLE
[XrdCl] Support HTTP directories in xrdcp

### DIFF
--- a/src/XrdCl/XrdClCopy.cc
+++ b/src/XrdCl/XrdClCopy.cc
@@ -379,6 +379,15 @@ const char *FileType2String( XrdCpFile::PType type )
 }
 
 //------------------------------------------------------------------------------
+// Return whether a remote protocol supports filesystem directory operations
+//------------------------------------------------------------------------------
+bool SupportsRemoteDirectories( XrdCpFile::PType type )
+{
+  return type == XrdCpFile::isXroot  || type == XrdCpFile::isXroots ||
+         type == XrdCpFile::isHttp   || type == XrdCpFile::isHttps;
+}
+
+//------------------------------------------------------------------------------
 // Count the sources
 //------------------------------------------------------------------------------
 uint32_t CountSources( XrdCpFile *file )
@@ -713,8 +722,7 @@ int main( int argc, char **argv )
   bool targetExists = false;
   if( config.dstFile->Protocol == XrdCpFile::isDir )
     targetIsDir = true;
-  else if( config.dstFile->Protocol == XrdCpFile::isXroot ||
-           config.dstFile->Protocol == XrdCpFile::isXroots )
+  else if( SupportsRemoteDirectories( config.dstFile->Protocol ) )
   {
     URL target( dest );
     FileSystem fs( target );
@@ -769,8 +777,7 @@ int main( int argc, char **argv )
   //----------------------------------------------------------------------------
   bool remoteSrcIsDir = false;
   if( config.Want( XrdCpConfig::DoRecurse ) &&
-      (config.srcFile->Protocol == XrdCpFile::isXroot ||
-       config.srcFile->Protocol == XrdCpFile::isXroots) )
+      SupportsRemoteDirectories( config.srcFile->Protocol ) )
   {
     URL          source( config.srcFile->Path );
     FileSystem  *fs       = new FileSystem( source );
@@ -970,4 +977,3 @@ int main( int argc, char **argv )
   CleanUpResults( resultVect );
   return 0;
 }
-

--- a/src/XrdCl/XrdClFileSystem.cc
+++ b/src/XrdCl/XrdClFileSystem.cc
@@ -1671,13 +1671,9 @@ namespace XrdCl
                                     ResponseHandler     *handler,
                                     time_t               timeout )
   {
-    if( pPlugIn )
-      return pPlugIn->DirList( path, flags, handler, timeout );
-
-    URL url = URL( path );
     std::string fPath = FilterXrdClCgi( path );
 
-    if( flags & DirListFlags::Zip )
+    if( !pPlugIn && ( flags & DirListFlags::Zip ) )
     {
       // stat the file to check if it is a directory or a file
       // the ZIP handler will take care of the rest
@@ -1688,6 +1684,20 @@ namespace XrdCl
       return st;
     }
 
+    if( flags & DirListFlags::Recursive )
+    {
+      handler = new RecursiveDirListHandler( *pImpl->fsdata->pUrl,
+                                             path, flags,
+                                             handler, timeout );
+      flags = ( flags & (~DirListFlags::Recursive) ) | DirListFlags::Stat;
+    }
+
+    if( flags & DirListFlags::Merge )
+      handler = new MergeDirListHandler( flags & DirListFlags::Chunked, handler );
+
+    if( pPlugIn )
+      return pPlugIn->DirList( path, flags, handler, timeout );
+
     Message           *msg;
     ClientDirlistRequest *req;
     MessageUtils::CreateRequest( msg, req, fPath.length() );
@@ -1695,17 +1705,11 @@ namespace XrdCl
     req->requestid  = kXR_dirlist;
     req->dlen       = fPath.length();
 
-    if( ( flags & DirListFlags::Stat ) || ( flags & DirListFlags::Recursive ) )
+    if( flags & DirListFlags::Stat )
       req->options[0] = kXR_dstat;
 
     if( ( flags & DirListFlags::Cksm ) )
       req->options[0] = kXR_dstat | kXR_dcksm;
-
-    if( flags & DirListFlags::Recursive )
-      handler = new RecursiveDirListHandler( *pImpl->fsdata->pUrl, url.GetPath(), flags, handler, timeout );
-
-    if( flags & DirListFlags::Merge )
-      handler = new MergeDirListHandler( flags & DirListFlags::Chunked, handler );
 
     msg->Append( fPath.c_str(), fPath.length(), 24 );
     MessageSendParams params; params.timeout = timeout;

--- a/src/XrdClHttp/XrdClHttpFilesystem.cc
+++ b/src/XrdClHttp/XrdClHttpFilesystem.cc
@@ -76,7 +76,7 @@ Filesystem::DirList(const std::string          &path,
 
     m_logger->Debug(kLogXrdClHttp, "Filesystem::DirList path %s", path.c_str());
     auto listdirOp = std::make_unique<XrdClHttp::CurlListdirOp>(
-        handler, full_url,
+        handler, full_url, path,
         m_url.GetHostName() + ":" + std::to_string(m_url.GetPort()),
         SendResponseInfo(), ts, m_logger,
         GetConnCallout(), m_header_callout.load(std::memory_order_acquire));

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -29,11 +29,14 @@
 
 using namespace XrdClHttp;
 
-CurlListdirOp::CurlListdirOp(XrdCl::ResponseHandler *handler, const std::string &url, const std::string &host_addr,
-    bool set_response_info, struct timespec timeout, XrdCl::Log *logger, CreateConnCalloutType callout,
+CurlListdirOp::CurlListdirOp(XrdCl::ResponseHandler *handler,
+    const std::string &url, const std::string &parent,
+    const std::string &host_addr, bool set_response_info,
+    struct timespec timeout, XrdCl::Log *logger, CreateConnCalloutType callout,
     HeaderCallout *header_callout) :
     CurlOperation(handler, url, timeout, logger, callout, header_callout),
     m_response_info(set_response_info),
+    m_parent(parent),
     m_host_addr(host_addr)
 {
     m_minimum_rate = 1024.0 * 1;
@@ -171,6 +174,7 @@ CurlListdirOp::Success()
     m_logger->Debug(kLogXrdClHttp, "CurlListdirOp::Success");
 
     std::unique_ptr<XrdCl::DirectoryList> dirlist(m_response_info ? new DirectoryListResponse() : new XrdCl::DirectoryList());
+    dirlist->SetParentName(m_parent);
 
     TiXmlDocument doc;
     doc.Parse(m_response.c_str());

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -814,8 +814,10 @@ public:
 
 class CurlListdirOp final : public CurlOperation {
 public:
-    CurlListdirOp(XrdCl::ResponseHandler *handler, const std::string &url, const std::string &host_addr, bool response_info,
-        struct timespec timeout, XrdCl::Log *logger, CreateConnCalloutType callout, HeaderCallout *header_callout);
+    CurlListdirOp(XrdCl::ResponseHandler *handler, const std::string &url,
+        const std::string &parent, const std::string &host_addr,
+        bool response_info, struct timespec timeout, XrdCl::Log *logger,
+        CreateConnCalloutType callout, HeaderCallout *header_callout);
 
     virtual ~CurlListdirOp() {}
 
@@ -853,6 +855,9 @@ private:
 
     // Response body from the PROPFIND request.
     std::string m_response;
+
+    // Path whose entries are returned by the PROPFIND request.
+    std::string m_parent;
 
     // Host address (hostname:port) of the data federation
     std::string m_host_addr;

--- a/tests/XRootD/http.sh
+++ b/tests/XRootD/http.sh
@@ -109,6 +109,30 @@ function test_http() {
 		assert xrdcp "${DAV_HOST}/${TMPDIR}/${i}.ref" "${TMPDIR}/${i}.dat"
 	done
 
+	# Upload multiple sources to an HTTP directory in one xrdcp invocation.
+	MULTI_UPLOAD_DIR="${TMPDIR}/multi-upload"
+	printf 'first HTTP directory copy\n' > "${TMPDIR}/multi-one.ref"
+	printf 'second HTTP directory copy\n' > "${TMPDIR}/multi-two.ref"
+	printf 'nested HTTP directory copy\n' > "${TMPDIR}/multi-three.ref"
+	assert xrdfs "${DAV_HOST}" mkdir -p "${MULTI_UPLOAD_DIR}/nested"
+	assert xrdcp --parallel 2 \
+		"${TMPDIR}/multi-one.ref" "${TMPDIR}/multi-two.ref" \
+		"${DAV_HOST}/${MULTI_UPLOAD_DIR}"
+	assert xrdcp "${TMPDIR}/multi-three.ref" \
+		"${DAV_HOST}/${MULTI_UPLOAD_DIR}/nested/multi-three.ref"
+
+	# Recursively download the HTTP directory and preserve its hierarchy.
+	RECURSIVE_DOWNLOAD_DIR="${TMPDIR}/recursive-download"
+	mkdir "${RECURSIVE_DOWNLOAD_DIR}"
+	assert xrdcp --recursive "${DAV_HOST}/${MULTI_UPLOAD_DIR}" \
+		"${RECURSIVE_DOWNLOAD_DIR}"
+	assert cmp "${TMPDIR}/multi-one.ref" \
+		"${RECURSIVE_DOWNLOAD_DIR}/multi-upload/multi-one.ref"
+	assert cmp "${TMPDIR}/multi-two.ref" \
+		"${RECURSIVE_DOWNLOAD_DIR}/multi-upload/multi-two.ref"
+	assert cmp "${TMPDIR}/multi-three.ref" \
+		"${RECURSIVE_DOWNLOAD_DIR}/multi-upload/nested/multi-three.ref"
+
 	# check that all checksums for downloaded files match
 
 	for i in $FILES; do


### PR DESCRIPTION
Remote directory detection in xrdcp was limited to the XRootD protocols. As a result, multiple uploads rejected valid HTTP directory targets and recursive HTTP downloads attempted to open directories as files.

Apply recursive and merge directory-list handling before dispatching to filesystem plug-ins, preserve each plug-in response parent without reparsing relative paths as URLs, and allow xrdcp to use these operations for HTTP and HTTPS. Add an end-to-end test covering parallel uploads and a nested recursive download.

This was discovered during the validation of tape rest api but its unrelated to the tape client implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for remote directory operations over HTTP and HTTPS.
  * Improved directory listing behavior for recursive requests, plugins, and archive-backed paths.
  * Preserved parent directory information in HTTP directory listings.

* **Bug Fixes**
  * Improved recursive downloads and multi-source uploads involving HTTP directories.
  * Ensured nested paths and file contents are preserved correctly.

* **Tests**
  * Added coverage for parallel HTTP uploads, recursive downloads, nested directories, and content integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->