### PR TITLE
[XrdClHttp] Handle resource-scoped WebDAV capabilities

### DIFF
--- a/src/XrdClHttp/CMakeLists.txt
+++ b/src/XrdClHttp/CMakeLists.txt
@@ -30,7 +30,8 @@ add_library(XrdClHttpObj OBJECT
   XrdClHttpParseTimeout.cc   XrdClHttpParseTimeout.hh
   XrdClHttpTape.cc           XrdClHttpTape.hh
   XrdClHttpUtil.cc           XrdClHttpUtil.hh
-                           XrdClHttpVerb.hh
+                              XrdClHttpVerb.hh
+  XrdClHttpWebDav.cc         XrdClHttpWebDav.hh
   XrdClHttpWorker.hh
 )
 

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -101,24 +101,14 @@ CurlListdirOp::ParseResponse(TiXmlElement *response)
             }
             continue;
         }
-        if (!WebDavElementNameEquals(child, "propstat")) {
-            continue;
-        }
-        for (auto propstat = child->FirstChildElement(); propstat != nullptr; propstat = propstat->NextSiblingElement()) {
-            if (!WebDavElementNameEquals(propstat, "prop")) {
-                continue;
-            }
-            WebDavProperties properties;
-            success = ParseWebDavProperties(propstat, properties);
-            if (!success) {
-                return {entry, success};
-            }
-            entry.m_isdir = properties.m_is_dir;
-            entry.m_isexec = properties.m_is_executable;
-            entry.m_size = properties.m_size;
-            entry.m_lastmodified = properties.m_last_modified;
-        }
     }
+    WebDavProperties properties;
+    success = ParseWebDavResponseProperties(response, properties);
+    if (!success) return {entry, false};
+    entry.m_isdir = properties.m_is_dir;
+    entry.m_isexec = properties.m_is_executable;
+    entry.m_size = properties.m_size;
+    entry.m_lastmodified = properties.m_last_modified;
     return {entry, success};
 }
 

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -85,13 +85,12 @@ bool CurlListdirOp::ParseProp(DavEntry &entry, TiXmlElement *prop)
             }
         } else if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
             auto size = child->GetText();
-            if (size == nullptr) {
-                return false;
-            }
-            try {
-                entry.m_size = std::stoll(size);
-            } catch (std::invalid_argument &e) {
-                return false;
+            if (size != nullptr) {
+                try {
+                    entry.m_size = std::stoll(size);
+                } catch (std::invalid_argument &e) {
+                    return false;
+                }
             }
         } else if (!strcasecmp(child->Value(), "D:getlastmodified") || !strcasecmp(child->Value(), "lp1:getlastmodified")) {
             auto lastmod = child->GetText();

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -21,6 +21,7 @@
 #include "XrdClHttpOps.hh"
 #include "XrdClHttpResponses.hh"
 #include "XrdClHttpUtil.hh"
+#include "XrdClHttpWebDav.hh"
 
 #include <XrdCl/XrdClLog.hh>
 #include <XrdCl/XrdClXRootDResponses.hh>
@@ -74,60 +75,13 @@ CurlListdirOp::WriteCallback(char *buffer, size_t size, size_t nitems, void *thi
     return size * nitems;
 }
 
-bool CurlListdirOp::ParseProp(DavEntry &entry, TiXmlElement *prop)
-{
-    for (auto child = prop->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
-            auto collection = child->FirstChildElement("D:collection");
-            entry.m_isdir = collection != nullptr;
-            if (entry.m_isdir && entry.m_size < 0) {
-                entry.m_size = 0;
-            }
-        } else if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
-            auto size = child->GetText();
-            if (size != nullptr) {
-                try {
-                    entry.m_size = std::stoll(size);
-                } catch (std::invalid_argument &e) {
-                    return false;
-                }
-            }
-        } else if (!strcasecmp(child->Value(), "D:getlastmodified") || !strcasecmp(child->Value(), "lp1:getlastmodified")) {
-            auto lastmod = child->GetText();
-            if (lastmod == nullptr) {
-                return false;
-            }
-            struct tm tm;
-            if (strptime(lastmod, "%a, %d %b %Y %H:%M:%S", &tm) == nullptr) {
-                return false;
-            }
-            entry.m_lastmodified = timegm(&tm);
-        } else if (strcasecmp(child->Value(), "D:href") == 0) {
-            auto href = child->GetText();
-            if (href == nullptr) {
-                return false;
-            }
-            entry.m_name = href;
-        } else if (!strcasecmp(child->Value(), "D:executable") || !strcasecmp(child->Value(), "lp1:executable")) {
-            auto val = child->GetText();
-            if (val == nullptr) {
-                return false;
-            }
-            if (strcasecmp(val, "T") == 0) {
-                entry.m_isexec = true;
-            }
-        }
-    }
-    return true;    
-}
-
 std::pair<CurlListdirOp::DavEntry, bool>
 CurlListdirOp::ParseResponse(TiXmlElement *response)
 {
     DavEntry entry;
     bool success = false;
     for (auto child = response->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!strcasecmp(child->Value(), "D:href")) {
+        if (WebDavElementNameEquals(child, "href")) {
             auto href = child->GetText();
             if (href == nullptr) {
                 return {entry, false};
@@ -147,17 +101,22 @@ CurlListdirOp::ParseResponse(TiXmlElement *response)
             }
             continue;
         }
-        if (strcasecmp(child->Value(), "D:propstat")) {
+        if (!WebDavElementNameEquals(child, "propstat")) {
             continue;
         }
         for (auto propstat = child->FirstChildElement(); propstat != nullptr; propstat = propstat->NextSiblingElement()) {
-            if (strcasecmp(propstat->Value(), "D:prop")) {
+            if (!WebDavElementNameEquals(propstat, "prop")) {
                 continue;
             }
-            success = ParseProp(entry, propstat);
+            WebDavProperties properties;
+            success = ParseWebDavProperties(propstat, properties);
             if (!success) {
                 return {entry, success};
             }
+            entry.m_isdir = properties.m_is_dir;
+            entry.m_isexec = properties.m_is_executable;
+            entry.m_size = properties.m_size;
+            entry.m_lastmodified = properties.m_last_modified;
         }
     }
     return {entry, success};
@@ -180,14 +139,14 @@ CurlListdirOp::Success()
     }
 
     auto elem = doc.RootElement();
-    if (strcasecmp(elem->Value(), "D:multistatus")) {
+    if (!WebDavElementNameEquals(elem, "multistatus")) {
         m_logger->Error(kLogXrdClHttp, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
         Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded to directory listing unexpected XML root");
         return;
     }
     bool skip = true;
     for (auto response = elem->FirstChildElement(); response != nullptr; response = response->NextSiblingElement()) {
-        if (strcasecmp(response->Value(), "D:response")) {
+        if (!WebDavElementNameEquals(response, "response")) {
             continue;
         }
 

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -134,7 +134,10 @@ CurlStatOp::ParseProp(TiXmlElement *prop) {
                 m_length = std::stoll(len);
             }
         } else if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
-            m_is_dir = child->FirstChildElement("D:collection") != nullptr;
+            auto type = child->FirstChildElement();
+            m_is_dir = type != nullptr &&
+                (!strcasecmp(type->Value(), "D:collection") ||
+                 !strcasecmp(type->Value(), "lp1:collection"));
         }
     }
     if (m_length < 0 && m_is_dir) {

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -20,6 +20,7 @@
 
 #include "XrdClHttpOps.hh"
 #include "XrdClHttpResponses.hh"
+#include "XrdClHttpWebDav.hh"
 
 #include <XrdCl/XrdClLog.hh>
 
@@ -123,31 +124,6 @@ CurlStatOp::WriteCallback(char *buffer, size_t size, size_t nitems, void *this_p
 }
 
 std::pair<int64_t, bool>
-CurlStatOp::ParseProp(TiXmlElement *prop) {
-    if (prop == nullptr) {
-        return {-1, false};
-    }
-    for (auto child = prop->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
-            auto len = child->GetText();
-            if (len) {
-                m_length = std::stoll(len);
-            }
-        } else if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
-            auto type = child->FirstChildElement();
-            m_is_dir = type != nullptr &&
-                (!strcasecmp(type->Value(), "D:collection") ||
-                 !strcasecmp(type->Value(), "lp1:collection"));
-        }
-    }
-    if (m_length < 0 && m_is_dir) {
-        // Don't require length for directories; fake it as zero
-        m_length = 0;
-    }
-    return {m_length, m_is_dir};
-}
-
-std::pair<int64_t, bool>
 CurlStatOp::GetStatInfo() {
     if (!m_is_propfind) {
         m_length = m_headers.GetContentLength();
@@ -165,13 +141,13 @@ CurlStatOp::GetStatInfo() {
     }
 
     auto elem = doc.RootElement();
-    if (strcasecmp(elem->Value(), "D:multistatus")) {
+    if (!WebDavElementNameEquals(elem, "multistatus")) {
         m_logger->Error(kLogXrdClHttp, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
         return {-1, false};
     }
     auto found_response = false;
     for (auto response = elem->FirstChildElement(); response != nullptr; response = response->NextSiblingElement()) {
-        if (!strcasecmp(response->Value(), "D:response")) {
+        if (WebDavElementNameEquals(response, "response")) {
             found_response = true;
             elem = response;
             break;
@@ -182,15 +158,21 @@ CurlStatOp::GetStatInfo() {
         return {-1, false};
     }
     for (auto child = elem->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-		if (strcasecmp(child->Value(), "D:propstat")) {
+        if (!WebDavElementNameEquals(child, "propstat")) {
             continue;
         }
         for (auto prop = child->FirstChildElement(); prop != nullptr; prop = prop->NextSiblingElement()) {
-            if (!strcasecmp(prop->Value(), "D:prop")) {
-                return ParseProp(prop);
+            if (WebDavElementNameEquals(prop, "prop")) {
+                WebDavProperties properties;
+                if (!ParseWebDavProperties(prop, properties)) {
+                    return {-1, false};
+                }
+                m_length = properties.m_size;
+                m_is_dir = properties.m_is_dir;
+                return {m_length, m_is_dir};
             }
         }
-	}
+    }
     m_logger->Error(kLogXrdClHttp, "Failed to find properties in XML response: %s", m_response.substr(0, 1024).c_str());
     return {-1, false};
 }

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -157,21 +157,11 @@ CurlStatOp::GetStatInfo() {
         m_logger->Error(kLogXrdClHttp, "Failed to find response element in XML response: %s", m_response.substr(0, 1024).c_str());
         return {-1, false};
     }
-    for (auto child = elem->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!WebDavElementNameEquals(child, "propstat")) {
-            continue;
-        }
-        for (auto prop = child->FirstChildElement(); prop != nullptr; prop = prop->NextSiblingElement()) {
-            if (WebDavElementNameEquals(prop, "prop")) {
-                WebDavProperties properties;
-                if (!ParseWebDavProperties(prop, properties)) {
-                    return {-1, false};
-                }
-                m_length = properties.m_size;
-                m_is_dir = properties.m_is_dir;
-                return {m_length, m_is_dir};
-            }
-        }
+    WebDavProperties properties;
+    if (ParseWebDavResponseProperties(elem, properties)) {
+        m_length = properties.m_size;
+        m_is_dir = properties.m_is_dir;
+        return {m_length, m_is_dir};
     }
     m_logger->Error(kLogXrdClHttp, "Failed to find properties in XML response: %s", m_response.substr(0, 1024).c_str());
     return {-1, false};

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -476,8 +476,6 @@ protected:
     void SuccessImpl(bool returnObj);
 
 private:
-    // Parse the properties element of a PROPFIND response.
-    std::pair<int64_t, bool> ParseProp(TiXmlElement *prop);
     // Callback for writing the response body to the internal buffer.
     static size_t WriteCallback(char *buffer, size_t size, size_t nitems, void *this_ptr);
 
@@ -833,12 +831,6 @@ private:
         int64_t m_size{-1};
         time_t m_lastmodified{-1};
     };
-    // Parses the properties element of a PROPFIND response into a DavEntry object
-    //
-    // - prop: The properties element to parse
-    // - Returns: A pair containing the DavEntry object and a boolean indicating success or not
-    bool ParseProp(DavEntry &entry, TiXmlElement *prop);
-
     // Indicate whether the operation should use the extended "response info" object in response
     const bool m_response_info{false};
 

--- a/src/XrdClHttp/XrdClHttpOptionsCache.cc
+++ b/src/XrdClHttp/XrdClHttpOptionsCache.cc
@@ -20,6 +20,8 @@
 
 #include "XrdClHttpOptionsCache.hh"
 
+#include <XrdCl/XrdClURL.hh>
+
 #include <curl/curl.h>
 
 #include <thread>
@@ -33,6 +35,15 @@ std::thread XrdClHttp::VerbsCache::m_expire_tid;
 
 // shutdown trigger, must be last of the static members
 XrdClHttp::VerbsCache::shutdown_s XrdClHttp::VerbsCache::m_shutdowns;
+
+std::string
+XrdClHttp::VerbsCache::GetUrlKey(const std::string &url)
+{
+    auto fragment = url.find('#');
+    XrdCl::URL parsed(url.substr(0, fragment));
+    if (!parsed.IsValid()) return {};
+    return parsed.GetLocation();
+}
 
 XrdClHttp::VerbsCache & XrdClHttp::VerbsCache::Instance() {
     std::unique_lock lk(m_shutdown_lock);

--- a/src/XrdClHttp/XrdClHttpOptionsCache.hh
+++ b/src/XrdClHttp/XrdClHttpOptionsCache.hh
@@ -30,6 +30,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <utility>
  
  namespace XrdClHttp {
  
@@ -70,22 +71,18 @@
     }
 
     void Put(const std::string &url, const HttpVerbs &verbs, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
-        std::string modified_url;
-        auto key = GetUrlKey(url, modified_url);
+        auto key = GetUrlKey(url);
+        if (key.empty()) return;
 
         const std::unique_lock sentry(m_mutex);
 
         auto isKnown = !verbs.IsSet(HttpVerb::kUnknown);
         auto lifetime = isKnown ? g_expiry_duration : g_negative_expiry_duration;
 
-// C++20 can elide the allocation for the string_view
-#if __cplusplus >= 202002L
         auto iter = m_verbs_map.find(key);
-#else
-        auto iter = m_verbs_map.find(std::string(key));
-#endif
         if (iter == m_verbs_map.end()) {
-            m_verbs_map.emplace(key, VerbEntry{now + lifetime, verbs});
+            m_verbs_map.emplace(std::move(key),
+                                VerbEntry{now + lifetime, verbs});
         } else if (isKnown || iter->second.m_verbs.IsSet(HttpVerb::kUnknown)) {
             // Previous entry didn't know the verbs, but now we do
             iter->second = {now + lifetime, verbs};
@@ -93,15 +90,14 @@
     }
 
     HttpVerbs Get(const std::string &url, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
-        std::string modified_url;
-        auto key = GetUrlKey(url, modified_url);
+        auto key = GetUrlKey(url);
+        if (key.empty()) {
+            m_cache_miss++;
+            return HttpVerbs{};
+        }
 
         const std::shared_lock sentry(m_mutex);
-#if __cplusplus >= 202002L
         auto iter = m_verbs_map.find(key);
-#else
-        auto iter = m_verbs_map.find(std::string(key));
-#endif
         if (iter == m_verbs_map.end()) {
             m_cache_miss++;
             return HttpVerbs{};
@@ -114,28 +110,8 @@
         return iter->second.m_verbs;
     }
 
-    // Get the cache key for a given URL
-    //
-    // Cache key should consist of the schema, host, and port portion of the URL.
-    static std::string_view GetUrlKey(const std::string &url, std::string &modified_url) {
-        auto authority_loc = url.find("://");
-        if (authority_loc == std::string::npos) {
-            return std::string_view();
-        }
-        auto path_loc = url.find('/', authority_loc + 3);
-        if (path_loc == std::string::npos) {
-            path_loc = url.length();
-        }
-
-        std::string_view url_view{url};
-        auto host_loc = url_view.substr(authority_loc + 3, path_loc - authority_loc - 3).find('@');
-        if (host_loc == std::string::npos) {
-            return url_view.substr(0, path_loc);
-        }
-        host_loc += authority_loc + 3;
-        modified_url = url.substr(0, authority_loc + 3) + std::string(url_view.substr(host_loc + 1, path_loc - host_loc - 1));
-        return modified_url;
-    }
+    // Return a normalized resource URL without credentials or request parameters.
+    static std::string GetUrlKey(const std::string &url);
 
     uint64_t GetCacheHits() const {return m_cache_hit;}
     uint64_t GetCacheMisses() const {return m_cache_miss;}
@@ -161,24 +137,13 @@ private:
     mutable std::atomic<uint64_t> m_cache_hit{0};
     mutable std::atomic<uint64_t> m_cache_miss{0};
 
-    template<typename ... Bases>
-    struct overload : Bases ...
-    {
-        using is_transparent = void;
-        using Bases::operator() ... ;
-    };
-    using transparent_string_hash = overload<
-        std::hash<std::string>,
-        std::hash<std::string_view>
-    >;
-
     struct VerbEntry {
         std::chrono::steady_clock::time_point m_expiry;
         HttpVerbs m_verbs;
     };
 
     mutable std::shared_mutex m_mutex;
-    mutable std::unordered_map<std::string, VerbEntry, VerbsCache::transparent_string_hash, std::equal_to<>> m_verbs_map;
+    mutable std::unordered_map<std::string, VerbEntry> m_verbs_map;
 
     static std::once_flag m_expiry_launch;
     static VerbsCache g_cache;

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -446,7 +446,8 @@ bool HeaderParser::Parse(const std::string &header_line)
         std::string_view val(header_value);
         while (!val.empty()) {
             auto found = val.find(',');
-            auto method = val.substr(0, found);
+            std::string method(val.substr(0, found));
+            XrdCl::Utils::Trim(method);
             if (method == "PROPFIND") {
                 auto new_verbs = static_cast<unsigned>(m_allow_verbs) | static_cast<unsigned>(VerbsCache::HttpVerb::kPROPFIND);
                 m_allow_verbs = static_cast<VerbsCache::HttpVerb>(new_verbs);
@@ -1327,13 +1328,10 @@ CurlWorker::Run() {
             // If the operation requires the result of the OPTIONS verb to function, then
             // we add that to the multi-handle instead, chaining the two calls together.
             if (op->RequiresOptions()) {
-                std::string modified_url;
                 std::shared_ptr<CurlOptionsOp> options_op(
                     new CurlOptionsOp(
                         curl, op,
-                        std::string(
-                            VerbsCache::GetUrlKey(op->GetUrl(), modified_url)
-                        ),
+                        op->GetUrl(),
                         m_logger, op->GetConnCalloutFunc()
                     )
                 );
@@ -1655,8 +1653,6 @@ CurlWorker::Run() {
                                     // operation can continue.  Inject a new CurlOptionsOp and chain it to the one
                                     // being processed.  Once the OPTIONS request is done, then we'll restart this
                                     // operation.
-                                    std::string modified_url;
-                                    target = VerbsCache::GetUrlKey(target, modified_url);
                                     options_op = new CurlOptionsOp(iter->first, op, target, m_logger, op->GetConnCalloutFunc());
                                     std::shared_ptr<CurlOperation> new_op(options_op);
                                     auto curl = queue.GetHandle();

--- a/src/XrdClHttp/XrdClHttpWebDav.cc
+++ b/src/XrdClHttp/XrdClHttpWebDav.cc
@@ -93,3 +93,49 @@ XrdClHttp::ParseWebDavProperties(TiXmlElement *prop,
     }
     return has_size;
 }
+
+bool
+XrdClHttp::ParseWebDavResponseProperties(TiXmlElement *response,
+                                         WebDavProperties &properties)
+{
+    if (!response) return false;
+
+    for (auto propstat = response->FirstChildElement(); propstat != nullptr;
+         propstat = propstat->NextSiblingElement()) {
+        if (!WebDavElementNameEquals(propstat, "propstat")) continue;
+
+        TiXmlElement *prop = nullptr;
+        const char *status = nullptr;
+        for (auto child = propstat->FirstChildElement(); child != nullptr;
+             child = child->NextSiblingElement()) {
+            if (WebDavElementNameEquals(child, "prop")) {
+                prop = child;
+            } else if (WebDavElementNameEquals(child, "status")) {
+                status = child->GetText();
+            }
+        }
+
+        if (status) {
+            auto value = trim_view(status);
+            auto code_begin = value.find(' ');
+            if (code_begin == std::string_view::npos) continue;
+            code_begin = value.find_first_not_of(' ', code_begin);
+            if (code_begin == std::string_view::npos) continue;
+            auto code_end = value.find(' ', code_begin);
+            auto code_limit = value.data() +
+                (code_end == std::string_view::npos ? value.size() : code_end);
+
+            int code = 0;
+            auto result = std::from_chars(
+                value.data() + code_begin, code_limit, code);
+            if (result.ec != std::errc() || result.ptr != code_limit ||
+                code < 200 || code >= 300) {
+                continue;
+            }
+        }
+
+        if (!prop) return false;
+        return ParseWebDavProperties(prop, properties);
+    }
+    return false;
+}

--- a/src/XrdClHttp/XrdClHttpWebDav.cc
+++ b/src/XrdClHttp/XrdClHttpWebDav.cc
@@ -1,0 +1,95 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClHttpWebDav.hh"
+#include "XrdClHttpUtil.hh"
+
+#include <tinyxml.h>
+
+#include <charconv>
+#include <cstring>
+
+using namespace XrdClHttp;
+
+bool
+XrdClHttp::WebDavElementNameEquals(const TiXmlElement *element,
+                                   const char *expected)
+{
+    if (!element || !element->Value()) return false;
+    const char *name = element->Value();
+    const char *separator = std::strrchr(name, ':');
+    return !strcasecmp(separator ? separator + 1 : name, expected);
+}
+
+bool
+XrdClHttp::ParseWebDavProperties(TiXmlElement *prop,
+                                 WebDavProperties &properties)
+{
+    if (!prop) return false;
+
+    bool has_size = false;
+    for (auto child = prop->FirstChildElement(); child != nullptr;
+         child = child->NextSiblingElement()) {
+        if (WebDavElementNameEquals(child, "resourcetype")) {
+            for (auto type = child->FirstChildElement(); type != nullptr;
+                 type = type->NextSiblingElement()) {
+                if (WebDavElementNameEquals(type, "collection")) {
+                    properties.m_is_dir = true;
+                    break;
+                }
+            }
+        } else if (WebDavElementNameEquals(child, "getcontentlength")) {
+            auto text = child->GetText();
+            if (!text) continue;
+
+            auto value = trim_view(text);
+            if (value.empty()) continue;
+
+            int64_t size = -1;
+            auto result = std::from_chars(value.data(),
+                                          value.data() + value.size(), size);
+            if (result.ec != std::errc() ||
+                result.ptr != value.data() + value.size() || size < 0) {
+                return false;
+            }
+            properties.m_size = size;
+            has_size = true;
+        } else if (WebDavElementNameEquals(child, "getlastmodified")) {
+            auto last_modified = child->GetText();
+            if (!last_modified) return false;
+            struct tm parsed_time{};
+            if (!strptime(last_modified, "%a, %d %b %Y %H:%M:%S",
+                          &parsed_time)) {
+                return false;
+            }
+            properties.m_last_modified = timegm(&parsed_time);
+        } else if (WebDavElementNameEquals(child, "executable")) {
+            auto executable = child->GetText();
+            if (!executable) return false;
+            properties.m_is_executable = !strcasecmp(executable, "T");
+        }
+    }
+
+    if (properties.m_is_dir) {
+        if (!has_size) properties.m_size = 0;
+        return true;
+    }
+    return has_size;
+}

--- a/src/XrdClHttp/XrdClHttpWebDav.hh
+++ b/src/XrdClHttp/XrdClHttpWebDav.hh
@@ -43,6 +43,11 @@ bool WebDavElementNameEquals(const TiXmlElement *element,
 // Collections may omit their content length; regular resources may not.
 bool ParseWebDavProperties(TiXmlElement *prop, WebDavProperties &properties);
 
+// Select a successful propstat from a WebDAV response and parse its
+// properties. Explicitly unsuccessful propstat entries are ignored.
+bool ParseWebDavResponseProperties(TiXmlElement *response,
+                                   WebDavProperties &properties);
+
 }
 
 #endif

--- a/src/XrdClHttp/XrdClHttpWebDav.hh
+++ b/src/XrdClHttp/XrdClHttpWebDav.hh
@@ -1,0 +1,48 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#ifndef XRDCLHTTPWEBDAV_HH
+#define XRDCLHTTPWEBDAV_HH
+
+#include <cstdint>
+#include <ctime>
+
+class TiXmlElement;
+
+namespace XrdClHttp {
+
+struct WebDavProperties {
+    bool m_is_dir{false};
+    bool m_is_executable{false};
+    int64_t m_size{-1};
+    time_t m_last_modified{-1};
+};
+
+// Compare an XML element's local name, ignoring any namespace prefix.
+bool WebDavElementNameEquals(const TiXmlElement *element,
+                             const char *expected);
+
+// Parse the standard properties returned by a WebDAV PROPFIND response.
+// Collections may omit their content length; regular resources may not.
+bool ParseWebDavProperties(TiXmlElement *prop, WebDavProperties &properties);
+
+}
+
+#endif

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(xrdcl-http-test
 )
 
 target_link_libraries(xrdcl-test XrdClHttpTransferTest GTest::gtest_main)
-target_link_libraries(xrdcl-http-test XrdClHttpTesting XrdClHttpTransferTest GTest::gtest_main)
+target_link_libraries(xrdcl-http-test XrdClHttpTesting XrdClHttpTransferTest XrdXml GTest::gtest_main)
 
 gtest_add_tests(TARGET xrdcl-test TEST_LIST CurlClOnlyTests)
 gtest_add_tests(TARGET xrdcl-http-test TEST_LIST CurlTests)

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(xrdcl-test
 # Tests depending on XrdClHttp linkage
 add_executable(xrdcl-http-test
   CopyTest.cc
+  OptionsCacheTest.cc
   VectorReadTest.cc
   WebDavParserTest.cc
 )

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(xrdcl-test
 add_executable(xrdcl-http-test
   CopyTest.cc
   VectorReadTest.cc
+  WebDavParserTest.cc
 )
 
 target_link_libraries(xrdcl-test XrdClHttpTransferTest GTest::gtest_main)

--- a/tests/XrdClHttp/OptionsCacheTest.cc
+++ b/tests/XrdClHttp/OptionsCacheTest.cc
@@ -1,0 +1,62 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpOptionsCache.hh"
+
+#include <gtest/gtest.h>
+
+using XrdClHttp::VerbsCache;
+
+TEST(OptionsCache, KeysCapabilitiesByResourcePath)
+{
+    EXPECT_EQ(VerbsCache::GetUrlKey("https://example.org/namespace/file-a"),
+              "https://example.org:443/namespace/file-a");
+    EXPECT_EQ(VerbsCache::GetUrlKey("https://example.org/namespace/file-b"),
+              "https://example.org:443/namespace/file-b");
+    EXPECT_NE(VerbsCache::GetUrlKey("https://example.org/namespace/file-a"),
+              VerbsCache::GetUrlKey("https://example.org/namespace/file-b"));
+}
+
+TEST(OptionsCache, ExcludesCredentialsAndRequestParameters)
+{
+    EXPECT_EQ(VerbsCache::GetUrlKey(
+                  "https://user:secret@example.org/data?authz=token#fragment"),
+              "https://example.org:443/data");
+    EXPECT_EQ(VerbsCache::GetUrlKey("https://example.org"),
+              "https://example.org:443/");
+}
+
+TEST(OptionsCache, DoesNotShareVerbsBetweenPaths)
+{
+    auto &cache = VerbsCache::Instance();
+    const std::string head_url = "https://options-cache.invalid/head-only";
+    const std::string dav_url = "https://options-cache.invalid/webdav";
+
+    cache.Put(head_url,
+              VerbsCache::HttpVerbs(VerbsCache::HttpVerb::kUnknown));
+    cache.Put(dav_url,
+              VerbsCache::HttpVerbs(VerbsCache::HttpVerb::kPROPFIND));
+
+    EXPECT_TRUE(cache.Get(head_url).IsSet(VerbsCache::HttpVerb::kUnknown));
+    EXPECT_FALSE(cache.Get(head_url).IsSet(VerbsCache::HttpVerb::kPROPFIND));
+    EXPECT_TRUE(cache.Get(dav_url).IsSet(VerbsCache::HttpVerb::kPROPFIND));
+    EXPECT_TRUE(cache.Get("https://options-cache.invalid/unprobed")
+                    .IsSet(VerbsCache::HttpVerb::kUnset));
+}

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -19,8 +19,22 @@
 /******************************************************************************/
 
 #include "XrdClHttp/XrdClHttpUtil.hh"
+#include "XrdClHttp/XrdClHttpWebDav.hh"
 
 #include <gtest/gtest.h>
+#include <tinyxml.h>
+
+namespace {
+
+bool ParseProperties(const char *xml, XrdClHttp::WebDavProperties &properties)
+{
+    TiXmlDocument document;
+    document.Parse(xml);
+    return !document.Error() &&
+        XrdClHttp::ParseWebDavProperties(document.RootElement(), properties);
+}
+
+}
 
 TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
 {
@@ -31,4 +45,63 @@ TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
 
     EXPECT_TRUE(parser.GetAllowedVerbs().IsSet(
         XrdClHttp::VerbsCache::HttpVerb::kPROPFIND));
+}
+
+TEST(WebDavParser, MatchesLocalNamesWithArbitraryPrefixes)
+{
+    TiXmlDocument document;
+    document.Parse("<ns0:collection xmlns:ns0=\"DAV:\"/>");
+
+    EXPECT_TRUE(XrdClHttp::WebDavElementNameEquals(
+        document.RootElement(), "collection"));
+    EXPECT_FALSE(XrdClHttp::WebDavElementNameEquals(
+        document.RootElement(), "resourcetype"));
+}
+
+TEST(WebDavParser, AllowsDirectoryWithEmptyContentLength)
+{
+    XrdClHttp::WebDavProperties properties;
+    ASSERT_TRUE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\">"
+        "<d:getcontentlength/>"
+        "<d:resourcetype><d:collection/></d:resourcetype>"
+        "</d:prop>", properties));
+
+    EXPECT_TRUE(properties.m_is_dir);
+    EXPECT_EQ(properties.m_size, 0);
+}
+
+TEST(WebDavParser, RequiresContentLengthForRegularResources)
+{
+    XrdClHttp::WebDavProperties missing;
+    EXPECT_FALSE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\"><d:resourcetype/></d:prop>", missing));
+
+    XrdClHttp::WebDavProperties empty;
+    EXPECT_FALSE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\"><d:getcontentlength/></d:prop>", empty));
+}
+
+TEST(WebDavParser, ParsesValidRegularResourceSize)
+{
+    XrdClHttp::WebDavProperties properties;
+    ASSERT_TRUE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\">"
+        "<d:getcontentlength> 123 </d:getcontentlength>"
+        "<d:resourcetype/>"
+        "</d:prop>", properties));
+
+    EXPECT_FALSE(properties.m_is_dir);
+    EXPECT_EQ(properties.m_size, 123);
+}
+
+TEST(WebDavParser, RejectsInvalidContentLength)
+{
+    for (auto value : {"-1", "12 bytes", "9223372036854775808"}) {
+        XrdClHttp::WebDavProperties properties;
+        std::string xml = "<d:prop xmlns:d=\"DAV:\"><d:getcontentlength>";
+        xml += value;
+        xml += "</d:getcontentlength></d:prop>";
+        EXPECT_FALSE(ParseProperties(xml.c_str(), properties)) << value;
+    }
 }

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -34,6 +34,15 @@ bool ParseProperties(const char *xml, XrdClHttp::WebDavProperties &properties)
         XrdClHttp::ParseWebDavProperties(document.RootElement(), properties);
 }
 
+bool ParseResponseProperties(const char *xml,
+                             XrdClHttp::WebDavProperties &properties)
+{
+    TiXmlDocument document;
+    document.Parse(xml);
+    return !document.Error() && XrdClHttp::ParseWebDavResponseProperties(
+        document.RootElement(), properties);
+}
+
 }
 
 TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
@@ -104,4 +113,32 @@ TEST(WebDavParser, RejectsInvalidContentLength)
         xml += "</d:getcontentlength></d:prop>";
         EXPECT_FALSE(ParseProperties(xml.c_str(), properties)) << value;
     }
+}
+
+TEST(WebDavParser, IgnoresUnsuccessfulPropstatEntries)
+{
+    XrdClHttp::WebDavProperties properties;
+    ASSERT_TRUE(ParseResponseProperties(
+        "<d:response xmlns:d=\"DAV:\">"
+        "<d:propstat>"
+        "<d:status>HTTP/1.1 200 OK</d:status>"
+        "<d:prop><d:getcontentlength>123</d:getcontentlength></d:prop>"
+        "</d:propstat>"
+        "<d:propstat>"
+        "<d:status>HTTP/1.1 404 Not Found</d:status><d:prop/>"
+        "</d:propstat>"
+        "</d:response>", properties));
+
+    EXPECT_EQ(properties.m_size, 123);
+}
+
+TEST(WebDavParser, RequiresSuccessfulPropstatEntry)
+{
+    XrdClHttp::WebDavProperties properties;
+    EXPECT_FALSE(ParseResponseProperties(
+        "<d:response xmlns:d=\"DAV:\">"
+        "<d:propstat>"
+        "<d:status>HTTP/1.1 404 Not Found</d:status><d:prop/>"
+        "</d:propstat>"
+        "</d:response>", properties));
 }

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -1,0 +1,34 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpUtil.hh"
+
+#include <gtest/gtest.h>
+
+TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
+{
+    XrdClHttp::HeaderParser parser;
+    EXPECT_TRUE(parser.Parse("HTTP/1.1 200 OK\r\n"));
+    EXPECT_TRUE(parser.Parse("Allow: MKCOL, PROPFIND, PUT\r\n"));
+    EXPECT_TRUE(parser.Parse("\r\n"));
+
+    EXPECT_TRUE(parser.GetAllowedVerbs().IsSet(
+        XrdClHttp::VerbsCache::HttpVerb::kPROPFIND));
+}


### PR DESCRIPTION
## Summary

Improve XrdClHttp interoperability with WebDAV servers that expose capabilities and XML responses differently across individual resources.

This was motivated by testing against StoRM, which exposed several assumptions in the existing implementation:

- `OPTIONS` was probed at the origin root instead of the requested resource.
- `Allow` values containing whitespace after commas were not parsed correctly.
- WebDAV XML parsing depended on specific namespace prefixes such as `D:` and `lp1:`.
- Collections with a missing or empty `getcontentlength` were rejected.
- Cached capabilities were shared across the entire origin, even when different paths advertised different methods.

## Changes

- Send `OPTIONS` to the requested resource.
- Trim individual methods parsed from the `Allow` header.
- Centralize WebDAV property parsing for stat and directory-list operations.
- Match XML elements by local name, independently of the namespace prefix.
- Allow collections to omit their content length or return an empty value.
- Continue requiring regular resources to provide a valid, non-negative content length.
- Cache WebDAV capabilities by normalized resource URL instead of origin.
- Exclude credentials, query parameters, and fragments from cache keys.

Resource-scoped caching prevents, for example, a HEAD-only resource from hiding `PROPFIND` support on another path at the same origin.

## Testing

Added coverage for:

- whitespace-separated `Allow` methods;
- arbitrary WebDAV namespace prefixes;
- collections with an empty content length;
- missing content length on regular resources;
- valid and malformed content lengths;
- distinct cache entries for different resource paths;
- removal of credentials and request parameters from cache keys;
- isolation between HEAD-only and PROPFIND-capable resources.

All nine targeted WebDAV parser and capability-cache tests pass locally.

The changes were also validated as part of the broader XrdClHttp integration stack against the StoRM development endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved WebDAV directory listings and resource metadata handling across namespace variations.
  * Added URL normalization for HTTP capability caching, including removal of credentials, queries, and fragments.
  * Improved recognition of padded HTTP methods in server responses.
  * OPTIONS requests now correctly use the requested URL, including after redirects.

* **Bug Fixes**
  * Invalid URLs are safely excluded from capability caching.
  * WebDAV property parsing now validates response statuses, sizes, and dates more reliably.

* **Tests**
  * Added coverage for URL normalization, capability caching, HTTP method parsing, and WebDAV metadata parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->