### PR TITLE
Build Python bindings during regular build and run Python tests with CTest like the rest of the test suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -283,12 +283,20 @@ jobs:
       run: |
         sudo python3 -m pip install \
           --target /usr/lib/python3/dist-packages \
-          --use-pep517 --verbose build/python
+          --verbose build/python/dist/*.whl
 
     - name: Run post-install tests
       run: |
         tests/post-install.sh
         tests/check-headers.sh
+
+    - name: Build Python bindings standalone against installed XRootD
+      run: |
+        sudo apt install -y python3-venv
+        python3 -m venv /tmp/standalone
+        /tmp/standalone/bin/pip install --verbose ./python
+        /tmp/standalone/bin/python -c \
+          'from XRootD import client; print(client.FileSystem("root://localhost:1094"))'
 
   macos:
     name: macOS

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,7 @@ jobs:
           py3-setuptools \
           py3-wheel \
           python3-dev \
+          pytest \
           readline-dev \
           sudo \
           util-linux-dev \
@@ -305,6 +306,9 @@ jobs:
 
     - name: Install dependencies with Homebrew
       run: brew install googletest libzip nlohmann-json python-setuptools
+
+    - name: Install Python dependencies with pip
+      run: pip install --user pytest
 
     - name: Clone repository
       uses: actions/checkout@v6

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Build-Depends:
  libsystemd-dev [linux-any],
  python3-dev,
  python3-pip,
+ python3-pytest,
  python3-setuptools,
  python3-wheel,
  libjson-c-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -59,8 +59,8 @@ override_dh_auto_build:
 override_dh_auto_install:
 	dh_auto_install
 	python3 -m pip install --target debian/tmp/usr/lib/python3/dist-packages \
-		--no-deps --no-build-isolation --disable-pip-version-check --verbose \
-		--ignore-installed --use-pep517 obj-$(DEB_HOST_MULTIARCH)/python
+		--no-deps --disable-pip-version-check --verbose \
+		--ignore-installed obj-$(DEB_HOST_MULTIARCH)/python/dist/*.whl
 
 	rm -f debian/tmp/usr/bin/xrdshmap
 	rm -f debian/tmp/usr/lib/*/libXrd*Test*

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -14,8 +14,13 @@ list of optional features and which dependencies are required to enable them.
 XRootD unit and integration tests are enabled via the CMake configuration option
 `-DENABLE_TESTS=ON`. Unit and integration tests may depend on GoogleTest.
 Therefore, the development packages for GoogleTest are needed in order to enable
-all available tests. Here we discuss how to use the [test.cmake](../test.cmake) 
-CTest script to run all steps to configure and build the project, then run all 
+all available tests. When the Python bindings are enabled as well, the test
+suite includes the tests for the bindings, which are driven by
+[pytest](https://pytest.org). It must be importable by the Python interpreter
+used for the build, and configuration fails when it is not, so install pytest,
+or disable the tests that need it with `-DENABLE_PYTHON=OFF` or
+`-DENABLE_SERVER_TESTS=OFF`. Here we discuss how to use the [test.cmake](../test.cmake)
+CTest script to run all steps to configure and build the project, then run all
 tests using CTest. The script [test.cmake](../test.cmake) can be generically
 called from the top directory of the repository as shown below
 
@@ -206,17 +211,6 @@ installation procedure is working as expected, by inspecting the contents of the
 
 ```sh
 xrootd $ ctest -DINSTALL=1 -S test.cmake
-   Each . represents 1024 bytes of output
-    ..... Size of output: 4K
-   Each symbol represents 1024 bytes of output.
-   '!' represents an error and '*' a warning.
-    ..................................................  Size: 49K
-    .. Size of output: 52K
-   Each symbol represents 1024 bytes of output.
-   '!' represents an error and '*' a warning.
-    ............................................*!....  Size: 49K
-    . Size of output: 50K
-Error(s) when building project
 xrootd $ tree -L 3 -d build/install
 build/install
 └── usr
@@ -232,11 +226,6 @@ build/install
 
 11 directories
 ```
-
-Note that, as shown above, `CTest` erroneously shows build errors when
-installing XRootD with this command. This is because of a deprecation
-warning emitted by `pip` while installing the Python bindings and can be
-safely ignored.
 
 ### Dependencies Required for Coverage, Memory Checking, and Static Analysis
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,6 +10,37 @@ else()
   configure_file(setup.py setup.py)
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/VERSION "${XRootD_VERSION_STRING}")
 
+  add_custom_target(PyXRootD ALL
+    ${Python_EXECUTABLE} -m pip install --upgrade --target . .
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/XRootD DEPENDS XrdCl
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+  if(NOT BUILD_TESTS OR NOT ENABLE_SERVER_TESTS)
+    return()
+  endif()
+
+  # We need to set a library path because we need to build the bindings C++
+  # libraries with their final install RPATH. We need to build with install
+  # RPATH because the libraries are installed by pip instead of CMake, so
+  # CMake cannot fix the RPATH during installation as with other libraries.
+
+  if(NOT APPLE)
+    list(APPEND ENVIRON "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  else()
+    list(APPEND ENVIRON "DYLD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  endif()
+
+  list(APPEND ENVIRON "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}")
+
+  foreach(test copy file filesystem glob threads url)
+    add_test(NAME PyXRootD::${test}
+      COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_${test}.py)
+    set_tests_properties(PyXRootD::${test}
+      PROPERTIES FIXTURES_REQUIRED XRootD::noauth ENVIRONMENT "${ENVIRON}" RUN_SERIAL TRUE)
+  endforeach()
+
+  set_tests_properties(PyXRootD::filesystem PROPERTIES DEPENDS PyXRootD::file)
+
   option(INSTALL_PYTHON_BINDINGS "Install Python bindings" TRUE)
 
   if(INSTALL_PYTHON_BINDINGS)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,55 +4,231 @@ project(PyXRootD LANGUAGES CXX)
 
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 
+add_subdirectory(src)
+
+# When building standalone or for PyPI, setup.py drives the build and takes
+# care of installation, so there is nothing else to do here.
+
 if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR OR PYPI_BUILD)
-  add_subdirectory(src)
-else()
-  configure_file(setup.py setup.py)
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/VERSION "${XRootD_VERSION_STRING}")
-
-  add_custom_target(PyXRootD ALL
-    ${Python_EXECUTABLE} -m pip install --upgrade --target . .
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/XRootD DEPENDS XrdCl
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-  if(NOT BUILD_TESTS OR NOT ENABLE_SERVER_TESTS)
-    return()
-  endif()
-
-  # We need to set a library path because we need to build the bindings C++
-  # libraries with their final install RPATH. We need to build with install
-  # RPATH because the libraries are installed by pip instead of CMake, so
-  # CMake cannot fix the RPATH during installation as with other libraries.
-
-  if(NOT APPLE)
-    list(APPEND ENVIRON "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
-  else()
-    list(APPEND ENVIRON "DYLD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
-  endif()
-
-  list(APPEND ENVIRON "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}")
-
-  foreach(test copy file filesystem glob threads url)
-    add_test(NAME PyXRootD::${test}
-      COMMAND ${Python_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_${test}.py)
-    set_tests_properties(PyXRootD::${test}
-      PROPERTIES FIXTURES_REQUIRED XRootD::noauth ENVIRONMENT "${ENVIRON}" RUN_SERIAL TRUE)
-  endforeach()
-
-  set_tests_properties(PyXRootD::filesystem PROPERTIES DEPENDS PyXRootD::file)
-
-  option(INSTALL_PYTHON_BINDINGS "Install Python bindings" TRUE)
-
-  if(INSTALL_PYTHON_BINDINGS)
-    set(PIP_OPTIONS "" CACHE STRING "Install options for pip")
-
-    install(CODE "
-      execute_process(COMMAND ${Python_EXECUTABLE} -m pip install ${PIP_OPTIONS}
-        --prefix \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX} ${CMAKE_CURRENT_BINARY_DIR}
-        RESULT_VARIABLE INSTALL_STATUS COMMAND_ECHO STDOUT)
-      if(NOT INSTALL_STATUS EQUAL 0)
-        message(FATAL_ERROR \"Failed to install Python bindings\")
-      endif()
-    ")
-  endif()
+  return()
 endif()
+
+# As part of the main build, the extension module above is all that needs to
+# be compiled, and setup.py only packages it into a wheel.
+#
+# Build with the install RPATH, using a path relative to the site-packages
+# directory, since the module is installed by pip instead of CMake, and CMake
+# cannot fix the RPATH during installation as it does with other libraries.
+
+set_target_properties(client PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE)
+
+if(APPLE)
+  set_target_properties(client PROPERTIES INSTALL_RPATH "@loader_path/../../..")
+else()
+  set_target_properties(client PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../../\$LIB")
+endif()
+
+configure_file(setup.py setup.py)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/VERSION "${XRootD_VERSION_STRING}")
+
+# On macOS, the name of the wheel depends on the deployment target: the wheel
+# builder inspects the compiled module and raises the platform tag to match
+# its minimum OS version. When a deployment target is set, pass it on to the
+# tag prediction below and to the wheel build, so that the two agree.
+
+if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET)
+  set(PYXROOTD_ENV ${CMAKE_COMMAND} -E env
+    "MACOSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+endif()
+
+# Determine the name of the wheel in advance, so that it can be used as the
+# output of the command which builds it. Ask setup.py for the version in order
+# to keep a single implementation of the conversion to a PEP 440 version, and
+# ask the wheel builder itself for the platform tag.
+
+execute_process(COMMAND ${Python_EXECUTABLE} setup.py --version
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  OUTPUT_VARIABLE PYXROOTD_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_VARIABLE PYXROOTD_ERROR RESULT_VARIABLE PYXROOTD_STATUS)
+
+if(NOT PYXROOTD_STATUS EQUAL 0)
+  message(FATAL_ERROR "Failed to determine version of the Python bindings\n"
+                      "${PYXROOTD_ERROR}")
+endif()
+
+execute_process(COMMAND ${PYXROOTD_ENV} ${Python_EXECUTABLE} -c "
+from setuptools.dist import Distribution
+
+try:
+    from setuptools.command.bdist_wheel import bdist_wheel
+except ImportError:
+    from wheel.bdist_wheel import bdist_wheel
+
+distribution = Distribution({'name': 'xrootd', 'version': '0'})
+distribution.has_ext_modules = lambda: True
+
+command = bdist_wheel(distribution)
+command.ensure_finalized()
+
+print('-'.join(command.get_tag()))
+"
+  OUTPUT_VARIABLE PYXROOTD_TAG OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_VARIABLE PYXROOTD_ERROR RESULT_VARIABLE PYXROOTD_STATUS)
+
+if(NOT PYXROOTD_STATUS EQUAL 0)
+  message(FATAL_ERROR "Failed to determine tag for the Python bindings wheel. "
+                      "Please install setuptools 70.1 or later, or the wheel "
+                      "package.\n${PYXROOTD_ERROR}")
+endif()
+
+set(PYXROOTD_WHEEL
+  ${CMAKE_CURRENT_BINARY_DIR}/dist/xrootd-${PYXROOTD_VERSION}-${PYXROOTD_TAG}.whl)
+set(PYXROOTD_SITEDIR ${CMAKE_CURRENT_BINARY_DIR}/site-packages)
+
+message(STATUS "Python bindings wheel: ${PYXROOTD_WHEEL}")
+
+# The C++ dependencies of the wheel are tracked via the module built above.
+# The remaining files it packages have to be listed here, though. README.md
+# is in the list because setup.py reads it for the package description.
+
+set(PYXROOTD_SOURCES
+  README.md
+  libs/__init__.py
+  libs/client/__init__.py
+  libs/client/_version.py
+  libs/client/copyprocess.py
+  libs/client/env.py
+  libs/client/file.py
+  libs/client/filesystem.py
+  libs/client/finalize.py
+  libs/client/flags.py
+  libs/client/glob_funcs.py
+  libs/client/py.typed
+  libs/client/responses.py
+  libs/client/url.py
+  libs/client/utils.py
+  src/__init__.py)
+
+list(TRANSFORM PYXROOTD_SOURCES PREPEND ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+# Building the wheel without isolation avoids creating a virtual environment
+# and fetching setuptools from PyPI, but old versions of pip, like the one on
+# RHEL 8, do not know the option. There, pip predates build isolation
+# entirely, so nothing needs to be turned off.
+
+execute_process(COMMAND ${Python_EXECUTABLE} -m pip wheel --help
+  OUTPUT_VARIABLE PIP_HELP ERROR_QUIET RESULT_VARIABLE PYXROOTD_STATUS)
+
+if(PYXROOTD_STATUS EQUAL 0 AND PIP_HELP MATCHES "--no-build-isolation")
+  set(PYXROOTD_PIP_OPTIONS --no-build-isolation)
+else()
+  set(PYXROOTD_PIP_OPTIONS)
+endif()
+
+# Stage exactly the module built above for setup.py to package, recreating
+# the staging directory every time so that a wheel can never pick up stale
+# files, such as a module left behind by a build with another Python version.
+# Clear the wheel directory as well, so that it holds exactly one wheel,
+# which allows it to be referred to with a wildcard when building packages.
+# The wheel is then unpacked so that the bindings can be imported from the
+# build directory, both by the tests below and for manual testing. Note that
+# this last step also verifies that the wheel has the predicted name.
+
+add_custom_command(
+  OUTPUT ${PYXROOTD_WHEEL} ${PYXROOTD_SITEDIR}/pyxrootd/__init__.py
+  COMMAND ${CMAKE_COMMAND} -E rm -rf
+          ${CMAKE_CURRENT_BINARY_DIR}/extension ${CMAKE_CURRENT_BINARY_DIR}/dist
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/extension
+  COMMAND ${CMAKE_COMMAND} -E copy
+          $<TARGET_FILE:client> ${CMAKE_CURRENT_BINARY_DIR}/extension
+  COMMAND ${PYXROOTD_ENV} ${Python_EXECUTABLE} -m pip wheel --no-deps --no-index
+          ${PYXROOTD_PIP_OPTIONS} --disable-pip-version-check --wheel-dir ${CMAKE_CURRENT_BINARY_DIR}/dist .
+  COMMAND ${Python_EXECUTABLE} -m pip install --no-deps --no-index --upgrade
+          --disable-pip-version-check --target ${PYXROOTD_SITEDIR} ${PYXROOTD_WHEEL}
+  DEPENDS client $<TARGET_FILE:client> ${PYXROOTD_SOURCES}
+          ${CMAKE_CURRENT_BINARY_DIR}/setup.py
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "Building Python bindings wheel")
+
+add_custom_target(PyXRootD ALL DEPENDS ${PYXROOTD_WHEEL})
+
+# None of what pip leaves behind in the build directory is known to CMake.
+
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/build
+  ${CMAKE_CURRENT_BINARY_DIR}/dist
+  ${CMAKE_CURRENT_BINARY_DIR}/extension
+  ${CMAKE_CURRENT_BINARY_DIR}/xrootd.egg-info
+  ${PYXROOTD_SITEDIR})
+
+option(INSTALL_PYTHON_BINDINGS "Install Python bindings" TRUE)
+
+if(INSTALL_PYTHON_BINDINGS)
+  set(PIP_OPTIONS "" CACHE STRING "Install options for pip")
+
+  install(CODE "
+    if(NOT EXISTS \"${PYXROOTD_WHEEL}\")
+      message(FATAL_ERROR \"Python bindings wheel not found: ${PYXROOTD_WHEEL}\n\"
+                          \"Please build the project before installing it.\")
+    endif()
+
+    # Note: without --ignore-installed, pip skips installing a wheel whose
+    # version matches an already installed distribution, and would silently
+    # install nothing here since the environment cannot be changed anyway.
+
+    execute_process(COMMAND ${Python_EXECUTABLE} -m pip install ${PIP_OPTIONS}
+      --no-deps --ignore-installed
+      --prefix \$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX} ${PYXROOTD_WHEEL}
+      RESULT_VARIABLE INSTALL_STATUS COMMAND_ECHO STDOUT)
+    if(NOT INSTALL_STATUS EQUAL 0)
+      message(FATAL_ERROR \"Failed to install Python bindings\")
+    endif()
+  ")
+endif()
+
+if(NOT BUILD_TESTS OR NOT ENABLE_SERVER_TESTS)
+  return()
+endif()
+
+# The tests below are driven by pytest, a prerequisite the other tests do not
+# have. Probe for it now, so that a missing pytest is reported by a single
+# configuration failure instead of by every test at CTest time.
+
+execute_process(COMMAND ${Python_EXECUTABLE} -m pytest --version
+  OUTPUT_VARIABLE PYXROOTD_PYTEST_VERSION ERROR_VARIABLE PYXROOTD_PYTEST_VERSION
+  RESULT_VARIABLE PYXROOTD_STATUS)
+
+if(NOT PYXROOTD_STATUS EQUAL 0)
+  message(FATAL_ERROR "The tests for the Python bindings require pytest, "
+                      "which could not be imported by ${Python_EXECUTABLE}. "
+                      "Please install pytest, or disable these tests with "
+                      "-DENABLE_PYTHON=OFF or -DENABLE_SERVER_TESTS=OFF.")
+endif()
+
+string(REGEX REPLACE "\n.*" "" PYXROOTD_PYTEST_VERSION "${PYXROOTD_PYTEST_VERSION}")
+message(STATUS "Found pytest: ${PYXROOTD_PYTEST_VERSION}")
+
+# The module is built with its install RPATH, which does not resolve from the
+# build tree, so the client library has to be found via the library path.
+
+if(NOT APPLE)
+  list(APPEND ENVIRON "LD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+else()
+  list(APPEND ENVIRON "DYLD_LIBRARY_PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+endif()
+
+list(APPEND ENVIRON "PYTHONPATH=${PYXROOTD_SITEDIR}")
+
+# The tests start their own server via conftest.py, so they need to know
+# where to find it. Keep the source tree clean of caches while at it.
+
+list(APPEND ENVIRON "XROOTD=$<TARGET_FILE:xrootd>")
+list(APPEND ENVIRON "XRDFS=$<TARGET_FILE:xrdfs>")
+list(APPEND ENVIRON "PYTHONDONTWRITEBYTECODE=1")
+
+foreach(test copy file filesystem glob threads url)
+  add_test(NAME PyXRootD::${test}
+    COMMAND ${Python_EXECUTABLE} -m pytest -p no:cacheprovider
+            ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_${test}.py)
+  set_tests_properties(PyXRootD::${test} PROPERTIES ENVIRONMENT "${ENVIRON}")
+endforeach()

--- a/python/setup.py
+++ b/python/setup.py
@@ -29,22 +29,17 @@ cmdline_args = []
 # of a regular CMake build or a Python build using setup.py.
 
 if not srcdir.startswith('$'):
-    # When building the Python bindings as part of a standard CMake build,
-    # propagate down which cmake command to use, and the build type, C++
-    # compiler, build flags, and how to link libXrdCl from the main build.
+    # As part of a standard CMake build, the extension module has already been
+    # compiled by the enclosing build, which knows how to link it against the
+    # client library and tracks its dependencies. All that is left to do here
+    # is to pick it up from where CMake left it and package it into a wheel.
 
-    cmake = '${CMAKE_COMMAND}'
+    prebuilt = '${CMAKE_CURRENT_BINARY_DIR}/extension'
 
-    cmdline_args += [
-        '-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}',
-        '-DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}',
-        '-DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}',
-        '-DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}',
-        '-DXRootD_CLIENT_LIBRARY=${CMAKE_BINARY_DIR}/lib/libXrdCl${CMAKE_SHARED_LIBRARY_SUFFIX}',
-        '-DXRootD_UTILS_LIBRARY=${CMAKE_BINARY_DIR}/lib/libXrdUtils${CMAKE_SHARED_LIBRARY_SUFFIX}',
-        '-DXRootD_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/src;${CMAKE_BINARY_DIR}/src',
-    ]
+    cmake = None
 else:
+    prebuilt = None
+
     srcdir = '.'
 
     cmake = which("cmake3") or which("cmake")
@@ -88,11 +83,20 @@ class CMakeExtension(Extension):
 
 class CMakeBuild(build_ext):
     def build_extensions(self):
-        if cmake is None:
-            raise RuntimeError('Cannot find CMake executable')
-
         for ext in self.extensions:
             extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+            destdir = os.path.join(extdir, ext.name)
+
+            if prebuilt is not None:
+                self.mkpath(destdir)
+
+                for entry in sorted(os.listdir(prebuilt)):
+                    self.copy_file(os.path.join(prebuilt, entry), destdir)
+
+                continue
+
+            if cmake is None:
+                raise RuntimeError('Cannot find CMake executable')
 
             # Use relative RPATHs to ensure the correct libraries are picked up.
             # The RPATH below covers most cases where a non-standard path is
@@ -105,7 +109,7 @@ class CMakeBuild(build_ext):
                 '-DPython_EXECUTABLE={}'.format(sys.executable),
                 '-DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE',
                 '-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY={}/{}'.format(self.build_temp, ext.name),
-                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}/{}'.format(extdir, ext.name),
+                '-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={}'.format(destdir),
             ]
 
             if sys.platform == 'darwin':

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -26,6 +26,15 @@ Python_add_library(client MODULE WITH_SOABI
 
 target_compile_options(client PRIVATE -w) # TODO: fix build warnings
 
+# The module exchanges off_t with the client library, so it must agree with it
+# on the size of a file offset. This is set for the whole project in
+# XRootDOSDefs.cmake, but when building the bindings standalone against an
+# installed XRootD this directory is configured as a project of its own and
+# does not inherit the definitions, so set them here explicitly.
+
+target_compile_definitions(client PRIVATE
+  _LARGEFILE_SOURCE _LARGEFILE64_SOURCE _FILE_OFFSET_BITS=64)
+
 if(APPLE)
   set(CMAKE_MACOSX_RPATH TRUE)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,234 @@
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+from pathlib import Path
+
+import pytest
+
+# pytest already puts this directory at the front of sys.path before importing
+# conftest.py, but be explicit so the import below keeps working if the tests
+# are ever run with --import-mode=importlib.
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from env import SERVER_PORT, SERVER_URL, release_reserved_port
+
+CONFIG = Path(__file__).resolve().parent / 'xrootd.cfg'
+
+# The remaining test modules do not talk to a server, so there is no point in
+# starting one for them.
+
+NEEDS_SERVER = {'test_copy.py', 'test_file.py', 'test_filesystem.py',
+                'test_glob.py', 'test_threads.py'}
+
+TIMEOUT = 30
+
+# A hard-killed pytest, e.g. one cut down by a CTest timeout, never reaches
+# the teardown of the fixture below and would leave the server running
+# forever. The watchdog below holds the read end of a pipe from pytest, so
+# the pipe closing tells it that pytest exited, however that happened. A
+# byte arriving first means the teardown ran and there is nothing to do;
+# end of file without one means the server is orphaned, and the watchdog
+# kills it and removes its directory.
+
+WATCHDOG = """
+import os, shutil, signal, sys, time
+
+pid, basedir = int(sys.argv[1]), sys.argv[2]
+
+if sys.stdin.buffer.read(1):
+    sys.exit(0)
+
+try:
+    os.kill(pid, signal.SIGKILL)
+except OSError:
+    pass
+
+deadline = time.monotonic() + 10
+
+while time.monotonic() < deadline:
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        break
+    time.sleep(0.1)
+
+shutil.rmtree(basedir, ignore_errors=True)
+"""
+
+
+@pytest.fixture(scope='session', autouse=True)
+def xrootd_server(request):
+    """Run an XRootD server for the duration of the test session."""
+
+    collected = {os.path.basename(str(getattr(item, 'path', None) or item.fspath))
+                 for item in request.session.items}
+
+    if not collected & NEEDS_SERVER:
+        yield None
+        return
+
+    xrootd = os.environ.get('XROOTD') or shutil.which('xrootd')
+
+    if xrootd is None:
+        pytest.skip('cannot find the xrootd server binary, set $XROOTD')
+
+    # The server runs with its working directory set to the temporary
+    # directory below, so a relative path would not resolve there.
+
+    xrootd = os.path.abspath(xrootd)
+
+    # The readiness check below queries the server with xrdfs, which usually
+    # sits next to the server binary.
+
+    xrdfs = (os.environ.get('XRDFS')
+             or shutil.which('xrdfs', path=os.path.dirname(xrootd))
+             or shutil.which('xrdfs'))
+
+    if xrdfs is None:
+        pytest.skip('cannot find the xrdfs binary, set $XRDFS')
+
+    xrdfs = os.path.abspath(xrdfs)
+
+    # A short path directly under /tmp is required here: the server appends
+    # <instance>/.xrd/admin to it to create its admin socket, and the path of
+    # a unix socket must stay under 104 characters on macOS, less than the
+    # pytest temporary directory alone needs there. The directory is removed
+    # in the teardown below, so that nothing is left behind under /tmp.
+
+    basedir = Path(tempfile.mkdtemp(prefix='pyxrootd-', dir='/tmp'))
+
+    # Directories are created on demand when opening a file for writing, but
+    # not by locate(), dirlist() or truncate(), which some tests call first.
+
+    (basedir / 'data' / 'tmp').mkdir(parents=True)
+
+    logfile = basedir / 'xrootd.log'
+
+    # Restrict the server to IPv4, matching the loopback address used by the
+    # clients, see env.py. This must not be left to chance on either side.
+
+    command = [xrootd, '-c', str(CONFIG), '-n', 'pyxrootd',
+               '-p', str(SERVER_PORT), '-I', 'v4']
+
+    if os.environ.get('PYXROOTD_TEST_DEBUG'):
+        command.append('-d')
+
+    environ = dict(os.environ, PYXROOTD_TEST_BASEDIR=str(basedir))
+
+    release_reserved_port()
+
+    try:
+        with open(logfile, 'wb') as log:
+            # Run in the foreground and stay in the same process group, so
+            # that a timeout kill from CTest reaches the server as well.
+            server = subprocess.Popen(command, cwd=str(basedir), env=environ,
+                                      stdout=log, stderr=subprocess.STDOUT)
+    except Exception:
+        shutil.rmtree(basedir, ignore_errors=True)
+        raise
+
+    try:
+        watchdog = subprocess.Popen([sys.executable, '-c', WATCHDOG,
+                                     str(server.pid), str(basedir)],
+                                    stdin=subprocess.PIPE)
+    except Exception:
+        server.kill()
+        server.wait()
+        shutil.rmtree(basedir, ignore_errors=True)
+        raise
+
+    try:
+        wait_until_ready(server, xrdfs, logfile)
+        yield SERVER_URL
+    finally:
+        server.terminate()
+
+        try:
+            server.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            server.kill()
+            server.wait()
+
+        if request.session.testsfailed:
+            sys.stderr.write(read(logfile))
+
+        shutil.rmtree(basedir, ignore_errors=True)
+
+        # Stand the watchdog down: the byte says the teardown above ran.
+
+        try:
+            watchdog.communicate(b'.', timeout=10)
+        except Exception:
+            watchdog.kill()
+            watchdog.wait()
+
+
+def wait_until_ready(server, xrdfs, logfile):
+    """Wait until the server answers a query, like the shell tests do.
+
+    Using a fresh xrdfs process for each attempt matters: a failed request on
+    an in-process client would leave its connection in an error state which
+    outlives the deadline used here, turning one slow start into a failure.
+    """
+
+    deadline = time.monotonic() + TIMEOUT
+    output = b''
+
+    # Give up on a connection quickly: with the default settings, a query
+    # started before the server listens waits out a long connection window
+    # instead of failing, which would make every startup take seconds. Short
+    # timeouts are safe precisely because each attempt is a fresh process.
+
+    environ = dict(os.environ, XRD_CONNECTIONWINDOW='3', XRD_CONNECTIONRETRY='2',
+                   XRD_REQUESTTIMEOUT='5', XRD_TIMEOUTRESOLUTION='1')
+
+    # Give the server a moment to bind its port, so that the first query
+    # usually succeeds at once instead of waiting out a connection window.
+
+    time.sleep(0.2)
+
+    while time.monotonic() < deadline:
+        check_alive(server, logfile)
+
+        try:
+            result = subprocess.run([xrdfs, SERVER_URL, 'query', 'config',
+                                     'version'], stdout=subprocess.PIPE,
+                                    stderr=subprocess.STDOUT, env=environ,
+                                    timeout=15)
+
+            if result.returncode == 0:
+                return
+
+            output = result.stdout
+        except subprocess.TimeoutExpired as error:
+            output = error.stdout or b''
+
+        time.sleep(0.5)
+
+    fail(server, logfile, 'did not answer a version query within %ds: %s'
+         % (TIMEOUT, output.decode(errors='replace').strip()))
+
+
+def check_alive(server, logfile):
+    if server.poll() is not None:
+        fail(server, logfile, 'exited with status %d' % server.returncode)
+
+
+def fail(server, logfile, message):
+    if server.poll() is None:
+        server.kill()
+        server.wait()
+
+    pytest.fail('XRootD server %s\n\n%s' % (message, read(logfile)))
+
+
+def read(logfile):
+    try:
+        return logfile.read_text(errors='replace')
+    except OSError as error:
+        return 'could not read %s: %s' % (logfile, error)

--- a/python/tests/env.py
+++ b/python/tests/env.py
@@ -1,4 +1,4 @@
-SERVER_URL  = 'root://localhost/'
+SERVER_URL  = 'root://localhost:3094/'
 smallfile   = SERVER_URL + '/tmp/spam'
 smallcopy   = SERVER_URL + '/tmp/eggs'
 smallbuffer = 'gre\0en\neggs\nand\nham\n'

--- a/python/tests/env.py
+++ b/python/tests/env.py
@@ -1,4 +1,45 @@
-SERVER_URL  = 'root://localhost:3094/'
+import os
+import socket
+
+__all__ = ['SERVER_PORT', 'SERVER_URL', 'smallfile', 'smallcopy',
+           'smallbuffer', 'bigfile', 'bigcopy', 'release_reserved_port']
+
+_reserved = None
+
+
+def _reserve_port():
+    """Reserve an unused port for the test server.
+
+    The socket is kept listening until conftest.py releases it just before
+    starting the server, so that no other process can take the port in the
+    meantime. A socket which is bound but not listening does not exclude
+    another binder using SO_REUSEADDR, while a listening socket which never
+    accepts anything leaves no connection in TIME_WAIT when it is closed.
+    """
+    global _reserved
+    _reserved = socket.socket()
+    _reserved.bind(('127.0.0.1', 0))
+    _reserved.listen(1)
+    return _reserved.getsockname()[1]
+
+
+def release_reserved_port():
+    global _reserved
+    if _reserved is not None:
+        _reserved.close()
+        _reserved = None
+
+
+# Use the IPv4 loopback address literally rather than localhost: an address
+# needs no name resolution, which cannot be relied upon in every test
+# environment, and pinning the address family matters because the client
+# prefers IPv6 and retries a failed connection within a window much longer
+# than the server startup timeout, so it cannot be left to discover by
+# falling back that the server answers on IPv4, as on hosts where localhost
+# resolves to ::1 first. The server is restricted to IPv4 by conftest.py.
+
+SERVER_PORT = int(os.environ.get('PYXROOTD_TEST_PORT') or _reserve_port())
+SERVER_URL  = 'root://127.0.0.1:%d/' % SERVER_PORT
 smallfile   = SERVER_URL + '/tmp/spam'
 smallcopy   = SERVER_URL + '/tmp/eggs'
 smallbuffer = 'gre\0en\neggs\nand\nham\n'

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -29,15 +29,24 @@ def test_filesystem():
                (c.prepare,    (['/tmp/foo'], PrepareFlags.STAGE), True),
                ]
 
+  # Each pass consumes the file: it is truncated, renamed, and then removed.
+
+  create(smallfile)
+
   for func, args, hasReturnObject in funcspecs:
       sync (func, args, hasReturnObject)
 
-  # Create new temp file
-  f = client.File()
-  status, response = f.open(smallfile, OpenFlags.NEW)
+  create(smallfile)
 
   for func, args, hasReturnObject in funcspecs:
       run_async(func, args, hasReturnObject)
+
+def create(path):
+  f = client.File()
+  status, response = f.open(path, OpenFlags.DELETE)
+  assert status.ok
+  status, response = f.close()
+  assert status.ok
 
 def sync(func, args, hasReturnObject):
   status, response = func(*args)

--- a/python/tests/test_glob.py
+++ b/python/tests/test_glob.py
@@ -1,17 +1,41 @@
 import pytest
 import os
 import glob as norm_glob
+import shutil
+import tempfile
 import XRootD.client.glob_funcs as glob
+from XRootD import client
+from XRootD.client.flags import OpenFlags
 from pathlib import Path
+from env import *
 
-LHCB_EOS_PUBLIC_PREFIX = (
-    "root://eospublic.cern.ch//eos/opendata/lhcb/Collision11/CHARM/"
-    "LHCb_2011_Beam3500GeV_VeloClosed_MagDown_RealData_Reco14_Stripping21r1_CHARM_MDST/"
-)
+
+@pytest.fixture(scope='module')
+def remote_tree():
+    """Create a small directory tree on the test server to glob over.
+
+    Parent directories are created on demand when a file is opened for
+    writing, and the whole tree is removed together with the server area
+    when the server fixture is torn down.
+    """
+    for path in ('dataset1/run_1.dat', 'dataset1/run_2.dat',
+                 'dataset1/run_10.dat', 'dataset2/run_3.dat'):
+        f = client.File()
+        status, __ = f.open(SERVER_URL + '/tmp/glob/' + path, OpenFlags.DELETE)
+        assert status.ok
+        status, __ = f.write('data')
+        assert status.ok
+        status, __ = f.close()
+        assert status.ok
+
+    return SERVER_URL + '/tmp/glob'
 
 
 @pytest.fixture
-def tmptree(tmpdir):
+def tmptree():
+    # Use a short-lived directory instead of the pytest tmpdir, which is
+    # retained for a few runs, so that nothing is left behind under /tmp.
+    tmpdir = Path(tempfile.mkdtemp(prefix='pyxrootd-glob-', dir='/tmp'))
     subdir1 = tmpdir / "subdir1"
     subdir1.mkdir()
     subdir2 = tmpdir / "subdir2"
@@ -19,7 +43,8 @@ def tmptree(tmpdir):
     for i in range(3):
         dummy = subdir1 / ("a_file_%d.txt" % i)
         dummy.write_text("This is file %d\n" % i, encoding="utf-8")
-    return tmpdir
+    yield tmpdir
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_glob_local(tmptree):
@@ -37,14 +62,14 @@ def test_glob_local(tmptree):
     assert str(tmptree) in str(excinfo.value)
 
 
-def test_glob_remote(tmptree):
-    assert len(glob.glob("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoad/")) == 0
-    assert len(glob.glob("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoa*")) == 2
-    assert len(glob.glob("root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/*")) > 0
-    assert len(glob.glob("root://eospublic.cern.ch//eos/root-*/cms_opendata_2012_nanoaod/*")) > 0
+def test_glob_remote(remote_tree):
+    assert len(glob.glob(remote_tree + "/nonexistent/")) == 0
+    assert len(glob.glob(remote_tree + "/dataset*")) == 2
+    assert len(glob.glob(remote_tree + "/dataset1/*")) == 3
+    assert len(glob.glob(remote_tree + "/dataset*/*.dat")) == 4
 
     with pytest.raises(RuntimeError) as excinfo:
-        glob.glob("root://eospublic.cern.ch//eos/root-NOTREAL/cms_opendata_2012_nanoaod/*", raise_error=True)
+        glob.glob(remote_tree + "/nonexistent/*", raise_error=True)
     assert "[ERROR]" in str(excinfo.value)
 
 
@@ -120,48 +145,46 @@ def test_iglob_with_url_params(tmptree):
         assert "?key1=val1&key2=val2" in result
 
 
-def test_glob_remote_with_url_params():
+def test_glob_remote_with_url_params(remote_tree):
     """Test that URL parameters work with remote XRootD paths"""
 
-    # Test with public endpoint and URL parameters
-    base_path = "root://eospublic.cern.ch//eos/root-eos/cms_opendata_2012_nanoaod/*"
     url_params = "?xrd.wantprot=unix"
 
-    results = glob.glob(base_path + url_params)
+    results = glob.glob(remote_tree + "/dataset1/*" + url_params)
 
     # Should get results
-    assert len(results) > 0
+    assert len(results) == 3
 
     # All results should have URL parameters preserved
     for result in results:
-        assert url_params in result
+        assert result.endswith(url_params)
 
 
-def test_multiple_glob_with_url_params():
+def test_multiple_glob_with_url_params(remote_tree):
     """Test multiple glob patterns with URL parameters"""
-    results = glob.glob(LHCB_EOS_PUBLIC_PREFIX + "00041840/*/*.mdst?xrd.wantprot=unix")
+    results = glob.glob(remote_tree + "/dataset*/*.dat?xrd.wantprot=unix")
 
     # Ensure we have results from all subdirectories
-    assert len(results) > 4000
+    assert len(results) == 4
 
     # Check that URL parameters are preserved in all results
     for result in results:
         assert "?xrd.wantprot=unix" in result
 
 
-def test_folder_glob_with_url_params(tmptree):
-    """Test globbing for folders with URL parameters"""
-    pattern = (
-        LHCB_EOS_PUBLIC_PREFIX + "00041840/*/00041840_000?4866_1.charm.mdst?xrd.wantprot=unix"
-    )
-    results = glob.glob(pattern)
+def test_folder_glob_with_url_params(remote_tree):
+    """Test globbing across folders with URL parameters"""
+
+    # The single character wildcard must match run_1 to run_3, but not run_10,
+    # and must not be confused with the start of the URL parameters.
+
+    results = glob.glob(remote_tree + "/dataset*/run_?.dat?xrd.wantprot=unix")
     expected = [
-        "00041840/0001/00041840_00014866_1.charm.mdst?xrd.wantprot=unix",
-        "00041840/0003/00041840_00034866_1.charm.mdst?xrd.wantprot=unix",
-        "00041840/0004/00041840_00044866_1.charm.mdst?xrd.wantprot=unix",
-        "00041840/0006/00041840_00064866_1.charm.mdst?xrd.wantprot=unix",
+        "dataset1/run_1.dat?xrd.wantprot=unix",
+        "dataset1/run_2.dat?xrd.wantprot=unix",
+        "dataset2/run_3.dat?xrd.wantprot=unix",
     ]
-    assert results == [LHCB_EOS_PUBLIC_PREFIX + path for path in expected]
+    assert sorted(results) == [remote_tree + "/" + path for path in expected]
 
 
 def test_glob_backward_compatibility(tmptree):

--- a/python/tests/xrootd.cfg
+++ b/python/tests/xrootd.cfg
@@ -1,0 +1,14 @@
+# XRootD server configuration for the Python bindings tests.
+#
+# The server is started and stopped by conftest.py, which passes the port to
+# listen on with -p and sets PYXROOTD_TEST_BASEDIR in the server environment.
+#
+# The admin path and pid path must be set explicitly: both default to /tmp,
+# which would be shared by concurrent test servers.
+
+set basedir = $PYXROOTD_TEST_BASEDIR
+
+all.export    /
+all.adminpath $basedir
+all.pidpath   $basedir
+oss.localroot $basedir/data

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -37,12 +37,17 @@ target_link_libraries(xrdcl-http-test XrdClHttpTesting XrdClHttpTransferTest GTe
 gtest_add_tests(TARGET xrdcl-test TEST_LIST CurlClOnlyTests)
 gtest_add_tests(TARGET xrdcl-http-test TEST_LIST CurlTests)
 
+# The client picks up a grid proxy from $X509_USER_PROXY or /tmp/x509up_u<uid>
+# and presents it to the servers, whose test CA cannot verify it, failing the
+# TLS handshake. Point the client at a path that can never exist, so that a
+# proxy belonging to the user running the tests is never used.
+
 set_tests_properties(${CurlTests} ${CurlClOnlyTests}
   PROPERTIES
     FIXTURES_REQUIRED
       XrdClHttp
     ENVIRONMENT
-      "ENV_FILE=${CMAKE_BINARY_DIR}/tests/curl/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/curl/client.plugins.d"
+      "ENV_FILE=${CMAKE_BINARY_DIR}/tests/curl/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/curl/client.plugins.d;X509_USER_PROXY=/dev/null/x509"
 )
 
 ######################################

--- a/tests/XrdClHttp/setup.sh
+++ b/tests/XrdClHttp/setup.sh
@@ -197,7 +197,7 @@ EOF
 # limits.  Hence, we explicitly place the XRootD rundir in /tmp
 XROOTD_RUNDIR="$(mktemp -d -p /tmp xrdcl-http-rundir.XXXXXXXX)"
 chmod 0755 "$XROOTD_RUNDIR"
-mkdir -p "$XROOTD_RUNDIR/cache" "XROOTD_RUNDIR/origin"
+mkdir -p "$XROOTD_RUNDIR/cache" "$XROOTD_RUNDIR/origin"
 XROOTD_CONFIGDIR="$RUNDIR/xrootd"
 rm -rf "$XROOTD_CONFIGDIR"
 mkdir -p "$XROOTD_CONFIGDIR"
@@ -374,6 +374,10 @@ export XRD_HTTPSLOWRATEBYTESSEC=1024
 export XRD_HTTPSTALLTIMEOUT=2
 export XRD_HTTPCERTFILE=$CA_DIR/tlsca.pem
 export XRD_LOGLEVEL=Debug
+# The cache is itself an HTTP client of the origin and would pick up a grid
+# proxy of the user running the tests from /tmp/x509up_u<uid>, which the test
+# CA cannot verify. Point it at a path that can never exist instead.
+export X509_USER_PROXY=/dev/null/x509
 set -x
 exec "$XROOTD_BIN" "\$@"
 EOF

--- a/tests/XrdClHttp/teardown.sh
+++ b/tests/XrdClHttp/teardown.sh
@@ -20,27 +20,50 @@ fi
 . "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
 
 
-if [ -z "$ORIGIN_PID" ]; then
-  echo "\$ORIGIN_PID environment variable is not set; cannot tear down process"
-  exit 1
+STATUS=0
+
+# Stop one server and wait until it is gone. Every server gets a stop attempt
+# no matter what happens to the others: an early exit when the origin was
+# already gone used to leave the cache running forever.
+
+stop() {
+  NAME=$1
+  PID=$2
+
+  if [ -z "$PID" ]; then
+    echo "PID of the $NAME process is not recorded; cannot tear it down"
+    STATUS=1
+    return
+  fi
+
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "$NAME process was already shut down by time the tear down was started"
+    return
+  fi
+
+  kill "$PID"
+
+  IDX=0
+  while kill -0 "$PID" 2>/dev/null; do
+    IDX=$((IDX+1))
+    if [ $IDX -ge 10 ]; then
+      echo "$NAME process did not exit within 10 seconds; killing it"
+      kill -9 "$PID" 2>/dev/null
+      break
+    fi
+    sleep 1
+  done
+}
+
+stop origin "$ORIGIN_PID"
+stop cache "$CACHE_PID"
+
+# The setup created the run directory with mktemp under /tmp; remove it here
+# so that runs do not accumulate directories there.
+
+if [ -n "$XROOTD_RUNDIR" ] && [ -d "$XROOTD_RUNDIR" ]; then
+  rm -rf "$XROOTD_RUNDIR"
 fi
 
-if ! kill -0 "$ORIGIN_PID" 2>/dev/null; then
-  echo "Origin process was already shut down by time the tear down was started"
-  exit
-else
-  kill "$ORIGIN_PID"
-fi
-
-if [ -z "$CACHE_PID" ]; then
-  echo "\$CACHE_PID environment variable is not set; cannot tear down process"
-  exit 1
-fi
-
-if ! kill -0 "$CACHE_PID" 2>/dev/null; then
-  echo "Cache process was already shut down by time the tear down was started"
-  exit
-else 
-  kill "$CACHE_PID"
-fi
+exit $STATUS
 

--- a/tests/XrdClS3/CMakeLists.txt
+++ b/tests/XrdClS3/CMakeLists.txt
@@ -77,11 +77,15 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
   target_link_libraries(xrdcl-s3-unittest stdc++fs)
 endif()
 
+# See tests/XrdClHttp/CMakeLists.txt: X509_USER_PROXY points at a path that
+# can never exist, so that a grid proxy belonging to the user running the
+# tests is never presented to minio, which cannot verify it.
+
 gtest_add_tests(TARGET xrdcl-s3-test TEST_LIST S3Tests)
 set_tests_properties(${S3Tests}
   PROPERTIES
     FIXTURES_REQUIRED XrdClS3::s3
-    ENVIRONMENT "XRD_LOGLEVEL=Debug;ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/s3/client.plugins.d"
+    ENVIRONMENT "XRD_LOGLEVEL=Debug;ENV_FILE=${CMAKE_BINARY_DIR}/tests/s3/setup.sh;XRD_PLUGINCONFDIR=${CMAKE_BINARY_DIR}/tests/s3/client.plugins.d;X509_USER_PROXY=/dev/null/x509"
 )
 
 gtest_add_tests(TARGET xrdcl-s3-unittest TEST_LIST S3UnitTests)

--- a/tests/XrdClS3/s3-setup.sh
+++ b/tests/XrdClS3/s3-setup.sh
@@ -392,6 +392,10 @@ export XRDCLS3_ACCESSKEYLOCATION="$RUNDIR/access_key"
 export XRDCLS3_SECRETKEYLOCATION="$RUNDIR/secret_key"
 export XRDCLS3_URLSTYLE=path
 export X509_CERT_FILE=$MINIO_CERTSDIR/CAs/tlsca.pem
+# The gateway is an HTTP client of minio and would pick up a grid proxy of
+# the user running the tests from /tmp/x509up_u<uid>, which minio cannot
+# verify. Point it at a path that can never exist instead.
+export X509_USER_PROXY=/dev/null/x509
 "$XROOTD_BIN" -c "$XROOTD_CONFIG" -l "$BINARY_DIR/tests/$TEST_NAME/server.log" 0<&- 2>>"$BINARY_DIR/tests/$TEST_NAME/server.log" >>"$BINARY_DIR/tests/$TEST_NAME/server.log" &
 XROOTD_PID=$!
 echo "xrootd daemon PID: $XROOTD_PID"
@@ -422,6 +426,7 @@ echo "xrootd started at $XROOTD_URL"
 
 cat >> "$BINARY_DIR/tests/$TEST_NAME/setup.sh" <<EOF
 XROOTD_PID=$XROOTD_PID
+XROOTD_RUNDIR=$XROOTD_RUNDIR
 XROOTD_URL=$XROOTD_URL
 BUCKET_NAME=$BUCKET_NAME
 ORIGIN_URL=$MINIO_URL

--- a/tests/XrdClS3/s3-teardown.sh
+++ b/tests/XrdClS3/s3-teardown.sh
@@ -20,13 +20,48 @@ fi
 . "$BINARY_DIR/tests/$TEST_NAME/setup.sh"
 
 
-if [ -z "$MINIO_PID" ]; then
-  echo "\$MINIO_PID environment variable is not set; cannot tear down process"
-  exit 1
+STATUS=0
+
+# Stop one server and wait until it is gone. Every server gets a stop attempt
+# no matter what happens to the others, so that none is ever left running.
+
+stop() {
+  NAME=$1
+  PID=$2
+
+  if [ -z "$PID" ]; then
+    echo "PID of the $NAME process is not recorded; cannot tear it down"
+    STATUS=1
+    return
+  fi
+
+  if ! kill -0 "$PID" 2>/dev/null; then
+    echo "$NAME process was already shut down by time the tear down was started"
+    return
+  fi
+
+  kill "$PID"
+
+  IDX=0
+  while kill -0 "$PID" 2>/dev/null; do
+    IDX=$((IDX+1))
+    if [ $IDX -ge 10 ]; then
+      echo "$NAME process did not exit within 10 seconds; killing it"
+      kill -9 "$PID" 2>/dev/null
+      break
+    fi
+    sleep 1
+  done
+}
+
+stop minio "$MINIO_PID"
+stop xrootd "$XROOTD_PID"
+
+# The setup created the run directory with mktemp under /tmp; remove it here
+# so that runs do not accumulate directories there.
+
+if [ -n "$XROOTD_RUNDIR" ] && [ -d "$XROOTD_RUNDIR" ]; then
+  rm -rf "$XROOTD_RUNDIR"
 fi
 
-kill "$MINIO_PID"
-
-if [ ! -z "$XROOTD_PID" ]; then
-  kill "$XROOTD_PID" || (tail -n 1000 $BINARY_DIR/tests/$TEST_NAME/server.log && exit 1)
-fi
+exit $STATUS

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -49,6 +49,7 @@ BuildRequires:	systemd-rpm-macros
 BuildRequires:	systemd-devel
 BuildRequires:	python3-devel
 BuildRequires:	python3-pip
+BuildRequires:	python3-pytest
 BuildRequires:	python3-setuptools
 BuildRequires:	python3-wheel
 BuildRequires:	json-c-devel

--- a/xrootd.spec
+++ b/xrootd.spec
@@ -49,7 +49,6 @@ BuildRequires:	systemd-rpm-macros
 BuildRequires:	systemd-devel
 BuildRequires:	python3-devel
 BuildRequires:	python3-pip
-BuildRequires:	python3-pytest
 BuildRequires:	python3-setuptools
 BuildRequires:	python3-wheel
 BuildRequires:	json-c-devel
@@ -88,6 +87,7 @@ BuildRequires:	krb5-server
 BuildRequires:	krb5-workstation
 BuildRequires:	openssl
 BuildRequires:	procps-ng
+BuildRequires:	python3-pytest
 BuildRequires:	sqlite
 %endif
 
@@ -355,14 +355,14 @@ doxygen Doxyfile
 	rm -f %{buildroot}%{_libdir}/libXrdCephPosix.so
 %endif
 
+%{__python3} -m pip install \
+	--no-deps --ignore-installed --disable-pip-version-check --verbose \
+	--prefix %{buildroot}%{_prefix} %{_vpath_builddir}/python/dist/*.whl
+
 rm -f %{buildroot}%{python3_sitearch}/xrootd-*.*-info/direct_url.json
 rm -f %{buildroot}%{python3_sitearch}/xrootd-*.*-info/RECORD
 [ -r %{buildroot}%{python3_sitearch}/xrootd-*.*-info/INSTALLER ] && \
 	sed s/pip/rpm/ -i %{buildroot}%{python3_sitearch}/xrootd-*.*-info/INSTALLER
-
-%{__python3} -m pip install \
-	--no-deps --ignore-installed --disable-pip-version-check --verbose \
-	--prefix %{buildroot}%{_prefix} %{_vpath_builddir}/python
 
 %if %{with docs}
 LD_LIBRARY_PATH=%{buildroot}%{_libdir} \


### PR DESCRIPTION
This pull request is a replacement for #2821.

I revived my old branch from a couple of years ago and used Claude to fix the issues I had pending, which kept me from merging that work into `master` before. The problems were:

- The Python build would always run again with `make`. This is because `add_custom_target` always considers the custom target out of date (see CMake's own [documentation](https://cmake.org/cmake/help/latest/command/add_custom_target.html)). The usual solution for this is to wrap the build into an `add_custom_command()` instead, and add a custom target that depends on an output of the custom command.
- The Python bindings were not properly rebuilt on source changes. There were two choices for handling this problem, by adding the proper dependencies. Either integrating the extension client library into the CMake build, or keeping `pip` launching a CMake sub-build. In the end, using `pip` to launch a sub-build had a silent problem that some definitions were not being passed to the compilation of the extension and that led to a mismatch between the main and the Python module builds. This was fixed by the integration of the client library into the main build, and using `pip` to only bundle stuff into the wheel.
- A requirement I gave to Claude was that all 3 build modes (standalone, embedded, and native) should keep working, so an extra check was added in CI to cover the case which was missing (and we did have recent problems with that lack of coverage, as can be seen from #2816). Now we will detect when something breaks that build.
- Finally, I used the opportunity to convert the tests which depended on EOS public to use the new server configuration created just for the Python bindings tests.

Claude made some mistakes along the way, which I had to fixup in later commits. If you're curious how I used Claude for this, I am attaching the exported Markdown of my session below.

[xrootd-python-bindings.md](https://github.com/user-attachments/files/31558383/xrootd-python-bindings.md)

I still intend to make a few adjustments on top of what Claude did, I will take this out of draft when I'm done.

*Note: I intend to squash this on merge, the commit history is just to have a trace of the process in the commit messages, which should remain visible here afterwards.*