### PR TITLE
[Python] Add object-scoped authentication contexts

### DIFF
--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -31,6 +31,7 @@ API Reference
    modules/client/filesystem
    modules/client/file
    modules/client/copyprocess
+   modules/client/auth
    modules/client/responses
    modules/client/env
    modules/client/flags

--- a/python/docs/source/modules/client/auth.rst
+++ b/python/docs/source/modules/client/auth.rst
@@ -1,0 +1,26 @@
+AuthContext
+===========
+
+.. autoclass:: XRootD.client.AuthContext
+   :members:
+
+Authentication contexts attach credentials to individual XRootD client
+objects without changing process-wide environment values.  A context may be
+shared by concurrent operations.  Separate contexts use separate authenticated
+channels, including when they target the same endpoint.
+
+Bearer token example::
+
+  from XRootD import client
+
+  with client.AuthContext.bearer(token=token) as auth:
+      filesystem = client.FileSystem('root://storage.example/', auth=auth)
+      status, info = filesystem.stat('/data/file', timeout=30)
+
+X.509 proxy example::
+
+  auth = client.AuthContext.x509(proxy='/tmp/x509up_u1000')
+  copy = client.CopyProcess(auth=auth)
+  copy.add_job('root://storage.example//data/file', 'file:///tmp/file')
+  copy.prepare()
+  status, results = copy.run()

--- a/python/examples/client_workflows.py
+++ b/python/examples/client_workflows.py
@@ -2,7 +2,7 @@
 Common FileSystem workflows.
 
 This example maps common ``xrdfs`` and ``xrdcp`` operations to the Python
-bindings, including authentication environment values, endpoint checks, checksum
+bindings, including object-scoped authentication, endpoint checks, checksum
 queries, copy, rename, and delete.
 """
 
@@ -18,10 +18,8 @@ target = endpoint + '/tmp/target.dat'
 renamed = endpoint + '/tmp/renamed.dat'
 
 
-client.EnvPutString('XrdSecPROTOCOL', 'ztn')
-client.EnvPutString('BEARER_TOKEN', 'replace-with-token')
-
-fs = client.FileSystem(endpoint)
+auth = client.AuthContext.bearer(token='replace-with-token')
+fs = client.FileSystem(endpoint, auth=auth)
 
 status, _ = fs.ping(timeout=10)
 print(status)
@@ -40,3 +38,5 @@ print(status)
 
 status, _ = fs.rm(renamed, timeout=10)
 print(status)
+
+auth.close()

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -7,6 +7,7 @@ from pyxrootd.client import setXAttrAdler32_cpp as setXAttrAdler32
 from .url import URL
 from .copyprocess import CopyProcess
 from .tape import TapeClient
+from .auth import AuthContext
 from .env import EnvPutString
 from .env import EnvGetString
 from .env import EnvDelString

--- a/python/libs/client/auth.py
+++ b/python/libs/client/auth.py
@@ -1,0 +1,142 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2026 by European Organization for Nuclear Research (CERN)
+#-------------------------------------------------------------------------------
+# This file is part of the XRootD software suite.
+#
+# XRootD is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# XRootD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function
+
+import os
+import tempfile
+import uuid
+
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _credential_path(path):
+  path = os.fsdecode(os.fspath(path))
+  if any(separator in path for separator in ('&', '?', '#')):
+    raise ValueError('credential paths cannot contain URL query separators')
+  return path
+
+
+class AuthContext(object):
+  """Object-scoped authentication configuration for XRootD clients.
+
+  Authentication is attached to individual URLs and channels instead of being
+  written to the process-wide XRootD environment.  Contexts are safe to share
+  between threads.  Distinct contexts always use distinct client channels,
+  even when they refer to the same endpoint and credential path.
+
+  Create contexts with :meth:`bearer` or :meth:`x509`.
+  """
+
+  _ROOT_SCHEMES = frozenset(('root', 'roots', 'xroot', 'xroots'))
+
+  def __init__(self, protocol, parameters, token_handle=None):
+    self.__protocol = protocol
+    self.__parameters = tuple(parameters)
+    self.__token_handle = token_handle
+    self.__identity = uuid.uuid4().hex
+    self.__closed = False
+
+  @classmethod
+  def bearer(cls, token=None, token_file=None):
+    """Create a bearer-token authentication context.
+
+    Exactly one of ``token`` or ``token_file`` must be supplied.  A token
+    supplied by value is stored in a private temporary file for the lifetime of
+    the context because the ZTN security plug-in consumes a credential file.
+    """
+    if (token is None) == (token_file is None):
+      raise ValueError('exactly one of token or token_file is required')
+
+    token_handle = None
+    if token is not None:
+      if not isinstance(token, str):
+        raise TypeError('token must be a string')
+      if not token.strip():
+        raise ValueError('token must not be empty')
+      token_handle = tempfile.NamedTemporaryFile(
+        mode='w', prefix='xrootd-token-', delete=True)
+      token_handle.write(token)
+      token_handle.flush()
+      token_file = token_handle.name
+    else:
+      token_file = _credential_path(token_file)
+
+    return cls('ztn', (('xrd.ztn', token_file),), token_handle)
+
+  @classmethod
+  def x509(cls, proxy=None, cert=None, key=None):
+    """Create an X.509 authentication context.
+
+    Supply either a proxy path or both a certificate and private-key path.
+    """
+    has_proxy = proxy is not None
+    has_cert_key = cert is not None or key is not None
+    if has_proxy == has_cert_key:
+      raise ValueError('supply either proxy or both cert and key')
+    if has_cert_key and (cert is None or key is None):
+      raise ValueError('cert and key must be supplied together')
+
+    if has_proxy:
+      parameters = (('xrd.gsiusrpxy', _credential_path(proxy)),)
+    else:
+      parameters = (
+        ('xrd.gsiusrcrt', _credential_path(cert)),
+        ('xrd.gsiusrkey', _credential_path(key)),
+      )
+    return cls('gsi', parameters)
+
+  def apply(self, url):
+    """Return ``url`` with this context's client authentication parameters."""
+    if self.__closed:
+      raise RuntimeError('authentication context is closed')
+
+    url = str(url)
+    parsed = urlsplit(url)
+    if parsed.scheme not in self._ROOT_SCHEMES:
+      return url
+
+    owned_keys = set(key for key, _ in self.__parameters)
+    owned_keys.update(('xrd.wantprot', 'xrdcl.authctx'))
+    parameters = [
+      parameter
+      for parameter in parsed.query.split('&')
+      if parameter and parameter.split('=', 1)[0] not in owned_keys
+    ]
+    parameters.append('xrd.wantprot={}'.format(self.__protocol))
+    parameters.extend(
+      '{}={}'.format(key, value) for key, value in self.__parameters)
+    parameters.append('xrdcl.authctx={}'.format(self.__identity))
+    query = '&'.join(parameters)
+    return urlunsplit(parsed._replace(query=query))
+
+  def close(self):
+    """Release any temporary credential owned by this context."""
+    if self.__closed:
+      return
+    self.__closed = True
+    if self.__token_handle is not None:
+      self.__token_handle.close()
+
+  def __enter__(self):
+    if self.__closed:
+      raise RuntimeError('authentication context is closed')
+    return self
+
+  def __exit__(self, type, value, traceback):
+    self.close()

--- a/python/libs/client/copyprocess.py
+++ b/python/libs/client/copyprocess.py
@@ -27,6 +27,7 @@ from pyxrootd import client
 from XRootD.client.url import URL
 from XRootD.client.responses import XRootDStatus
 from .env import EnvGetInt, EnvGetString
+from .auth import AuthContext
 
 class ProgressHandlerWrapper(object):
   """Internal progress handler wrapper to convert parameters to friendly 
@@ -57,9 +58,17 @@ class ProgressHandlerWrapper(object):
 class CopyProcess(object):
   """Add multiple individually-configurable copy jobs to a "copy process" and
   run them in parallel (yes, in parallel, because ``xrootd`` isn't limited
-  by the `GIL`."""
+  by the `GIL`.
 
-  def __init__(self):
+  :param auth: Optional default authentication context for source and target
+  :type  auth: :class:`XRootD.client.AuthContext`
+  """
+
+  def __init__(self, auth=None):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    self.__auth = auth
+    self.__auth_contexts = []
     self.__process = client.CopyProcess()
 
   def parallel(self, parallel):
@@ -94,7 +103,9 @@ class CopyProcess(object):
               xrate           = 0,
               retry           = EnvGetInt('CpRetry'),
               cont            = False,
-              rtrplc          = EnvGetString('CpRetryPolicy') ):
+              rtrplc          = EnvGetString('CpRetryPolicy'),
+              source_auth     = None,
+              target_auth     = None ):
     """Add a job to the copy process.
 
     :param         source: original source URL
@@ -145,7 +156,24 @@ class CopyProcess(object):
     :type      cont: boolean
     :param     rtrplc: the retry polic (force or continue)
     :type      rtrplc: string
+    :param source_auth: authentication context for the source URL; defaults to
+                        the context passed to :class:`CopyProcess`
+    :type  source_auth: :class:`XRootD.client.AuthContext`
+    :param target_auth: authentication context for the target URL; defaults to
+                        the context passed to :class:`CopyProcess`
+    :type  target_auth: :class:`XRootD.client.AuthContext`
     """
+    source_auth = self.__auth if source_auth is None else source_auth
+    target_auth = self.__auth if target_auth is None else target_auth
+    for auth in (source_auth, target_auth):
+      if auth is not None and not isinstance(auth, AuthContext):
+        raise TypeError('source_auth and target_auth must be AuthContext objects')
+    self.__auth_contexts.extend(
+      auth for auth in (source_auth, target_auth) if auth is not None)
+    if source_auth is not None:
+      source = source_auth.apply(source)
+    if target_auth is not None:
+      target = target_auth.apply(target)
     self.__process.add_job(source, target, sourcelimit, force, posc,
                            coerce, mkdir, thirdparty, checksummode, checksumtype,
                            checksumpreset, dynamicsource, chunksize, parallelchunks, inittimeout,

--- a/python/libs/client/file.py
+++ b/python/libs/client/file.py
@@ -26,12 +26,20 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, VectorReadInfo
 from XRootD.client.utils import CallbackWrapper
+from XRootD.client.auth import AuthContext
 
 class File(object):
   """Interact with an ``xrootd`` server to perform file-based operations such
-  as reading, writing, vector reading, etc."""
+  as reading, writing, vector reading, etc.
 
-  def __init__(self):
+  :param auth: Optional object-scoped authentication context
+  :type  auth: :class:`XRootD.client.AuthContext`
+  """
+
+  def __init__(self, auth=None):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    self.__auth = auth
     self.__file = client.File()
 
   def __enter__(self):
@@ -63,6 +71,8 @@ class File(object):
     :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                  object and None
     """
+    if self.__auth is not None:
+      url = self.__auth.apply(url)
     if callback:
       callback = CallbackWrapper(callback, None)
       return XRootDStatus(self.__file.open(url, flags, mode, timeout, callback))
@@ -86,6 +96,8 @@ class File(object):
     :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                  object and None
     """
+    if self.__auth is not None:
+      url = self.__auth.apply(url)
     if callback:
       callback = CallbackWrapper(callback, None)
       return XRootDStatus(self.__file.openusingtemplate(src_file.__file, url, flags, mode, timeout, callback))

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -28,17 +28,25 @@ from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
 from XRootD.client.utils import CallbackWrapper
 from XRootD.client.flags import AccessMode
+from XRootD.client.auth import AuthContext
 
 class FileSystem(object):
   """Interact with an ``xrootd`` server to perform filesystem-based operations
   such as copying files, creating directories, changing file permissions,
   listing directories, etc.
 
-  :param url: The URL of the server to connect with
-  :type  url: string
+  :param  url: The URL of the server to connect with
+  :type   url: string
+  :param auth: Optional object-scoped authentication context
+  :type  auth: :class:`XRootD.client.AuthContext`
   """
 
-  def __init__(self, url):
+  def __init__(self, url, auth=None):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    self.__auth = auth
+    if auth is not None:
+      url = auth.apply(url)
     self.__fs = client.FileSystem(url)
 
   @property
@@ -65,6 +73,9 @@ class FileSystem(object):
     :returns:      tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                    object and None
     """
+    if self.__auth is not None:
+      source = self.__auth.apply(source)
+      target = self.__auth.apply(target)
     result = self.__fs.copy(source=source, target=target, force=force)[0]
     return XRootDStatus(result), None
 
@@ -372,6 +383,9 @@ class FileSystem(object):
     :type  path: string
     """
     source = self.__fs.url.hostid + '/' + path
+    if self.__auth is not None:
+      source = '{}://{}'.format(self.__fs.url.protocol, source)
+      source = self.__auth.apply(source)
     return self.__fs.cat(source)
 
   def set_xattr(self, path, attrs, timeout=0, callback=None):

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import, division, print_function
+
+import gc
+import os
+
+from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from XRootD.client import AuthContext
+from XRootD.client.copyprocess import CopyProcess
+from XRootD.client.file import File
+from XRootD.client.filesystem import FileSystem
+import XRootD.client.copyprocess as copyprocess_module
+import XRootD.client.file as file_module
+import XRootD.client.filesystem as filesystem_module
+
+
+def _query(url):
+  return parse_qs(urlsplit(url).query)
+
+
+def test_bearer_token_is_scoped_to_context():
+  first = AuthContext.bearer(token='first-token')
+  second = AuthContext.bearer(token='second-token')
+  try:
+    first_url = first.apply('root://localhost//data?existing=value')
+    second_url = second.apply('root://localhost//data?existing=value')
+    first_query = _query(first_url)
+    second_query = _query(second_url)
+
+    assert first_query['existing'] == ['value']
+    assert first_query['xrd.wantprot'] == ['ztn']
+    assert first_query['xrdcl.authctx'] != second_query['xrdcl.authctx']
+    with open(first_query['xrd.ztn'][0]) as token_file:
+      assert token_file.read() == 'first-token'
+  finally:
+    first.close()
+    second.close()
+
+
+def test_bearer_context_removes_owned_token_file():
+  context = AuthContext.bearer(token='secret')
+  token_file = _query(context.apply('root://localhost/'))['xrd.ztn'][0]
+  assert os.path.exists(token_file)
+  context.close()
+  assert not os.path.exists(token_file)
+  with pytest.raises(RuntimeError):
+    context.apply('root://localhost/')
+
+
+def test_x509_proxy_and_cert_key_parameters():
+  proxy = AuthContext.x509(proxy='/tmp/proxy')
+  cert_key = AuthContext.x509(cert='/tmp/cert', key='/tmp/key')
+
+  proxy_query = _query(proxy.apply('roots://localhost//data'))
+  cert_key_query = _query(cert_key.apply('root://localhost//data'))
+
+  assert proxy_query['xrd.wantprot'] == ['gsi']
+  assert proxy_query['xrd.gsiusrpxy'] == ['/tmp/proxy']
+  assert cert_key_query['xrd.gsiusrcrt'] == ['/tmp/cert']
+  assert cert_key_query['xrd.gsiusrkey'] == ['/tmp/key']
+
+
+@pytest.mark.parametrize('arguments', (
+  {},
+  {'token': ''},
+  {'token': 'value', 'token_file': '/tmp/token'},
+))
+def test_bearer_requires_one_credential(arguments):
+  with pytest.raises(ValueError):
+    AuthContext.bearer(**arguments)
+
+
+def test_credential_paths_reject_query_separators():
+  with pytest.raises(ValueError):
+    AuthContext.bearer(token_file='/tmp/token&xrd.wantprot=unix')
+  with pytest.raises(ValueError):
+    AuthContext.x509(proxy='/tmp/proxy#fragment')
+
+
+@pytest.mark.parametrize('arguments', (
+  {},
+  {'proxy': '/tmp/proxy', 'cert': '/tmp/cert', 'key': '/tmp/key'},
+  {'cert': '/tmp/cert'},
+  {'key': '/tmp/key'},
+))
+def test_x509_requires_one_complete_credential(arguments):
+  with pytest.raises(ValueError):
+    AuthContext.x509(**arguments)
+
+
+def test_non_xrootd_urls_are_unchanged():
+  context = AuthContext.bearer(token='secret')
+  try:
+    url = 'file:///tmp/data?existing=value'
+    assert context.apply(url) == url
+  finally:
+    context.close()
+
+
+def test_xroots_url_is_authenticated():
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  assert _query(context.apply('xroots://localhost//data'))['xrd.wantprot'] == ['gsi']
+
+
+def test_existing_opaque_parameters_are_preserved_verbatim():
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  url = 'root://localhost//data?cap.sym=abc+def==&empty='
+  authenticated = context.apply(url)
+  assert 'cap.sym=abc+def==' in authenticated
+  assert 'empty=' in authenticated
+
+
+def test_context_can_be_shared_between_threads():
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  url = 'root://localhost//data'
+  with ThreadPoolExecutor(max_workers=16) as executor:
+    urls = list(executor.map(context.apply, [url] * 128))
+  assert len(set(urls)) == 1
+
+
+def test_filesystem_applies_context_to_endpoint(monkeypatch):
+  endpoints = []
+
+  class NativeFileSystem(object):
+    def __init__(self, url):
+      endpoints.append(url)
+
+  monkeypatch.setattr(filesystem_module.client, 'FileSystem', NativeFileSystem)
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  filesystem = FileSystem('root://localhost/', auth=context)
+
+  assert filesystem is not None
+  assert _query(endpoints[0])['xrd.gsiusrpxy'] == ['/tmp/proxy']
+
+
+def test_file_applies_context_when_opening(monkeypatch):
+  opened = []
+
+  class NativeFile(object):
+    def open(self, url, flags, mode, timeout):
+      opened.append(url)
+      return {'ok': True, 'message': ''}, None
+
+  monkeypatch.setattr(file_module.client, 'File', NativeFile)
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  file_handle = File(auth=context)
+  status, _ = file_handle.open('root://localhost//data')
+
+  assert status.ok
+  assert _query(opened[0])['xrd.gsiusrpxy'] == ['/tmp/proxy']
+
+
+def test_copy_process_supports_distinct_endpoint_contexts(monkeypatch):
+  jobs = []
+
+  class NativeCopyProcess(object):
+    def add_job(self, *arguments):
+      jobs.append(arguments)
+
+  monkeypatch.setattr(copyprocess_module.client, 'CopyProcess', NativeCopyProcess)
+  source_auth = AuthContext.x509(proxy='/tmp/source-proxy')
+  target_auth = AuthContext.bearer(token='target-token')
+  try:
+    copy = CopyProcess()
+    copy.add_job(
+      'root://source.example//data',
+      'root://target.example//data',
+      source_auth=source_auth,
+      target_auth=target_auth,
+    )
+
+    assert _query(jobs[0][0])['xrd.gsiusrpxy'] == ['/tmp/source-proxy']
+    assert _query(jobs[0][1])['xrd.wantprot'] == ['ztn']
+    assert _query(jobs[0][0])['xrdcl.authctx'] != _query(jobs[0][1])['xrdcl.authctx']
+  finally:
+    target_auth.close()
+
+
+def test_copy_process_retains_per_job_contexts(monkeypatch):
+  jobs = []
+
+  class NativeCopyProcess(object):
+    def add_job(self, *arguments):
+      jobs.append(arguments)
+
+  monkeypatch.setattr(copyprocess_module.client, 'CopyProcess', NativeCopyProcess)
+  copy = CopyProcess()
+  copy.add_job(
+    'root://source.example//data',
+    'file:///tmp/data',
+    source_auth=AuthContext.bearer(token='source-token'),
+  )
+
+  token_file = _query(jobs[0][0])['xrd.ztn'][0]
+  gc.collect()
+  assert os.path.exists(token_file)

--- a/src/XrdCl/XrdClURL.cc
+++ b/src/XrdCl/XrdClURL.cc
@@ -483,7 +483,7 @@ namespace XrdCl
 
   //------------------------------------------------------------------------
   //Get the host part of the URL (user:password\@host:port) plus channel
-  //specific CGI (xrdcl.identity & xrd.gsiusrpxy)
+  //specific CGI (intent, authentication context, and credentials)
   //------------------------------------------------------------------------
   std::string URL::GetChannelId() const
   {
@@ -491,6 +491,7 @@ namespace XrdCl
     bool hascgi = false;
 
     std::string keys[] = { "xrdcl.intent",
+                           "xrdcl.authctx",
                            "xrd.gsiusrpxy",
                            "xrd.gsiusrcrt",
                            "xrd.gsiusrkey",

--- a/src/XrdCl/XrdClURL.hh
+++ b/src/XrdCl/XrdClURL.hh
@@ -103,7 +103,7 @@ namespace XrdCl
 
       //------------------------------------------------------------------------
       //! Get the host part of the URL (user:password\@host:port) plus channel
-      //! specific CGI (xrdcl.identity & xrd.gsiusrpxy)
+      //! specific CGI (xrdcl.intent, xrdcl.authctx, and credentials)
       //------------------------------------------------------------------------
       std::string GetChannelId() const;
 

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -322,6 +322,12 @@ XrdSecCredentials *XrdSecProtocolztn::findToken(XrdOucErrInfo *erp,
    const char *aTok, *bTok;
    int sz;
 
+// An explicitly selected credential cache belongs to this client request and
+// must take precedence over process-wide defaults.
+//
+   char *ccn = (erp && erp->getEnv()) ? erp->getEnv()->Get("xrd.ztn") : 0;
+   if (ccn) return readToken(erp, ccn, isbad);
+
 // Look through all of the possible envars
 //
    for (int i = 0; i < (int)Vec.size(); i++)
@@ -353,16 +359,6 @@ XrdSecCredentials *XrdSecProtocolztn::findToken(XrdOucErrInfo *erp,
         if ((bTok = Strip(aTok, sz))) return retToken(erp, bTok, sz);
        }
 
-// We support passing the credential cache path via Url parameter
-//
-   char *ccn = (erp && erp->getEnv()) ? erp->getEnv()->Get("xrd.ztn") : 0;
-   if (ccn)
-     {
-       resp = readToken(erp, ccn, isbad);
-       if (resp || isbad) return resp;
-     }
-
-// Look through all of the possible envars   
 // Nothing found
 //
   isbad = false;

--- a/tests/XRootD/scitokens.sh
+++ b/tests/XRootD/scitokens.sh
@@ -107,6 +107,8 @@ function test_scitokens() {
 	export BEARER_TOKEN_FILE=scitokens/token_create
 	xrdcp "$SOURCE_DIR/scitokens.cfg" "$HOST/protected/subdir/root/scitokens.cfg"
 	assert_failure xrdcp -f "$HOST/protected/subdir/root/scitokens.cfg" .
+	assert xrdcp -f "$HOST/protected/subdir/root/scitokens.cfg?xrd.ztn=$PWD/scitokens/token" .
+	assert diff -u "$SOURCE_DIR/scitokens.cfg" scitokens.cfg
 	export BEARER_TOKEN_FILE=scitokens/token
 	assert xrdcp -f "$HOST/protected/subdir/root/scitokens.cfg" .
 	assert diff -u "$SOURCE_DIR/scitokens.cfg" scitokens.cfg

--- a/tests/XrdCl/XrdClURL.cc
+++ b/tests/XrdCl/XrdClURL.cc
@@ -132,3 +132,15 @@ TEST(URLTest, InvalidURLs)
     EXPECT_FALSE(XrdCl::URL(url).IsValid()) << "URL " << url << " is not invalid" << std::endl;
 }
 
+TEST(URLTest, AuthenticationContextSeparatesChannels)
+{
+  XrdCl::URL first(
+    "root://localhost//data?xrd.wantprot=ztn&xrd.ztn=/tmp/token&xrdcl.authctx=first");
+  XrdCl::URL second(
+    "root://localhost//data?xrd.wantprot=ztn&xrd.ztn=/tmp/token&xrdcl.authctx=second");
+
+  EXPECT_NE(first.GetChannelId(), second.GetChannelId());
+  EXPECT_NE(first.GetChannelId().find("xrdcl.authctx=first"), std::string::npos);
+  EXPECT_EQ(first.GetPathWithFilteredParams(),
+            "/data?xrd.wantprot=ztn&xrd.ztn=/tmp/token");
+}


### PR DESCRIPTION
## Summary

- add `XRootD.client.AuthContext` factories for bearer tokens and X.509 proxy/certificate credentials
- accept optional contexts on `FileSystem`, `File`, and `CopyProcess`, including independent source and target contexts for copy jobs
- isolate client channels with a non-secret `xrdcl.authctx` identifier so credentials cannot be reused across contexts targeting the same endpoint
- make an explicit `xrd.ztn` credential path override ambient bearer-token variables
- document the API and update the Python workflow example

## Motivation

This is the authentication part of #2828, motivated by the integration work in [rucio/rucio#8721](https://github.com/rucio/rucio/pull/8721). Applications with concurrent transfers currently have to mutate process-wide authentication state or add their own locking/process isolation. This API keeps credential selection attached to client objects and URLs instead.

The PR is intentionally limited to object-scoped authentication. Higher-level transfer helpers and unified timeout semantics can be addressed separately on top of this primitive.

## Example

```python
from XRootD import client

with client.AuthContext.bearer(token=token) as auth:
    fs = client.FileSystem("root://storage.example/", auth=auth)
    status, info = fs.stat("/data/file", timeout=30)

source_auth = client.AuthContext.x509(proxy="/tmp/source.proxy")
target_auth = client.AuthContext.bearer(token_file="/tmp/target.token")
copy = client.CopyProcess()
copy.add_job(source, target, source_auth=source_auth, target_auth=target_auth)
copy.prepare()
status, results = copy.run()
```

## Concurrency and credential lifetime

A context is safe to share between threads. Reusing one context reuses its channel identity; different contexts always get different channel identities. Raw bearer-token values are stored in owner-only temporary files because the ZTN plug-in consumes a credential path. Client wrappers retain their contexts, including per-job copy contexts, and callers close contexts after their operations finish.

Existing opaque CGI parameters are preserved byte-for-byte, and the client-only context identifier is filtered from requests sent to the server.

## Verification

- built `XrdSecztn-6`, `xrdcl-unit-tests`, and the Python extension
- 4 focused `XrdCl::URLTest` tests passed
- 19 new Python authentication tests passed
- 4 existing Python copy/filesystem smoke tests passed
- `tests/XRootD/scitokens.sh` passes shell syntax validation; CI exercises the added explicit-token-precedence integration assertion

Refs: #2828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added object-scoped authentication contexts supporting bearer tokens and X.509 credentials.
  * Added authentication support for filesystem, file, and copy operations, including separate source and target credentials.
  * Added request-specific credential-cache support for token-based access.
* **Documentation**
  * Added API reference documentation and examples for authentication contexts, credential scoping, concurrency, and lifecycle management.
* **Bug Fixes**
  * Improved authentication-aware connection separation while preserving unrelated URL parameters.
  * Updated workflows to use scoped authentication instead of environment-based credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->