### PR TITLE
[XrdClHttp] Add Rucio-ready WebDAV client operations

### DIFF
--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -31,6 +31,7 @@ API Reference
    modules/client/filesystem
    modules/client/file
    modules/client/copyprocess
+   modules/client/auth
    modules/client/responses
    modules/client/env
    modules/client/flags

--- a/python/docs/source/index.rst
+++ b/python/docs/source/index.rst
@@ -32,6 +32,7 @@ API Reference
    modules/client/file
    modules/client/copyprocess
    modules/client/auth
+   modules/client/storage
    modules/client/responses
    modules/client/env
    modules/client/flags

--- a/python/docs/source/modules/client/auth.rst
+++ b/python/docs/source/modules/client/auth.rst
@@ -1,0 +1,26 @@
+AuthContext
+===========
+
+.. autoclass:: XRootD.client.AuthContext
+   :members:
+
+Authentication contexts attach credentials to individual XRootD client
+objects without changing process-wide environment values.  A context may be
+shared by concurrent operations.  Separate contexts use separate authenticated
+channels, including when they target the same endpoint.
+
+Bearer token example::
+
+  from XRootD import client
+
+  with client.AuthContext.bearer(token=token) as auth:
+      filesystem = client.FileSystem('root://storage.example/', auth=auth)
+      status, info = filesystem.stat('/data/file', timeout=30)
+
+X.509 proxy example::
+
+  auth = client.AuthContext.x509(proxy='/tmp/x509up_u1000')
+  copy = client.CopyProcess(auth=auth)
+  copy.add_job('root://storage.example//data/file', 'file:///tmp/file')
+  copy.prepare()
+  status, results = copy.run()

--- a/python/docs/source/modules/client/auth.rst
+++ b/python/docs/source/modules/client/auth.rst
@@ -24,3 +24,11 @@ X.509 proxy example::
   copy.add_job('root://storage.example//data/file', 'file:///tmp/file')
   copy.prepare()
   status, results = copy.run()
+
+Environment-snapshot example::
+
+  auth = client.AuthContext.from_environment(fallback='none')
+
+This resolves standard bearer, XRootD GSI, X.509, and TLS environment values
+once without mutating them.  ``fallback='none'`` prevents later ambient
+credential selection when no usable credential is present.

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -17,6 +17,8 @@ Attributes
 Methods
 *******
 
+.. automethod:: XRootD.client.FileSystem.__enter__
+.. automethod:: XRootD.client.FileSystem.__exit__
 .. automethod:: XRootD.client.FileSystem.copy
 .. automethod:: XRootD.client.FileSystem.checksum
 .. automethod:: XRootD.client.FileSystem.locate

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -18,6 +18,7 @@ Methods
 *******
 
 .. automethod:: XRootD.client.FileSystem.copy
+.. automethod:: XRootD.client.FileSystem.checksum
 .. automethod:: XRootD.client.FileSystem.locate
 .. automethod:: XRootD.client.FileSystem.deeplocate
 .. automethod:: XRootD.client.FileSystem.mv

--- a/python/docs/source/modules/client/filesystem.rst
+++ b/python/docs/source/modules/client/filesystem.rst
@@ -26,6 +26,7 @@ Methods
 .. automethod:: XRootD.client.FileSystem.truncate
 .. automethod:: XRootD.client.FileSystem.rm
 .. automethod:: XRootD.client.FileSystem.mkdir
+.. automethod:: XRootD.client.FileSystem.mkdir_p
 .. automethod:: XRootD.client.FileSystem.rmdir
 .. automethod:: XRootD.client.FileSystem.chmod
 .. automethod:: XRootD.client.FileSystem.ping

--- a/python/docs/source/modules/client/responses.rst
+++ b/python/docs/source/modules/client/responses.rst
@@ -30,3 +30,4 @@ requests to an `XRootD` server.
 .. autoclass:: XRootD.client.responses.HostList()
 .. autoclass:: XRootD.client.responses.HostInfo()
 .. autoclass:: XRootD.client.responses.ProtocolInfo()
+.. autoclass:: XRootD.client.responses.ChecksumInfo()

--- a/python/docs/source/modules/client/storage.rst
+++ b/python/docs/source/modules/client/storage.rst
@@ -1,0 +1,21 @@
+StorageClient
+=============
+
+.. autoclass:: XRootD.client.StorageClient
+   :members:
+
+``StorageClient`` provides thread-safe application operations with one default
+deadline and object-scoped authentication.  A client created with
+``from_environment`` owns and closes its authentication context::
+
+  from XRootD import client
+
+  with client.StorageClient.from_environment(timeout=300) as storage:
+      storage.probe('davs://storage.example/rucio', timeout=10)
+      info = storage.info(
+          'davs://storage.example/rucio/file',
+          checksum_algorithms=('adler32', 'md5'),
+          require_checksum=True)
+
+.. autoclass:: XRootD.client.StorageInfo
+   :members:

--- a/python/examples/client_workflows.py
+++ b/python/examples/client_workflows.py
@@ -2,7 +2,7 @@
 Common FileSystem workflows.
 
 This example maps common ``xrdfs`` and ``xrdcp`` operations to the Python
-bindings, including authentication environment values, endpoint checks, checksum
+bindings, including object-scoped authentication, endpoint checks, checksum
 queries, copy, rename, and delete.
 """
 
@@ -18,10 +18,8 @@ target = endpoint + '/tmp/target.dat'
 renamed = endpoint + '/tmp/renamed.dat'
 
 
-client.EnvPutString('XrdSecPROTOCOL', 'ztn')
-client.EnvPutString('BEARER_TOKEN', 'replace-with-token')
-
-fs = client.FileSystem(endpoint)
+auth = client.AuthContext.bearer(token='replace-with-token')
+fs = client.FileSystem(endpoint, auth=auth)
 
 status, _ = fs.ping(timeout=10)
 print(status)
@@ -40,3 +38,5 @@ print(status)
 
 status, _ = fs.rm(renamed, timeout=10)
 print(status)
+
+auth.close()

--- a/python/examples/client_workflows.py
+++ b/python/examples/client_workflows.py
@@ -9,7 +9,6 @@ queries, copy, rename, and delete.
 from __future__ import print_function
 
 from XRootD import client
-from XRootD.client.flags import QueryCode
 
 
 endpoint = 'root://localhost/'
@@ -30,7 +29,7 @@ print(status, protocol)
 status, _ = fs.copy(source, target, force=True)
 print(status)
 
-status, checksum = fs.query(QueryCode.CHECKSUM, target, timeout=10)
+status, checksum = fs.checksum(target, timeout=10)
 print(status, checksum)
 
 status, _ = fs.mv(target, renamed, timeout=10)

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -7,6 +7,7 @@ from pyxrootd.client import setXAttrAdler32_cpp as setXAttrAdler32
 from .url import URL
 from .copyprocess import CopyProcess
 from .tape import TapeClient
+from .auth import AuthContext
 from .env import EnvPutString
 from .env import EnvGetString
 from .env import EnvDelString

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -9,6 +9,8 @@ from .copyprocess import CopyProcess
 from .tape import TapeClient
 from .auth import AuthContext
 from .storage import StorageClient
+from .storage import StorageInfo
+from .storage import STORAGE_CLIENT_API_VERSION
 from .env import EnvPutString
 from .env import EnvGetString
 from .env import EnvDelString

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -30,5 +30,6 @@ from .responses import XRootDTemporaryError
 from .responses import XRootDUnsupportedError
 from .responses import XRootDOperationError
 from .responses import raise_on_error
+from .responses import ChecksumInfo
 
 import XRootD.client.finalize

--- a/python/libs/client/__init__.py
+++ b/python/libs/client/__init__.py
@@ -8,6 +8,7 @@ from .url import URL
 from .copyprocess import CopyProcess
 from .tape import TapeClient
 from .auth import AuthContext
+from .storage import StorageClient
 from .env import EnvPutString
 from .env import EnvGetString
 from .env import EnvDelString
@@ -23,6 +24,10 @@ from .responses import XRootDNotFoundError
 from .responses import XRootDAuthorizationError
 from .responses import XRootDTimeoutError
 from .responses import XRootDChecksumError
+from .responses import XRootDAlreadyExistsError
+from .responses import XRootDQuotaError
+from .responses import XRootDTemporaryError
+from .responses import XRootDUnsupportedError
 from .responses import XRootDOperationError
 from .responses import raise_on_error
 

--- a/python/libs/client/auth.py
+++ b/python/libs/client/auth.py
@@ -22,7 +22,7 @@ import os
 import tempfile
 import uuid
 
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 
 
 def _credential_path(path):
@@ -44,6 +44,7 @@ class AuthContext(object):
   """
 
   _ROOT_SCHEMES = frozenset(('root', 'roots', 'xroot', 'xroots'))
+  _HTTP_SCHEMES = frozenset(('http', 'https', 'dav', 'davs'))
 
   def __init__(self, protocol, parameters, token_handle=None):
     self.__protocol = protocol
@@ -53,7 +54,8 @@ class AuthContext(object):
     self.__closed = False
 
   @classmethod
-  def bearer(cls, token=None, token_file=None):
+  def bearer(cls, token=None, token_file=None, ca_file=None, ca_dir=None,
+             verify=True):
     """Create a bearer-token authentication context.
 
     Exactly one of ``token`` or ``token_file`` must be supplied.  A token
@@ -77,10 +79,14 @@ class AuthContext(object):
     else:
       token_file = _credential_path(token_file)
 
-    return cls('ztn', (('xrd.ztn', token_file),), token_handle)
+    parameters = [('xrd.ztn', token_file),
+                  ('xrdcl.http.bearertokenfile', token_file)]
+    cls._add_tls_parameters(parameters, ca_file, ca_dir, verify)
+    return cls('ztn', parameters, token_handle)
 
   @classmethod
-  def x509(cls, proxy=None, cert=None, key=None):
+  def x509(cls, proxy=None, cert=None, key=None, ca_file=None, ca_dir=None,
+           verify=True):
     """Create an X.509 authentication context.
 
     Supply either a proxy path or both a certificate and private-key path.
@@ -93,13 +99,37 @@ class AuthContext(object):
       raise ValueError('cert and key must be supplied together')
 
     if has_proxy:
-      parameters = (('xrd.gsiusrpxy', _credential_path(proxy)),)
+      proxy = _credential_path(proxy)
+      parameters = [('xrd.gsiusrpxy', proxy),
+                    ('xrdcl.http.clientcert', proxy),
+                    ('xrdcl.http.clientkey', proxy)]
     else:
-      parameters = (
+      cert = _credential_path(cert)
+      key = _credential_path(key)
+      parameters = [
         ('xrd.gsiusrcrt', _credential_path(cert)),
         ('xrd.gsiusrkey', _credential_path(key)),
-      )
+        ('xrdcl.http.clientcert', cert),
+        ('xrdcl.http.clientkey', key),
+      ]
+    cls._add_tls_parameters(parameters, ca_file, ca_dir, verify)
     return cls('gsi', parameters)
+
+  @classmethod
+  def anonymous(cls, ca_file=None, ca_dir=None, verify=True):
+    """Disable ambient credentials for public or presigned HTTP URLs."""
+    parameters = [('xrdcl.http.noauth', '1')]
+    cls._add_tls_parameters(parameters, ca_file, ca_dir, verify)
+    return cls(None, parameters)
+
+  @staticmethod
+  def _add_tls_parameters(parameters, ca_file, ca_dir, verify):
+    if ca_file is not None:
+      parameters.append(('xrdcl.http.cafile', _credential_path(ca_file)))
+    if ca_dir is not None:
+      parameters.append(('xrdcl.http.cadir', _credential_path(ca_dir)))
+    if not verify:
+      parameters.append(('xrdcl.http.noverify', '1'))
 
   def apply(self, url):
     """Return ``url`` with this context's client authentication parameters."""
@@ -108,19 +138,31 @@ class AuthContext(object):
 
     url = str(url)
     parsed = urlsplit(url)
-    if parsed.scheme not in self._ROOT_SCHEMES:
+    if parsed.scheme not in self._ROOT_SCHEMES | self._HTTP_SCHEMES:
       return url
 
-    owned_keys = set(key for key, _ in self.__parameters)
-    owned_keys.update(('xrd.wantprot', 'xrdcl.authctx'))
+    is_root = parsed.scheme in self._ROOT_SCHEMES
+    parameters_for_scheme = [
+      (key, value) for key, value in self.__parameters
+      if (is_root and not key.startswith('xrdcl.http.')) or
+         (not is_root and key.startswith('xrdcl.http.'))
+    ]
+    owned_keys = set(key for key, _ in parameters_for_scheme)
+    owned_keys.add('xrdcl.authctx')
+    if is_root:
+      owned_keys.add('xrd.wantprot')
     parameters = [
       parameter
       for parameter in parsed.query.split('&')
       if parameter and parameter.split('=', 1)[0] not in owned_keys
     ]
-    parameters.append('xrd.wantprot={}'.format(self.__protocol))
+    if is_root:
+      if self.__protocol is None:
+        raise ValueError('anonymous authentication is only supported for HTTP URLs')
+      parameters.append('xrd.wantprot={}'.format(self.__protocol))
     parameters.extend(
-      '{}={}'.format(key, value) for key, value in self.__parameters)
+      '{}={}'.format(key, quote(value, safe='/'))
+      for key, value in parameters_for_scheme)
     parameters.append('xrdcl.authctx={}'.format(self.__identity))
     query = '&'.join(parameters)
     return urlunsplit(parsed._replace(query=query))

--- a/python/libs/client/auth.py
+++ b/python/libs/client/auth.py
@@ -1,0 +1,142 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2026 by European Organization for Nuclear Research (CERN)
+#-------------------------------------------------------------------------------
+# This file is part of the XRootD software suite.
+#
+# XRootD is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# XRootD is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with XRootD.  If not, see <http://www.gnu.org/licenses/>.
+#-------------------------------------------------------------------------------
+from __future__ import absolute_import, division, print_function
+
+import os
+import tempfile
+import uuid
+
+from urllib.parse import urlsplit, urlunsplit
+
+
+def _credential_path(path):
+  path = os.fsdecode(os.fspath(path))
+  if any(separator in path for separator in ('&', '?', '#')):
+    raise ValueError('credential paths cannot contain URL query separators')
+  return path
+
+
+class AuthContext(object):
+  """Object-scoped authentication configuration for XRootD clients.
+
+  Authentication is attached to individual URLs and channels instead of being
+  written to the process-wide XRootD environment.  Contexts are safe to share
+  between threads.  Distinct contexts always use distinct client channels,
+  even when they refer to the same endpoint and credential path.
+
+  Create contexts with :meth:`bearer` or :meth:`x509`.
+  """
+
+  _ROOT_SCHEMES = frozenset(('root', 'roots', 'xroot', 'xroots'))
+
+  def __init__(self, protocol, parameters, token_handle=None):
+    self.__protocol = protocol
+    self.__parameters = tuple(parameters)
+    self.__token_handle = token_handle
+    self.__identity = uuid.uuid4().hex
+    self.__closed = False
+
+  @classmethod
+  def bearer(cls, token=None, token_file=None):
+    """Create a bearer-token authentication context.
+
+    Exactly one of ``token`` or ``token_file`` must be supplied.  A token
+    supplied by value is stored in a private temporary file for the lifetime of
+    the context because the ZTN security plug-in consumes a credential file.
+    """
+    if (token is None) == (token_file is None):
+      raise ValueError('exactly one of token or token_file is required')
+
+    token_handle = None
+    if token is not None:
+      if not isinstance(token, str):
+        raise TypeError('token must be a string')
+      if not token.strip():
+        raise ValueError('token must not be empty')
+      token_handle = tempfile.NamedTemporaryFile(
+        mode='w', prefix='xrootd-token-', delete=True)
+      token_handle.write(token)
+      token_handle.flush()
+      token_file = token_handle.name
+    else:
+      token_file = _credential_path(token_file)
+
+    return cls('ztn', (('xrd.ztn', token_file),), token_handle)
+
+  @classmethod
+  def x509(cls, proxy=None, cert=None, key=None):
+    """Create an X.509 authentication context.
+
+    Supply either a proxy path or both a certificate and private-key path.
+    """
+    has_proxy = proxy is not None
+    has_cert_key = cert is not None or key is not None
+    if has_proxy == has_cert_key:
+      raise ValueError('supply either proxy or both cert and key')
+    if has_cert_key and (cert is None or key is None):
+      raise ValueError('cert and key must be supplied together')
+
+    if has_proxy:
+      parameters = (('xrd.gsiusrpxy', _credential_path(proxy)),)
+    else:
+      parameters = (
+        ('xrd.gsiusrcrt', _credential_path(cert)),
+        ('xrd.gsiusrkey', _credential_path(key)),
+      )
+    return cls('gsi', parameters)
+
+  def apply(self, url):
+    """Return ``url`` with this context's client authentication parameters."""
+    if self.__closed:
+      raise RuntimeError('authentication context is closed')
+
+    url = str(url)
+    parsed = urlsplit(url)
+    if parsed.scheme not in self._ROOT_SCHEMES:
+      return url
+
+    owned_keys = set(key for key, _ in self.__parameters)
+    owned_keys.update(('xrd.wantprot', 'xrdcl.authctx'))
+    parameters = [
+      parameter
+      for parameter in parsed.query.split('&')
+      if parameter and parameter.split('=', 1)[0] not in owned_keys
+    ]
+    parameters.append('xrd.wantprot={}'.format(self.__protocol))
+    parameters.extend(
+      '{}={}'.format(key, value) for key, value in self.__parameters)
+    parameters.append('xrdcl.authctx={}'.format(self.__identity))
+    query = '&'.join(parameters)
+    return urlunsplit(parsed._replace(query=query))
+
+  def close(self):
+    """Release any temporary credential owned by this context."""
+    if self.__closed:
+      return
+    self.__closed = True
+    if self.__token_handle is not None:
+      self.__token_handle.close()
+
+  def __enter__(self):
+    if self.__closed:
+      raise RuntimeError('authentication context is closed')
+    return self
+
+  def __exit__(self, type, value, traceback):
+    self.close()

--- a/python/libs/client/auth.py
+++ b/python/libs/client/auth.py
@@ -27,9 +27,20 @@ from urllib.parse import quote, urlsplit, urlunsplit
 
 def _credential_path(path):
   path = os.fsdecode(os.fspath(path))
+  path = os.path.expandvars(os.path.expanduser(path))
+  if not path:
+    raise ValueError('credential paths must not be empty')
   if any(separator in path for separator in ('&', '?', '#')):
     raise ValueError('credential paths cannot contain URL query separators')
   return path
+
+
+def _existing_path(path, directory=False):
+  if not path:
+    return None
+  path = os.path.expandvars(os.path.expanduser(path))
+  predicate = os.path.isdir if directory else os.path.isfile
+  return path if predicate(path) else None
 
 
 class AuthContext(object):
@@ -121,6 +132,94 @@ class AuthContext(object):
     parameters = [('xrdcl.http.noauth', '1')]
     cls._add_tls_parameters(parameters, ca_file, ca_dir, verify)
     return cls(None, parameters)
+
+  @classmethod
+  def no_credentials(cls, ca_file=None, ca_dir=None, verify=True):
+    """Create a context which never selects ambient credentials.
+
+    HTTP URLs are explicitly anonymous. XRootD URLs request no security
+    protocol, allowing public endpoints while failing against endpoints which
+    require authentication.
+    """
+    parameters = [('xrdcl.http.noauth', '1')]
+    cls._add_tls_parameters(parameters, ca_file, ca_dir, verify)
+    return cls('none', parameters)
+
+  @classmethod
+  def from_environment(cls, token=None, token_file=None, proxy=None,
+                       cert=None, key=None, ca_file=None, ca_dir=None,
+                       verify=True, fallback='none', environ=None,
+                       use_bearer_environment=True, use_defaults=True):
+    """Snapshot credentials from explicit values and the environment.
+
+    Explicit bearer or X.509 arguments take precedence. Standard bearer,
+    XRootD GSI, X.509, and TLS environment variables are then considered,
+    followed by conventional proxy and ``~/.globus`` paths. No process-global
+    setting is modified.
+
+    :param fallback: ``'none'`` to suppress all ambient authentication,
+                     ``'anonymous'`` for HTTP-only anonymous access, or
+                     ``'error'`` to reject a missing credential
+    :param environ: optional environment mapping, primarily for applications
+                    which need a deterministic snapshot
+    """
+    environ = os.environ if environ is None else environ
+
+    if ca_file is None:
+      ca_file = _existing_path(
+        environ.get('X509_CERT_FILE') or environ.get('SSL_CERT_FILE'))
+    if ca_dir is None:
+      ca_dir = _existing_path(
+        environ.get('X509_CERT_DIR') or environ.get('SSL_CERT_DIR'),
+        directory=True)
+    tls = {'ca_file': ca_file, 'ca_dir': ca_dir, 'verify': verify}
+
+    if token is not None or token_file is not None:
+      return cls.bearer(token=token, token_file=token_file, **tls)
+    if use_bearer_environment:
+      if 'BEARER_TOKEN_FILE' in environ:
+        return cls.bearer(token_file=environ['BEARER_TOKEN_FILE'], **tls)
+      if 'BEARER_TOKEN' in environ:
+        return cls.bearer(token=environ['BEARER_TOKEN'], **tls)
+
+    if proxy is not None:
+      return cls.x509(proxy=proxy, **tls)
+    if cert is not None or key is not None:
+      return cls.x509(cert=cert, key=key, **tls)
+
+    for variable in ('XrdSecGSIUSERPROXY', 'X509_USER_PROXY'):
+      if variable in environ:
+        return cls.x509(proxy=environ[variable], **tls)
+
+    cert_variable = next((variable for variable in (
+      'XrdSecGSIUSERCERT', 'X509_USER_CERT') if variable in environ), None)
+    key_variable = next((variable for variable in (
+      'XrdSecGSIUSERKEY', 'X509_USER_KEY') if variable in environ), None)
+    if cert_variable is not None or key_variable is not None:
+      return cls.x509(
+        cert=environ.get(cert_variable) if cert_variable else None,
+        key=environ.get(key_variable) if key_variable else None,
+        **tls)
+
+    if use_defaults and hasattr(os, 'geteuid'):
+      default_proxy = _existing_path('/tmp/x509up_u%d' % os.geteuid())
+      if default_proxy is not None:
+        return cls.x509(proxy=default_proxy, **tls)
+    if use_defaults:
+      default_cert = _existing_path(os.path.join(
+        os.path.expanduser('~'), '.globus', 'usercert.pem'))
+      default_key = _existing_path(os.path.join(
+        os.path.expanduser('~'), '.globus', 'userkey.pem'))
+      if default_cert is not None and default_key is not None:
+        return cls.x509(cert=default_cert, key=default_key, **tls)
+
+    if fallback == 'none':
+      return cls.no_credentials(**tls)
+    if fallback == 'anonymous':
+      return cls.anonymous(**tls)
+    if fallback == 'error':
+      raise ValueError('no usable authentication credential was found')
+    raise ValueError("fallback must be 'none', 'anonymous', or 'error'")
 
   @staticmethod
   def _add_tls_parameters(parameters, ca_file, ca_dir, verify):

--- a/python/libs/client/copyprocess.py
+++ b/python/libs/client/copyprocess.py
@@ -27,6 +27,7 @@ from pyxrootd import client
 from XRootD.client.url import URL
 from XRootD.client.responses import XRootDStatus
 from .env import EnvGetInt, EnvGetString
+from .auth import AuthContext
 
 class ProgressHandlerWrapper(object):
   """Internal progress handler wrapper to convert parameters to friendly 
@@ -57,9 +58,17 @@ class ProgressHandlerWrapper(object):
 class CopyProcess(object):
   """Add multiple individually-configurable copy jobs to a "copy process" and
   run them in parallel (yes, in parallel, because ``xrootd`` isn't limited
-  by the `GIL`."""
+  by the `GIL`.
 
-  def __init__(self):
+  :param auth: Optional default authentication context for source and target
+  :type  auth: :class:`XRootD.client.AuthContext`
+  """
+
+  def __init__(self, auth=None):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    self.__auth = auth
+    self.__auth_contexts = []
     self.__process = client.CopyProcess()
 
   def parallel(self, parallel):
@@ -94,7 +103,9 @@ class CopyProcess(object):
               xrate           = 0,
               retry           = EnvGetInt('CpRetry'),
               cont            = False,
-              rtrplc          = EnvGetString('CpRetryPolicy') ):
+              rtrplc          = EnvGetString('CpRetryPolicy'),
+              source_auth     = None,
+              target_auth     = None ):
     """Add a job to the copy process.
 
     :param         source: original source URL
@@ -145,7 +156,24 @@ class CopyProcess(object):
     :type      cont: boolean
     :param     rtrplc: the retry polic (force or continue)
     :type      rtrplc: string
+    :param source_auth: authentication context for the source URL; defaults to
+                        the context passed to :class:`CopyProcess`
+    :type  source_auth: :class:`XRootD.client.AuthContext`
+    :param target_auth: authentication context for the target URL; defaults to
+                        the context passed to :class:`CopyProcess`
+    :type  target_auth: :class:`XRootD.client.AuthContext`
     """
+    source_auth = self.__auth if source_auth is None else source_auth
+    target_auth = self.__auth if target_auth is None else target_auth
+    for auth in (source_auth, target_auth):
+      if auth is not None and not isinstance(auth, AuthContext):
+        raise TypeError('source_auth and target_auth must be AuthContext objects')
+    self.__auth_contexts.extend(
+      auth for auth in (source_auth, target_auth) if auth is not None)
+    if source_auth is not None:
+      source = source_auth.apply(source)
+    if target_auth is not None:
+      target = target_auth.apply(target)
     self.__process.add_job(source, target, sourcelimit, force, posc,
                            coerce, mkdir, thirdparty, checksummode, checksumtype,
                            checksumpreset, dynamicsource, chunksize, parallelchunks, inittimeout,

--- a/python/libs/client/file.py
+++ b/python/libs/client/file.py
@@ -26,12 +26,20 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, VectorReadInfo
 from XRootD.client.utils import CallbackWrapper
+from XRootD.client.auth import AuthContext
 
 class File(object):
   """Interact with an ``xrootd`` server to perform file-based operations such
-  as reading, writing, vector reading, etc."""
+  as reading, writing, vector reading, etc.
 
-  def __init__(self):
+  :param auth: Optional object-scoped authentication context
+  :type  auth: :class:`XRootD.client.AuthContext`
+  """
+
+  def __init__(self, auth=None):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    self.__auth = auth
     self.__file = client.File()
 
   def __enter__(self):
@@ -63,6 +71,8 @@ class File(object):
     :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                  object and None
     """
+    if self.__auth is not None:
+      url = self.__auth.apply(url)
     if callback:
       callback = CallbackWrapper(callback, None)
       return XRootDStatus(self.__file.open(url, flags, mode, timeout, callback))
@@ -86,6 +96,8 @@ class File(object):
     :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                  object and None
     """
+    if self.__auth is not None:
+      url = self.__auth.apply(url)
     if callback:
       callback = CallbackWrapper(callback, None)
       return XRootDStatus(self.__file.openusingtemplate(src_file.__file, url, flags, mode, timeout, callback))

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -50,6 +50,14 @@ class FileSystem(object):
       url = auth.apply(url)
     self.__fs = client.FileSystem(url)
 
+  def __enter__(self):
+    """Return this filesystem instance for use in a ``with`` statement."""
+    return self
+
+  def __exit__(self, exc_type, exc_value, traceback):
+    """Exit a ``with`` statement without suppressing exceptions."""
+    return None
+
   @property
   def url(self):
     """The server URL object, instance of :mod:`XRootD.client.URL`"""

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -28,7 +28,7 @@ from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
 from XRootD.client.responses import ChecksumInfo
 from XRootD.client.utils import CallbackWrapper
-from XRootD.client.flags import AccessMode, QueryCode
+from XRootD.client.flags import AccessMode, MkDirFlags, QueryCode
 from XRootD.client.auth import AuthContext
 
 class FileSystem(object):
@@ -225,6 +225,22 @@ class FileSystem(object):
 
     status, response = self.__fs.mkdir(path, flags, mode, timeout)
     return XRootDStatus(status), None
+
+  def mkdir_p(self, path, flags=0, mode=0, timeout=0, callback=None):
+    """Create a directory and any missing parent directories.
+
+    This is a convenience wrapper around :meth:`mkdir` using
+    :data:`XRootD.client.flags.MkDirFlags.MAKEPATH`.
+
+    :param  path: path to the directory to create
+    :type   path: string
+    :param flags: Additional `ORed` flags from
+                  :mod:`XRootD.client.flags.MkDirFlags`
+    :param  mode: the initial file access mode, an `ORed` combination of
+                  :mod:`XRootD.client.flags.AccessMode`
+    """
+    return self.mkdir(path, flags | MkDirFlags.MAKEPATH, mode, timeout,
+                      callback)
 
   def rmdir(self, path, timeout=0, callback=None):
     """Remove a directory.

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -28,17 +28,25 @@ from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
 from XRootD.client.utils import CallbackWrapper
 from XRootD.client.flags import AccessMode
+from XRootD.client.auth import AuthContext
 
 class FileSystem(object):
   """Interact with an ``xrootd`` server to perform filesystem-based operations
   such as copying files, creating directories, changing file permissions,
   listing directories, etc.
 
-  :param url: The URL of the server to connect with
-  :type  url: string
+  :param  url: The URL of the server to connect with
+  :type   url: string
+  :param auth: Optional object-scoped authentication context
+  :type  auth: :class:`XRootD.client.AuthContext`
   """
 
-  def __init__(self, url):
+  def __init__(self, url, auth=None):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    self.__auth = auth
+    if auth is not None:
+      url = auth.apply(url)
     self.__fs = client.FileSystem(url)
 
   @property
@@ -65,6 +73,9 @@ class FileSystem(object):
     :returns:      tuple containing :mod:`XRootD.client.responses.XRootDStatus`
                    object and None
     """
+    if self.__auth is not None:
+      source = self.__auth.apply(source)
+      target = self.__auth.apply(target)
     result = self.__fs.copy(source=source, target=target, force=force)[0]
     return XRootDStatus(result), None
 
@@ -372,6 +383,9 @@ class FileSystem(object):
     :type  path: string
     """
     source = self.__fs.url.hostid + '/' + path
+    if self.__auth is not None:
+      source = '{}://{}'.format(self.__fs.url.protocol, source)
+      source = self.__auth.apply(source)
     return self.__fs.cat(source)
 
   def set_xattr(self, path, attrs, timeout=0, callback=None):

--- a/python/libs/client/filesystem.py
+++ b/python/libs/client/filesystem.py
@@ -26,8 +26,9 @@ from __future__ import absolute_import, division, print_function
 from pyxrootd import client
 from XRootD.client.responses import XRootDStatus, StatInfo, StatInfoVFS
 from XRootD.client.responses import LocationInfo, DirectoryList, ProtocolInfo
+from XRootD.client.responses import ChecksumInfo
 from XRootD.client.utils import CallbackWrapper
-from XRootD.client.flags import AccessMode
+from XRootD.client.flags import AccessMode, QueryCode
 from XRootD.client.auth import AuthContext
 
 class FileSystem(object):
@@ -150,6 +151,23 @@ class FileSystem(object):
       return XRootDStatus(self.__fs.query(querycode, arg, timeout, callback))
 
     status, response = self.__fs.query(querycode, arg, timeout)
+    return XRootDStatus(status), response
+
+  def checksum(self, path, timeout=0, callback=None):
+    """Obtain a structured checksum for a path.
+
+    :param path: path to the file
+    :type  path: string
+    :returns:    tuple containing :mod:`XRootD.client.responses.XRootDStatus`
+                 object and :mod:`XRootD.client.responses.ChecksumInfo` object
+    """
+    if callback:
+      callback = CallbackWrapper(callback, ChecksumInfo)
+      return XRootDStatus(self.__fs.query(QueryCode.CHECKSUM, path, timeout,
+                                          callback))
+
+    status, response = self.__fs.query(QueryCode.CHECKSUM, path, timeout)
+    if response: response = ChecksumInfo(response)
     return XRootDStatus(status), response
 
   def truncate(self, path, size, timeout=0, callback=None):

--- a/python/libs/client/responses.py
+++ b/python/libs/client/responses.py
@@ -388,6 +388,26 @@ class ProtocolInfo(Struct):
   def __init__(self, info):
     super(ProtocolInfo, self).__init__(info)
 
+
+class ChecksumInfo(Struct):
+  """Structured checksum response.
+
+  :param response: raw response returned by ``QueryCode.CHECKSUM``
+  :type  response: string
+  :var algorithm: checksum algorithm name, for example ``adler32``
+  :var value:     checksum value
+  """
+
+  def __init__(self, response):
+    parts = response.strip('\n\0').split(None, 1)
+    if len(parts) != 2:
+      raise ValueError('Invalid checksum response: %r' % response)
+    algorithm, value = parts
+    super(ChecksumInfo, self).__init__({
+      'algorithm': algorithm,
+      'value': value,
+    })
+
 class StatInfo(Struct):
   """Status information for files and directories.
 

--- a/python/libs/client/responses.py
+++ b/python/libs/client/responses.py
@@ -49,6 +49,22 @@ class XRootDChecksumError(XRootDError):
   """The request failed checksum validation."""
 
 
+class XRootDAlreadyExistsError(XRootDError):
+  """The destination already exists or conflicts with another resource."""
+
+
+class XRootDQuotaError(XRootDError):
+  """The operation exceeded the storage quota."""
+
+
+class XRootDTemporaryError(XRootDError):
+  """The service is overloaded, locked, or temporarily unavailable."""
+
+
+class XRootDUnsupportedError(XRootDError):
+  """The requested operation is not supported by the endpoint."""
+
+
 class XRootDOperationError(XRootDError):
   """Generic unsuccessful XRootD operation."""
 
@@ -197,10 +213,16 @@ class XRootDStatus(Struct):
   # XRootD protocol error numbers carried by errErrorResponse statuses.
   _SERVER_NOT_AUTHORIZED = 3010
   _SERVER_NOT_FOUND = 3011
+  _SERVER_UNSUPPORTED = 3013
+  _SERVER_ALREADY_EXISTS = 3018
   _SERVER_CHECKSUM_ERROR = 3019
+  _SERVER_OVER_QUOTA = 3021
+  _SERVER_OVERLOADED = 3024
   _SERVER_AUTH_FAILED = 3030
+  _SERVER_CONFLICT = 3032
   _SERVER_REQUEST_TIMED_OUT = 3034
   _SERVER_TIMER_EXPIRED = 3035
+  _SERVER_FILE_LOCKED = 3003
 
   def __init__(self, status):
     super(XRootDStatus, self).__init__(status)
@@ -234,6 +256,18 @@ class XRootDStatus(Struct):
     if code == self.errCheckSumError or (
         server_error and errno == self._SERVER_CHECKSUM_ERROR):
       return XRootDChecksumError(self)
+    if server_error and errno in (
+        self._SERVER_ALREADY_EXISTS, self._SERVER_CONFLICT):
+      return XRootDAlreadyExistsError(self)
+    if server_error and errno == self._SERVER_OVER_QUOTA:
+      return XRootDQuotaError(self)
+    if code == self.errRetry or (server_error and errno in (
+        self._SERVER_FILE_LOCKED, self._SERVER_OVERLOADED)):
+      return XRootDTemporaryError(self)
+    if code in (self.errNotSupported, self.errNotImplemented,
+                self.errQueryNotSupported) or (
+        server_error and errno == self._SERVER_UNSUPPORTED):
+      return XRootDUnsupportedError(self)
     return XRootDOperationError(self)
 
   def raise_on_error(self):

--- a/python/libs/client/responses.py
+++ b/python/libs/client/responses.py
@@ -399,6 +399,8 @@ class ChecksumInfo(Struct):
   """
 
   def __init__(self, response):
+    if isinstance(response, bytes):
+      response = response.decode('ascii')
     parts = response.strip('\n\0').split(None, 1)
     if len(parts) != 2:
       raise ValueError('Invalid checksum response: %r' % response)

--- a/python/libs/client/storage.py
+++ b/python/libs/client/storage.py
@@ -148,6 +148,28 @@ class StorageClient(object):
     status.raise_on_error()
     return info
 
+  def checksum(self, url, algorithm=None, timeout=None):
+    """Return the checksum algorithm and value for a remote resource.
+
+    :param algorithm: preferred checksum algorithm, such as ``adler32``;
+                      endpoints may return another supported algorithm
+    :returns: a two-item ``(algorithm, value)`` tuple
+    """
+    filesystem, path = self._filesystem(url)
+    if algorithm:
+      separator = '&' if '?' in path else '?'
+      path = '{}{}cks.type={}'.format(path, separator, algorithm)
+    status, response = filesystem.query(
+      QueryCode.CHECKSUM, path,
+      timeout=self._remaining(self._deadline(timeout)))
+    status.raise_on_error()
+    if isinstance(response, bytes):
+      response = response.decode('ascii')
+    checksum = str(response).strip('\n\0').split(None, 1)
+    if len(checksum) != 2:
+      raise ValueError('invalid checksum response: {!r}'.format(response))
+    return tuple(checksum)
+
   def exists(self, url, timeout=None):
     """Return whether a remote resource exists."""
     try:

--- a/python/libs/client/storage.py
+++ b/python/libs/client/storage.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 import math
 import os
+import posixpath
 import time
 
 from pathlib import Path
@@ -16,7 +17,7 @@ from XRootD.client.auth import AuthContext
 from XRootD.client.copyprocess import CopyProcess
 from XRootD.client.filesystem import FileSystem
 from XRootD.client.flags import MkDirFlags, QueryCode
-from XRootD.client.responses import XRootDNotFoundError
+from XRootD.client.responses import XRootDAlreadyExistsError, XRootDNotFoundError
 
 
 class StorageClient(object):
@@ -93,9 +94,16 @@ class StorageClient(object):
   def put(self, source, destination, timeout=None, force=False,
           create_parents=True):
     """Upload one local path, optionally creating destination parents."""
-    return self._copy(self._local_url(source), destination,
-                      self._deadline(timeout), force=force,
-                      mkdir=create_parents)
+    deadline = self._deadline(timeout)
+    parsed = urlsplit(str(destination))
+    if create_parents and not parsed.query:
+      parent = posixpath.dirname(parsed.path)
+      if parent and parent != '/':
+        parent_url = urlunsplit(parsed._replace(
+          path=parent, query='', fragment=''))
+        self.mkdir_p(parent_url, timeout=self._remaining(deadline))
+    return self._copy(self._local_url(source), destination, deadline,
+                      force=force)
 
   def delete(self, url, timeout=None):
     """Delete a file or collection; partial WebDAV deletes raise an error."""
@@ -104,7 +112,7 @@ class StorageClient(object):
       self._deadline(timeout)))
     status.raise_on_error()
 
-  def move(self, source, destination, timeout=None):
+  def move(self, source, destination, timeout=None, create_parents=True):
     """Atomically rename a resource within one storage endpoint."""
     source_parsed = urlsplit(str(source))
     destination_parsed = urlsplit(str(destination))
@@ -113,10 +121,24 @@ class StorageClient(object):
       raise ValueError('move source and destination must share an endpoint')
     if source_parsed.query or destination_parsed.query:
       raise ValueError('move does not accept URL query parameters')
+    deadline = self._deadline(timeout)
     filesystem, source_path = self._filesystem(source)
-    status, _ = filesystem.mv(source_path, destination_parsed.path,
-                              timeout=self._remaining(self._deadline(timeout)))
-    status.raise_on_error()
+
+    def perform_move():
+      status, _ = filesystem.mv(source_path, destination_parsed.path,
+                                timeout=self._remaining(deadline))
+      status.raise_on_error()
+
+    try:
+      perform_move()
+    except XRootDAlreadyExistsError:
+      parent = posixpath.dirname(destination_parsed.path)
+      if not create_parents or not parent or parent == '/':
+        raise
+      parent_url = urlunsplit(destination_parsed._replace(
+        path=parent, query='', fragment=''))
+      self.mkdir_p(parent_url, timeout=self._remaining(deadline))
+      perform_move()
 
   def stat(self, url, timeout=None):
     """Return metadata for a remote resource."""

--- a/python/libs/client/storage.py
+++ b/python/libs/client/storage.py
@@ -1,0 +1,171 @@
+#-------------------------------------------------------------------------------
+# Copyright (c) 2026 by European Organization for Nuclear Research (CERN)
+#-------------------------------------------------------------------------------
+"""Small, transport-neutral storage operations for application clients."""
+
+from __future__ import absolute_import, division, print_function
+
+import math
+import os
+import time
+
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+from XRootD.client.auth import AuthContext
+from XRootD.client.copyprocess import CopyProcess
+from XRootD.client.filesystem import FileSystem
+from XRootD.client.flags import MkDirFlags, QueryCode
+from XRootD.client.responses import XRootDNotFoundError
+
+
+class StorageClient(object):
+  """Convenient high-level operations over XRootD, HTTP, and WebDAV.
+
+  The client owns no process-global state and is safe to share between threads.
+  Authentication and the default deadline are configured once, then applied to
+  every operation. Methods raise the mapped exceptions from
+  :mod:`XRootD.client.responses` on failure.
+
+  :param auth: object-scoped credentials, including ``AuthContext.anonymous()``
+               for public or presigned HTTP URLs
+  :param timeout: default end-to-end operation deadline in seconds
+  """
+
+  def __init__(self, auth=None, timeout=300):
+    if auth is not None and not isinstance(auth, AuthContext):
+      raise TypeError('auth must be an AuthContext')
+    if timeout is not None and timeout <= 0:
+      raise ValueError('timeout must be positive or None')
+    self.__auth = auth
+    self.__timeout = timeout
+
+  def _deadline(self, timeout):
+    timeout = self.__timeout if timeout is None else timeout
+    if timeout is None:
+      return None
+    if timeout <= 0:
+      raise ValueError('timeout must be positive')
+    return time.monotonic() + timeout
+
+  @staticmethod
+  def _remaining(deadline):
+    if deadline is None:
+      return 0
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+      raise TimeoutError('storage operation deadline expired')
+    return max(1, int(math.ceil(remaining)))
+
+  def _filesystem(self, url):
+    parsed = urlsplit(str(url))
+    if not parsed.scheme or not parsed.netloc:
+      raise ValueError('a full remote URL is required')
+    endpoint = urlunsplit((parsed.scheme, parsed.netloc, '/', '', ''))
+    filesystem = FileSystem(endpoint, auth=self.__auth)
+    if parsed.query:
+      filesystem.set_property('XrdClHttpQueryParam', parsed.query)
+    return filesystem, parsed.path or '/'
+
+  @staticmethod
+  def _local_url(path):
+    return Path(os.path.abspath(os.fspath(path))).as_uri()
+
+  def _copy(self, source, target, deadline, force=False, mkdir=False):
+    timeout = self._remaining(deadline)
+    process = CopyProcess()
+    process.add_job(source, target, force=force, mkdir=mkdir,
+                    inittimeout=timeout, cptimeout=timeout,
+                    source_auth=self.__auth, target_auth=self.__auth)
+    process.prepare().raise_on_error()
+    status, results = process.run()
+    status.raise_on_error()
+    if not results:
+      raise RuntimeError('copy process returned no job result')
+    results[0]['status'].raise_on_error()
+    return results[0]
+
+  def get(self, source, destination, timeout=None, force=False):
+    """Download one URL to a local path."""
+    return self._copy(source, self._local_url(destination),
+                      self._deadline(timeout), force=force)
+
+  def put(self, source, destination, timeout=None, force=False,
+          create_parents=True):
+    """Upload one local path, optionally creating destination parents."""
+    return self._copy(self._local_url(source), destination,
+                      self._deadline(timeout), force=force,
+                      mkdir=create_parents)
+
+  def delete(self, url, timeout=None):
+    """Delete a file or collection; partial WebDAV deletes raise an error."""
+    filesystem, path = self._filesystem(url)
+    status, _ = filesystem.rm(path, timeout=self._remaining(
+      self._deadline(timeout)))
+    status.raise_on_error()
+
+  def move(self, source, destination, timeout=None):
+    """Atomically rename a resource within one storage endpoint."""
+    source_parsed = urlsplit(str(source))
+    destination_parsed = urlsplit(str(destination))
+    if (source_parsed.scheme, source_parsed.netloc) != (
+        destination_parsed.scheme, destination_parsed.netloc):
+      raise ValueError('move source and destination must share an endpoint')
+    if source_parsed.query or destination_parsed.query:
+      raise ValueError('move does not accept URL query parameters')
+    filesystem, source_path = self._filesystem(source)
+    status, _ = filesystem.mv(source_path, destination_parsed.path,
+                              timeout=self._remaining(self._deadline(timeout)))
+    status.raise_on_error()
+
+  def stat(self, url, timeout=None):
+    """Return metadata for a remote resource."""
+    filesystem, path = self._filesystem(url)
+    status, info = filesystem.stat(path, timeout=self._remaining(
+      self._deadline(timeout)))
+    status.raise_on_error()
+    return info
+
+  def exists(self, url, timeout=None):
+    """Return whether a remote resource exists."""
+    try:
+      self.stat(url, timeout=timeout)
+      return True
+    except XRootDNotFoundError:
+      return False
+
+  def listdir(self, url, timeout=None):
+    """Return a remote directory listing with entry metadata."""
+    filesystem, path = self._filesystem(url)
+    status, entries = filesystem.dirlist(path, timeout=self._remaining(
+      self._deadline(timeout)))
+    status.raise_on_error()
+    return entries
+
+  def mkdir_p(self, url, timeout=None):
+    """Create a remote directory and all missing parents."""
+    filesystem, path = self._filesystem(url)
+    status, _ = filesystem.mkdir(path, flags=MkDirFlags.MAKEPATH,
+                                 timeout=self._remaining(
+                                   self._deadline(timeout)))
+    status.raise_on_error()
+
+  def space(self, url, timeout=None):
+    """Return ``total``, ``free``, and ``used`` byte counts for an endpoint."""
+    filesystem, path = self._filesystem(url)
+    status, response = filesystem.query(QueryCode.SPACE, path,
+                                        timeout=self._remaining(
+                                          self._deadline(timeout)))
+    status.raise_on_error()
+    values = {}
+    if isinstance(response, bytes):
+      response = response.decode('ascii')
+    for parameter in str(response).split('&'):
+      key, separator, value = parameter.partition('=')
+      if separator:
+        values[key] = int(value)
+    return {
+      'total': values['oss.space'],
+      'free': values['oss.free'],
+      'used': values['oss.used'],
+    }

--- a/python/libs/client/storage.py
+++ b/python/libs/client/storage.py
@@ -16,7 +16,7 @@ from urllib.parse import urlsplit, urlunsplit
 from XRootD.client.auth import AuthContext
 from XRootD.client.copyprocess import CopyProcess
 from XRootD.client.filesystem import FileSystem
-from XRootD.client.flags import MkDirFlags, QueryCode
+from XRootD.client.flags import QueryCode
 from XRootD.client.responses import XRootDAlreadyExistsError, XRootDNotFoundError
 
 
@@ -159,16 +159,10 @@ class StorageClient(object):
     if algorithm:
       separator = '&' if '?' in path else '?'
       path = '{}{}cks.type={}'.format(path, separator, algorithm)
-    status, response = filesystem.query(
-      QueryCode.CHECKSUM, path,
-      timeout=self._remaining(self._deadline(timeout)))
+    status, response = filesystem.checksum(
+      path, timeout=self._remaining(self._deadline(timeout)))
     status.raise_on_error()
-    if isinstance(response, bytes):
-      response = response.decode('ascii')
-    checksum = str(response).strip('\n\0').split(None, 1)
-    if len(checksum) != 2:
-      raise ValueError('invalid checksum response: {!r}'.format(response))
-    return tuple(checksum)
+    return response.algorithm, response.value
 
   def exists(self, url, timeout=None):
     """Return whether a remote resource exists."""
@@ -189,9 +183,8 @@ class StorageClient(object):
   def mkdir_p(self, url, timeout=None):
     """Create a remote directory and all missing parents."""
     filesystem, path = self._filesystem(url)
-    status, _ = filesystem.mkdir(path, flags=MkDirFlags.MAKEPATH,
-                                 timeout=self._remaining(
-                                   self._deadline(timeout)))
+    status, _ = filesystem.mkdir_p(
+      path, timeout=self._remaining(self._deadline(timeout)))
     status.raise_on_error()
 
   def space(self, url, timeout=None):

--- a/python/libs/client/storage.py
+++ b/python/libs/client/storage.py
@@ -8,8 +8,10 @@ from __future__ import absolute_import, division, print_function
 import math
 import os
 import posixpath
+import threading
 import time
 
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit
 
@@ -17,7 +19,31 @@ from XRootD.client.auth import AuthContext
 from XRootD.client.copyprocess import CopyProcess
 from XRootD.client.filesystem import FileSystem
 from XRootD.client.flags import QueryCode
-from XRootD.client.responses import XRootDAlreadyExistsError, XRootDNotFoundError
+from XRootD.client.responses import (XRootDAlreadyExistsError,
+                                    XRootDChecksumError,
+                                    XRootDNotFoundError,
+                                    XRootDOperationError,
+                                    XRootDUnsupportedError,
+                                    XRootDTimeoutError)
+
+
+STORAGE_CLIENT_API_VERSION = 2
+
+
+class StorageInfo(object):
+  """Transport-neutral metadata returned by :class:`StorageClient`.
+
+  :var size: resource size in bytes
+  :var checksum: optional structured checksum response
+  :var stat: original native stat response
+  :var checksum_errors: errors encountered while negotiating a checksum
+  """
+
+  def __init__(self, stat, checksum=None, checksum_errors=()):
+    self.stat = stat
+    self.size = stat['size'] if isinstance(stat, dict) else stat.size
+    self.checksum = checksum
+    self.checksum_errors = tuple(checksum_errors)
 
 
 class StorageClient(object):
@@ -33,13 +59,65 @@ class StorageClient(object):
   :param timeout: default end-to-end operation deadline in seconds
   """
 
-  def __init__(self, auth=None, timeout=300):
+  def __init__(self, auth=None, timeout=300, owns_auth=False):
     if auth is not None and not isinstance(auth, AuthContext):
       raise TypeError('auth must be an AuthContext')
     if timeout is not None and timeout <= 0:
       raise ValueError('timeout must be positive or None')
+    if not isinstance(owns_auth, bool):
+      raise TypeError('owns_auth must be a boolean')
     self.__auth = auth
     self.__timeout = timeout
+    self.__owns_auth = owns_auth
+    self.__condition = threading.Condition()
+    self.__active_operations = 0
+    self.__closed = False
+    self.__checksum_algorithms = {}
+    self.__checksum_lock = threading.Lock()
+
+  @classmethod
+  def from_environment(cls, timeout=300, **auth_options):
+    """Create a client which owns an environment-snapshot auth context."""
+    auth = AuthContext.from_environment(**auth_options)
+    try:
+      return cls(auth=auth, timeout=timeout, owns_auth=True)
+    except Exception:
+      auth.close()
+      raise
+
+  @contextmanager
+  def _operation(self):
+    with self.__condition:
+      if self.__closed:
+        raise RuntimeError('storage client is closed')
+      self.__active_operations += 1
+    try:
+      yield
+    finally:
+      with self.__condition:
+        self.__active_operations -= 1
+        if not self.__active_operations:
+          self.__condition.notify_all()
+
+  def close(self):
+    """Wait for active operations and release an owned auth context."""
+    with self.__condition:
+      if self.__closed:
+        return
+      self.__closed = True
+      while self.__active_operations:
+        self.__condition.wait()
+    if self.__owns_auth and self.__auth is not None:
+      self.__auth.close()
+
+  def __enter__(self):
+    with self.__condition:
+      if self.__closed:
+        raise RuntimeError('storage client is closed')
+    return self
+
+  def __exit__(self, type, value, traceback):
+    self.close()
 
   def _deadline(self, timeout):
     timeout = self.__timeout if timeout is None else timeout
@@ -55,7 +133,7 @@ class StorageClient(object):
       return 0
     remaining = deadline - time.monotonic()
     if remaining <= 0:
-      raise TimeoutError('storage operation deadline expired')
+      raise XRootDTimeoutError('storage operation deadline expired')
     return max(1, int(math.ceil(remaining)))
 
   def _filesystem(self, url):
@@ -86,67 +164,151 @@ class StorageClient(object):
     results[0]['status'].raise_on_error()
     return results[0]
 
+  def _stat(self, url, deadline):
+    filesystem, path = self._filesystem(url)
+    status, response = filesystem.stat(
+      path, timeout=self._remaining(deadline))
+    status.raise_on_error()
+    return response
+
+  def _checksum(self, url, algorithm, deadline):
+    filesystem, path = self._filesystem(url)
+    if algorithm:
+      separator = '&' if '?' in path else '?'
+      path = '{}{}cks.type={}'.format(path, separator, algorithm)
+    status, response = filesystem.checksum(
+      path, timeout=self._remaining(deadline))
+    status.raise_on_error()
+    return response
+
+  def _mkdir_p(self, url, deadline):
+    filesystem, path = self._filesystem(url)
+    status, _ = filesystem.mkdir_p(
+      path, timeout=self._remaining(deadline))
+    status.raise_on_error()
+
+  @staticmethod
+  def _endpoint_key(url):
+    parsed = urlsplit(str(url))
+    return parsed.scheme, parsed.netloc
+
   def get(self, source, destination, timeout=None, force=False):
     """Download one URL to a local path."""
-    return self._copy(source, self._local_url(destination),
-                      self._deadline(timeout), force=force)
+    with self._operation():
+      return self._copy(source, self._local_url(destination),
+                        self._deadline(timeout), force=force)
 
   def put(self, source, destination, timeout=None, force=False,
           create_parents=True):
     """Upload one local path, optionally creating destination parents."""
-    deadline = self._deadline(timeout)
-    parsed = urlsplit(str(destination))
-    if create_parents and not parsed.query:
-      parent = posixpath.dirname(parsed.path)
-      if parent and parent != '/':
-        parent_url = urlunsplit(parsed._replace(
-          path=parent, query='', fragment=''))
-        self.mkdir_p(parent_url, timeout=self._remaining(deadline))
-    return self._copy(self._local_url(source), destination, deadline,
-                      force=force)
+    with self._operation():
+      deadline = self._deadline(timeout)
+      parsed = urlsplit(str(destination))
+      if create_parents and not parsed.query:
+        parent = posixpath.dirname(parsed.path)
+        if parent and parent != '/':
+          parent_url = urlunsplit(parsed._replace(
+            path=parent, query='', fragment=''))
+          self._mkdir_p(parent_url, deadline)
+      return self._copy(self._local_url(source), destination, deadline,
+                        force=force)
 
   def delete(self, url, timeout=None):
     """Delete a file or collection; partial WebDAV deletes raise an error."""
-    filesystem, path = self._filesystem(url)
-    status, _ = filesystem.rm(path, timeout=self._remaining(
-      self._deadline(timeout)))
-    status.raise_on_error()
+    with self._operation():
+      filesystem, path = self._filesystem(url)
+      status, _ = filesystem.rm(path, timeout=self._remaining(
+        self._deadline(timeout)))
+      status.raise_on_error()
 
   def move(self, source, destination, timeout=None, create_parents=True):
     """Atomically rename a resource within one storage endpoint."""
-    source_parsed = urlsplit(str(source))
-    destination_parsed = urlsplit(str(destination))
-    if (source_parsed.scheme, source_parsed.netloc) != (
-        destination_parsed.scheme, destination_parsed.netloc):
-      raise ValueError('move source and destination must share an endpoint')
-    if source_parsed.query or destination_parsed.query:
-      raise ValueError('move does not accept URL query parameters')
-    deadline = self._deadline(timeout)
-    filesystem, source_path = self._filesystem(source)
+    with self._operation():
+      source_parsed = urlsplit(str(source))
+      destination_parsed = urlsplit(str(destination))
+      if (source_parsed.scheme, source_parsed.netloc) != (
+          destination_parsed.scheme, destination_parsed.netloc):
+        raise ValueError('move source and destination must share an endpoint')
+      if source_parsed.query or destination_parsed.query:
+        raise ValueError('move does not accept URL query parameters')
+      deadline = self._deadline(timeout)
+      filesystem, source_path = self._filesystem(source)
 
-    def perform_move():
-      status, _ = filesystem.mv(source_path, destination_parsed.path,
-                                timeout=self._remaining(deadline))
-      status.raise_on_error()
+      def perform_move():
+        status, _ = filesystem.mv(source_path, destination_parsed.path,
+                                  timeout=self._remaining(deadline))
+        status.raise_on_error()
 
-    try:
-      perform_move()
-    except XRootDAlreadyExistsError:
-      parent = posixpath.dirname(destination_parsed.path)
-      if not create_parents or not parent or parent == '/':
-        raise
-      parent_url = urlunsplit(destination_parsed._replace(
-        path=parent, query='', fragment=''))
-      self.mkdir_p(parent_url, timeout=self._remaining(deadline))
-      perform_move()
+      try:
+        perform_move()
+      except XRootDAlreadyExistsError:
+        parent = posixpath.dirname(destination_parsed.path)
+        if not create_parents or not parent or parent == '/':
+          raise
+        parent_url = urlunsplit(destination_parsed._replace(
+          path=parent, query='', fragment=''))
+        self._mkdir_p(parent_url, deadline)
+        perform_move()
 
   def stat(self, url, timeout=None):
-    """Return metadata for a remote resource."""
-    filesystem, path = self._filesystem(url)
-    status, info = filesystem.stat(path, timeout=self._remaining(
-      self._deadline(timeout)))
-    status.raise_on_error()
-    return info
+    """Return normalized metadata for a remote resource."""
+    with self._operation():
+      return StorageInfo(self._stat(url, self._deadline(timeout)))
+
+  def probe(self, url, timeout=None):
+    """Verify bounded endpoint access by obtaining metadata for ``url``."""
+    return self.stat(url, timeout=timeout)
+
+  def info(self, url, checksum_algorithms=None, timeout=None,
+           require_checksum=False):
+    """Return metadata and negotiate a supported checksum under one deadline.
+
+    ``checksum_algorithms`` is an ordered iterable of algorithms accepted by
+    the application. Successful negotiation is cached per endpoint. When
+    ``require_checksum`` is true, failure to obtain an accepted checksum raises
+    :class:`XRootDChecksumError`.
+    """
+    with self._operation():
+      deadline = self._deadline(timeout)
+      stat = self._stat(url, deadline)
+      algorithms = []
+      for algorithm in checksum_algorithms or ():
+        algorithm = str(algorithm).lower()
+        if algorithm not in algorithms:
+          algorithms.append(algorithm)
+      if not algorithms:
+        return StorageInfo(stat)
+
+      endpoint = self._endpoint_key(url)
+      with self.__checksum_lock:
+        cached = self.__checksum_algorithms.get(endpoint)
+      if cached in algorithms:
+        algorithms.remove(cached)
+        algorithms.insert(0, cached)
+
+      errors = []
+      for algorithm in algorithms:
+        try:
+          checksum = self._checksum(url, algorithm, deadline)
+        except (XRootDChecksumError, XRootDOperationError,
+                XRootDUnsupportedError, ValueError) as error:
+          errors.append(error)
+          continue
+        returned = str(checksum.algorithm).lower()
+        if returned in algorithms:
+          checksum.algorithm = returned
+          with self.__checksum_lock:
+            self.__checksum_algorithms[endpoint] = returned
+          return StorageInfo(stat, checksum=checksum,
+                             checksum_errors=errors)
+        errors.append(ValueError(
+          'endpoint returned unsupported checksum {}'.format(returned)))
+
+      if require_checksum:
+        details = '; '.join(str(error) for error in errors)
+        raise XRootDChecksumError(
+          details or 'no accepted checksum was returned')
+      return StorageInfo(stat, checksum_errors=errors)
 
   def checksum(self, url, algorithm=None, timeout=None):
     """Return the checksum algorithm and value for a remote resource.
@@ -155,54 +317,50 @@ class StorageClient(object):
                       endpoints may return another supported algorithm
     :returns: a two-item ``(algorithm, value)`` tuple
     """
-    filesystem, path = self._filesystem(url)
-    if algorithm:
-      separator = '&' if '?' in path else '?'
-      path = '{}{}cks.type={}'.format(path, separator, algorithm)
-    status, response = filesystem.checksum(
-      path, timeout=self._remaining(self._deadline(timeout)))
-    status.raise_on_error()
-    return response.algorithm, response.value
+    with self._operation():
+      response = self._checksum(url, algorithm, self._deadline(timeout))
+      return response.algorithm, response.value
 
   def exists(self, url, timeout=None):
     """Return whether a remote resource exists."""
-    try:
-      self.stat(url, timeout=timeout)
-      return True
-    except XRootDNotFoundError:
-      return False
+    with self._operation():
+      try:
+        self._stat(url, self._deadline(timeout))
+        return True
+      except XRootDNotFoundError:
+        return False
 
   def listdir(self, url, timeout=None):
     """Return a remote directory listing with entry metadata."""
-    filesystem, path = self._filesystem(url)
-    status, entries = filesystem.dirlist(path, timeout=self._remaining(
-      self._deadline(timeout)))
-    status.raise_on_error()
-    return entries
+    with self._operation():
+      filesystem, path = self._filesystem(url)
+      status, entries = filesystem.dirlist(path, timeout=self._remaining(
+        self._deadline(timeout)))
+      status.raise_on_error()
+      return entries
 
   def mkdir_p(self, url, timeout=None):
     """Create a remote directory and all missing parents."""
-    filesystem, path = self._filesystem(url)
-    status, _ = filesystem.mkdir_p(
-      path, timeout=self._remaining(self._deadline(timeout)))
-    status.raise_on_error()
+    with self._operation():
+      self._mkdir_p(url, self._deadline(timeout))
 
   def space(self, url, timeout=None):
     """Return ``total``, ``free``, and ``used`` byte counts for an endpoint."""
-    filesystem, path = self._filesystem(url)
-    status, response = filesystem.query(QueryCode.SPACE, path,
-                                        timeout=self._remaining(
-                                          self._deadline(timeout)))
-    status.raise_on_error()
-    values = {}
-    if isinstance(response, bytes):
-      response = response.decode('ascii')
-    for parameter in str(response).split('&'):
-      key, separator, value = parameter.partition('=')
-      if separator:
-        values[key] = int(value)
-    return {
-      'total': values['oss.space'],
-      'free': values['oss.free'],
-      'used': values['oss.used'],
-    }
+    with self._operation():
+      filesystem, path = self._filesystem(url)
+      status, response = filesystem.query(QueryCode.SPACE, path,
+                                          timeout=self._remaining(
+                                            self._deadline(timeout)))
+      status.raise_on_error()
+      values = {}
+      if isinstance(response, bytes):
+        response = response.decode('ascii')
+      for parameter in str(response).split('&'):
+        key, separator, value = parameter.partition('=')
+        if separator:
+          values[key] = int(value)
+      return {
+        'total': values['oss.space'],
+        'free': values['oss.free'],
+        'used': values['oss.used'],
+      }

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -1,0 +1,199 @@
+from __future__ import absolute_import, division, print_function
+
+import gc
+import os
+
+from concurrent.futures import ThreadPoolExecutor
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from XRootD.client import AuthContext
+from XRootD.client.copyprocess import CopyProcess
+from XRootD.client.file import File
+from XRootD.client.filesystem import FileSystem
+import XRootD.client.copyprocess as copyprocess_module
+import XRootD.client.file as file_module
+import XRootD.client.filesystem as filesystem_module
+
+
+def _query(url):
+  return parse_qs(urlsplit(url).query)
+
+
+def test_bearer_token_is_scoped_to_context():
+  first = AuthContext.bearer(token='first-token')
+  second = AuthContext.bearer(token='second-token')
+  try:
+    first_url = first.apply('root://localhost//data?existing=value')
+    second_url = second.apply('root://localhost//data?existing=value')
+    first_query = _query(first_url)
+    second_query = _query(second_url)
+
+    assert first_query['existing'] == ['value']
+    assert first_query['xrd.wantprot'] == ['ztn']
+    assert first_query['xrdcl.authctx'] != second_query['xrdcl.authctx']
+    with open(first_query['xrd.ztn'][0]) as token_file:
+      assert token_file.read() == 'first-token'
+  finally:
+    first.close()
+    second.close()
+
+
+def test_bearer_context_removes_owned_token_file():
+  context = AuthContext.bearer(token='secret')
+  token_file = _query(context.apply('root://localhost/'))['xrd.ztn'][0]
+  assert os.path.exists(token_file)
+  context.close()
+  assert not os.path.exists(token_file)
+  with pytest.raises(RuntimeError):
+    context.apply('root://localhost/')
+
+
+def test_x509_proxy_and_cert_key_parameters():
+  proxy = AuthContext.x509(proxy='/tmp/proxy')
+  cert_key = AuthContext.x509(cert='/tmp/cert', key='/tmp/key')
+
+  proxy_query = _query(proxy.apply('roots://localhost//data'))
+  cert_key_query = _query(cert_key.apply('root://localhost//data'))
+
+  assert proxy_query['xrd.wantprot'] == ['gsi']
+  assert proxy_query['xrd.gsiusrpxy'] == ['/tmp/proxy']
+  assert cert_key_query['xrd.gsiusrcrt'] == ['/tmp/cert']
+  assert cert_key_query['xrd.gsiusrkey'] == ['/tmp/key']
+
+
+@pytest.mark.parametrize('arguments', (
+  {},
+  {'token': ''},
+  {'token': 'value', 'token_file': '/tmp/token'},
+))
+def test_bearer_requires_one_credential(arguments):
+  with pytest.raises(ValueError):
+    AuthContext.bearer(**arguments)
+
+
+def test_credential_paths_reject_query_separators():
+  with pytest.raises(ValueError):
+    AuthContext.bearer(token_file='/tmp/token&xrd.wantprot=unix')
+  with pytest.raises(ValueError):
+    AuthContext.x509(proxy='/tmp/proxy#fragment')
+
+
+@pytest.mark.parametrize('arguments', (
+  {},
+  {'proxy': '/tmp/proxy', 'cert': '/tmp/cert', 'key': '/tmp/key'},
+  {'cert': '/tmp/cert'},
+  {'key': '/tmp/key'},
+))
+def test_x509_requires_one_complete_credential(arguments):
+  with pytest.raises(ValueError):
+    AuthContext.x509(**arguments)
+
+
+def test_non_xrootd_urls_are_unchanged():
+  context = AuthContext.bearer(token='secret')
+  try:
+    url = 'file:///tmp/data?existing=value'
+    assert context.apply(url) == url
+  finally:
+    context.close()
+
+
+def test_xroots_url_is_authenticated():
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  assert _query(context.apply('xroots://localhost//data'))['xrd.wantprot'] == ['gsi']
+
+
+def test_existing_opaque_parameters_are_preserved_verbatim():
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  url = 'root://localhost//data?cap.sym=abc+def==&empty='
+  authenticated = context.apply(url)
+  assert 'cap.sym=abc+def==' in authenticated
+  assert 'empty=' in authenticated
+
+
+def test_context_can_be_shared_between_threads():
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  url = 'root://localhost//data'
+  with ThreadPoolExecutor(max_workers=16) as executor:
+    urls = list(executor.map(context.apply, [url] * 128))
+  assert len(set(urls)) == 1
+
+
+def test_filesystem_applies_context_to_endpoint(monkeypatch):
+  endpoints = []
+
+  class NativeFileSystem(object):
+    def __init__(self, url):
+      endpoints.append(url)
+
+  monkeypatch.setattr(filesystem_module.client, 'FileSystem', NativeFileSystem)
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  filesystem = FileSystem('root://localhost/', auth=context)
+
+  assert filesystem is not None
+  assert _query(endpoints[0])['xrd.gsiusrpxy'] == ['/tmp/proxy']
+
+
+def test_file_applies_context_when_opening(monkeypatch):
+  opened = []
+
+  class NativeFile(object):
+    def open(self, url, flags, mode, timeout):
+      opened.append(url)
+      return {'ok': True, 'message': ''}, None
+
+  monkeypatch.setattr(file_module.client, 'File', NativeFile)
+  context = AuthContext.x509(proxy='/tmp/proxy')
+  file_handle = File(auth=context)
+  status, _ = file_handle.open('root://localhost//data')
+
+  assert status.ok
+  assert _query(opened[0])['xrd.gsiusrpxy'] == ['/tmp/proxy']
+
+
+def test_copy_process_supports_distinct_endpoint_contexts(monkeypatch):
+  jobs = []
+
+  class NativeCopyProcess(object):
+    def add_job(self, *arguments):
+      jobs.append(arguments)
+
+  monkeypatch.setattr(copyprocess_module.client, 'CopyProcess', NativeCopyProcess)
+  source_auth = AuthContext.x509(proxy='/tmp/source-proxy')
+  target_auth = AuthContext.bearer(token='target-token')
+  try:
+    copy = CopyProcess()
+    copy.add_job(
+      'root://source.example//data',
+      'root://target.example//data',
+      source_auth=source_auth,
+      target_auth=target_auth,
+    )
+
+    assert _query(jobs[0][0])['xrd.gsiusrpxy'] == ['/tmp/source-proxy']
+    assert _query(jobs[0][1])['xrd.wantprot'] == ['ztn']
+    assert _query(jobs[0][0])['xrdcl.authctx'] != _query(jobs[0][1])['xrdcl.authctx']
+  finally:
+    target_auth.close()
+
+
+def test_copy_process_retains_per_job_contexts(monkeypatch):
+  jobs = []
+
+  class NativeCopyProcess(object):
+    def add_job(self, *arguments):
+      jobs.append(arguments)
+
+  monkeypatch.setattr(copyprocess_module.client, 'CopyProcess', NativeCopyProcess)
+  copy = CopyProcess()
+  copy.add_job(
+    'root://source.example//data',
+    'file:///tmp/data',
+    source_auth=AuthContext.bearer(token='source-token'),
+  )
+
+  token_file = _query(jobs[0][0])['xrd.ztn'][0]
+  gc.collect()
+  assert os.path.exists(token_file)

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -100,6 +100,37 @@ def test_non_xrootd_urls_are_unchanged():
     context.close()
 
 
+def test_http_bearer_is_object_scoped_and_preserves_signed_query():
+  context = AuthContext.bearer(token_file='/tmp/token file',
+                               ca_file='/tmp/custom ca.pem')
+  authenticated = context.apply(
+    'davs://storage.example/data?X-Amz-Signature=abc+def==&empty=')
+  query = _query(authenticated)
+
+  assert 'X-Amz-Signature=abc+def==' in authenticated
+  assert 'empty=' in authenticated
+  assert query['xrdcl.http.bearertokenfile'] == ['/tmp/token file']
+  assert query['xrdcl.http.cafile'] == ['/tmp/custom ca.pem']
+  assert 'xrd.wantprot' not in query
+
+
+def test_http_x509_and_anonymous_contexts():
+  x509 = AuthContext.x509(proxy='/tmp/proxy', verify=False)
+  anonymous = AuthContext.anonymous()
+
+  x509_query = _query(x509.apply('https://storage.example/data'))
+  anonymous_query = _query(anonymous.apply('https://storage.example/data'))
+  assert x509_query['xrdcl.http.clientcert'] == ['/tmp/proxy']
+  assert x509_query['xrdcl.http.clientkey'] == ['/tmp/proxy']
+  assert x509_query['xrdcl.http.noverify'] == ['1']
+  assert anonymous_query['xrdcl.http.noauth'] == ['1']
+
+
+def test_anonymous_context_rejects_root_protocol():
+  with pytest.raises(ValueError):
+    AuthContext.anonymous().apply('root://storage.example//data')
+
+
 def test_xroots_url_is_authenticated():
   context = AuthContext.x509(proxy='/tmp/proxy')
   assert _query(context.apply('xroots://localhost//data'))['xrd.wantprot'] == ['gsi']

--- a/python/tests/test_auth.py
+++ b/python/tests/test_auth.py
@@ -126,6 +126,57 @@ def test_http_x509_and_anonymous_contexts():
   assert anonymous_query['xrdcl.http.noauth'] == ['1']
 
 
+def test_environment_context_prefers_explicit_token(tmp_path):
+  proxy = tmp_path / 'proxy'
+  proxy.write_text('proxy')
+  context = AuthContext.from_environment(
+    token='explicit-token',
+    environ={'X509_USER_PROXY': str(proxy), 'X509_CERT_DIR': '/missing'})
+  try:
+    query = _query(context.apply('root://localhost//data'))
+    assert query['xrd.wantprot'] == ['ztn']
+    with open(query['xrd.ztn'][0]) as token_file:
+      assert token_file.read() == 'explicit-token'
+  finally:
+    context.close()
+
+
+def test_environment_context_uses_proxy_and_tls_snapshot(tmp_path):
+  proxy = tmp_path / 'proxy'
+  ca_dir = tmp_path / 'certificates'
+  proxy.write_text('proxy')
+  ca_dir.mkdir()
+  context = AuthContext.from_environment(environ={
+    'X509_USER_PROXY': str(proxy),
+    'X509_CERT_DIR': str(ca_dir),
+  })
+
+  query = _query(context.apply('davs://storage.example/data'))
+  assert query['xrdcl.http.clientcert'] == [str(proxy)]
+  assert query['xrdcl.http.cadir'] == [str(ca_dir)]
+
+
+def test_environment_context_fails_closed_without_credentials():
+  context = AuthContext.from_environment(
+    environ={}, fallback='none', use_defaults=False)
+
+  root_query = _query(context.apply('root://localhost//data'))
+  http_query = _query(context.apply('https://storage.example/data'))
+  assert root_query['xrd.wantprot'] == ['none']
+  assert http_query['xrdcl.http.noauth'] == ['1']
+
+
+def test_environment_context_can_require_credentials():
+  with pytest.raises(ValueError, match='no usable authentication'):
+    AuthContext.from_environment(
+      environ={}, fallback='error', use_defaults=False)
+
+
+def test_environment_context_rejects_selected_empty_proxy():
+  with pytest.raises(ValueError, match='must not be empty'):
+    AuthContext.from_environment(environ={'X509_USER_PROXY': ''})
+
+
 def test_anonymous_context_rejects_root_protocol():
   with pytest.raises(ValueError):
     AuthContext.anonymous().apply('root://storage.example//data')

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -169,6 +169,47 @@ def test_query_sync():
   assert response
   print(response)
 
+def test_checksum_sync():
+  c = client.FileSystem(SERVER_URL)
+  f = client.File()
+  status, response = f.open(smallfile, OpenFlags.DELETE)
+  assert status.ok
+  f.write(smallbuffer)
+  f.close()
+
+  status, response = c.checksum('/tmp/spam')
+  assert status.ok
+  assert response.algorithm
+  assert response.value
+
+
+def test_checksum_async_response():
+  raw_status = {'ok': True, 'message': 'ok'}
+
+  class Recorder(object):
+    def query(self, querycode, path, timeout, callback):
+      self.args = (querycode, path, timeout)
+      callback(raw_status, 'adler32 deadbeef\0', [])
+      return raw_status
+
+  class FileSystem(object):
+    def __init__(self):
+      self._FileSystem__fs = Recorder()
+
+  responses = []
+  filesystem = FileSystem()
+  status = client.FileSystem.checksum(
+    filesystem, '/tmp/file', timeout=12,
+    callback=lambda *args: responses.append(args))
+
+  assert status.ok
+  assert filesystem._FileSystem__fs.args == (
+    QueryCode.CHECKSUM, '/tmp/file', 12)
+  assert len(responses) == 1
+  assert responses[0][0].ok
+  assert responses[0][1].algorithm == 'adler32'
+  assert responses[0][1].value == 'deadbeef'
+
 def test_query_async():
   c = client.FileSystem(SERVER_URL)
   handler = AsyncResponseHandler()

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -189,7 +189,7 @@ def test_checksum_async_response():
   class Recorder(object):
     def query(self, querycode, path, timeout, callback):
       self.args = (querycode, path, timeout)
-      callback(raw_status, 'adler32 deadbeef\0', [])
+      callback(raw_status, b'adler32 deadbeef\0', [])
       return raw_status
 
   class FileSystem(object):

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -227,7 +227,29 @@ def test_mkdir_flags():
   assert status.ok
   c.rm('/tmp/dir1/dir2')
   c.rm('/tmp/dir1')
-  
+
+def test_mkdir_p():
+  c = client.FileSystem(SERVER_URL)
+  status, response = c.mkdir_p('/tmp/dir1/dir2', flags=MkDirFlags.NONE)
+  assert status.ok
+  c.rm('/tmp/dir1/dir2')
+  c.rm('/tmp/dir1')
+
+
+def test_mkdir_p_preserves_flags():
+  class Recorder(object):
+    def mkdir(self, path, flags=0, mode=0, timeout=0, callback=None):
+      self.args = (path, flags, mode, timeout, callback)
+      return 'result'
+
+  recorder = Recorder()
+  callback = object()
+  result = client.FileSystem.mkdir_p(recorder, '/tmp/dir', flags=4, mode=0o750,
+                                     timeout=12, callback=callback)
+
+  assert result == 'result'
+  assert recorder.args == ('/tmp/dir', 4 | MkDirFlags.MAKEPATH, 0o750, 12,
+                           callback)
 
 def test_args():
   c = client.FileSystem(url=SERVER_URL)

--- a/python/tests/test_filesystem.py
+++ b/python/tests/test_filesystem.py
@@ -262,6 +262,14 @@ def test_creation():
   c = client.FileSystem(SERVER_URL)
   assert c.url is not None
 
+def test_context_manager():
+  with client.FileSystem(SERVER_URL) as c:
+    assert c.url is not None
+
+  with pytest.raises(RuntimeError):
+    with client.FileSystem(SERVER_URL):
+      raise RuntimeError('failure')
+
 def test_deletion():
   c = client.FileSystem(SERVER_URL)
   del c

--- a/python/tests/test_responses.py
+++ b/python/tests/test_responses.py
@@ -74,6 +74,10 @@ def test_checksum_info():
   assert checksum.algorithm == 'adler32'
   assert checksum.value == 'deadbeef'
 
+  checksum = ChecksumInfo(b'adler32 deadbeef\0')
+  assert checksum.algorithm == 'adler32'
+  assert checksum.value == 'deadbeef'
+
   checksum = ChecksumInfo('md5 abc123\0')
   assert checksum.algorithm == 'md5'
   assert checksum.value == 'abc123'

--- a/python/tests/test_responses.py
+++ b/python/tests/test_responses.py
@@ -3,6 +3,8 @@ import pytest
 from XRootD.client.responses import XRootDStatus, XRootDNotFoundError, \
   XRootDAuthorizationError, \
   XRootDTimeoutError, XRootDChecksumError, XRootDOperationError, \
+  XRootDAlreadyExistsError, XRootDQuotaError, XRootDTemporaryError, \
+  XRootDUnsupportedError, \
   raise_on_error
 
 
@@ -44,6 +46,12 @@ def test_status_error_name_and_exceptions():
   (3034, XRootDTimeoutError),
   (3035, XRootDTimeoutError),
   (3019, XRootDChecksumError),
+  (3018, XRootDAlreadyExistsError),
+  (3032, XRootDAlreadyExistsError),
+  (3021, XRootDQuotaError),
+  (3003, XRootDTemporaryError),
+  (3024, XRootDTemporaryError),
+  (3013, XRootDUnsupportedError),
   (3012, XRootDOperationError),
 ])
 def test_server_error_exceptions(errno, exception_type):

--- a/python/tests/test_responses.py
+++ b/python/tests/test_responses.py
@@ -5,7 +5,7 @@ from XRootD.client.responses import XRootDStatus, XRootDNotFoundError, \
   XRootDTimeoutError, XRootDChecksumError, XRootDOperationError, \
   XRootDAlreadyExistsError, XRootDQuotaError, XRootDTemporaryError, \
   XRootDUnsupportedError, \
-  raise_on_error
+  ChecksumInfo, raise_on_error
 
 
 def status(code, ok=False, shellcode=0, message='error', errno=0):
@@ -67,3 +67,19 @@ def test_raise_on_error():
   with pytest.raises(XRootDNotFoundError) as excinfo:
     status(XRootDStatus.errNotFound).raise_on_error()
   assert excinfo.value.status.code == XRootDStatus.errNotFound
+
+
+def test_checksum_info():
+  checksum = ChecksumInfo('adler32 deadbeef\n')
+  assert checksum.algorithm == 'adler32'
+  assert checksum.value == 'deadbeef'
+
+  checksum = ChecksumInfo('md5 abc123\0')
+  assert checksum.algorithm == 'md5'
+  assert checksum.value == 'abc123'
+
+
+@pytest.mark.parametrize('response', ['', 'adler32', 'adler32\0'])
+def test_checksum_info_rejects_invalid_response(response):
+  with pytest.raises(ValueError, match='Invalid checksum response'):
+    ChecksumInfo(response)

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -92,3 +92,26 @@ def test_space_returns_application_friendly_counts(monkeypatch):
   assert StorageClient(timeout=10).space('https://storage.example/data') == {
     'total': 100, 'free': 75, 'used': 25,
   }
+
+
+def test_checksum_returns_algorithm_and_value(monkeypatch):
+  calls = []
+
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      calls.append(('endpoint', endpoint, auth))
+
+    def query(self, code, path, timeout=0):
+      calls.append(('query', code, path, timeout))
+      return OkStatus(), b'adler32 deadbeef\n\0'
+
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
+
+  result = StorageClient(timeout=10).checksum(
+    'root://storage.example/data/file', algorithm='adler32')
+
+  assert result == ('adler32', 'deadbeef')
+  assert calls[1][0:3] == (
+    'query', storage_module.QueryCode.CHECKSUM,
+    '/data/file?cks.type=adler32')
+  assert 1 <= calls[1][3] <= 10

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -1,6 +1,12 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from threading import Event
+from urllib.parse import parse_qs, urlsplit
 
-from XRootD.client import AuthContext, StorageClient
+import pytest
+
+from XRootD.client import AuthContext, StorageClient, XRootDTimeoutError
 import XRootD.client.storage as storage_module
 
 
@@ -29,7 +35,8 @@ def test_stat_preserves_signed_query_as_filesystem_property(monkeypatch):
   result = client.stat(
     'davs://storage.example/data/file?X-Amz-Signature=abc+def==&empty=')
 
-  assert result == {'size': 17}
+  assert result.size == 17
+  assert result.stat == {'size': 17}
   assert calls[0] == ('endpoint', 'davs://storage.example/', auth)
   assert calls[1] == (
     'property', 'XrdClHttpQueryParam', 'X-Amz-Signature=abc+def==&empty=')
@@ -115,3 +122,105 @@ def test_checksum_returns_algorithm_and_value(monkeypatch):
   assert calls[1][0:2] == (
     'checksum', '/data/file?cks.type=adler32')
   assert 1 <= calls[1][2] <= 10
+
+
+def test_probe_performs_bounded_stat(monkeypatch):
+  calls = []
+
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      pass
+
+    def stat(self, path, timeout=0):
+      calls.append((path, timeout))
+      return OkStatus(), {'size': 0}
+
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
+
+  result = StorageClient(timeout=30).probe(
+    'root://storage.example//rucio', timeout=7)
+
+  assert result.size == 0
+  assert calls[0][0] == '//rucio'
+  assert 1 <= calls[0][1] <= 7
+
+
+def test_info_negotiates_and_caches_checksum_algorithm(monkeypatch):
+  checksum_paths = []
+
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      pass
+
+    def stat(self, path, timeout=0):
+      return OkStatus(), {'size': 23}
+
+    def checksum(self, path, timeout=0):
+      checksum_paths.append(path)
+      algorithm = 'crc32c' if 'adler32' in path else 'md5'
+      return OkStatus(), type('Checksum', (), {
+        'algorithm': algorithm, 'value': 'deadbeef'})()
+
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
+  client = StorageClient(timeout=30)
+  url = 'root://storage.example//rucio/file'
+
+  first = client.info(
+    url, checksum_algorithms=('adler32', 'md5'), require_checksum=True)
+  second = client.info(
+    url, checksum_algorithms=('adler32', 'md5'), require_checksum=True)
+
+  assert first.size == 23
+  assert first.checksum.algorithm == 'md5'
+  assert first.checksum.value == 'deadbeef'
+  assert second.checksum.algorithm == 'md5'
+  assert checksum_paths == [
+    '//rucio/file?cks.type=adler32',
+    '//rucio/file?cks.type=md5',
+    '//rucio/file?cks.type=md5',
+  ]
+
+
+def test_owned_environment_auth_is_closed_with_client():
+  auth = AuthContext.bearer(token='secret')
+  client = StorageClient(auth=auth, owns_auth=True, timeout=10)
+  token_file = parse_qs(urlsplit(
+    auth.apply('root://localhost//data')).query)['xrd.ztn'][0]
+  assert os.path.exists(token_file)
+
+  client.close()
+
+  assert not os.path.exists(token_file)
+  with pytest.raises(RuntimeError, match='closed'):
+    client.exists('root://localhost//data')
+
+
+def test_local_deadline_uses_xrootd_timeout_error():
+  with pytest.raises(XRootDTimeoutError, match='deadline expired'):
+    StorageClient._remaining(0)
+
+
+def test_close_waits_for_active_operation(monkeypatch):
+  started = Event()
+  release = Event()
+
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      pass
+
+    def stat(self, path, timeout=0):
+      started.set()
+      assert release.wait(timeout=5)
+      return OkStatus(), {'size': 1}
+
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
+  client = StorageClient(timeout=10)
+  with ThreadPoolExecutor(max_workers=2) as executor:
+    operation = executor.submit(
+      client.stat, 'root://storage.example//rucio/file')
+    assert started.wait(timeout=5)
+    closing = executor.submit(client.close)
+    assert not closing.done()
+    release.set()
+    assert operation.result(timeout=5).size == 1
+    closing.result(timeout=5)

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -56,8 +56,8 @@ def test_put_uses_one_scoped_copy_job(monkeypatch, tmp_path):
     def __init__(self, endpoint, auth=None):
       calls.append(('filesystem', endpoint, auth))
 
-    def mkdir(self, path, flags=0, timeout=0):
-      calls.append(('mkdir', path, flags, timeout))
+    def mkdir_p(self, path, timeout=0):
+      calls.append(('mkdir_p', path, timeout))
       return OkStatus(), None
 
   monkeypatch.setattr(storage_module, 'CopyProcess', NativeCopyProcess)
@@ -70,9 +70,9 @@ def test_put_uses_one_scoped_copy_job(monkeypatch, tmp_path):
 
   assert result['size'] == 4
   job = next(call for call in calls if call[0] == 'job')
-  mkdir = next(call for call in calls if call[0] == 'mkdir')
+  mkdir = next(call for call in calls if call[0] == 'mkdir_p')
   assert mkdir[1] == '/data'
-  assert mkdir[2] == storage_module.MkDirFlags.MAKEPATH
+  assert 1 <= mkdir[2] <= 20
   assert job[1] == Path(source).resolve().as_uri()
   assert job[2] == 'davs://storage.example/data/file'
   assert job[3]['mkdir'] is False
@@ -101,9 +101,10 @@ def test_checksum_returns_algorithm_and_value(monkeypatch):
     def __init__(self, endpoint, auth=None):
       calls.append(('endpoint', endpoint, auth))
 
-    def query(self, code, path, timeout=0):
-      calls.append(('query', code, path, timeout))
-      return OkStatus(), b'adler32 deadbeef\n\0'
+    def checksum(self, path, timeout=0):
+      calls.append(('checksum', path, timeout))
+      return OkStatus(), type('Checksum', (), {
+        'algorithm': 'adler32', 'value': 'deadbeef'})()
 
   monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
 
@@ -111,7 +112,6 @@ def test_checksum_returns_algorithm_and_value(monkeypatch):
     'root://storage.example/data/file', algorithm='adler32')
 
   assert result == ('adler32', 'deadbeef')
-  assert calls[1][0:3] == (
-    'query', storage_module.QueryCode.CHECKSUM,
-    '/data/file?cks.type=adler32')
-  assert 1 <= calls[1][3] <= 10
+  assert calls[1][0:2] == (
+    'checksum', '/data/file?cks.type=adler32')
+  assert 1 <= calls[1][2] <= 10

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -1,0 +1,81 @@
+from pathlib import Path
+
+from XRootD.client import AuthContext, StorageClient
+import XRootD.client.storage as storage_module
+
+
+class OkStatus(object):
+  def raise_on_error(self):
+    return self
+
+
+def test_stat_preserves_signed_query_as_filesystem_property(monkeypatch):
+  calls = []
+
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      calls.append(('endpoint', endpoint, auth))
+
+    def set_property(self, name, value):
+      calls.append(('property', name, value))
+
+    def stat(self, path, timeout=0):
+      calls.append(('stat', path, timeout))
+      return OkStatus(), {'size': 17}
+
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
+  auth = AuthContext.anonymous()
+  client = StorageClient(auth=auth, timeout=10)
+  result = client.stat(
+    'davs://storage.example/data/file?X-Amz-Signature=abc+def==&empty=')
+
+  assert result == {'size': 17}
+  assert calls[0] == ('endpoint', 'davs://storage.example/', auth)
+  assert calls[1] == (
+    'property', 'XrdClHttpQueryParam', 'X-Amz-Signature=abc+def==&empty=')
+  assert calls[2][0:2] == ('stat', '/data/file')
+  assert 1 <= calls[2][2] <= 10
+
+
+def test_put_uses_one_scoped_copy_job(monkeypatch, tmp_path):
+  calls = []
+
+  class NativeCopyProcess(object):
+    def add_job(self, source, target, **options):
+      calls.append(('job', source, target, options))
+
+    def prepare(self):
+      calls.append(('prepare',))
+      return OkStatus()
+
+    def run(self):
+      calls.append(('run',))
+      return OkStatus(), [{'status': OkStatus(), 'size': 4}]
+
+  monkeypatch.setattr(storage_module, 'CopyProcess', NativeCopyProcess)
+  source = tmp_path / 'source'
+  source.write_bytes(b'data')
+  auth = AuthContext.x509(proxy='/tmp/proxy')
+  result = StorageClient(auth=auth, timeout=20).put(
+    source, 'davs://storage.example/data/file', create_parents=True)
+
+  assert result['size'] == 4
+  assert calls[0][1] == Path(source).resolve().as_uri()
+  assert calls[0][2] == 'davs://storage.example/data/file'
+  assert calls[0][3]['mkdir'] is True
+  assert calls[0][3]['source_auth'] is auth
+  assert calls[0][3]['target_auth'] is auth
+
+
+def test_space_returns_application_friendly_counts(monkeypatch):
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      pass
+
+    def query(self, code, path, timeout=0):
+      return OkStatus(), 'oss.space=100&oss.free=75&oss.used=25&oss.maxf=75'
+
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
+  assert StorageClient(timeout=10).space('https://storage.example/data') == {
+    'total': 100, 'free': 75, 'used': 25,
+  }

--- a/python/tests/test_storage.py
+++ b/python/tests/test_storage.py
@@ -52,7 +52,16 @@ def test_put_uses_one_scoped_copy_job(monkeypatch, tmp_path):
       calls.append(('run',))
       return OkStatus(), [{'status': OkStatus(), 'size': 4}]
 
+  class NativeFileSystem(object):
+    def __init__(self, endpoint, auth=None):
+      calls.append(('filesystem', endpoint, auth))
+
+    def mkdir(self, path, flags=0, timeout=0):
+      calls.append(('mkdir', path, flags, timeout))
+      return OkStatus(), None
+
   monkeypatch.setattr(storage_module, 'CopyProcess', NativeCopyProcess)
+  monkeypatch.setattr(storage_module, 'FileSystem', NativeFileSystem)
   source = tmp_path / 'source'
   source.write_bytes(b'data')
   auth = AuthContext.x509(proxy='/tmp/proxy')
@@ -60,11 +69,15 @@ def test_put_uses_one_scoped_copy_job(monkeypatch, tmp_path):
     source, 'davs://storage.example/data/file', create_parents=True)
 
   assert result['size'] == 4
-  assert calls[0][1] == Path(source).resolve().as_uri()
-  assert calls[0][2] == 'davs://storage.example/data/file'
-  assert calls[0][3]['mkdir'] is True
-  assert calls[0][3]['source_auth'] is auth
-  assert calls[0][3]['target_auth'] is auth
+  job = next(call for call in calls if call[0] == 'job')
+  mkdir = next(call for call in calls if call[0] == 'mkdir')
+  assert mkdir[1] == '/data'
+  assert mkdir[2] == storage_module.MkDirFlags.MAKEPATH
+  assert job[1] == Path(source).resolve().as_uri()
+  assert job[2] == 'davs://storage.example/data/file'
+  assert job[3]['mkdir'] is False
+  assert job[3]['source_auth'] is auth
+  assert job[3]['target_auth'] is auth
 
 
 def test_space_returns_application_friendly_counts(monkeypatch):

--- a/python/tests/xrootd.cfg
+++ b/python/tests/xrootd.cfg
@@ -12,3 +12,4 @@ all.export    /
 all.adminpath $basedir
 all.pidpath   $basedir
 oss.localroot $basedir/data
+xrootd.chksum adler32

--- a/src/XrdCl/XrdClURL.cc
+++ b/src/XrdCl/XrdClURL.cc
@@ -483,7 +483,7 @@ namespace XrdCl
 
   //------------------------------------------------------------------------
   //Get the host part of the URL (user:password\@host:port) plus channel
-  //specific CGI (xrdcl.identity & xrd.gsiusrpxy)
+  //specific CGI (intent, authentication context, and credentials)
   //------------------------------------------------------------------------
   std::string URL::GetChannelId() const
   {
@@ -491,6 +491,7 @@ namespace XrdCl
     bool hascgi = false;
 
     std::string keys[] = { "xrdcl.intent",
+                           "xrdcl.authctx",
                            "xrd.gsiusrpxy",
                            "xrd.gsiusrcrt",
                            "xrd.gsiusrkey",

--- a/src/XrdCl/XrdClURL.hh
+++ b/src/XrdCl/XrdClURL.hh
@@ -103,7 +103,7 @@ namespace XrdCl
 
       //------------------------------------------------------------------------
       //! Get the host part of the URL (user:password\@host:port) plus channel
-      //! specific CGI (xrdcl.identity & xrd.gsiusrpxy)
+      //! specific CGI (xrdcl.intent, xrdcl.authctx, and credentials)
       //------------------------------------------------------------------------
       std::string GetChannelId() const;
 

--- a/src/XrdClHttp/CMakeLists.txt
+++ b/src/XrdClHttp/CMakeLists.txt
@@ -17,12 +17,14 @@ add_library(XrdClHttpObj OBJECT
   XrdClHttpOpDelete.cc
   XrdClHttpOpListdir.cc
   XrdClHttpOpMkcol.cc
+  XrdClHttpOpMove.cc
   XrdClHttpOpOpen.cc
   XrdClHttpOpOptions.cc
   XrdClHttpOpPut.cc
   XrdClHttpOpQuery.cc
   XrdClHttpOpRead.cc
   XrdClHttpOpReadV.cc
+  XrdClHttpOpSpace.cc
   XrdClHttpOps.cc            XrdClHttpOps.hh
   XrdClHttpOpStat.cc
   XrdClHttpOpTape.cc

--- a/src/XrdClHttp/CMakeLists.txt
+++ b/src/XrdClHttp/CMakeLists.txt
@@ -30,7 +30,8 @@ add_library(XrdClHttpObj OBJECT
   XrdClHttpParseTimeout.cc   XrdClHttpParseTimeout.hh
   XrdClHttpTape.cc           XrdClHttpTape.hh
   XrdClHttpUtil.cc           XrdClHttpUtil.hh
-                           XrdClHttpVerb.hh
+                              XrdClHttpVerb.hh
+  XrdClHttpWebDav.cc         XrdClHttpWebDav.hh
   XrdClHttpWorker.hh
 )
 

--- a/src/XrdClHttp/XrdClHttpFile.cc
+++ b/src/XrdClHttp/XrdClHttpFile.cc
@@ -195,7 +195,7 @@ private:
 // Note: these values are typically overwritten by `CurlFactory::CurlFactory`;
 // they are set here just to avoid uninitialized globals.
 struct timespec XrdClHttp::File::m_min_client_timeout = {2, 0};
-struct timespec XrdClHttp::File::m_default_header_timeout = {9, 5};
+struct timespec XrdClHttp::File::m_default_header_timeout = {9, 500'000'000};
 struct timespec XrdClHttp::File::m_fed_timeout = {5, 0};
 
 
@@ -412,7 +412,7 @@ File::Close(XrdCl::ResponseHandler *handler,
             m_logger->Debug(kLogXrdClHttp, "Flushing final write buffer on close");
             auto put_handler = m_put_handler.load(std::memory_order_acquire);
             if (put_handler) {
-                return put_handler->QueueWrite(std::make_pair(nullptr, 0), handler);
+                return put_handler->QueueWrite(std::make_pair(nullptr, 0), handler, GetHeaderTimeout(timeout));
             } else {
                 m_logger->Error(kLogXrdClHttp, "Internal state error - put operation ongoing without handle");
                 return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
@@ -819,7 +819,7 @@ File::Write(uint64_t                offset,
         PutResponseHandler *expected_value = nullptr;
         if (!m_put_handler.compare_exchange_strong(expected_value, handler_wrapper, std::memory_order_acq_rel)) {
             delete handler_wrapper;
-            return expected_value->QueueWrite(std::make_pair(buffer, size), handler);
+            return expected_value->QueueWrite(std::make_pair(buffer, size), handler, ts);
         }
 
         if (offset != 0) {
@@ -852,7 +852,7 @@ File::Write(uint64_t                offset,
             static_cast<long long>(offset), static_cast<long long>(old_offset));
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, 0, "Requested write offset does not match current offset");
     }
-    return handler_wrapper->QueueWrite(std::make_pair(buffer, size), handler);
+    return handler_wrapper->QueueWrite(std::make_pair(buffer, size), handler, ts);
 }
 
 XrdCl::XRootDStatus
@@ -877,7 +877,7 @@ File::Write(uint64_t                offset,
         PutResponseHandler *expected_value = nullptr;
         if (!m_put_handler.compare_exchange_strong(expected_value, handler_wrapper, std::memory_order_acq_rel)) {
             delete handler_wrapper;
-            return expected_value->QueueWrite(std::move(buffer), handler);
+            return expected_value->QueueWrite(std::move(buffer), handler, ts);
         }
 
         if (offset != 0) {
@@ -909,7 +909,7 @@ File::Write(uint64_t                offset,
             static_cast<long long>(offset), static_cast<long long>(old_offset));
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidArgs, 0, "Requested write offset does not match current offset");
     }
-    return handler_wrapper->QueueWrite(std::move(buffer), handler);
+    return handler_wrapper->QueueWrite(std::move(buffer), handler, ts);
 }
 
 XrdCl::XRootDStatus
@@ -1337,7 +1337,7 @@ File::PutResponseHandler::HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl:
 }
 
 XrdCl::XRootDStatus
-File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer, XrdCl::ResponseHandler *handler)
+File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer, XrdCl::ResponseHandler *handler, struct timespec timeout)
 {
     if (m_op->HasFailed()) {
         auto sc = m_op->GetStatusCode();
@@ -1351,6 +1351,14 @@ File::PutResponseHandler::QueueWrite(std::variant<std::pair<const void *, size_t
         }
         return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errInvalidOp, 0, "Cannot continue writing to open file after error");
     }
+    // The PUT is one curl operation spanning every write the client makes, but
+    // the origin sends no response header until the body is complete.  Without
+    // pushing the deadline out per write, the header timeout derived from the
+    // first write would cap the whole upload regardless of how much data is
+    // still flowing.  A wedged transfer is still caught by the stall and
+    // slow-transfer detectors.
+    m_op->ExtendDeadline(timeout);
+
     std::lock_guard<std::mutex> lg(m_mutex);
     if (!m_active) {
         m_active = true;

--- a/src/XrdClHttp/XrdClHttpFile.hh
+++ b/src/XrdClHttp/XrdClHttpFile.hh
@@ -214,7 +214,13 @@ private:
 
         virtual void HandleResponse(XrdCl::XRootDStatus *status_raw, XrdCl::AnyObject *response_raw) override;
 
-        XrdCl::XRootDStatus QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer, XrdCl::ResponseHandler *handler);
+        // Queue another chunk of the in-progress PUT.
+        //
+        // `timeout` is the caller's timeout for this particular write; it
+        // extends the deadline of the underlying curl operation so that a
+        // multi-write upload is not bound by the first write's timeout.
+        XrdCl::XRootDStatus QueueWrite(std::variant<std::pair<const void *, size_t>, XrdCl::Buffer> buffer,
+                                       XrdCl::ResponseHandler *handler, struct timespec timeout);
 
         void SetOp(std::shared_ptr<XrdClHttp::CurlPutOp> op) {m_op = op;}
 

--- a/src/XrdClHttp/XrdClHttpFilesystem.cc
+++ b/src/XrdClHttp/XrdClHttpFilesystem.cc
@@ -26,7 +26,106 @@
 #include "XrdCl/XrdClAnyObject.hh"
 
 #include <cerrno>
+#include <chrono>
+#include <cmath>
 #include <exception>
+
+namespace {
+
+class MkPathHandler final : public XrdCl::ResponseHandler {
+public:
+    MkPathHandler(XrdClHttp::Filesystem *filesystem,
+        std::vector<std::string> paths, XrdCl::Access::Mode mode,
+        XrdCl::ResponseHandler *handler, time_t timeout) :
+        m_filesystem(filesystem), m_paths(std::move(paths)), m_mode(mode),
+        m_handler(handler), m_timeout(timeout),
+        m_deadline(std::chrono::steady_clock::now() + std::chrono::seconds(timeout))
+    {}
+
+    XrdCl::XRootDStatus Start() {return StartNext();}
+
+    void HandleResponse(XrdCl::XRootDStatus *status,
+                        XrdCl::AnyObject *response) override {
+        delete response;
+        if (!status->IsOK() && status->errNo != kXR_ItExists) {
+            auto handler = m_handler;
+            m_handler = nullptr;
+            handler->HandleResponse(status, nullptr);
+            delete this;
+            return;
+        }
+        delete status;
+        ++m_index;
+        if (m_index == m_paths.size()) {
+            auto handler = m_handler;
+            m_handler = nullptr;
+            handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
+            delete this;
+            return;
+        }
+        auto queued = StartNext();
+        if (!queued.IsOK()) {
+            auto handler = m_handler;
+            m_handler = nullptr;
+            handler->HandleResponse(new XrdCl::XRootDStatus(queued), nullptr);
+            delete this;
+        }
+    }
+
+private:
+    XrdCl::XRootDStatus StartNext() {
+        time_t remaining = m_timeout;
+        if (m_timeout > 0) {
+            auto duration = std::chrono::duration<double>(
+                m_deadline - std::chrono::steady_clock::now()).count();
+            if (duration <= 0)
+                return XrdCl::XRootDStatus(XrdCl::stError,
+                    XrdCl::errOperationExpired, kXR_ReqTimedOut,
+                    "MKCOL path creation deadline expired");
+            remaining = static_cast<time_t>(std::ceil(duration));
+        }
+        return m_filesystem->MkDir(m_paths[m_index], XrdCl::MkDirFlags::None,
+            m_mode, this, remaining);
+    }
+
+    XrdClHttp::Filesystem *m_filesystem;
+    std::vector<std::string> m_paths;
+    XrdCl::Access::Mode m_mode;
+    XrdCl::ResponseHandler *m_handler;
+    time_t m_timeout;
+    std::chrono::steady_clock::time_point m_deadline;
+    size_t m_index{0};
+};
+
+std::vector<std::string> DirectoryPrefixes(const std::string &path) {
+    std::vector<std::string> result;
+    auto query_position = path.find('?');
+    auto path_only = path.substr(0, query_position);
+    auto query = query_position == std::string::npos ? std::string() :
+        path.substr(query_position);
+    std::string current;
+    size_t begin = 0;
+    while (begin < path_only.size()) {
+        while (begin < path_only.size() && path_only[begin] == '/') ++begin;
+        if (begin == path_only.size()) break;
+        auto end = path_only.find('/', begin);
+        auto component = path_only.substr(begin,
+            end == std::string::npos ? std::string::npos : end - begin);
+        if (component == ".") {
+            // Nothing.
+        } else if (component == "..") {
+            return {};
+        } else {
+            current += "/" + component;
+            result.emplace_back(current + query);
+        }
+        if (end == std::string::npos) break;
+        begin = end + 1;
+    }
+    return result;
+}
+
+}
 
 using namespace XrdClHttp;
 
@@ -39,6 +138,9 @@ Filesystem::Filesystem(const std::string &url, std::shared_ptr<HandlerQueue> que
     // When constructed from the root protocol handler, we've observed it include the
     // path here (the code paths appear to be slightly different from http://).  Strip
     // it out so it's not included twice later.
+    HttpClientConfig client_config;
+    auto cleaned_url = ExtractHttpClientConfig(url, client_config, &m_client_query);
+    m_url.FromString(cleaned_url);
     m_url.SetPath("/");
     XrdCl::URL::ParamsMap map;
     m_url.SetParams(map);
@@ -145,6 +247,18 @@ XrdCl::XRootDStatus Filesystem::MkDir(const std::string        &path,
                                       XrdCl::ResponseHandler   *handler,
                                       time_t                    timeout)
 {
+    if (flags & XrdCl::MkDirFlags::MakePath) {
+        auto paths = DirectoryPrefixes(path);
+        if (paths.empty())
+            return XrdCl::XRootDStatus(XrdCl::stError,
+                XrdCl::errInvalidArgs, kXR_InvalidRequest,
+                "Invalid or empty directory path");
+        auto path_handler = new MkPathHandler(this, std::move(paths), mode,
+            handler, timeout);
+        auto status = path_handler->Start();
+        if (!status.IsOK()) delete path_handler;
+        return status;
+    }
     auto ts = XrdClHttp::Factory::GetHeaderTimeoutWithDefault(timeout);
 
     auto full_url = GetCurrentURL(path);
@@ -177,6 +291,24 @@ XrdCl::XRootDStatus Filesystem::Prepare(
         GetConnCallout(),
         m_header_callout.load(std::memory_order_acquire));
     return QueueOperation(std::move(tapeOp), "Tape prepare operation");
+}
+
+XrdCl::XRootDStatus
+Filesystem::Mv(const std::string &source, const std::string &dest,
+               XrdCl::ResponseHandler *handler, time_t timeout)
+{
+    auto ts = XrdClHttp::Factory::GetHeaderTimeoutWithDefault(timeout);
+    auto source_url = GetCurrentURL(source);
+    auto destination_url = GetCurrentURL(dest);
+    std::unique_ptr<CurlMoveOp> move_op(new CurlMoveOp(handler, source_url,
+        destination_url, ts, m_logger, GetConnCallout(),
+        m_header_callout.load(std::memory_order_acquire)));
+    try {
+        m_queue->Produce(std::move(move_op));
+    } catch (...) {
+        return XrdCl::XRootDStatus(XrdCl::stError, XrdCl::errOSError);
+    }
+    return XrdCl::XRootDStatus();
 }
 
 XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
@@ -239,6 +371,15 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
                 GetConnCallout(), queryCode,
                 m_header_callout.load(std::memory_order_acquire));
             description = "xattr query operation";
+            break;
+        }
+        case XrdCl::QueryCode::Space:
+        {
+            const auto url = GetCurrentURL(arg.ToString());
+            operation = std::make_unique<CurlSpaceOp>(
+                handler, url, ts, m_logger, GetConnCallout(),
+                m_header_callout.load(std::memory_order_acquire));
+            description = "space query operation";
             break;
         }
         default:
@@ -330,12 +471,16 @@ std::string Filesystem::GetCurrentURL(const std::string &path) const {
         path_view = path_view.substr(1);
     auto retval = std::string(prefix_view) + "/" + std::string(path_view);
 
+    if (!m_client_query.empty()) {
+        retval += ((retval.find('?') == std::string::npos) ? '?' : '&') + m_client_query;
+    }
+
     // Add in the query parameters, if relevant.
     {
         std::shared_lock lock(m_properties_mutex);
         auto iter = m_properties.find("XrdClHttpQueryParam");
         if (iter != m_properties.end() && !iter->second.empty()) {
-            retval += ((retval.find('?') == std::string::npos) ? '?' : ':') + iter->second;
+            retval += ((retval.find('?') == std::string::npos) ? '?' : '&') + iter->second;
         }
     }
     return retval;

--- a/src/XrdClHttp/XrdClHttpFilesystem.hh
+++ b/src/XrdClHttp/XrdClHttpFilesystem.hh
@@ -78,6 +78,11 @@ public:
         XrdCl::ResponseHandler         *handler,
         time_t                          timeout) override;
 
+    virtual XrdCl::XRootDStatus Mv(const std::string &source,
+                                   const std::string &dest,
+                                   XrdCl::ResponseHandler *handler,
+                                   time_t timeout) override;
+
     virtual XrdCl::XRootDStatus Rm(const std::string      &path,
                                    XrdCl::ResponseHandler *handler,
                                    time_t                  timeout) override;
@@ -124,6 +129,7 @@ private:
     std::atomic<XrdClHttp::HeaderCallout *> m_header_callout{};
     XrdCl::Log *m_logger{nullptr};
     XrdCl::URL m_url;
+    std::string m_client_query;
     std::unordered_map<std::string, std::string> m_properties;
 };
 

--- a/src/XrdClHttp/XrdClHttpOpDelete.cc
+++ b/src/XrdClHttp/XrdClHttpOpDelete.cc
@@ -51,6 +51,11 @@ CurlDeleteOp::Setup(CURL *curl, CurlWorker &worker) {
 
 void
 CurlDeleteOp::Success() {
+    if (GetStatusCode() == 207) {
+        Fail(XrdCl::errErrorResponse, kXR_ServerError,
+            "WebDAV DELETE completed only partially (207 Multi-Status)");
+        return;
+    }
     SetDone(false);
     m_logger->Debug(kLogXrdClHttp, "CurlDeleteOp::Success");
     if (m_handler == nullptr) {return;}

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -101,24 +101,14 @@ CurlListdirOp::ParseResponse(TiXmlElement *response)
             }
             continue;
         }
-        if (!WebDavElementNameEquals(child, "propstat")) {
-            continue;
-        }
-        for (auto propstat = child->FirstChildElement(); propstat != nullptr; propstat = propstat->NextSiblingElement()) {
-            if (!WebDavElementNameEquals(propstat, "prop")) {
-                continue;
-            }
-            WebDavProperties properties;
-            success = ParseWebDavProperties(propstat, properties);
-            if (!success) {
-                return {entry, success};
-            }
-            entry.m_isdir = properties.m_is_dir;
-            entry.m_isexec = properties.m_is_executable;
-            entry.m_size = properties.m_size;
-            entry.m_lastmodified = properties.m_last_modified;
-        }
     }
+    WebDavProperties properties;
+    success = ParseWebDavResponseProperties(response, properties);
+    if (!success) return {entry, false};
+    entry.m_isdir = properties.m_is_dir;
+    entry.m_isexec = properties.m_is_executable;
+    entry.m_size = properties.m_size;
+    entry.m_lastmodified = properties.m_last_modified;
     return {entry, success};
 }
 

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -85,13 +85,12 @@ bool CurlListdirOp::ParseProp(DavEntry &entry, TiXmlElement *prop)
             }
         } else if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
             auto size = child->GetText();
-            if (size == nullptr) {
-                return false;
-            }
-            try {
-                entry.m_size = std::stoll(size);
-            } catch (std::invalid_argument &e) {
-                return false;
+            if (size != nullptr) {
+                try {
+                    entry.m_size = std::stoll(size);
+                } catch (std::invalid_argument &e) {
+                    return false;
+                }
             }
         } else if (!strcasecmp(child->Value(), "D:getlastmodified") || !strcasecmp(child->Value(), "lp1:getlastmodified")) {
             auto lastmod = child->GetText();

--- a/src/XrdClHttp/XrdClHttpOpListdir.cc
+++ b/src/XrdClHttp/XrdClHttpOpListdir.cc
@@ -21,6 +21,7 @@
 #include "XrdClHttpOps.hh"
 #include "XrdClHttpResponses.hh"
 #include "XrdClHttpUtil.hh"
+#include "XrdClHttpWebDav.hh"
 
 #include <XrdCl/XrdClLog.hh>
 #include <XrdCl/XrdClXRootDResponses.hh>
@@ -74,60 +75,13 @@ CurlListdirOp::WriteCallback(char *buffer, size_t size, size_t nitems, void *thi
     return size * nitems;
 }
 
-bool CurlListdirOp::ParseProp(DavEntry &entry, TiXmlElement *prop)
-{
-    for (auto child = prop->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
-            auto collection = child->FirstChildElement("D:collection");
-            entry.m_isdir = collection != nullptr;
-            if (entry.m_isdir && entry.m_size < 0) {
-                entry.m_size = 0;
-            }
-        } else if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
-            auto size = child->GetText();
-            if (size != nullptr) {
-                try {
-                    entry.m_size = std::stoll(size);
-                } catch (std::invalid_argument &e) {
-                    return false;
-                }
-            }
-        } else if (!strcasecmp(child->Value(), "D:getlastmodified") || !strcasecmp(child->Value(), "lp1:getlastmodified")) {
-            auto lastmod = child->GetText();
-            if (lastmod == nullptr) {
-                return false;
-            }
-            struct tm tm;
-            if (strptime(lastmod, "%a, %d %b %Y %H:%M:%S", &tm) == nullptr) {
-                return false;
-            }
-            entry.m_lastmodified = timegm(&tm);
-        } else if (strcasecmp(child->Value(), "D:href") == 0) {
-            auto href = child->GetText();
-            if (href == nullptr) {
-                return false;
-            }
-            entry.m_name = href;
-        } else if (!strcasecmp(child->Value(), "D:executable") || !strcasecmp(child->Value(), "lp1:executable")) {
-            auto val = child->GetText();
-            if (val == nullptr) {
-                return false;
-            }
-            if (strcasecmp(val, "T") == 0) {
-                entry.m_isexec = true;
-            }
-        }
-    }
-    return true;    
-}
-
 std::pair<CurlListdirOp::DavEntry, bool>
 CurlListdirOp::ParseResponse(TiXmlElement *response)
 {
     DavEntry entry;
     bool success = false;
     for (auto child = response->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!strcasecmp(child->Value(), "D:href")) {
+        if (WebDavElementNameEquals(child, "href")) {
             auto href = child->GetText();
             if (href == nullptr) {
                 return {entry, false};
@@ -147,17 +101,22 @@ CurlListdirOp::ParseResponse(TiXmlElement *response)
             }
             continue;
         }
-        if (strcasecmp(child->Value(), "D:propstat")) {
+        if (!WebDavElementNameEquals(child, "propstat")) {
             continue;
         }
         for (auto propstat = child->FirstChildElement(); propstat != nullptr; propstat = propstat->NextSiblingElement()) {
-            if (strcasecmp(propstat->Value(), "D:prop")) {
+            if (!WebDavElementNameEquals(propstat, "prop")) {
                 continue;
             }
-            success = ParseProp(entry, propstat);
+            WebDavProperties properties;
+            success = ParseWebDavProperties(propstat, properties);
             if (!success) {
                 return {entry, success};
             }
+            entry.m_isdir = properties.m_is_dir;
+            entry.m_isexec = properties.m_is_executable;
+            entry.m_size = properties.m_size;
+            entry.m_lastmodified = properties.m_last_modified;
         }
     }
     return {entry, success};
@@ -180,14 +139,14 @@ CurlListdirOp::Success()
     }
 
     auto elem = doc.RootElement();
-    if (strcasecmp(elem->Value(), "D:multistatus")) {
+    if (!WebDavElementNameEquals(elem, "multistatus")) {
         m_logger->Error(kLogXrdClHttp, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
         Fail(XrdCl::errErrorResponse, kXR_FSError, "Server responded to directory listing unexpected XML root");
         return;
     }
     bool skip = true;
     for (auto response = elem->FirstChildElement(); response != nullptr; response = response->NextSiblingElement()) {
-        if (strcasecmp(response->Value(), "D:response")) {
+        if (!WebDavElementNameEquals(response, "response")) {
             continue;
         }
 

--- a/src/XrdClHttp/XrdClHttpOpMkcol.cc
+++ b/src/XrdClHttp/XrdClHttpOpMkcol.cc
@@ -38,10 +38,10 @@ void
 CurlMkcolOp::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 {
     // Note: the generic status code handler maps HTTP status "405 Method Not Allowed"
-    // to kXR_InvalidRequest.
+    // to kXR_Unsupported.
     //
     // However, for the MKCOL operation, 405 maps better to kXR_ItExists
-    if (errCode == XrdCl::errErrorResponse &&  errNum == kXR_InvalidRequest && GetStatusCode() == 405) {
+    if (errCode == XrdCl::errErrorResponse && errNum == kXR_Unsupported && GetStatusCode() == 405) {
         m_logger->Debug(kLogXrdClHttp, "MKCOL was performed on a directory that exists");
         errNum = kXR_ItExists;
     }

--- a/src/XrdClHttp/XrdClHttpOpMove.cc
+++ b/src/XrdClHttp/XrdClHttpOpMove.cc
@@ -23,7 +23,7 @@ CurlMoveOp::CurlMoveOp(XrdCl::ResponseHandler *handler,
         m_destination = "http://" + m_destination.substr(6);
     else if (m_destination.compare(0, 7, "davs://") == 0)
         m_destination = "https://" + m_destination.substr(7);
-    m_operation_expiry = m_header_expiry;
+    m_operation_expiry = GetHeaderExpiry();
 }
 
 bool CurlMoveOp::Setup(CURL *curl, CurlWorker &worker) {

--- a/src/XrdClHttp/XrdClHttpOpMove.cc
+++ b/src/XrdClHttp/XrdClHttpOpMove.cc
@@ -1,0 +1,70 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/******************************************************************************/
+
+#include "XrdClHttpOps.hh"
+
+#include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClURL.hh>
+
+using namespace XrdClHttp;
+
+CurlMoveOp::CurlMoveOp(XrdCl::ResponseHandler *handler,
+    const std::string &source, const std::string &destination,
+    struct timespec timeout, XrdCl::Log *logger,
+    CreateConnCalloutType callout, HeaderCallout *header_callout) :
+    CurlOperation(handler, source, timeout, logger, callout, header_callout)
+{
+    HttpClientConfig ignored;
+    m_destination = ExtractHttpClientConfig(destination, ignored);
+    if (m_destination.compare(0, 6, "dav://") == 0)
+        m_destination = "http://" + m_destination.substr(6);
+    else if (m_destination.compare(0, 7, "davs://") == 0)
+        m_destination = "https://" + m_destination.substr(7);
+    m_operation_expiry = m_header_expiry;
+}
+
+bool CurlMoveOp::Setup(CURL *curl, CurlWorker &worker) {
+    if (!CurlOperation::Setup(curl, worker)) return false;
+    XrdCl::URL source(m_url);
+    XrdCl::URL destination(m_destination);
+    if (!source.IsValid() || !destination.IsValid() ||
+        source.GetProtocol() != destination.GetProtocol() ||
+        source.GetHostName() != destination.GetHostName() ||
+        source.GetPort() != destination.GetPort()) {
+        m_logger->Error(kLogXrdClHttp,
+            "WebDAV MOVE destination must use the source origin");
+        return false;
+    }
+    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "MOVE");
+    m_headers_list.emplace_back("Destination", m_destination);
+    m_headers_list.emplace_back("Overwrite", "F");
+    return true;
+}
+
+void CurlMoveOp::Fail(uint16_t errCode, uint32_t errNum,
+                      const std::string &msg) {
+    if (GetStatusCode() == 412) errNum = kXR_ItExists;
+    CurlOperation::Fail(errCode, errNum, msg);
+}
+
+void CurlMoveOp::Success() {
+    if (GetStatusCode() == 207) {
+        Fail(XrdCl::errErrorResponse, kXR_ServerError,
+            "WebDAV MOVE completed only partially (207 Multi-Status)");
+        return;
+    }
+    SetDone(false);
+    if (!m_handler) return;
+    auto handler = m_handler;
+    m_handler = nullptr;
+    handler->HandleResponse(new XrdCl::XRootDStatus(), nullptr);
+}
+
+void CurlMoveOp::ReleaseHandle() {
+    if (!m_curl) return;
+    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, nullptr);
+    CurlOperation::ReleaseHandle();
+}

--- a/src/XrdClHttp/XrdClHttpOpSpace.cc
+++ b/src/XrdClHttp/XrdClHttpOpSpace.cc
@@ -1,0 +1,103 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/******************************************************************************/
+
+#include "XrdClHttpOps.hh"
+#include "XrdClHttpWebDav.hh"
+
+#include <XrdCl/XrdClLog.hh>
+#include <XrdCl/XrdClXRootDResponses.hh>
+
+#include <tinyxml.h>
+
+#include <limits>
+
+using namespace XrdClHttp;
+
+CurlSpaceOp::CurlSpaceOp(XrdCl::ResponseHandler *handler,
+    const std::string &url, struct timespec timeout, XrdCl::Log *logger,
+    CreateConnCalloutType callout, HeaderCallout *header_callout) :
+    CurlOperation(handler, url, timeout, logger, callout, header_callout),
+    m_request("<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+              "<d:propfind xmlns:d=\"DAV:\"><d:prop>"
+              "<d:quota-available-bytes/><d:quota-used-bytes/>"
+              "</d:prop></d:propfind>")
+{
+    m_operation_expiry = m_header_expiry;
+}
+
+bool CurlSpaceOp::Setup(CURL *curl, CurlWorker &worker) {
+    if (!CurlOperation::Setup(curl, worker)) return false;
+    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, "PROPFIND");
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDS, m_request.c_str());
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDSIZE,
+        static_cast<long>(m_request.size()));
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, CurlSpaceOp::WriteCallback);
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, this);
+    m_headers_list.emplace_back("Depth", "0");
+    m_headers_list.emplace_back("Content-Type", "application/xml; charset=utf-8");
+    return true;
+}
+
+size_t CurlSpaceOp::WriteCallback(char *buffer, size_t size, size_t nitems,
+                                  void *this_ptr) {
+    auto operation = static_cast<CurlSpaceOp *>(this_ptr);
+    const auto bytes = size * nitems;
+    if (bytes + operation->m_response.size() > 1024 * 1024)
+        return operation->FailCallback(kXR_ServerError,
+            "Response too large for WebDAV quota query");
+    operation->UpdateBytes(bytes);
+    operation->m_response.append(buffer, bytes);
+    return bytes;
+}
+
+void CurlSpaceOp::Success() {
+    TiXmlDocument document;
+    document.Parse(m_response.c_str());
+    auto root = document.RootElement();
+    if (document.Error() || !WebDavElementNameEquals(root, "multistatus")) {
+        Fail(XrdCl::errErrorResponse, kXR_FSError,
+            "Server returned invalid XML for WebDAV quota query");
+        return;
+    }
+    WebDavQuota quota;
+    bool parsed = false;
+    for (auto response = root->FirstChildElement(); response;
+         response = response->NextSiblingElement()) {
+        if (WebDavElementNameEquals(response, "response") &&
+            ParseWebDavResponseQuota(response, quota)) {
+            parsed = true;
+            break;
+        }
+    }
+    if (!parsed || quota.m_used > std::numeric_limits<uint64_t>::max() - quota.m_available) {
+        Fail(XrdCl::errErrorResponse, kXR_Unsupported,
+            "Server did not return valid WebDAV quota properties");
+        return;
+    }
+    auto total = quota.m_used + quota.m_available;
+    auto value = "oss.space=" + std::to_string(total) +
+        "&oss.free=" + std::to_string(quota.m_available) +
+        "&oss.used=" + std::to_string(quota.m_used) +
+        "&oss.maxf=" + std::to_string(quota.m_available);
+    auto buffer = new XrdCl::Buffer();
+    buffer->FromString(value);
+    auto object = new XrdCl::AnyObject();
+    object->Set(buffer);
+    SetDone(false);
+    auto handler = m_handler;
+    m_handler = nullptr;
+    handler->HandleResponse(new XrdCl::XRootDStatus(), object);
+}
+
+void CurlSpaceOp::ReleaseHandle() {
+    if (!m_curl) return;
+    curl_easy_setopt(m_curl.get(), CURLOPT_CUSTOMREQUEST, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDS, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDSIZE, 0L);
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, nullptr);
+    CurlOperation::ReleaseHandle();
+}

--- a/src/XrdClHttp/XrdClHttpOpSpace.cc
+++ b/src/XrdClHttp/XrdClHttpOpSpace.cc
@@ -25,7 +25,7 @@ CurlSpaceOp::CurlSpaceOp(XrdCl::ResponseHandler *handler,
               "<d:quota-available-bytes/><d:quota-used-bytes/>"
               "</d:prop></d:propfind>")
 {
-    m_operation_expiry = m_header_expiry;
+    m_operation_expiry = GetHeaderExpiry();
 }
 
 bool CurlSpaceOp::Setup(CURL *curl, CurlWorker &worker) {

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -134,7 +134,10 @@ CurlStatOp::ParseProp(TiXmlElement *prop) {
                 m_length = std::stoll(len);
             }
         } else if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
-            m_is_dir = child->FirstChildElement("D:collection") != nullptr;
+            auto type = child->FirstChildElement();
+            m_is_dir = type != nullptr &&
+                (!strcasecmp(type->Value(), "D:collection") ||
+                 !strcasecmp(type->Value(), "lp1:collection"));
         }
     }
     if (m_length < 0 && m_is_dir) {

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -20,6 +20,7 @@
 
 #include "XrdClHttpOps.hh"
 #include "XrdClHttpResponses.hh"
+#include "XrdClHttpWebDav.hh"
 
 #include <XrdCl/XrdClLog.hh>
 
@@ -123,31 +124,6 @@ CurlStatOp::WriteCallback(char *buffer, size_t size, size_t nitems, void *this_p
 }
 
 std::pair<int64_t, bool>
-CurlStatOp::ParseProp(TiXmlElement *prop) {
-    if (prop == nullptr) {
-        return {-1, false};
-    }
-    for (auto child = prop->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!strcasecmp(child->Value(), "D:getcontentlength") || !strcasecmp(child->Value(), "lp1:getcontentlength")) {
-            auto len = child->GetText();
-            if (len) {
-                m_length = std::stoll(len);
-            }
-        } else if (!strcasecmp(child->Value(), "D:resourcetype") || !strcasecmp(child->Value(), "lp1:resourcetype")) {
-            auto type = child->FirstChildElement();
-            m_is_dir = type != nullptr &&
-                (!strcasecmp(type->Value(), "D:collection") ||
-                 !strcasecmp(type->Value(), "lp1:collection"));
-        }
-    }
-    if (m_length < 0 && m_is_dir) {
-        // Don't require length for directories; fake it as zero
-        m_length = 0;
-    }
-    return {m_length, m_is_dir};
-}
-
-std::pair<int64_t, bool>
 CurlStatOp::GetStatInfo() {
     if (!m_is_propfind) {
         m_length = m_headers.GetContentLength();
@@ -165,13 +141,13 @@ CurlStatOp::GetStatInfo() {
     }
 
     auto elem = doc.RootElement();
-    if (strcasecmp(elem->Value(), "D:multistatus")) {
+    if (!WebDavElementNameEquals(elem, "multistatus")) {
         m_logger->Error(kLogXrdClHttp, "Unexpected XML response: %s", m_response.substr(0, 1024).c_str());
         return {-1, false};
     }
     auto found_response = false;
     for (auto response = elem->FirstChildElement(); response != nullptr; response = response->NextSiblingElement()) {
-        if (!strcasecmp(response->Value(), "D:response")) {
+        if (WebDavElementNameEquals(response, "response")) {
             found_response = true;
             elem = response;
             break;
@@ -182,15 +158,21 @@ CurlStatOp::GetStatInfo() {
         return {-1, false};
     }
     for (auto child = elem->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-		if (strcasecmp(child->Value(), "D:propstat")) {
+        if (!WebDavElementNameEquals(child, "propstat")) {
             continue;
         }
         for (auto prop = child->FirstChildElement(); prop != nullptr; prop = prop->NextSiblingElement()) {
-            if (!strcasecmp(prop->Value(), "D:prop")) {
-                return ParseProp(prop);
+            if (WebDavElementNameEquals(prop, "prop")) {
+                WebDavProperties properties;
+                if (!ParseWebDavProperties(prop, properties)) {
+                    return {-1, false};
+                }
+                m_length = properties.m_size;
+                m_is_dir = properties.m_is_dir;
+                return {m_length, m_is_dir};
             }
         }
-	}
+    }
     m_logger->Error(kLogXrdClHttp, "Failed to find properties in XML response: %s", m_response.substr(0, 1024).c_str());
     return {-1, false};
 }

--- a/src/XrdClHttp/XrdClHttpOpStat.cc
+++ b/src/XrdClHttp/XrdClHttpOpStat.cc
@@ -157,21 +157,11 @@ CurlStatOp::GetStatInfo() {
         m_logger->Error(kLogXrdClHttp, "Failed to find response element in XML response: %s", m_response.substr(0, 1024).c_str());
         return {-1, false};
     }
-    for (auto child = elem->FirstChildElement(); child != nullptr; child = child->NextSiblingElement()) {
-        if (!WebDavElementNameEquals(child, "propstat")) {
-            continue;
-        }
-        for (auto prop = child->FirstChildElement(); prop != nullptr; prop = prop->NextSiblingElement()) {
-            if (WebDavElementNameEquals(prop, "prop")) {
-                WebDavProperties properties;
-                if (!ParseWebDavProperties(prop, properties)) {
-                    return {-1, false};
-                }
-                m_length = properties.m_size;
-                m_is_dir = properties.m_is_dir;
-                return {m_length, m_is_dir};
-            }
-        }
+    WebDavProperties properties;
+    if (ParseWebDavResponseProperties(elem, properties)) {
+        m_length = properties.m_size;
+        m_is_dir = properties.m_is_dir;
+        return {m_length, m_is_dir};
     }
     m_logger->Error(kLogXrdClHttp, "Failed to find properties in XML response: %s", m_response.substr(0, 1024).c_str());
     return {-1, false};

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -88,8 +88,16 @@ bool IsTrue(const std::string &value) {
 bool ReadBearerToken(const std::string &path, std::string &token) {
     std::ifstream input(path, std::ios::binary);
     if (!input) return false;
-    token.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
-    if (token.size() > 1024 * 1024) return false;
+    constexpr size_t max_token_size = 1024 * 1024;
+    char buffer[4096];
+    token.clear();
+    while (input) {
+        input.read(buffer, sizeof(buffer));
+        const auto count = static_cast<size_t>(input.gcount());
+        if (count > max_token_size - token.size()) return false;
+        token.append(buffer, count);
+    }
+    if (!input.eof()) return false;
     auto first = token.find_first_not_of(" \t\r\n");
     auto last = token.find_last_not_of(" \t\r\n");
     if (first == std::string::npos) return false;

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -312,6 +312,17 @@ CurlOperation::CurlOperation(XrdCl::ResponseHandler *handler, const std::string 
 CurlOperation::~CurlOperation() {}
 
 void
+CurlOperation::ExtendDeadline(struct timespec timeout)
+{
+    auto expiry = CalculateExpiry(timeout);
+    auto current = m_header_expiry.load(std::memory_order_relaxed);
+    while (expiry > current &&
+           !m_header_expiry.compare_exchange_weak(current, expiry,
+                                                  std::memory_order_relaxed))
+        ;
+}
+
+void
 CurlOperation::Fail(uint16_t errCode, uint32_t errNum, const std::string &msg)
 {
     SetDone(true);
@@ -502,7 +513,10 @@ CurlOperation::Redirect(std::string &target)
             m_callout.reset(conn_callout);
             std::string err;
             SetTriedBoker();
-            if ((m_conn_callout_listener = m_callout->BeginCallout(err, m_header_expiry)) == -1) {
+            // BeginCallout takes the expiration by non-const reference; hand it
+            // a copy rather than the atomic's storage.
+            auto expiry = GetHeaderExpiry();
+            if ((m_conn_callout_listener = m_callout->BeginCallout(err, expiry)) == -1) {
                 auto errMsg = "Failed to start a connection callout request: " + err;
                 Fail(XrdCl::errInternal, 0, errMsg.c_str());
                 return RedirectAction::Fail;
@@ -546,7 +560,8 @@ CurlOperation::SetPaused(bool paused) {
 bool
 CurlOperation::StartConnectionCallout(std::string &err)
 {
-    if ((m_conn_callout_listener = m_callout->BeginCallout(err, m_header_expiry)) == -1) {
+    auto expiry = GetHeaderExpiry();
+    if ((m_conn_callout_listener = m_callout->BeginCallout(err, expiry)) == -1) {
         err = "Failed to start a callout for a socket connection: " + err;
         Fail(XrdCl::errInternal, 1, err.c_str());
         return false;
@@ -586,7 +601,7 @@ bool
 CurlOperation::HeaderTimeoutExpired(const std::chrono::steady_clock::time_point &now) {
     if (m_received_header) return false;
 
-    if (now > m_header_expiry) {
+    if (now > GetHeaderExpiry()) {
         if (m_error == OpError::ErrNone) m_error = OpError::ErrHeaderTimeout;
         return true;
     }
@@ -829,7 +844,8 @@ CurlOperation::OpenSocketCallback(void *clientp, curlsocktype purpose, struct cu
     me->m_conn_callout_result = -1;
     if (fd == -1) {
         std::string err;
-        if ((me->m_conn_callout_listener = me->m_callout->BeginCallout(err, me->m_header_expiry)) == -1) {
+        auto expiry = me->GetHeaderExpiry();
+        if ((me->m_conn_callout_listener = me->m_callout->BeginCallout(err, expiry)) == -1) {
             me->m_logger->Debug(kLogXrdClHttp, "Failed to start a connection callout request: %s", err.c_str());
         }
         return CURL_SOCKET_BAD;

--- a/src/XrdClHttp/XrdClHttpOps.cc
+++ b/src/XrdClHttp/XrdClHttpOps.cc
@@ -32,6 +32,8 @@
 #include <cerrno>
 #include <chrono>
 #include <cmath>
+#include <fstream>
+#include <cstdlib>
 #ifdef __APPLE__
 #include <stdlib.h>
 #else
@@ -45,6 +47,70 @@ std::chrono::steady_clock::duration CurlOperation::m_stall_interval{CurlOperatio
 int CurlOperation::m_minimum_transfer_rate{CurlOperation::m_default_minimum_rate};
 
 namespace {
+
+bool IsClientParameter(const std::string &key) {
+    return key == "xrdcl.http.bearertokenfile" ||
+        key == "xrdcl.http.clientcert" || key == "xrdcl.http.clientkey" ||
+        key == "xrdcl.http.cafile" || key == "xrdcl.http.cadir" ||
+        key == "xrdcl.http.noauth" || key == "xrdcl.http.noverify" ||
+        key == "xrdcl.authctx";
+}
+
+int HexValue(char value) {
+    if (value >= '0' && value <= '9') return value - '0';
+    if (value >= 'a' && value <= 'f') return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F') return value - 'A' + 10;
+    return -1;
+}
+
+std::string DecodeParameter(const std::string &value) {
+    std::string result;
+    result.reserve(value.size());
+    for (size_t idx = 0; idx < value.size(); ++idx) {
+        if (value[idx] == '%' && idx + 2 < value.size()) {
+            auto high = HexValue(value[idx + 1]);
+            auto low = HexValue(value[idx + 2]);
+            if (high >= 0 && low >= 0) {
+                result.push_back(static_cast<char>((high << 4) | low));
+                idx += 2;
+                continue;
+            }
+        }
+        result.push_back(value[idx]);
+    }
+    return result;
+}
+
+bool IsTrue(const std::string &value) {
+    return value.empty() || value == "1" || value == "true" || value == "yes";
+}
+
+bool ReadBearerToken(const std::string &path, std::string &token) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input) return false;
+    token.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+    if (token.size() > 1024 * 1024) return false;
+    auto first = token.find_first_not_of(" \t\r\n");
+    auto last = token.find_last_not_of(" \t\r\n");
+    if (first == std::string::npos) return false;
+    token = token.substr(first, last - first + 1);
+    return token.find_first_of("\r\n") == std::string::npos;
+}
+
+std::pair<std::string, std::string> DefaultCertificateAuthorities() {
+    auto env = XrdCl::DefaultEnv::GetEnv();
+    std::string ca_file;
+    if (!env->GetString("HttpCertFile", ca_file) || ca_file.empty()) {
+        auto value = getenv("X509_CERT_FILE");
+        if (value) ca_file = value;
+    }
+    std::string ca_dir;
+    if (!env->GetString("HttpCertDir", ca_dir) || ca_dir.empty()) {
+        auto value = getenv("X509_CERT_DIR");
+        if (value) ca_dir = value;
+    }
+    return {ca_file, ca_dir};
+}
 
 // For connection callbacks, we don't want to require a real DNS lookup; instead, we
 // will generate a fake address in the 169.254.x.y range and use that for the connection.
@@ -157,6 +223,62 @@ std::string DavToHttp(const std::string &url) {
 
 } // namespace
 
+std::string
+XrdClHttp::ExtractHttpClientConfig(const std::string &url,
+    HttpClientConfig &config, std::string *client_query)
+{
+    auto fragment_pos = url.find('#');
+    auto query_pos = url.find('?');
+    if (query_pos == std::string::npos ||
+        (fragment_pos != std::string::npos && query_pos > fragment_pos)) {
+        return url;
+    }
+
+    const auto query_end = fragment_pos == std::string::npos ? url.size() : fragment_pos;
+    const auto query = url.substr(query_pos + 1, query_end - query_pos - 1);
+    std::vector<std::string> server_parameters;
+    std::vector<std::string> client_parameters;
+    size_t begin = 0;
+    while (begin <= query.size()) {
+        auto end = query.find('&', begin);
+        if (end == std::string::npos) end = query.size();
+        auto parameter = query.substr(begin, end - begin);
+        auto equals = parameter.find('=');
+        auto key = parameter.substr(0, equals);
+        auto encoded_value = equals == std::string::npos ? std::string() : parameter.substr(equals + 1);
+        if (IsClientParameter(key)) {
+            client_parameters.emplace_back(parameter);
+            auto value = DecodeParameter(encoded_value);
+            if (key == "xrdcl.http.bearertokenfile") config.bearer_token_file = value;
+            else if (key == "xrdcl.http.clientcert") config.client_cert = value;
+            else if (key == "xrdcl.http.clientkey") config.client_key = value;
+            else if (key == "xrdcl.http.cafile") config.ca_file = value;
+            else if (key == "xrdcl.http.cadir") config.ca_dir = value;
+            else if (key == "xrdcl.http.noauth") config.no_auth = IsTrue(value);
+            else if (key == "xrdcl.http.noverify") config.no_verify = IsTrue(value);
+        } else if (!parameter.empty()) {
+            server_parameters.emplace_back(parameter);
+        }
+        if (end == query.size()) break;
+        begin = end + 1;
+    }
+
+    auto join = [](const std::vector<std::string> &parameters) {
+        std::string result;
+        for (const auto &parameter : parameters) {
+            if (!result.empty()) result += '&';
+            result += parameter;
+        }
+        return result;
+    };
+    if (client_query) *client_query = join(client_parameters);
+    auto result = url.substr(0, query_pos);
+    auto server_query = join(server_parameters);
+    if (!server_query.empty()) result += '?' + server_query;
+    if (fragment_pos != std::string::npos) result += url.substr(fragment_pos);
+    return result;
+}
+
 std::chrono::steady_clock::time_point CalculateExpiry(struct timespec timeout) {
     if (timeout.tv_sec == 0 && timeout.tv_nsec == 0) {
         return std::chrono::steady_clock::now() + std::chrono::seconds(30);
@@ -180,7 +302,7 @@ CurlOperation::CurlOperation(XrdCl::ResponseHandler *handler, const std::string 
     m_start_op(m_last_reset),
     m_header_start(m_last_reset),
     m_conn_callout(callout),
-    m_url(DavToHttp(url)),
+    m_url(DavToHttp(ExtractHttpClientConfig(url, m_client_config))),
     m_request_url(m_url),
     m_handler(handler),
     m_curl(nullptr, &curl_easy_cleanup),
@@ -217,11 +339,21 @@ CurlOperation::FailCallback(XErrorCode ecode, const std::string &emsg) {
 bool
 CurlOperation::FinishSetup(CURL *curl)
 {
-    if(m_parsed_url)
-    {
+    if (!m_client_config.no_auth &&
+        !m_client_config.bearer_token_file.empty()) {
+        std::string token;
+        if (!ReadBearerToken(m_client_config.bearer_token_file, token)) {
+            m_logger->Error(kLogXrdClHttp,
+                "Unable to read bearer token from %s",
+                m_client_config.bearer_token_file.c_str());
+            return false;
+        }
+        m_headers_list.emplace_back("Authorization", "Bearer " + token);
+    }
+    if (!m_client_config.no_auth && m_client_config.client_cert.empty() &&
+        m_parsed_url) {
         InjectBearerToken(*m_parsed_url, m_headers_list, m_logger);
     }
-
     if (!m_header_callout) {
         m_header_slist.reset();
         for (const auto &header : m_headers_list) {
@@ -269,6 +401,8 @@ CurlOperation::GetVerbString(CurlOperation::HttpVerb verb)
         return "HEAD";
     case HttpVerb::MKCOL:
         return "MKCOL";
+    case HttpVerb::MOVE:
+        return "MOVE";
     case HttpVerb::OPTIONS:
         return "OPTIONS";
     case HttpVerb::PROPFIND:
@@ -345,17 +479,6 @@ CurlOperation::Redirect(std::string &target)
     m_request_url = DavToHttp(location);
     target = m_request_url;
     curl_easy_setopt(m_curl.get(), CURLOPT_URL, m_request_url.c_str());
-    int disable_x509;
-    auto env = XrdCl::DefaultEnv::GetEnv();
-    if (env->GetInt("HttpDisableX509", disable_x509) && !disable_x509) {
-        std::string cert, key;
-        env->GetString("HttpClientCertFile", cert);
-        env->GetString("HttpClientKeyFile", key);
-        if (!cert.empty())
-            curl_easy_setopt(m_curl.get(), CURLOPT_SSLCERT, cert.c_str());
-        if (!key.empty())
-            curl_easy_setopt(m_curl.get(), CURLOPT_SSLKEY, key.c_str());
-    }
     m_headers = HeaderParser();
 
     if (m_conn_callout) {
@@ -561,10 +684,32 @@ CurlOperation::Setup(CURL *curl, CurlWorker &worker)
     // Before we set it, we saw deadlocks (and partial deadlocks) in practice.
     curl_easy_setopt(m_curl.get(), CURLOPT_NOSIGNAL, 1L);
 
+    // Handles are pooled.  Establish secure defaults before applying settings
+    // for this operation so credentials and TLS policy cannot leak between
+    // unrelated client objects.
+    curl_easy_setopt(m_curl.get(), CURLOPT_SSLCERT, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_SSLKEY, nullptr);
+    auto [default_ca_file, default_ca_dir] = DefaultCertificateAuthorities();
+    curl_easy_setopt(m_curl.get(), CURLOPT_CAINFO,
+        default_ca_file.empty() ? nullptr : default_ca_file.c_str());
+    curl_easy_setopt(m_curl.get(), CURLOPT_CAPATH,
+        default_ca_dir.empty() ? nullptr : default_ca_dir.c_str());
+    curl_easy_setopt(m_curl.get(), CURLOPT_SSL_VERIFYPEER, 1L);
+    curl_easy_setopt(m_curl.get(), CURLOPT_SSL_VERIFYHOST, 2L);
+
     m_parsed_url = std::make_unique<XrdCl::URL>(m_request_url);
     auto env = XrdCl::DefaultEnv::GetEnv();
-    int disable_x509;
-    if (env->GetInt("HttpDisableX509", disable_x509) && !disable_x509) {
+    int disable_x509 = 0;
+    if (!m_client_config.no_auth && !m_client_config.client_cert.empty()) {
+        if (m_client_config.client_key.empty()) {
+            m_logger->Error(kLogXrdClHttp,
+                "X.509 client certificate specified without a private key");
+            return false;
+        }
+        curl_easy_setopt(m_curl.get(), CURLOPT_SSLCERT, m_client_config.client_cert.c_str());
+        curl_easy_setopt(m_curl.get(), CURLOPT_SSLKEY, m_client_config.client_key.c_str());
+    } else if (!m_client_config.no_auth &&
+        (env->GetInt("HttpDisableX509", disable_x509) && !disable_x509)) {
         auto [cert, key] = worker.ClientX509CertKeyFile();
         if (!cert.empty()) {
             m_logger->Debug(kLogXrdClHttp,
@@ -577,6 +722,14 @@ CurlOperation::Setup(CURL *curl, CurlWorker &worker)
                 curl_easy_setopt(m_curl.get(), CURLOPT_SSLKEY, key.c_str());
             }
         }
+    }
+    if (!m_client_config.ca_file.empty())
+        curl_easy_setopt(m_curl.get(), CURLOPT_CAINFO, m_client_config.ca_file.c_str());
+    if (!m_client_config.ca_dir.empty())
+        curl_easy_setopt(m_curl.get(), CURLOPT_CAPATH, m_client_config.ca_dir.c_str());
+    if (m_client_config.no_verify) {
+        curl_easy_setopt(m_curl.get(), CURLOPT_SSL_VERIFYPEER, 0L);
+        curl_easy_setopt(m_curl.get(), CURLOPT_SSL_VERIFYHOST, 0L);
     }
 
     if (m_conn_callout) {

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -56,6 +56,25 @@ class CurlWorker;
 class File;
 class ResponseInfo;
 
+// Authentication and TLS settings encoded in client-only URL parameters.
+// These parameters are removed before a request is sent to the server.
+struct HttpClientConfig {
+    std::string bearer_token_file;
+    std::string client_cert;
+    std::string client_key;
+    std::string ca_file;
+    std::string ca_dir;
+    bool no_auth{false};
+    bool no_verify{false};
+};
+
+// Extract XrdClHttp client-only parameters from a URL.  All unrelated query
+// parameters retain their original spelling and order, which is required for
+// signed URLs.  If client_query is provided, it receives the extracted,
+// still-encoded parameter fragments for propagation by FileSystem operations.
+std::string ExtractHttpClientConfig(const std::string &url,
+    HttpClientConfig &config, std::string *client_query = nullptr);
+
 class CurlOperation {
 public:
     using HeaderList = std::vector<std::pair<std::string, std::string>>;
@@ -167,6 +186,10 @@ public:
 
     // Returns the URL used by the current request.
     const std::string &GetUrl() const {return m_request_url;}
+
+    // Return object-scoped settings for internal sub-operations such as the
+    // authenticated OPTIONS probe.
+    const HttpClientConfig &GetClientConfig() const {return m_client_config;}
 
     // Returns the response info for the operation
     std::unique_ptr<ResponseInfo> GetResponseInfo();
@@ -387,6 +410,7 @@ private:
 
 protected:
     void SetDone(bool has_failed) {m_done = true; m_has_failed.store(has_failed, std::memory_order_release);}
+    HttpClientConfig m_client_config;
     const std::string m_url;
     // Multi-step operations retain their immutable input URL in m_url while
     // advancing the URL used for each individual HTTP request here.
@@ -413,6 +437,7 @@ public:
         m_parent(op),
         m_parent_curl(curl)
     {
+        m_client_config = op->GetClientConfig();
         m_operation_expiry = m_header_expiry;
     }
 
@@ -585,6 +610,44 @@ CurlMkcolOp(XrdCl::ResponseHandler *handler, const std::string &url,
 
 private:
     bool m_response_info{false}; // Indicate whether to give extended information in the response.
+};
+
+// Operation issuing a WebDAV MOVE request to the remote server.
+class CurlMoveOp final : public CurlOperation {
+public:
+    CurlMoveOp(XrdCl::ResponseHandler *handler, const std::string &source,
+        const std::string &destination, struct timespec timeout,
+        XrdCl::Log *logger, CreateConnCalloutType callout,
+        HeaderCallout *header_callout);
+
+    void Fail(uint16_t errCode, uint32_t errNum, const std::string &msg) override;
+    bool Setup(CURL *curl, CurlWorker &) override;
+    void Success() override;
+    void ReleaseHandle() override;
+
+    HttpVerb GetVerb() const override {return HttpVerb::MOVE;}
+
+private:
+    std::string m_destination;
+};
+
+// RFC 4331 quota query, returned using the XRootD QueryCode::Space format.
+class CurlSpaceOp final : public CurlOperation {
+public:
+    CurlSpaceOp(XrdCl::ResponseHandler *handler, const std::string &url,
+        struct timespec timeout, XrdCl::Log *logger,
+        CreateConnCalloutType callout, HeaderCallout *header_callout);
+
+    bool Setup(CURL *curl, CurlWorker &) override;
+    void Success() override;
+    void ReleaseHandle() override;
+    HttpVerb GetVerb() const override {return HttpVerb::PROPFIND;}
+
+private:
+    static size_t WriteCallback(char *buffer, size_t size, size_t nitems,
+        void *this_ptr);
+    std::string m_response;
+    const std::string m_request;
 };
 
 //  Cache control query

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -476,8 +476,6 @@ protected:
     void SuccessImpl(bool returnObj);
 
 private:
-    // Parse the properties element of a PROPFIND response.
-    std::pair<int64_t, bool> ParseProp(TiXmlElement *prop);
     // Callback for writing the response body to the internal buffer.
     static size_t WriteCallback(char *buffer, size_t size, size_t nitems, void *this_ptr);
 
@@ -833,12 +831,6 @@ private:
         int64_t m_size{-1};
         time_t m_lastmodified{-1};
     };
-    // Parses the properties element of a PROPFIND response into a DavEntry object
-    //
-    // - prop: The properties element to parse
-    // - Returns: A pair containing the DavEntry object and a boolean indicating success or not
-    bool ParseProp(DavEntry &entry, TiXmlElement *prop);
-
     // Indicate whether the operation should use the extended "response info" object in response
     const bool m_response_info{false};
 

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -118,14 +118,31 @@ public:
     // Returns when the curl header timeout expires.
     //
     // The first byte of the header must be received before this time.
-    std::chrono::steady_clock::time_point GetHeaderExpiry() const {return m_header_expiry;}
+    std::chrono::steady_clock::time_point GetHeaderExpiry() const {
+        return m_header_expiry.load(std::memory_order_relaxed);
+    }
+
+    // Push the header deadline out to `timeout` from now, if that is later than
+    // the current deadline; never brings it forward.
+    //
+    // A chunked PUT is a single curl operation that spans many client writes,
+    // each carrying its own timeout.  Without this, the whole upload would stay
+    // bound by the deadline derived from the very first write.
+    void ExtendDeadline(struct timespec timeout);
 
     // Returns when the curl operation expires
     std::chrono::steady_clock::time_point GetOperationExpiry() {
-        if (m_last_xfer == std::chrono::steady_clock::time_point()) {
-            return GetHeaderExpiry();
+        if (m_last_xfer != std::chrono::steady_clock::time_point()) {
+            return m_last_xfer + m_stall_interval;
         }
-        return m_last_xfer + m_stall_interval;
+        // Headers have arrived but no payload byte has been accounted for yet.
+        // The header deadline no longer applies (HeaderTimeoutExpired stops
+        // enforcing it at the same point), so anchor the stall clock on the
+        // last header activity instead of reviving a deadline that is moot.
+        if (m_received_header) {
+            return m_header_lastop + m_stall_interval;
+        }
+        return GetHeaderExpiry();
     }
 
     // Clean up the thread-local DNS cache for fake lookups associated with the
@@ -335,7 +352,10 @@ protected:
     std::chrono::steady_clock::time_point m_operation_expiry;
 
     // The expiration time for receiving the first header.
-    std::chrono::steady_clock::time_point m_header_expiry;
+    //
+    // Atomic because ExtendDeadline() is invoked from the client thread that
+    // submits writes while the curl worker thread evaluates the deadline.
+    std::atomic<std::chrono::steady_clock::time_point> m_header_expiry;
 
     // Any additional headers to send with the request.
     HeaderCallout *m_header_callout;
@@ -438,7 +458,7 @@ public:
         m_parent_curl(curl)
     {
         m_client_config = op->GetClientConfig();
-        m_operation_expiry = m_header_expiry;
+        m_operation_expiry = GetHeaderExpiry();
     }
 
     virtual ~CurlOptionsOp() {}
@@ -474,7 +494,7 @@ public:
     CurlOperation(handler, url, timeout, log, callout, header_callout),
     m_response_info(response_info)
     {
-        m_operation_expiry = m_header_expiry;
+        m_operation_expiry = GetHeaderExpiry();
     }
 
     virtual ~CurlStatOp() {}

--- a/src/XrdClHttp/XrdClHttpOptionsCache.cc
+++ b/src/XrdClHttp/XrdClHttpOptionsCache.cc
@@ -20,6 +20,8 @@
 
 #include "XrdClHttpOptionsCache.hh"
 
+#include <XrdCl/XrdClURL.hh>
+
 #include <curl/curl.h>
 
 #include <thread>
@@ -33,6 +35,15 @@ std::thread XrdClHttp::VerbsCache::m_expire_tid;
 
 // shutdown trigger, must be last of the static members
 XrdClHttp::VerbsCache::shutdown_s XrdClHttp::VerbsCache::m_shutdowns;
+
+std::string
+XrdClHttp::VerbsCache::GetUrlKey(const std::string &url)
+{
+    auto fragment = url.find('#');
+    XrdCl::URL parsed(url.substr(0, fragment));
+    if (!parsed.IsValid()) return {};
+    return parsed.GetLocation();
+}
 
 XrdClHttp::VerbsCache & XrdClHttp::VerbsCache::Instance() {
     std::unique_lock lk(m_shutdown_lock);

--- a/src/XrdClHttp/XrdClHttpOptionsCache.hh
+++ b/src/XrdClHttp/XrdClHttpOptionsCache.hh
@@ -30,6 +30,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <utility>
  
  namespace XrdClHttp {
  
@@ -70,22 +71,18 @@
     }
 
     void Put(const std::string &url, const HttpVerbs &verbs, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
-        std::string modified_url;
-        auto key = GetUrlKey(url, modified_url);
+        auto key = GetUrlKey(url);
+        if (key.empty()) return;
 
         const std::unique_lock sentry(m_mutex);
 
         auto isKnown = !verbs.IsSet(HttpVerb::kUnknown);
         auto lifetime = isKnown ? g_expiry_duration : g_negative_expiry_duration;
 
-// C++20 can elide the allocation for the string_view
-#if __cplusplus >= 202002L
         auto iter = m_verbs_map.find(key);
-#else
-        auto iter = m_verbs_map.find(std::string(key));
-#endif
         if (iter == m_verbs_map.end()) {
-            m_verbs_map.emplace(key, VerbEntry{now + lifetime, verbs});
+            m_verbs_map.emplace(std::move(key),
+                                VerbEntry{now + lifetime, verbs});
         } else if (isKnown || iter->second.m_verbs.IsSet(HttpVerb::kUnknown)) {
             // Previous entry didn't know the verbs, but now we do
             iter->second = {now + lifetime, verbs};
@@ -93,15 +90,14 @@
     }
 
     HttpVerbs Get(const std::string &url, const std::chrono::steady_clock::time_point &now=std::chrono::steady_clock::now()) const {
-        std::string modified_url;
-        auto key = GetUrlKey(url, modified_url);
+        auto key = GetUrlKey(url);
+        if (key.empty()) {
+            m_cache_miss++;
+            return HttpVerbs{};
+        }
 
         const std::shared_lock sentry(m_mutex);
-#if __cplusplus >= 202002L
         auto iter = m_verbs_map.find(key);
-#else
-        auto iter = m_verbs_map.find(std::string(key));
-#endif
         if (iter == m_verbs_map.end()) {
             m_cache_miss++;
             return HttpVerbs{};
@@ -114,28 +110,8 @@
         return iter->second.m_verbs;
     }
 
-    // Get the cache key for a given URL
-    //
-    // Cache key should consist of the schema, host, and port portion of the URL.
-    static std::string_view GetUrlKey(const std::string &url, std::string &modified_url) {
-        auto authority_loc = url.find("://");
-        if (authority_loc == std::string::npos) {
-            return std::string_view();
-        }
-        auto path_loc = url.find('/', authority_loc + 3);
-        if (path_loc == std::string::npos) {
-            path_loc = url.length();
-        }
-
-        std::string_view url_view{url};
-        auto host_loc = url_view.substr(authority_loc + 3, path_loc - authority_loc - 3).find('@');
-        if (host_loc == std::string::npos) {
-            return url_view.substr(0, path_loc);
-        }
-        host_loc += authority_loc + 3;
-        modified_url = url.substr(0, authority_loc + 3) + std::string(url_view.substr(host_loc + 1, path_loc - host_loc - 1));
-        return modified_url;
-    }
+    // Return a normalized resource URL without credentials or request parameters.
+    static std::string GetUrlKey(const std::string &url);
 
     uint64_t GetCacheHits() const {return m_cache_hit;}
     uint64_t GetCacheMisses() const {return m_cache_miss;}
@@ -161,24 +137,13 @@ private:
     mutable std::atomic<uint64_t> m_cache_hit{0};
     mutable std::atomic<uint64_t> m_cache_miss{0};
 
-    template<typename ... Bases>
-    struct overload : Bases ...
-    {
-        using is_transparent = void;
-        using Bases::operator() ... ;
-    };
-    using transparent_string_hash = overload<
-        std::hash<std::string>,
-        std::hash<std::string_view>
-    >;
-
     struct VerbEntry {
         std::chrono::steady_clock::time_point m_expiry;
         HttpVerbs m_verbs;
     };
 
     mutable std::shared_mutex m_mutex;
-    mutable std::unordered_map<std::string, VerbEntry, VerbsCache::transparent_string_hash, std::equal_to<>> m_verbs_map;
+    mutable std::unordered_map<std::string, VerbEntry> m_verbs_map;
 
     static std::once_flag m_expiry_launch;
     static VerbsCache g_cache;

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -446,7 +446,8 @@ bool HeaderParser::Parse(const std::string &header_line)
         std::string_view val(header_value);
         while (!val.empty()) {
             auto found = val.find(',');
-            auto method = val.substr(0, found);
+            std::string method(val.substr(0, found));
+            XrdCl::Utils::Trim(method);
             if (method == "PROPFIND") {
                 auto new_verbs = static_cast<unsigned>(m_allow_verbs) | static_cast<unsigned>(VerbsCache::HttpVerb::kPROPFIND);
                 m_allow_verbs = static_cast<VerbsCache::HttpVerb>(new_verbs);
@@ -1327,13 +1328,10 @@ CurlWorker::Run() {
             // If the operation requires the result of the OPTIONS verb to function, then
             // we add that to the multi-handle instead, chaining the two calls together.
             if (op->RequiresOptions()) {
-                std::string modified_url;
                 std::shared_ptr<CurlOptionsOp> options_op(
                     new CurlOptionsOp(
                         curl, op,
-                        std::string(
-                            VerbsCache::GetUrlKey(op->GetUrl(), modified_url)
-                        ),
+                        op->GetUrl(),
                         m_logger, op->GetConnCalloutFunc()
                     )
                 );
@@ -1655,8 +1653,6 @@ CurlWorker::Run() {
                                     // operation can continue.  Inject a new CurlOptionsOp and chain it to the one
                                     // being processed.  Once the OPTIONS request is done, then we'll restart this
                                     // operation.
-                                    std::string modified_url;
-                                    target = VerbsCache::GetUrlKey(target, modified_url);
                                     options_op = new CurlOptionsOp(iter->first, op, target, m_logger, op->GetConnCalloutFunc());
                                     std::shared_ptr<CurlOperation> new_op(options_op);
                                     auto curl = queue.GetHandle();

--- a/src/XrdClHttp/XrdClHttpVerb.hh
+++ b/src/XrdClHttp/XrdClHttpVerb.hh
@@ -35,6 +35,7 @@ namespace XrdClHttp
     GET,
     POST,
     MKCOL,
+    MOVE,
     OPTIONS,
     PROPFIND,
     PUT,

--- a/src/XrdClHttp/XrdClHttpWebDav.cc
+++ b/src/XrdClHttp/XrdClHttpWebDav.cc
@@ -93,3 +93,49 @@ XrdClHttp::ParseWebDavProperties(TiXmlElement *prop,
     }
     return has_size;
 }
+
+bool
+XrdClHttp::ParseWebDavResponseProperties(TiXmlElement *response,
+                                         WebDavProperties &properties)
+{
+    if (!response) return false;
+
+    for (auto propstat = response->FirstChildElement(); propstat != nullptr;
+         propstat = propstat->NextSiblingElement()) {
+        if (!WebDavElementNameEquals(propstat, "propstat")) continue;
+
+        TiXmlElement *prop = nullptr;
+        const char *status = nullptr;
+        for (auto child = propstat->FirstChildElement(); child != nullptr;
+             child = child->NextSiblingElement()) {
+            if (WebDavElementNameEquals(child, "prop")) {
+                prop = child;
+            } else if (WebDavElementNameEquals(child, "status")) {
+                status = child->GetText();
+            }
+        }
+
+        if (status) {
+            auto value = trim_view(status);
+            auto code_begin = value.find(' ');
+            if (code_begin == std::string_view::npos) continue;
+            code_begin = value.find_first_not_of(' ', code_begin);
+            if (code_begin == std::string_view::npos) continue;
+            auto code_end = value.find(' ', code_begin);
+            auto code_limit = value.data() +
+                (code_end == std::string_view::npos ? value.size() : code_end);
+
+            int code = 0;
+            auto result = std::from_chars(
+                value.data() + code_begin, code_limit, code);
+            if (result.ec != std::errc() || result.ptr != code_limit ||
+                code < 200 || code >= 300) {
+                continue;
+            }
+        }
+
+        if (!prop) return false;
+        return ParseWebDavProperties(prop, properties);
+    }
+    return false;
+}

--- a/src/XrdClHttp/XrdClHttpWebDav.cc
+++ b/src/XrdClHttp/XrdClHttpWebDav.cc
@@ -28,6 +28,27 @@
 
 using namespace XrdClHttp;
 
+namespace {
+
+bool WebDavStatusIsSuccessful(const char *status)
+{
+    if (!status) return true;
+    auto value = trim_view(status);
+    auto code_begin = value.find(' ');
+    if (code_begin == std::string_view::npos) return false;
+    code_begin = value.find_first_not_of(' ', code_begin);
+    if (code_begin == std::string_view::npos) return false;
+    auto code_end = value.find(' ', code_begin);
+    auto code_limit = value.data() +
+        (code_end == std::string_view::npos ? value.size() : code_end);
+    int code = 0;
+    auto result = std::from_chars(value.data() + code_begin, code_limit, code);
+    return result.ec == std::errc() && result.ptr == code_limit &&
+        code >= 200 && code < 300;
+}
+
+}
+
 bool
 XrdClHttp::WebDavElementNameEquals(const TiXmlElement *element,
                                    const char *expected)
@@ -115,27 +136,49 @@ XrdClHttp::ParseWebDavResponseProperties(TiXmlElement *response,
             }
         }
 
-        if (status) {
-            auto value = trim_view(status);
-            auto code_begin = value.find(' ');
-            if (code_begin == std::string_view::npos) continue;
-            code_begin = value.find_first_not_of(' ', code_begin);
-            if (code_begin == std::string_view::npos) continue;
-            auto code_end = value.find(' ', code_begin);
-            auto code_limit = value.data() +
-                (code_end == std::string_view::npos ? value.size() : code_end);
-
-            int code = 0;
-            auto result = std::from_chars(
-                value.data() + code_begin, code_limit, code);
-            if (result.ec != std::errc() || result.ptr != code_limit ||
-                code < 200 || code >= 300) {
-                continue;
-            }
-        }
+        if (!WebDavStatusIsSuccessful(status)) continue;
 
         if (!prop) return false;
         return ParseWebDavProperties(prop, properties);
+    }
+    return false;
+}
+
+bool
+XrdClHttp::ParseWebDavResponseQuota(TiXmlElement *response, WebDavQuota &quota)
+{
+    if (!response) return false;
+    for (auto propstat = response->FirstChildElement(); propstat != nullptr;
+         propstat = propstat->NextSiblingElement()) {
+        if (!WebDavElementNameEquals(propstat, "propstat")) continue;
+        TiXmlElement *prop = nullptr;
+        const char *status = nullptr;
+        for (auto child = propstat->FirstChildElement(); child != nullptr;
+             child = child->NextSiblingElement()) {
+            if (WebDavElementNameEquals(child, "prop")) prop = child;
+            if (WebDavElementNameEquals(child, "status")) status = child->GetText();
+        }
+        if (!WebDavStatusIsSuccessful(status) || !prop) continue;
+        bool has_available = false;
+        bool has_used = false;
+        for (auto child = prop->FirstChildElement(); child != nullptr;
+             child = child->NextSiblingElement()) {
+            auto text = child->GetText();
+            if (!text) continue;
+            auto value = trim_view(text);
+            uint64_t parsed = 0;
+            auto result = std::from_chars(value.data(), value.data() + value.size(), parsed);
+            if (result.ec != std::errc() || result.ptr != value.data() + value.size())
+                return false;
+            if (WebDavElementNameEquals(child, "quota-available-bytes")) {
+                quota.m_available = parsed;
+                has_available = true;
+            } else if (WebDavElementNameEquals(child, "quota-used-bytes")) {
+                quota.m_used = parsed;
+                has_used = true;
+            }
+        }
+        if (has_available && has_used) return true;
     }
     return false;
 }

--- a/src/XrdClHttp/XrdClHttpWebDav.cc
+++ b/src/XrdClHttp/XrdClHttpWebDav.cc
@@ -1,0 +1,95 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClHttpWebDav.hh"
+#include "XrdClHttpUtil.hh"
+
+#include <tinyxml.h>
+
+#include <charconv>
+#include <cstring>
+
+using namespace XrdClHttp;
+
+bool
+XrdClHttp::WebDavElementNameEquals(const TiXmlElement *element,
+                                   const char *expected)
+{
+    if (!element || !element->Value()) return false;
+    const char *name = element->Value();
+    const char *separator = std::strrchr(name, ':');
+    return !strcasecmp(separator ? separator + 1 : name, expected);
+}
+
+bool
+XrdClHttp::ParseWebDavProperties(TiXmlElement *prop,
+                                 WebDavProperties &properties)
+{
+    if (!prop) return false;
+
+    bool has_size = false;
+    for (auto child = prop->FirstChildElement(); child != nullptr;
+         child = child->NextSiblingElement()) {
+        if (WebDavElementNameEquals(child, "resourcetype")) {
+            for (auto type = child->FirstChildElement(); type != nullptr;
+                 type = type->NextSiblingElement()) {
+                if (WebDavElementNameEquals(type, "collection")) {
+                    properties.m_is_dir = true;
+                    break;
+                }
+            }
+        } else if (WebDavElementNameEquals(child, "getcontentlength")) {
+            auto text = child->GetText();
+            if (!text) continue;
+
+            auto value = trim_view(text);
+            if (value.empty()) continue;
+
+            int64_t size = -1;
+            auto result = std::from_chars(value.data(),
+                                          value.data() + value.size(), size);
+            if (result.ec != std::errc() ||
+                result.ptr != value.data() + value.size() || size < 0) {
+                return false;
+            }
+            properties.m_size = size;
+            has_size = true;
+        } else if (WebDavElementNameEquals(child, "getlastmodified")) {
+            auto last_modified = child->GetText();
+            if (!last_modified) return false;
+            struct tm parsed_time{};
+            if (!strptime(last_modified, "%a, %d %b %Y %H:%M:%S",
+                          &parsed_time)) {
+                return false;
+            }
+            properties.m_last_modified = timegm(&parsed_time);
+        } else if (WebDavElementNameEquals(child, "executable")) {
+            auto executable = child->GetText();
+            if (!executable) return false;
+            properties.m_is_executable = !strcasecmp(executable, "T");
+        }
+    }
+
+    if (properties.m_is_dir) {
+        if (!has_size) properties.m_size = 0;
+        return true;
+    }
+    return has_size;
+}

--- a/src/XrdClHttp/XrdClHttpWebDav.hh
+++ b/src/XrdClHttp/XrdClHttpWebDav.hh
@@ -35,6 +35,11 @@ struct WebDavProperties {
     time_t m_last_modified{-1};
 };
 
+struct WebDavQuota {
+    uint64_t m_available{0};
+    uint64_t m_used{0};
+};
+
 // Compare an XML element's local name, ignoring any namespace prefix.
 bool WebDavElementNameEquals(const TiXmlElement *element,
                              const char *expected);
@@ -47,6 +52,9 @@ bool ParseWebDavProperties(TiXmlElement *prop, WebDavProperties &properties);
 // properties. Explicitly unsuccessful propstat entries are ignored.
 bool ParseWebDavResponseProperties(TiXmlElement *response,
                                    WebDavProperties &properties);
+
+// Parse RFC 4331 quota properties from a successful WebDAV propstat.
+bool ParseWebDavResponseQuota(TiXmlElement *response, WebDavQuota &quota);
 
 }
 

--- a/src/XrdClHttp/XrdClHttpWebDav.hh
+++ b/src/XrdClHttp/XrdClHttpWebDav.hh
@@ -43,6 +43,11 @@ bool WebDavElementNameEquals(const TiXmlElement *element,
 // Collections may omit their content length; regular resources may not.
 bool ParseWebDavProperties(TiXmlElement *prop, WebDavProperties &properties);
 
+// Select a successful propstat from a WebDAV response and parse its
+// properties. Explicitly unsuccessful propstat entries are ignored.
+bool ParseWebDavResponseProperties(TiXmlElement *response,
+                                   WebDavProperties &properties);
+
 }
 
 #endif

--- a/src/XrdClHttp/XrdClHttpWebDav.hh
+++ b/src/XrdClHttp/XrdClHttpWebDav.hh
@@ -1,0 +1,48 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#ifndef XRDCLHTTPWEBDAV_HH
+#define XRDCLHTTPWEBDAV_HH
+
+#include <cstdint>
+#include <ctime>
+
+class TiXmlElement;
+
+namespace XrdClHttp {
+
+struct WebDavProperties {
+    bool m_is_dir{false};
+    bool m_is_executable{false};
+    int64_t m_size{-1};
+    time_t m_last_modified{-1};
+};
+
+// Compare an XML element's local name, ignoring any namespace prefix.
+bool WebDavElementNameEquals(const TiXmlElement *element,
+                             const char *expected);
+
+// Parse the standard properties returned by a WebDAV PROPFIND response.
+// Collections may omit their content length; regular resources may not.
+bool ParseWebDavProperties(TiXmlElement *prop, WebDavProperties &properties);
+
+}
+
+#endif

--- a/src/XrdSecztn/XrdSecProtocolztn.cc
+++ b/src/XrdSecztn/XrdSecProtocolztn.cc
@@ -322,6 +322,12 @@ XrdSecCredentials *XrdSecProtocolztn::findToken(XrdOucErrInfo *erp,
    const char *aTok, *bTok;
    int sz;
 
+// An explicitly selected credential cache belongs to this client request and
+// must take precedence over process-wide defaults.
+//
+   char *ccn = (erp && erp->getEnv()) ? erp->getEnv()->Get("xrd.ztn") : 0;
+   if (ccn) return readToken(erp, ccn, isbad);
+
 // Look through all of the possible envars
 //
    for (int i = 0; i < (int)Vec.size(); i++)
@@ -353,16 +359,6 @@ XrdSecCredentials *XrdSecProtocolztn::findToken(XrdOucErrInfo *erp,
         if ((bTok = Strip(aTok, sz))) return retToken(erp, bTok, sz);
        }
 
-// We support passing the credential cache path via Url parameter
-//
-   char *ccn = (erp && erp->getEnv()) ? erp->getEnv()->Get("xrd.ztn") : 0;
-   if (ccn)
-     {
-       resp = readToken(erp, ccn, isbad);
-       if (resp || isbad) return resp;
-     }
-
-// Look through all of the possible envars   
 // Nothing found
 //
   isbad = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,9 @@ add_subdirectory(XrdXrootdTests)
 
 add_subdirectory(XrdOssMirageTests)
 
+add_subdirectory(XrdClHttpCommon)
+add_subdirectory(XrdClHttp)
+
 if(NOT ENABLE_SERVER_TESTS)
   return()
 endif()
@@ -43,8 +46,6 @@ add_subdirectory(krb5)
 add_subdirectory(scitokens)
 add_subdirectory(tls)
 
-add_subdirectory(XrdClHttpCommon)
-add_subdirectory(XrdClHttp)
 add_subdirectory(XrdClS3)
 
 add_subdirectory( XrdOssTests )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,20 @@ endif()
 
 include(GoogleTest)
 
+function(add_bats_test name script)
+  set(environment
+    "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
+    "BINARY_DIR=${CMAKE_BINARY_DIR}"
+  )
+
+  add_test(NAME ${name}
+    COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
+            ${CMAKE_CURRENT_SOURCE_DIR}/${script})
+
+  set_tests_properties(${name} PROPERTIES ENVIRONMENT
+    "${environment}")
+endfunction()
+
 add_subdirectory(unit)
 
 add_subdirectory(common)
@@ -33,7 +47,9 @@ add_subdirectory(XrdXrootdTests)
 
 add_subdirectory(XrdOssMirageTests)
 
-add_subdirectory(XrdClHttpCommon)
+if(ENABLE_SERVER_TESTS)
+  add_subdirectory(XrdClHttpCommon)
+endif()
 add_subdirectory(XrdClHttp)
 
 if(NOT ENABLE_SERVER_TESTS)

--- a/tests/XRootD/scitokens.sh
+++ b/tests/XRootD/scitokens.sh
@@ -107,6 +107,8 @@ function test_scitokens() {
 	export BEARER_TOKEN_FILE=scitokens/token_create
 	xrdcp "$SOURCE_DIR/scitokens.cfg" "$HOST/protected/subdir/root/scitokens.cfg"
 	assert_failure xrdcp -f "$HOST/protected/subdir/root/scitokens.cfg" .
+	assert xrdcp -f "$HOST/protected/subdir/root/scitokens.cfg?xrd.ztn=$PWD/scitokens/token" .
+	assert diff -u "$SOURCE_DIR/scitokens.cfg" scitokens.cfg
 	export BEARER_TOKEN_FILE=scitokens/token
 	assert xrdcp -f "$HOST/protected/subdir/root/scitokens.cfg" .
 	assert diff -u "$SOURCE_DIR/scitokens.cfg" scitokens.cfg

--- a/tests/XrdCl/XrdClURL.cc
+++ b/tests/XrdCl/XrdClURL.cc
@@ -132,3 +132,15 @@ TEST(URLTest, InvalidURLs)
     EXPECT_FALSE(XrdCl::URL(url).IsValid()) << "URL " << url << " is not invalid" << std::endl;
 }
 
+TEST(URLTest, AuthenticationContextSeparatesChannels)
+{
+  XrdCl::URL first(
+    "root://localhost//data?xrd.wantprot=ztn&xrd.ztn=/tmp/token&xrdcl.authctx=first");
+  XrdCl::URL second(
+    "root://localhost//data?xrd.wantprot=ztn&xrd.ztn=/tmp/token&xrdcl.authctx=second");
+
+  EXPECT_NE(first.GetChannelId(), second.GetChannelId());
+  EXPECT_NE(first.GetChannelId().find("xrdcl.authctx=first"), std::string::npos);
+  EXPECT_EQ(first.GetPathWithFilteredParams(),
+            "/data?xrd.wantprot=ztn&xrd.ztn=/tmp/token");
+}

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -25,8 +25,8 @@ target_include_directories(xrdcl-http-unit-tests
 gtest_discover_tests(xrdcl-http-unit-tests TEST_PREFIX XrdClHttp::
   PROPERTIES DISCOVERY_TIMEOUT 10)
 
-# XrdClHttp integration tests depend on scitokens fixture for authentication
-if(NOT BUILD_SCITOKENS)
+# The remaining XrdClHttp tests depend on the server and SciTokens fixtures.
+if(NOT ENABLE_SERVER_TESTS OR NOT BUILD_SCITOKENS)
   return()
 endif()
 find_program(OPENSSL_BIN openssl REQUIRED)

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -10,13 +10,15 @@ target_link_libraries(XrdClHttpTesting PRIVATE XrdClHttpObj)
 include(GoogleTest)
 
 add_executable(xrdcl-http-unit-tests
+  ClientConfigTest.cc
   HeaderParserTest.cc
   ParseTimeoutTest.cc
   TapeTest.cc
+  WebDavParserTest.cc
 )
 
 target_link_libraries(xrdcl-http-unit-tests
-  XrdClHttpTesting XrdCl CURL::libcurl GTest::gtest_main)
+  XrdClHttpTesting XrdCl XrdXml CURL::libcurl GTest::gtest_main)
 target_include_directories(xrdcl-http-unit-tests
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../src")
 
@@ -27,7 +29,6 @@ gtest_discover_tests(xrdcl-http-unit-tests TEST_PREFIX XrdClHttp::
 if(NOT BUILD_SCITOKENS)
   return()
 endif()
-
 find_program(OPENSSL_BIN openssl REQUIRED)
 
 # All tests that only depend on the pure XrdCl interfaces and
@@ -36,6 +37,7 @@ add_executable(xrdcl-test
   ChecksumTest.cc
   DeleteTest.cc
   MkcolTest.cc
+  MoveTest.cc
   ReadTest.cc
   WriteTest.cc
 )
@@ -45,7 +47,6 @@ add_executable(xrdcl-http-test
   CopyTest.cc
   OptionsCacheTest.cc
   VectorReadTest.cc
-  WebDavParserTest.cc
 )
 
 target_link_libraries(xrdcl-test XrdClHttpTransferTest GTest::gtest_main)

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -48,7 +48,7 @@ add_executable(xrdcl-http-test
 )
 
 target_link_libraries(xrdcl-test XrdClHttpTransferTest GTest::gtest_main)
-target_link_libraries(xrdcl-http-test XrdClHttpTesting XrdClHttpTransferTest GTest::gtest_main)
+target_link_libraries(xrdcl-http-test XrdClHttpTesting XrdClHttpTransferTest XrdXml GTest::gtest_main)
 
 gtest_add_tests(TARGET xrdcl-test TEST_LIST CurlClOnlyTests)
 gtest_add_tests(TARGET xrdcl-http-test TEST_LIST CurlTests)

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(xrdcl-test
 # Tests depending on XrdClHttp linkage
 add_executable(xrdcl-http-test
   CopyTest.cc
+  OptionsCacheTest.cc
   VectorReadTest.cc
   WebDavParserTest.cc
 )

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(xrdcl-test
 add_executable(xrdcl-http-test
   CopyTest.cc
   VectorReadTest.cc
+  WebDavParserTest.cc
 )
 
 target_link_libraries(xrdcl-test XrdClHttpTransferTest GTest::gtest_main)

--- a/tests/XrdClHttp/ClientConfigTest.cc
+++ b/tests/XrdClHttp/ClientConfigTest.cc
@@ -1,0 +1,38 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpOps.hh"
+
+#include <gtest/gtest.h>
+
+using namespace XrdClHttp;
+
+TEST(ClientConfig, StripsOnlyClientParameters) {
+    HttpClientConfig config;
+    std::string client_query;
+    auto cleaned = ExtractHttpClientConfig(
+        "davs://example/data?X-Amz-Signature=abc+def==&"
+        "xrdcl.http.clientcert=%2Ftmp%2Fproxy&empty=",
+        config, &client_query);
+
+    EXPECT_EQ(cleaned,
+        "davs://example/data?X-Amz-Signature=abc+def==&empty=");
+    EXPECT_EQ(config.client_cert, "/tmp/proxy");
+    EXPECT_EQ(client_query, "xrdcl.http.clientcert=%2Ftmp%2Fproxy");
+}
+
+TEST(ClientConfig, ParsesAuthenticationAndTlsPolicy) {
+    HttpClientConfig config;
+    auto cleaned = ExtractHttpClientConfig(
+        "https://example/data?xrdcl.http.bearertokenfile=%2Ftmp%2Ftoken&"
+        "xrdcl.http.cafile=%2Ftmp%2Fca.pem&xrdcl.http.noverify=1&"
+        "xrdcl.http.noauth=true&xrdcl.authctx=identity",
+        config);
+
+    EXPECT_EQ(cleaned, "https://example/data");
+    EXPECT_EQ(config.bearer_token_file, "/tmp/token");
+    EXPECT_EQ(config.ca_file, "/tmp/ca.pem");
+    EXPECT_TRUE(config.no_verify);
+    EXPECT_TRUE(config.no_auth);
+}

--- a/tests/XrdClHttp/MoveTest.cc
+++ b/tests/XrdClHttp/MoveTest.cc
@@ -1,0 +1,37 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/******************************************************************************/
+
+#include "../XrdClHttpCommon/TransferTest.hh"
+
+#include <XrdCl/XrdClFileSystem.hh>
+
+#include <memory>
+
+class CurlMoveFixture : public TransferFixture {};
+
+TEST_F(CurlMoveFixture, RenameWithinEndpoint)
+{
+    const std::string source = "/test/move_source";
+    const std::string destination = "/test/move_destination";
+    WritePattern(GetOriginURL() + source, 8, 'a', 2);
+
+    XrdCl::FileSystem filesystem(GetOriginURL());
+    ASSERT_TRUE(filesystem.SetProperty(
+        "XrdClHttpQueryParam", "authz=" + GetWriteToken()));
+    auto status = filesystem.Mv(source, destination, 10);
+    ASSERT_TRUE(status.IsOK()) << status.ToStr();
+
+    std::unique_ptr<XrdCl::StatInfo> info;
+    XrdCl::StatInfo *raw_info = nullptr;
+    status = filesystem.Stat(source, raw_info, 10);
+    info.reset(raw_info);
+    EXPECT_FALSE(status.IsOK());
+    EXPECT_EQ(status.errNo, kXR_NotFound);
+
+    raw_info = nullptr;
+    status = filesystem.Stat(destination, raw_info, 10);
+    info.reset(raw_info);
+    ASSERT_TRUE(status.IsOK()) << status.ToStr();
+    EXPECT_EQ(info->GetSize(), 8);
+}

--- a/tests/XrdClHttp/OptionsCacheTest.cc
+++ b/tests/XrdClHttp/OptionsCacheTest.cc
@@ -1,0 +1,62 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpOptionsCache.hh"
+
+#include <gtest/gtest.h>
+
+using XrdClHttp::VerbsCache;
+
+TEST(OptionsCache, KeysCapabilitiesByResourcePath)
+{
+    EXPECT_EQ(VerbsCache::GetUrlKey("https://example.org/namespace/file-a"),
+              "https://example.org:443/namespace/file-a");
+    EXPECT_EQ(VerbsCache::GetUrlKey("https://example.org/namespace/file-b"),
+              "https://example.org:443/namespace/file-b");
+    EXPECT_NE(VerbsCache::GetUrlKey("https://example.org/namespace/file-a"),
+              VerbsCache::GetUrlKey("https://example.org/namespace/file-b"));
+}
+
+TEST(OptionsCache, ExcludesCredentialsAndRequestParameters)
+{
+    EXPECT_EQ(VerbsCache::GetUrlKey(
+                  "https://user:secret@example.org/data?authz=token#fragment"),
+              "https://example.org:443/data");
+    EXPECT_EQ(VerbsCache::GetUrlKey("https://example.org"),
+              "https://example.org:443/");
+}
+
+TEST(OptionsCache, DoesNotShareVerbsBetweenPaths)
+{
+    auto &cache = VerbsCache::Instance();
+    const std::string head_url = "https://options-cache.invalid/head-only";
+    const std::string dav_url = "https://options-cache.invalid/webdav";
+
+    cache.Put(head_url,
+              VerbsCache::HttpVerbs(VerbsCache::HttpVerb::kUnknown));
+    cache.Put(dav_url,
+              VerbsCache::HttpVerbs(VerbsCache::HttpVerb::kPROPFIND));
+
+    EXPECT_TRUE(cache.Get(head_url).IsSet(VerbsCache::HttpVerb::kUnknown));
+    EXPECT_FALSE(cache.Get(head_url).IsSet(VerbsCache::HttpVerb::kPROPFIND));
+    EXPECT_TRUE(cache.Get(dav_url).IsSet(VerbsCache::HttpVerb::kPROPFIND));
+    EXPECT_TRUE(cache.Get("https://options-cache.invalid/unprobed")
+                    .IsSet(VerbsCache::HttpVerb::kUnset));
+}

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -19,8 +19,22 @@
 /******************************************************************************/
 
 #include "XrdClHttp/XrdClHttpUtil.hh"
+#include "XrdClHttp/XrdClHttpWebDav.hh"
 
 #include <gtest/gtest.h>
+#include <tinyxml.h>
+
+namespace {
+
+bool ParseProperties(const char *xml, XrdClHttp::WebDavProperties &properties)
+{
+    TiXmlDocument document;
+    document.Parse(xml);
+    return !document.Error() &&
+        XrdClHttp::ParseWebDavProperties(document.RootElement(), properties);
+}
+
+}
 
 TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
 {
@@ -31,4 +45,63 @@ TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
 
     EXPECT_TRUE(parser.GetAllowedVerbs().IsSet(
         XrdClHttp::VerbsCache::HttpVerb::kPROPFIND));
+}
+
+TEST(WebDavParser, MatchesLocalNamesWithArbitraryPrefixes)
+{
+    TiXmlDocument document;
+    document.Parse("<ns0:collection xmlns:ns0=\"DAV:\"/>");
+
+    EXPECT_TRUE(XrdClHttp::WebDavElementNameEquals(
+        document.RootElement(), "collection"));
+    EXPECT_FALSE(XrdClHttp::WebDavElementNameEquals(
+        document.RootElement(), "resourcetype"));
+}
+
+TEST(WebDavParser, AllowsDirectoryWithEmptyContentLength)
+{
+    XrdClHttp::WebDavProperties properties;
+    ASSERT_TRUE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\">"
+        "<d:getcontentlength/>"
+        "<d:resourcetype><d:collection/></d:resourcetype>"
+        "</d:prop>", properties));
+
+    EXPECT_TRUE(properties.m_is_dir);
+    EXPECT_EQ(properties.m_size, 0);
+}
+
+TEST(WebDavParser, RequiresContentLengthForRegularResources)
+{
+    XrdClHttp::WebDavProperties missing;
+    EXPECT_FALSE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\"><d:resourcetype/></d:prop>", missing));
+
+    XrdClHttp::WebDavProperties empty;
+    EXPECT_FALSE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\"><d:getcontentlength/></d:prop>", empty));
+}
+
+TEST(WebDavParser, ParsesValidRegularResourceSize)
+{
+    XrdClHttp::WebDavProperties properties;
+    ASSERT_TRUE(ParseProperties(
+        "<d:prop xmlns:d=\"DAV:\">"
+        "<d:getcontentlength> 123 </d:getcontentlength>"
+        "<d:resourcetype/>"
+        "</d:prop>", properties));
+
+    EXPECT_FALSE(properties.m_is_dir);
+    EXPECT_EQ(properties.m_size, 123);
+}
+
+TEST(WebDavParser, RejectsInvalidContentLength)
+{
+    for (auto value : {"-1", "12 bytes", "9223372036854775808"}) {
+        XrdClHttp::WebDavProperties properties;
+        std::string xml = "<d:prop xmlns:d=\"DAV:\"><d:getcontentlength>";
+        xml += value;
+        xml += "</d:getcontentlength></d:prop>";
+        EXPECT_FALSE(ParseProperties(xml.c_str(), properties)) << value;
+    }
 }

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -34,6 +34,15 @@ bool ParseProperties(const char *xml, XrdClHttp::WebDavProperties &properties)
         XrdClHttp::ParseWebDavProperties(document.RootElement(), properties);
 }
 
+bool ParseResponseProperties(const char *xml,
+                             XrdClHttp::WebDavProperties &properties)
+{
+    TiXmlDocument document;
+    document.Parse(xml);
+    return !document.Error() && XrdClHttp::ParseWebDavResponseProperties(
+        document.RootElement(), properties);
+}
+
 }
 
 TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
@@ -104,4 +113,32 @@ TEST(WebDavParser, RejectsInvalidContentLength)
         xml += "</d:getcontentlength></d:prop>";
         EXPECT_FALSE(ParseProperties(xml.c_str(), properties)) << value;
     }
+}
+
+TEST(WebDavParser, IgnoresUnsuccessfulPropstatEntries)
+{
+    XrdClHttp::WebDavProperties properties;
+    ASSERT_TRUE(ParseResponseProperties(
+        "<d:response xmlns:d=\"DAV:\">"
+        "<d:propstat>"
+        "<d:status>HTTP/1.1 200 OK</d:status>"
+        "<d:prop><d:getcontentlength>123</d:getcontentlength></d:prop>"
+        "</d:propstat>"
+        "<d:propstat>"
+        "<d:status>HTTP/1.1 404 Not Found</d:status><d:prop/>"
+        "</d:propstat>"
+        "</d:response>", properties));
+
+    EXPECT_EQ(properties.m_size, 123);
+}
+
+TEST(WebDavParser, RequiresSuccessfulPropstatEntry)
+{
+    XrdClHttp::WebDavProperties properties;
+    EXPECT_FALSE(ParseResponseProperties(
+        "<d:response xmlns:d=\"DAV:\">"
+        "<d:propstat>"
+        "<d:status>HTTP/1.1 404 Not Found</d:status><d:prop/>"
+        "</d:propstat>"
+        "</d:response>", properties));
 }

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -43,6 +43,14 @@ bool ParseResponseProperties(const char *xml,
         document.RootElement(), properties);
 }
 
+bool ParseResponseQuota(const char *xml, XrdClHttp::WebDavQuota &quota)
+{
+    TiXmlDocument document;
+    document.Parse(xml);
+    return !document.Error() && XrdClHttp::ParseWebDavResponseQuota(
+        document.RootElement(), quota);
+}
+
 }
 
 TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
@@ -141,4 +149,27 @@ TEST(WebDavParser, RequiresSuccessfulPropstatEntry)
         "<d:status>HTTP/1.1 404 Not Found</d:status><d:prop/>"
         "</d:propstat>"
         "</d:response>", properties));
+}
+
+TEST(WebDavParser, ParsesQuotaWithArbitraryPrefix)
+{
+    XrdClHttp::WebDavQuota quota;
+    ASSERT_TRUE(ParseResponseQuota(
+        "<x:response xmlns:x=\"DAV:\"><x:propstat>"
+        "<x:status>HTTP/1.1 200 OK</x:status><x:prop>"
+        "<x:quota-used-bytes>17</x:quota-used-bytes>"
+        "<x:quota-available-bytes>83</x:quota-available-bytes>"
+        "</x:prop></x:propstat></x:response>", quota));
+    EXPECT_EQ(quota.m_used, 17);
+    EXPECT_EQ(quota.m_available, 83);
+}
+
+TEST(WebDavParser, RequiresBothQuotaProperties)
+{
+    XrdClHttp::WebDavQuota quota;
+    EXPECT_FALSE(ParseResponseQuota(
+        "<d:response xmlns:d=\"DAV:\"><d:propstat>"
+        "<d:status>HTTP/1.1 200 OK</d:status><d:prop>"
+        "<d:quota-used-bytes>17</d:quota-used-bytes>"
+        "</d:prop></d:propstat></d:response>", quota));
 }

--- a/tests/XrdClHttp/WebDavParserTest.cc
+++ b/tests/XrdClHttp/WebDavParserTest.cc
@@ -1,0 +1,34 @@
+/******************************************************************************/
+/* Copyright (C) 2026, XRootD Collaboration                                  */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/*                                                                            */
+/* The copyright holder's institutional names and contributor's names may not */
+/* be used to endorse or promote products derived from this software without  */
+/* specific prior written permission of the institution or contributor.       */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpUtil.hh"
+
+#include <gtest/gtest.h>
+
+TEST(WebDavParser, ParsesWhitespaceSeparatedAllowMethods)
+{
+    XrdClHttp::HeaderParser parser;
+    EXPECT_TRUE(parser.Parse("HTTP/1.1 200 OK\r\n"));
+    EXPECT_TRUE(parser.Parse("Allow: MKCOL, PROPFIND, PUT\r\n"));
+    EXPECT_TRUE(parser.Parse("\r\n"));
+
+    EXPECT_TRUE(parser.GetAllowedVerbs().IsSet(
+        XrdClHttp::VerbsCache::HttpVerb::kPROPFIND));
+}

--- a/tests/XrdClHttp/WriteTest.cc
+++ b/tests/XrdClHttp/WriteTest.cc
@@ -26,6 +26,7 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <thread>
 
 class CurlWriteFixture : public TransferFixture {
@@ -66,6 +67,44 @@ TEST_F(CurlWriteFixture, ParallelTest)
     for (unsigned ctr=0; ctr<10; ctr++) {
         threads[ctr].join();
     }
+}
+
+// A PUT is one curl operation that spans all Write()s made by the client, and the
+// origin only sends a response at the end, when the body is complete. Ensure the
+// upload is not capped by the header timeout derived from the first write, but that
+// each individual write is within the timeout.
+//
+// `xrdclhttp.timeout` is reduced by a second when parsed, so the header timeout
+// here is 2s while the writes span about 4s.  Every individual gap is well
+// inside both that and the 10s timeout each Write() asks for.
+TEST_F(CurlWriteFixture, SlowClientWriteTest)
+{
+    constexpr uint32_t chunkSize = 10'000;
+    constexpr unsigned chunkCount = 5;
+
+    XrdCl::File fh;
+    auto name = GetOriginURL() + "/test/write_slow_client";
+    auto url = name + "?authz=" + GetWriteToken()
+             + "&oss.asize=" + std::to_string(chunkCount * chunkSize)
+             + "&xrdclhttp.timeout=3s";
+    auto rv = fh.Open(url, XrdCl::OpenFlags::Write, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToStr();
+
+    unsigned char chunkByte = 'a';
+    uint64_t offset = 0;
+    for (unsigned ctr = 0; ctr < chunkCount; ctr++) {
+        if (ctr) std::this_thread::sleep_for(std::chrono::seconds(1));
+        std::string writeBuffer(chunkSize, chunkByte);
+        rv = fh.Write(offset, chunkSize, writeBuffer.data(), static_cast<time_t>(10));
+        ASSERT_TRUE(rv.IsOK()) << "Failed to write chunk " << ctr << " of " << name << ": " << rv.ToStr();
+        offset += chunkSize;
+        chunkByte += 1;
+    }
+
+    rv = fh.Close();
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close " << name << ": " << rv.ToStr();
+
+    VerifyContents(name, chunkCount * chunkSize, 'a', chunkSize);
 }
 
 // Ensure that writes fail after the PUT times out.

--- a/tests/XrdClHttpCommon/TransferTest.cc
+++ b/tests/XrdClHttpCommon/TransferTest.cc
@@ -105,7 +105,7 @@ TransferFixture::WritePattern(const std::string &name, const off_t writeSize,
 
     auto url = name + "?authz=" + GetWriteToken() + "&oss.asize=" + std::to_string(writeSize);
     auto rv = fh.Open(url, XrdCl::OpenFlags::Write, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
-    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToString();
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << name << " for write: " << rv.ToStr();
 
     size_t sizeToWrite = (static_cast<off_t>(chunkSize) >= writeSize)
                                                         ? static_cast<size_t>(writeSize)
@@ -117,7 +117,8 @@ TransferFixture::WritePattern(const std::string &name, const off_t writeSize,
         std::string writeBuffer(sizeToWrite, curChunkByte);
 
         rv = fh.Write(offset, sizeToWrite, writeBuffer.data(), static_cast<time_t>(10));
-        ASSERT_TRUE(rv.IsOK()) << "Failed to write " << name << ": " << rv.ToString();
+        ASSERT_TRUE(rv.IsOK()) << "Failed to write " << name << " at offset " << offset
+                               << " (" << sizeToWrite << " bytes): " << rv.ToStr();
         
         curWriteSize -= sizeToWrite;
         offset += sizeToWrite;
@@ -128,7 +129,7 @@ TransferFixture::WritePattern(const std::string &name, const off_t writeSize,
     }
 
     rv = fh.Close();
-    ASSERT_TRUE(rv.IsOK());
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close " << name << " after write: " << rv.ToStr();
     m_log->Debug(XrdCl::UtilityMsg, "Finished writing transfer pattern to %s", name.c_str());
 
     VerifyContents(name, writeSize, chunkByte, chunkSize);
@@ -141,7 +142,7 @@ TransferFixture::VerifyContents(const std::string &obj,
     XrdCl::File fh;
     auto url = obj + "?authz=" + GetReadToken();
     auto rv = fh.Open(url, XrdCl::OpenFlags::Read, XrdCl::Access::Mode(0755), static_cast<time_t>(0));
-    ASSERT_TRUE(rv.IsOK());
+    ASSERT_TRUE(rv.IsOK()) << "Failed to open " << obj << " for read: " << rv.ToStr();
 
     return VerifyContents(fh, expectedSize, chunkByte, chunkSize);
 }
@@ -160,7 +161,8 @@ TransferFixture::VerifyContents(XrdCl::File &fh,
         std::string readBuffer(sizeToRead, curChunkByte - 1);
         uint32_t bytesRead;
         auto rv = fh.Read(offset, sizeToRead, readBuffer.data(), bytesRead, static_cast<time_t>(0));
-        ASSERT_TRUE(rv.IsOK());
+        ASSERT_TRUE(rv.IsOK()) << "Failed to read at offset " << offset
+                               << " (" << sizeToRead << " bytes): " << rv.ToStr();
         ASSERT_EQ(bytesRead, sizeToRead);
         readBuffer.resize(sizeToRead);
 
@@ -176,7 +178,7 @@ TransferFixture::VerifyContents(XrdCl::File &fh,
     }
 
     auto rv = fh.Close();
-    ASSERT_TRUE(rv.IsOK());
+    ASSERT_TRUE(rv.IsOK()) << "Failed to close after read: " << rv.ToStr();
 }
 
 void

--- a/tests/end-to-end/CMakeLists.txt
+++ b/tests/end-to-end/CMakeLists.txt
@@ -1,15 +1,1 @@
-function(add_bats_test name script)
-  set(environment
-    "BATS_LIB_PATH=${PROJECT_SOURCE_DIR}/vendor/bats/lib/bats"
-    "BINARY_DIR=${CMAKE_BINARY_DIR}"
-  )
-
-  add_test(NAME ${name}
-    COMMAND ${PROJECT_SOURCE_DIR}/vendor/bats/bin/bats
-            ${CMAKE_CURRENT_SOURCE_DIR}/${script})
-
-  set_tests_properties(${name} PROPERTIES ENVIRONMENT
-    "${environment}")
-endfunction()
-
 add_subdirectory(xrdfs)


### PR DESCRIPTION
## Summary

- add a thread-safe Python `StorageClient` with `get`, `put`, `delete`, `move`, `stat`, `checksum`, `exists`, `listdir`, `mkdir_p`, and `space`
- extend object-scoped `AuthContext` to HTTP/WebDAV bearer, X.509, anonymous/presigned, CA, and TLS verification settings
- add environment-snapshot authentication and explicit suppression of ambient credentials
- add client-owned credential lifecycle, bounded endpoint probing, and composite metadata/checksum negotiation under one deadline
- add WebDAV `MOVE`, recursive `MKCOL`, partial `DELETE` detection, and RFC 4331 quota querying
- add structured Python exceptions and end-to-end timeout handling

## Base and related work

This branch is based on `master` plus the work from:

- #2914 (object-scoped authentication)
- #2906 (WebDAV capability/property interoperability)
- #2831 (structured checksum, recursive mkdir, and filesystem helpers)

It also carries the PUT deadline fix from #2901 as a separate commit so it can be dropped once that PR is merged.

The implementation builds on #2906 and does not duplicate its OPTIONS caching or namespace-independent PROPFIND parsing. `StorageClient` builds on #2831 rather than parsing checksum responses or reconstructing recursive mkdir flags itself.

## Application API

The Rucio adapter now uses `StorageClient.from_environment`, `probe`, and `info`. Credential discovery and TLS settings are snapshotted without process-global mutation, closing a client waits for active operations before releasing an owned token, and checksum fallback shares one operation deadline and caches successful endpoint negotiation.

## Verification

- complete local XRootD build
- 12 focused XrdClHttp unit tests pass
- 57 focused Python authentication, response, storage, checksum, and lifecycle tests pass
- local WebDAV smoke test: recursive MKCOL, MOVE, stat, quota query, DELETE, and not-found mapping
- installable binding exports `STORAGE_CLIENT_API_VERSION = 2`, `StorageClient.from_environment`, `StorageClient.probe`, and `StorageClient.info`
- server-backed SciTokens tests included for CI; SciTokensCpp was unavailable locally
- GitHub ABI, coverage, Python source distribution, and the complete Python 3.9–3.14 Linux/macOS matrix pass
- both failing GCC release checks pass all 371 tests (confirmed across reruns) and fail only when CDash submission exits 255; no code/test failure is present in those jobs
