### PR TITLE
[XrdCl] Add storage and issuer token requests to xrdfs

### DIFF
--- a/docs/man/xrdfs.1
+++ b/docs/man/xrdfs.1
@@ -9,7 +9,7 @@ xrdfs - xrootd file and directory meta-data utility
 \fBxrdfs\fR \fI[global-options]\fR \fIcommand\fR \fI[args containing complete URLs]\fR
 
 \fBcommand\fR: help, cache, chmod, ls, locate, mkdir, mv, stat, statvfs, query,
-           rm, rmdir, truncate, prepare, cat, tail, spaceinfo, xattr
+           rm, rmdir, truncate, prepare, cat, tail, spaceinfo, token, xattr
 .fi
 .br
 .ad l
@@ -27,6 +27,9 @@ The \fBquery\fR command remains server-first because its implementation-dependen
 parameters may themselves look like URLs.
 Local \fBfile://\fR and \fBstdio://\fR operands are not remote endpoints and are
 rejected in command-first form.
+The command-first complete-URL form is supported by cache, cat, chmod, locate,
+ls, mkdir, mv, prepare, rm, rmdir, spaceinfo, stat, statvfs, tail, token,
+truncate, and xattr.
 Command help is available by invoking \fBxrdfs\fR with no command
 line options or parameters and then typing "help" in response to the
 input prompt.
@@ -71,6 +74,10 @@ In an XRootD URL, the double slash after the host consists of the slash
 separating the authority from the path and the leading slash of the absolute
 path. A single slash is also accepted and normalized to an absolute command
 path.
+.PP
+.nf
+\fBxrdfs token --validity 30 https://storage.example.org/store/file DOWNLOAD\fR
+.fi
 
 .SH COMMANDS
 \fBchmod\fR \fIpath\fR \fI<user><group><other>\fR
@@ -266,6 +273,26 @@ Output last part of files to stdout.
 \fI-c\fR num_bytes out last num_bytes
 .br
 \fI-f\fR           output appended data as file grows
+
+.RE
+\fBtoken\fR \fI[-w|--write]\fR \fI[--validity minutes]\fR \fI[--issuer URL]\fR \fI[--]\fR \fIpath\fR \fI[activity ...]\fR
+.RS 3
+Request a token for a storage path and print it to standard output.
+The storage endpoint must use HTTPS or DAVS. Without explicit activities, the
+request uses LIST and DOWNLOAD for read access; write access also adds MANAGE,
+UPLOAD, and DELETE.
+.br
+\fI-w\fR, \fI--write\fR request write access instead of read access
+.br
+\fI--validity minutes\fR request a nonnegative validity in minutes (default: 60)
+.br
+\fI--issuer URL\fR request the token through an explicit HTTPS or DAVS issuer. The
+client discovers an OAuth token endpoint using RFC 8414 and OpenID metadata,
+then tries the supported SciTokens and macaroon flows. If issuer discovery is
+unavailable, the request falls back to direct storage issuance. Omit this
+option to request a storage-issued token directly
+.br
+\fI--\fR stop option parsing, allowing a path beginning with a dash
 
 .RE
 \fBspaceinfo\fR \fIpath\fR

--- a/src/XrdCl/XrdClFS.cc
+++ b/src/XrdCl/XrdClFS.cc
@@ -37,11 +37,14 @@
 #include "XrdCl/XrdClURL.hh"
 #include "XrdCl/XrdClUtils.hh"
 #include "XrdCl/XrdClXRootDResponses.hh"
+#include "XrdOuc/XrdOucJson.hh"
 #include "XrdOuc/XrdOucPrivateUtils.hh"
 #include "XrdSys/XrdSysE2T.hh"
 
 #include <algorithm>
+#include <cerrno>
 #include <cctype>
+#include <cstdint>
 #include <getopt.h>
 #include <iterator>
 #include <cmath>
@@ -71,7 +74,7 @@ namespace
     static const char *commands[] = {
       "cache", "cat", "chmod", "locate", "ls", "mkdir", "mv",
       "prepare", "rm", "rmdir", "spaceinfo", "stat", "statvfs",
-      "tail", "truncate", "xattr"
+      "tail", "token", "truncate", "xattr"
     };
 
     return std::find( std::begin( commands ), std::end( commands ), command )
@@ -99,6 +102,49 @@ namespace
     return true;
   }
 
+  bool IsLongOptionAbbreviation( const std::string &argument,
+                                 const char        *option )
+  {
+    const std::string fullOption( option );
+    return argument.size() > 2 && argument.size() < fullOption.size() &&
+           fullOption.compare( 0, argument.size(), argument ) == 0;
+  }
+
+  bool IsTokenPathOperand( const FSExecutor::CommandParams &arguments,
+                           std::size_t index )
+  {
+    bool parseOptions = true;
+    for( std::size_t i = 1; i < arguments.size(); ++i )
+    {
+      if( parseOptions && arguments[i] == "--" )
+      {
+        parseOptions = false;
+        continue;
+      }
+      if( parseOptions &&
+          (arguments[i] == "-w" || arguments[i] == "--write" ||
+           IsLongOptionAbbreviation( arguments[i], "--write" )) )
+        continue;
+      if( parseOptions &&
+          (arguments[i] == "--validity" || arguments[i] == "--issuer" ||
+           IsLongOptionAbbreviation( arguments[i], "--validity" ) ||
+           IsLongOptionAbbreviation( arguments[i], "--issuer" )) )
+      {
+        if( i + 1 < arguments.size() ) ++i;
+        continue;
+      }
+      if( parseOptions &&
+          (arguments[i].compare( 0, 11, "--validity=" ) == 0 ||
+           arguments[i].compare( 0, 9, "--issuer=" ) == 0) )
+        continue;
+      if( parseOptions && !arguments[i].empty() && arguments[i][0] == '-' )
+        continue;
+
+      return i == index;
+    }
+    return false;
+  }
+
   URLCommandResult ParseURLCommand( FSExecutor::CommandParams &arguments,
                                     URL &endpoint, std::string &error )
   {
@@ -124,6 +170,8 @@ namespace
     bool foundURL = false;
     for( std::size_t i = 1; i < arguments.size(); ++i )
     {
+      if( arguments[0] == "token" && !IsTokenPathOperand( arguments, i ) )
+        continue;
       if( !HasExplicitURLScheme( arguments[i] ) )
         continue;
 
@@ -155,6 +203,49 @@ namespace
     }
 
     return foundURL ? ValidURLCommand : NotURLCommand;
+  }
+
+  class ScopedGetoptState
+  {
+    public:
+      ScopedGetoptState():
+        pOptind( optind ), pOpterr( opterr ), pOptopt( optopt ),
+        pOptarg( optarg )
+      {
+        optind = 0;
+        opterr = 0;
+        optopt = 0;
+        optarg = nullptr;
+      }
+
+      ~ScopedGetoptState()
+      {
+        optind = pOptind;
+        opterr = pOpterr;
+        optopt = pOptopt;
+        optarg = pOptarg;
+      }
+
+    private:
+      int   pOptind;
+      int   pOpterr;
+      int   pOptopt;
+      char *pOptarg;
+  };
+
+  bool ParseTokenValidity( const char *argument, std::uint64_t &validity )
+  {
+    if( !argument || !*argument ) return false;
+    for( const unsigned char character : std::string( argument ) )
+      if( !std::isdigit( character ) ) return false;
+
+    errno = 0;
+    char *end = nullptr;
+    const unsigned long long parsed = std::strtoull( argument, &end, 10 );
+    if( errno == ERANGE || !end || *end ) return false;
+
+    validity = static_cast<std::uint64_t>( parsed );
+    return true;
   }
 }
 
@@ -1444,6 +1535,199 @@ XRootDStatus DoQuery( FileSystem                      *fs,
 }
 
 //------------------------------------------------------------------------------
+// Request a storage-issued token
+//------------------------------------------------------------------------------
+XRootDStatus DoToken( FileSystem                      *fs,
+                      Env                             *env,
+                      const FSExecutor::CommandParams &args )
+{
+  Log *log = DefaultEnv::GetLog();
+
+  enum
+  {
+    TokenValidityOption = 256,
+    TokenIssuerOption
+  };
+  static const option options[] = {
+    { "write",    no_argument,       nullptr, 'w' },
+    { "validity", required_argument, nullptr, TokenValidityOption },
+    { "issuer",   required_argument, nullptr, TokenIssuerOption },
+    { nullptr, 0, nullptr, 0 }
+  };
+
+  bool writeAccess = false;
+  std::uint64_t validity = 60;
+  std::string issuer;
+  std::string parseError;
+  int firstOperand = 0;
+
+  // getopt_long requires a mutable argv even though it does not modify the
+  // argument strings. Keep this command's parser state isolated from main()
+  // and from subsequent commands in interactive mode.
+  std::vector<std::string> commandArguments( args );
+  std::vector<char *> argv;
+  argv.reserve( commandArguments.size() + 1 );
+  for( std::string &argument : commandArguments )
+    argv.push_back( argument.data() );
+  argv.push_back( nullptr );
+
+  // getopt_long accepts unique long-option abbreviations. Reject them so the
+  // command-first URL scanner and the command parser use the same grammar.
+  for( std::size_t i = 1; i < commandArguments.size(); ++i )
+  {
+    const std::string &argument = commandArguments[i];
+    if( argument == "--" || argument.empty() || argument[0] != '-' )
+      break;
+    if( argument.compare( 0, 2, "--" ) != 0 )
+      continue;
+    if( argument == "--write" )
+      continue;
+    if( argument == "--validity" || argument == "--issuer" )
+    {
+      if( i + 1 < commandArguments.size() ) ++i;
+      continue;
+    }
+    if( argument.compare( 0, 11, "--validity=" ) == 0 ||
+        argument.compare( 0, 9, "--issuer=" ) == 0 )
+      continue;
+
+    parseError = "Invalid token option: " + argument;
+    break;
+  }
+
+  if( parseError.empty() )
+  {
+    ScopedGetoptState getoptState;
+    int parsedOption = 0;
+    while( (parsedOption = getopt_long(
+              static_cast<int>( commandArguments.size() ), argv.data(),
+              "+:w", options, nullptr )) != -1 )
+    {
+      switch( parsedOption )
+      {
+        case 'w':
+          writeAccess = true;
+          break;
+        case TokenValidityOption:
+          if( !ParseTokenValidity( optarg, validity ) )
+            parseError = "Validity must be a number >= 0.";
+          break;
+        case TokenIssuerOption:
+          issuer = optarg ? optarg : "";
+          if( issuer.empty() )
+            parseError = "Issuer URL cannot be empty.";
+          break;
+        case ':':
+          if( optopt == TokenValidityOption )
+            parseError = "Parameter '--validity' requires an argument.";
+          else if( optopt == TokenIssuerOption )
+            parseError = "Parameter '--issuer' requires an argument.";
+          else
+            parseError = "A token option requires an argument.";
+          break;
+        default:
+        {
+          const int invalidIndex = optind > 0 ? optind - 1 : 0;
+          const std::string invalid =
+            invalidIndex < static_cast<int>( commandArguments.size() ) ?
+              commandArguments[invalidIndex] : std::string();
+          parseError = invalid.empty() ? "Invalid token option." :
+                       "Invalid token option: " + invalid;
+          break;
+        }
+      }
+
+      if( !parseError.empty() ) break;
+    }
+    firstOperand = optind;
+  }
+
+  if( !parseError.empty() )
+  {
+    log->Error( AppMsg, "%s", parseError.c_str() );
+    return XRootDStatus( stError, errInvalidArgs, 0, parseError );
+  }
+
+  if( firstOperand >= static_cast<int>( commandArguments.size() ) )
+  {
+    const std::string error = "Missing path for token request.";
+    log->Error( AppMsg, "%s", error.c_str() );
+    return XRootDStatus( stError, errInvalidArgs, 0, error );
+  }
+
+  std::string path;
+  if( !BuildPath( path, env, commandArguments[firstOperand] ).IsOK() )
+  {
+    const std::string error = "Invalid path for token request.";
+    log->Error( AppMsg, "%s", error.c_str() );
+    return XRootDStatus( stError, errInvalidArgs, 0, error );
+  }
+
+  std::string server;
+  env->GetString( "ServerURL", server );
+  URL endpoint( server );
+  std::string protocol = endpoint.GetProtocol();
+  std::transform( protocol.begin(), protocol.end(), protocol.begin(),
+                  []( unsigned char character )
+  {
+    return static_cast<char>( std::tolower( character ) );
+  } );
+  if( protocol != "https" && protocol != "davs" )
+  {
+    const std::string error =
+      "Token requests require an HTTPS or DAVS storage endpoint.";
+    log->Error( AppMsg, "%s", error.c_str() );
+    return XRootDStatus( stError, errNotSupported, 0, error );
+  }
+
+  std::vector<std::string> activities;
+  for( std::size_t i = static_cast<std::size_t>( firstOperand + 1 );
+       i < commandArguments.size(); ++i )
+  {
+    if( commandArguments[i].empty() )
+    {
+      const std::string error = "Token activities cannot be empty.";
+      log->Error( AppMsg, "%s", error.c_str() );
+      return XRootDStatus( stError, errInvalidArgs, 0, error );
+    }
+    activities.emplace_back( commandArguments[i] );
+  }
+
+  nlohmann::json request = {
+    { "path", path },
+    { "validity", validity },
+    { "write", writeAccess },
+    { "activities", activities }
+  };
+  if( !issuer.empty() ) request["issuer"] = issuer;
+
+  Buffer argument;
+  argument.FromString( request.dump() );
+
+  Buffer *rawResponse = nullptr;
+  XRootDStatus status = fs->Query(
+    QueryCode::Visa, argument, rawResponse );
+  std::unique_ptr<Buffer> response( rawResponse );
+  if( !status.IsOK() )
+  {
+    // The path may contain an authz query parameter; do not copy it into the
+    // client log on failure.
+    log->Error( AppMsg, "Unable to request token: %s",
+                status.ToStr().c_str() );
+    return status;
+  }
+  if( !response )
+  {
+    const std::string error = "Token query returned no response.";
+    log->Error( AppMsg, "%s", error.c_str() );
+    return XRootDStatus( stError, errInvalidResponse, 0, error );
+  }
+
+  std::cout << response->ToString() << '\n';
+  return XRootDStatus();
+}
+
+//------------------------------------------------------------------------------
 // Query the server
 //------------------------------------------------------------------------------
 XRootDStatus DoPrepare( FileSystem                      *fs,
@@ -2192,6 +2476,19 @@ XRootDStatus PrintHelp( FileSystem *, Env *,
   printf( "   spaceinfo path\n"                                             );
   printf( "     Get space statistics for given path.\n\n"                   );
 
+  printf( "   token [-w|--write] [--validity minutes] [--issuer URL]\n"      );
+  printf( "         [--] <path> [activity ...]\n"                            );
+  printf( "     Request a token for a storage path.\n"                       );
+  printf( "     The storage endpoint must use HTTPS or DAVS.\n"              );
+  printf( "     -w|--write request write access; otherwise request read\n"    );
+  printf( "                access\n"                                        );
+  printf( "     --validity token validity in minutes (default: 60)\n"         );
+  printf( "     --issuer request through an explicit HTTPS or DAVS issuer;\n" );
+  printf( "              omit it to request directly from the storage\n"      );
+  printf( "              endpoint\n"                                         );
+  printf( "     -- stop option parsing, allowing a dash-prefixed path\n"      );
+  printf( "     Optional activities override the read/write defaults.\n\n"   );
+
   printf( "   xattr <path> <code> <params> \n"                              );
   printf( "     Operation on extended attributes. Codes:\n\n"               );
   printf( "     set   <attr>          Set extended attribute; <attr> is\n"  );
@@ -2229,6 +2526,7 @@ FSExecutor *CreateExecutor( const URL &url )
   executor->AddCommand( "cat",         DoCat        );
   executor->AddCommand( "tail",        DoTail       );
   executor->AddCommand( "spaceinfo",   DoSpaceInfo  );
+  executor->AddCommand( "token",       DoToken      );
   executor->AddCommand( "xattr",       DoXAttr      );
   return executor;
 }

--- a/src/XrdClHttp/CMakeLists.txt
+++ b/src/XrdClHttp/CMakeLists.txt
@@ -26,9 +26,11 @@ add_library(XrdClHttpObj OBJECT
   XrdClHttpOps.cc            XrdClHttpOps.hh
   XrdClHttpOpStat.cc
   XrdClHttpOpTape.cc
+  XrdClHttpOpToken.cc
   XrdClHttpOptionsCache.cc   XrdClHttpOptionsCache.hh
   XrdClHttpParseTimeout.cc   XrdClHttpParseTimeout.hh
   XrdClHttpTape.cc           XrdClHttpTape.hh
+  XrdClHttpToken.cc          XrdClHttpToken.hh
   XrdClHttpUtil.cc           XrdClHttpUtil.hh
                            XrdClHttpVerb.hh
   XrdClHttpWorker.hh

--- a/src/XrdClHttp/XrdClHttpFilesystem.cc
+++ b/src/XrdClHttp/XrdClHttpFilesystem.cc
@@ -22,13 +22,273 @@
 #include "XrdClHttpFilesystem.hh"
 #include "XrdClHttpOps.hh"
 #include "XrdClHttpResponses.hh"
+#include "XrdClHttpToken.hh"
 
 #include "XrdCl/XrdClAnyObject.hh"
 
 #include <cerrno>
+#include <chrono>
 #include <exception>
+#include <memory>
+#include <new>
 
 using namespace XrdClHttp;
+
+namespace {
+
+std::chrono::steady_clock::time_point
+TokenWorkflowExpiry(struct timespec timeout)
+{
+    // Match CurlOperation's zero-timeout default, but calculate it only once
+    // so discovery and all fallback requests share one operation deadline.
+    auto now = std::chrono::steady_clock::now();
+    if (timeout.tv_sec == 0 && timeout.tv_nsec == 0) {
+        return now + std::chrono::seconds(30);
+    }
+    return now + std::chrono::seconds(timeout.tv_sec) +
+        std::chrono::nanoseconds(timeout.tv_nsec);
+}
+
+struct TokenWorkflowQueueError {};
+struct TokenWorkflowExpired {};
+
+// Coordinate the issuer workflow without blocking a curl worker.  Each step is
+// a regular CurlTokenOp queued through the same worker pool as any other HTTP
+// filesystem request; this handler only interprets the step result and queues
+// its successor.
+class TokenIssuerWorkflow final
+    : public XrdCl::ResponseHandler,
+      public std::enable_shared_from_this<TokenIssuerWorkflow> {
+public:
+    TokenIssuerWorkflow(std::shared_ptr<HandlerQueue> queue,
+                        XrdCl::ResponseHandler *handler,
+                        std::string target_url, TokenRequest request,
+                        struct timespec timeout, XrdCl::Log *logger,
+                        CreateConnCalloutType callout)
+        : m_queue(std::move(queue)), m_handler(handler),
+          m_target_url(std::move(target_url)), m_request(std::move(request)),
+          m_expiry(TokenWorkflowExpiry(timeout)), m_logger(logger),
+          m_callout(callout)
+    {}
+
+    // Queue the first stage.  A false return means nothing was queued and the
+    // caller should return an immediate error without invoking the handler.
+    bool Start()
+    {
+        try {
+            BeginSciTokensDiscovery();
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+
+    void HandleResponse(XrdCl::XRootDStatus *status_raw,
+                        XrdCl::AnyObject *response_raw) override
+    {
+        std::unique_ptr<XrdCl::XRootDStatus> status(status_raw);
+        std::unique_ptr<XrdCl::AnyObject> response(response_raw);
+
+        try {
+            bool success = status && status->IsOK();
+            std::string value;
+            if (success) {
+                XrdCl::Buffer *buffer = nullptr;
+                if (response) response->Get(buffer);
+                if (buffer) {
+                    value = buffer->ToString();
+                } else {
+                    success = false;
+                }
+            }
+
+            switch (m_stage) {
+            case Stage::SciTokensDiscovery:
+                if (success) BeginSciTokensRequest(value);
+                else BeginOAuthDiscovery();
+                return;
+            case Stage::SciTokensRequest:
+                if (success) Finish(std::move(status), std::move(response));
+                else BeginOAuthDiscovery();
+                return;
+            case Stage::OAuthDiscovery:
+                if (success) BeginOAuthRequest(value);
+                else BeginOpenIdDiscovery();
+                return;
+            case Stage::OpenIdDiscovery:
+                if (success) BeginOAuthRequest(value);
+                else BeginDirectRequest();
+                return;
+            case Stage::OAuthRequest:
+            case Stage::DirectRequest:
+                if (success) {
+                    Finish(std::move(status), std::move(response));
+                } else if (status && !status->IsOK()) {
+                    Finish(std::move(status), std::move(response));
+                } else {
+                    FinishError(XrdCl::errInvalidResponse, 0,
+                                "Token request returned an invalid response");
+                }
+                return;
+            }
+        } catch (const TokenWorkflowExpired &) {
+            FinishError(XrdCl::errOperationExpired, 0,
+                        "Token issuer workflow expired");
+        } catch (...) {
+            FinishError(XrdCl::errOSError, 0,
+                        "Failed to queue the next token request stage");
+        }
+    }
+
+private:
+    enum class Stage {
+        SciTokensDiscovery,
+        SciTokensRequest,
+        OAuthDiscovery,
+        OpenIdDiscovery,
+        OAuthRequest,
+        DirectRequest
+    };
+
+    using HttpVerb = CurlOperation::HttpVerb;
+    using HeaderList = CurlOperation::HeaderList;
+
+    void Queue(Stage stage, const std::string &url, HttpVerb verb,
+               HeaderList headers, const std::string &body,
+               const std::string &response_key)
+    {
+        if (std::chrono::steady_clock::now() > m_expiry) {
+            throw TokenWorkflowExpired{};
+        }
+        m_stage = stage;
+        auto self = shared_from_this();
+        std::unique_ptr<CurlTokenOp> operation(new CurlTokenOp(
+            this, std::move(self), url, verb, std::move(headers), body,
+            response_key, m_expiry, m_logger, m_callout));
+        // Start() runs on the caller thread and follows the normal queue
+        // backpressure behavior. Successor stages run from a curl worker
+        // callback, where blocking behind a full queue could stall every
+        // worker.
+        if (m_first_stage) {
+            m_first_stage = false;
+            m_queue->Produce(std::move(operation));
+        } else if (!m_queue->TryProduce(std::move(operation))) {
+            if (std::chrono::steady_clock::now() > m_expiry) {
+                throw TokenWorkflowExpired{};
+            }
+            throw TokenWorkflowQueueError{};
+        }
+    }
+
+    void BeginSciTokensDiscovery()
+    {
+        std::string url;
+        if (!BuildOAuthAuthorizationServerUrl(m_request.issuer, url)) {
+            BeginOAuthDiscovery();
+            return;
+        }
+        Queue(Stage::SciTokensDiscovery, url, HttpVerb::GET, {}, {},
+              "token_endpoint");
+    }
+
+    void BeginSciTokensRequest(const std::string &endpoint)
+    {
+        std::string url;
+        if (!NormalizeTokenUrl(endpoint, url)) {
+            BeginOAuthDiscovery();
+            return;
+        }
+        Queue(Stage::SciTokensRequest, url, HttpVerb::POST,
+              {{"Content-Type", "application/x-www-form-urlencoded"},
+               {"Accept", "application/json"}},
+              BuildSciTokensRequest(), "access_token");
+    }
+
+    void BeginOAuthDiscovery()
+    {
+        std::string url;
+        if (!BuildOAuthAuthorizationServerUrl(m_request.issuer, url)) {
+            BeginOpenIdDiscovery();
+            return;
+        }
+        Queue(Stage::OAuthDiscovery, url, HttpVerb::GET, {}, {},
+              "token_endpoint");
+    }
+
+    void BeginOpenIdDiscovery()
+    {
+        std::string url;
+        if (!BuildOpenIdConfigurationUrl(m_request.issuer, url)) {
+            BeginDirectRequest();
+            return;
+        }
+        Queue(Stage::OpenIdDiscovery, url, HttpVerb::GET, {}, {},
+              "token_endpoint");
+    }
+
+    void BeginOAuthRequest(const std::string &endpoint)
+    {
+        std::string url;
+        std::string body;
+        std::string error;
+        if (!NormalizeTokenUrl(endpoint, url)) {
+            if (m_stage == Stage::OAuthDiscovery) {
+                BeginOpenIdDiscovery();
+            } else {
+                BeginDirectRequest();
+            }
+            return;
+        }
+        if (!BuildOAuthMacaroonRequest(m_request.path, m_request.validity,
+                                       m_request.activities, body, error)) {
+            FinishError(XrdCl::errInvalidArgs, 0, error);
+            return;
+        }
+        Queue(Stage::OAuthRequest, url, HttpVerb::POST,
+              {{"Content-Type", "application/x-www-form-urlencoded"},
+               {"Accept", "application/json"}},
+              body, "access_token");
+    }
+
+    void BeginDirectRequest()
+    {
+        Queue(Stage::DirectRequest, m_target_url, HttpVerb::POST,
+              {{"Content-Type", "application/macaroon-request"}},
+              BuildMacaroonRequest(m_request.validity,
+                                   m_request.activities),
+              "macaroon");
+    }
+
+    void Finish(std::unique_ptr<XrdCl::XRootDStatus> status,
+                std::unique_ptr<XrdCl::AnyObject> response)
+    {
+        auto handler = m_handler;
+        m_handler = nullptr;
+        if (handler) {
+            handler->HandleResponse(status.release(), response.release());
+        }
+    }
+
+    void FinishError(uint16_t err_code, uint32_t err_num,
+                     const std::string &message)
+    {
+        auto status = std::make_unique<XrdCl::XRootDStatus>(
+            XrdCl::stError, err_code, err_num, message);
+        Finish(std::move(status), {});
+    }
+
+    std::shared_ptr<HandlerQueue> m_queue;
+    XrdCl::ResponseHandler *m_handler{nullptr};
+    std::string m_target_url;
+    TokenRequest m_request;
+    std::chrono::steady_clock::time_point m_expiry;
+    XrdCl::Log *m_logger{nullptr};
+    CreateConnCalloutType m_callout{nullptr};
+    Stage m_stage{Stage::SciTokensDiscovery};
+    bool m_first_stage{true};
+};
+
+} // anonymous namespace
 
 Filesystem::Filesystem(const std::string &url, std::shared_ptr<HandlerQueue> queue, XrdCl::Log *log)
     : m_queue(queue),
@@ -239,6 +499,66 @@ XrdCl::XRootDStatus Filesystem::Query(XrdCl::QueryCode::Code  queryCode,
                 GetConnCallout(), queryCode,
                 m_header_callout.load(std::memory_order_acquire));
             description = "xattr query operation";
+            break;
+        }
+        case XrdCl::QueryCode::Visa:
+        {
+            std::size_t size = arg.GetSize();
+            if (size && arg.GetBuffer()[size - 1] == '\0') --size;
+            std::string input;
+            if (size) input.assign(arg.GetBuffer(), size);
+
+            TokenRequest request;
+            std::string error;
+            if (!ParseTokenRequest(input, request, error)) {
+                return XrdCl::XRootDStatus(
+                    XrdCl::stError, XrdCl::errInvalidArgs, 0, error
+                );
+            }
+
+            std::string target_url;
+            if (!NormalizeTokenUrl(GetCurrentURL(request.path), target_url)) {
+                return XrdCl::XRootDStatus(
+                    XrdCl::stError, XrdCl::errNotSupported, 0,
+                    "Token requests require an HTTPS or DAVS filesystem URL"
+                );
+            }
+
+            if (!request.issuer.empty()) {
+                std::string normalized_issuer;
+                if (!NormalizeTokenUrl(request.issuer, normalized_issuer)) {
+                    return XrdCl::XRootDStatus(
+                        XrdCl::stError, XrdCl::errNotSupported, 0,
+                        "Token issuers require an HTTPS or DAVS URL"
+                    );
+                }
+                std::string discovery_url;
+                if (!BuildOAuthAuthorizationServerUrl(request.issuer,
+                                                      discovery_url)) {
+                    return XrdCl::XRootDStatus(
+                        XrdCl::stError, XrdCl::errInvalidArgs, 0,
+                        "Invalid token issuer URL"
+                    );
+                }
+                auto workflow = std::make_shared<TokenIssuerWorkflow>(
+                    m_queue, handler, target_url, std::move(request), ts,
+                    m_logger, GetConnCallout());
+                if (!workflow->Start()) {
+                    m_logger->Warning(kLogXrdClHttp,
+                        "Failed to add issuer token workflow to queue");
+                    return XrdCl::XRootDStatus(XrdCl::stError,
+                                               XrdCl::errOSError);
+                }
+                return XrdCl::XRootDStatus();
+            }
+
+            operation = std::make_unique<CurlTokenOp>(
+                handler, target_url,
+                BuildMacaroonRequest(request.validity,
+                                     request.activities),
+                ts, m_logger, GetConnCallout()
+            );
+            description = "token operation";
             break;
         }
         default:

--- a/src/XrdClHttp/XrdClHttpOpToken.cc
+++ b/src/XrdClHttp/XrdClHttpOpToken.cc
@@ -1,0 +1,194 @@
+/******************************************************************************/
+/* Copyright (C) 2026 by European Organization for Nuclear Research (CERN)   */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/******************************************************************************/
+
+#include "XrdClHttpOps.hh"
+#include "XrdClHttpToken.hh"
+
+#include <XrdCl/XrdClFileSystem.hh>
+#include <XrdCl/XrdClLog.hh>
+
+#include <limits>
+#include <utility>
+
+using namespace XrdClHttp;
+
+CurlTokenOp::CurlTokenOp(XrdCl::ResponseHandler *handler,
+                         std::shared_ptr<XrdCl::ResponseHandler> handler_owner,
+                         const std::string &url,
+                         HttpVerb verb,
+                         HeaderList headers,
+                         const std::string &request_body,
+                         const std::string &response_key,
+                         struct timespec timeout, XrdCl::Log *logger,
+                         CreateConnCalloutType callout)
+    : CurlOperation(handler, url, timeout, logger, callout, nullptr),
+      m_handler_owner(std::move(handler_owner)),
+      m_verb(verb),
+      m_request_body(request_body),
+      m_response_key(response_key)
+{
+    m_operation_expiry = m_header_expiry;
+    m_headers_list = std::move(headers);
+}
+
+CurlTokenOp::CurlTokenOp(XrdCl::ResponseHandler *handler,
+                         std::shared_ptr<XrdCl::ResponseHandler> handler_owner,
+                         const std::string &url,
+                         HttpVerb verb,
+                         HeaderList headers,
+                         const std::string &request_body,
+                         const std::string &response_key,
+                         std::chrono::steady_clock::time_point expiry,
+                         XrdCl::Log *logger,
+                         CreateConnCalloutType callout)
+    : CurlOperation(handler, url, expiry, logger, callout, nullptr),
+      m_handler_owner(std::move(handler_owner)),
+      m_verb(verb),
+      m_request_body(request_body),
+      m_response_key(response_key)
+{
+    m_operation_expiry = m_header_expiry;
+    m_headers_list = std::move(headers);
+}
+
+CurlTokenOp::CurlTokenOp(XrdCl::ResponseHandler *handler,
+                         const std::string &url,
+                         const std::string &request_body,
+                         struct timespec timeout, XrdCl::Log *logger,
+                         CreateConnCalloutType callout)
+    : CurlTokenOp(handler, {}, url, HttpVerb::POST,
+          {{"Content-Type", "application/macaroon-request"}}, request_body,
+          "macaroon", timeout, logger, callout)
+{
+}
+
+bool
+CurlTokenOp::Setup(CURL *curl, CurlWorker &worker)
+{
+    if (!CurlOperation::Setup(curl, worker)) return false;
+
+    if (m_verb == HttpVerb::POST) {
+        curl_easy_setopt(m_curl.get(), CURLOPT_POST, 1L);
+        curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDS,
+                         m_request_body.data());
+        curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDSIZE_LARGE,
+                         static_cast<curl_off_t>(m_request_body.size()));
+    } else if (m_verb == HttpVerb::GET) {
+        // Set this explicitly: handles are pooled and a prior user may have
+        // configured a request body.
+        curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDS, nullptr);
+        curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDSIZE_LARGE,
+                         static_cast<curl_off_t>(-1));
+        curl_easy_setopt(m_curl.get(), CURLOPT_HTTPGET, 1L);
+    } else {
+        Fail(XrdCl::errInternal, 0,
+             "Unsupported HTTP verb for token request");
+        return false;
+    }
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION,
+                     CurlTokenOp::WriteCallback);
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, this);
+    return true;
+}
+
+void
+CurlTokenOp::ReleaseHandle()
+{
+    if (m_curl == nullptr) return;
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDS, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_POSTFIELDSIZE_LARGE,
+                     static_cast<curl_off_t>(-1));
+    // CURLOPT_POSTFIELDS selects POST even when its value is null.  Restore a
+    // neutral GET state last so a pooled handle cannot turn a later read into
+    // an empty POST.
+    curl_easy_setopt(m_curl.get(), CURLOPT_HTTPGET, 1L);
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEFUNCTION, nullptr);
+    curl_easy_setopt(m_curl.get(), CURLOPT_WRITEDATA, nullptr);
+    CurlOperation::ReleaseHandle();
+}
+
+CurlOperation::RedirectAction
+CurlTokenOp::Redirect(std::string &target)
+{
+    auto action = CurlOperation::Redirect(target);
+    if (action == RedirectAction::Fail) return action;
+
+    std::string normalized;
+    if (!NormalizeTokenUrl(target, normalized)) {
+        Fail(XrdCl::errErrorResponse, kXR_ServerError,
+             "Refusing to redirect a token request to a non-HTTPS URL");
+        return RedirectAction::Fail;
+    }
+
+    target = std::move(normalized);
+    curl_easy_setopt(m_curl.get(), CURLOPT_URL, target.c_str());
+    m_response.clear();
+    return action;
+}
+
+void
+CurlTokenOp::Success()
+{
+    if (GetStatusCode() != 200) {
+        Fail(XrdCl::errErrorResponse, kXR_ServerError,
+             "Token endpoint returned an unexpected HTTP status");
+        return;
+    }
+
+    std::string value;
+    std::string error;
+    if (!ParseJsonStringResponse(m_response, m_response_key, value, error)) {
+        Fail(XrdCl::errErrorResponse, kXR_ServerError, error);
+        return;
+    }
+
+    SetDone(false);
+    if (m_handler == nullptr) return;
+
+    auto response = new XrdCl::Buffer();
+    response->FromString(value);
+    auto object = new XrdCl::AnyObject();
+    object->Set(response);
+
+    auto handler = m_handler;
+    m_handler = nullptr;
+    handler->HandleResponse(new XrdCl::XRootDStatus(), object);
+}
+
+size_t
+CurlTokenOp::WriteCallback(char *buffer, size_t size, size_t nitems,
+                           void *this_ptr)
+{
+    auto operation = static_cast<CurlTokenOp *>(this_ptr);
+    if (size != 0 && nitems > std::numeric_limits<size_t>::max() / size) {
+        return operation->FailCallback(kXR_ServerError,
+            "Token response exceeds maximum size");
+    }
+    return operation->Write(buffer, size * nitems);
+}
+
+size_t
+CurlTokenOp::Write(const char *buffer, size_t length)
+{
+    UpdateBytes(length);
+    if (length >= kMaxTokenResponseSize ||
+        m_response.size() >= kMaxTokenResponseSize - length) {
+        return FailCallback(kXR_ServerError,
+                            "Token response exceeds maximum size");
+    }
+    m_response.append(buffer, length);
+    return length;
+}

--- a/src/XrdClHttp/XrdClHttpOps.hh
+++ b/src/XrdClHttp/XrdClHttpOps.hh
@@ -657,6 +657,51 @@ public:
         CreateConnCalloutType callout, HeaderCallout *header_callout);
 };
 
+// Perform a bounded HTTPS token request and extract one string from its JSON
+// response.  Token discovery uses GET while token issuance uses POST; keeping
+// both in the same operation ensures they share the redirect and response-body
+// safety rules.
+class CurlTokenOp final : public CurlOperation {
+public:
+    CurlTokenOp(XrdCl::ResponseHandler *handler,
+        std::shared_ptr<XrdCl::ResponseHandler> handler_owner,
+        const std::string &url, HttpVerb verb, HeaderList headers,
+        const std::string &request_body, const std::string &response_key,
+        struct timespec timeout, XrdCl::Log *log,
+        CreateConnCalloutType callout);
+
+    CurlTokenOp(XrdCl::ResponseHandler *handler,
+        std::shared_ptr<XrdCl::ResponseHandler> handler_owner,
+        const std::string &url, HttpVerb verb, HeaderList headers,
+        const std::string &request_body, const std::string &response_key,
+        std::chrono::steady_clock::time_point expiry, XrdCl::Log *log,
+        CreateConnCalloutType callout);
+
+    // Convenience constructor for the direct storage macaroon workflow.
+    CurlTokenOp(XrdCl::ResponseHandler *handler, const std::string &url,
+        const std::string &request_body, struct timespec timeout,
+        XrdCl::Log *log, CreateConnCalloutType callout);
+
+    virtual ~CurlTokenOp() {}
+
+    bool Setup(CURL *curl, CurlWorker &) override;
+    void Success() override;
+    void ReleaseHandle() override;
+    RedirectAction Redirect(std::string &target) override;
+
+    virtual HttpVerb GetVerb() const override {return m_verb;}
+
+private:
+    static size_t WriteCallback(char *buffer, size_t size, size_t nitems,
+                                void *this_ptr);
+    size_t Write(const char *buffer, size_t length);
+
+    std::shared_ptr<XrdCl::ResponseHandler> m_handler_owner;
+    HttpVerb m_verb;
+    std::string m_request_body;
+    std::string m_response_key;
+    std::string m_response;
+};
 class CurlReadOp : public CurlOperation {
 public:
     CurlReadOp(XrdCl::ResponseHandler *handler, std::shared_ptr<XrdCl::ResponseHandler> default_handler,

--- a/src/XrdClHttp/XrdClHttpToken.cc
+++ b/src/XrdClHttp/XrdClHttpToken.cc
@@ -1,0 +1,388 @@
+/******************************************************************************/
+/* Copyright (C) 2026 by European Organization for Nuclear Research (CERN)   */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/******************************************************************************/
+
+#include "XrdClHttpToken.hh"
+
+#include <XrdOuc/XrdOucJson.hh>
+
+#include <limits>
+
+namespace {
+
+const std::vector<std::string> &DefaultActivities(bool write)
+{
+    static const std::vector<std::string> read{"LIST", "DOWNLOAD"};
+    static const std::vector<std::string> write_access{
+        "LIST", "DOWNLOAD", "MANAGE", "UPLOAD", "DELETE"
+    };
+    return write ? write_access : read;
+}
+
+bool ValidPort(std::string_view port)
+{
+    if (port.empty()) return false;
+    unsigned int value = 0;
+    for (char character : port) {
+        if (character < '0' || character > '9') return false;
+        value = value * 10 + static_cast<unsigned int>(character - '0');
+        if (value > 65535) return false;
+    }
+    return true;
+}
+
+bool ParseIssuerUrl(std::string_view issuer, std::string &authority,
+                    std::string &path)
+{
+    authority.clear();
+    path.clear();
+
+    std::string normalized;
+    if (!XrdClHttp::NormalizeTokenUrl(issuer, normalized)) return false;
+
+    constexpr std::string_view prefix{"https://"};
+    auto authority_end = normalized.find_first_of("/?#", prefix.size());
+    if (authority_end == std::string::npos) authority_end = normalized.size();
+    auto authority_view = std::string_view(normalized).substr(
+        prefix.size(), authority_end - prefix.size());
+
+    // Never forward embedded credentials to a discovery endpoint. Query and
+    // fragment components are not part of either discovery URL and are
+    // intentionally omitted, matching gfal2's URL transformation.
+    if (authority_view.find('@') != std::string_view::npos) return false;
+
+    authority.assign(prefix);
+    authority.append(authority_view);
+    if (authority_end < normalized.size() &&
+        normalized[authority_end] == '/') {
+        auto path_end = normalized.find_first_of("?#", authority_end);
+        path = normalized.substr(authority_end, path_end - authority_end);
+    }
+    return true;
+}
+
+std::string PercentEncode(std::string_view input)
+{
+    static constexpr char hex[] = "0123456789ABCDEF";
+    std::string encoded;
+    encoded.reserve(input.size());
+    for (unsigned char byte : input) {
+        if ((byte >= 'a' && byte <= 'z') ||
+            (byte >= 'A' && byte <= 'Z') ||
+            (byte >= '0' && byte <= '9') || byte == '-' || byte == '.' ||
+            byte == '_' || byte == '~') {
+            encoded += static_cast<char>(byte);
+        } else {
+            encoded += '%';
+            encoded += hex[byte >> 4];
+            encoded += hex[byte & 0x0f];
+        }
+    }
+    return encoded;
+}
+
+} // namespace
+
+bool
+XrdClHttp::NormalizeTokenUrl(std::string_view input, std::string &https_url)
+{
+    https_url.clear();
+    auto separator = input.find("://");
+    if (separator == std::string_view::npos) {
+        return false;
+    }
+    auto scheme = input.substr(0, separator);
+    std::string lowered_scheme;
+    lowered_scheme.reserve(scheme.size());
+    for (char value : scheme) {
+        lowered_scheme += value >= 'A' && value <= 'Z'
+            ? static_cast<char>(value - 'A' + 'a') : value;
+    }
+    if (lowered_scheme != "https" && lowered_scheme != "davs") return false;
+
+    auto authority_start = separator + 3;
+    https_url = "https://";
+    https_url.append(input.substr(authority_start));
+
+    auto authority_end = input.find_first_of("/?#", authority_start);
+    if (authority_end == std::string_view::npos) authority_end = input.size();
+    auto authority = input.substr(authority_start,
+                                  authority_end - authority_start);
+    auto userinfo_end = authority.rfind('@');
+    auto host_port = userinfo_end == std::string_view::npos
+        ? authority : authority.substr(userinfo_end + 1);
+    if (host_port.empty()) {
+        https_url.clear();
+        return false;
+    }
+
+    std::string_view host;
+    if (host_port.front() == '[') {
+        auto bracket = host_port.find(']');
+        if (bracket == std::string_view::npos) {
+            https_url.clear();
+            return false;
+        }
+        host = host_port.substr(1, bracket - 1);
+        auto remainder = host_port.substr(bracket + 1);
+        if (!remainder.empty() &&
+            (remainder.front() != ':' || !ValidPort(remainder.substr(1)))) {
+            https_url.clear();
+            return false;
+        }
+    } else {
+        auto colon = host_port.rfind(':');
+        if (colon != std::string_view::npos &&
+            host_port.find(':') != colon) {
+            https_url.clear();
+            return false;
+        }
+        host = colon == std::string_view::npos
+            ? host_port : host_port.substr(0, colon);
+        if (colon != std::string_view::npos &&
+            !ValidPort(host_port.substr(colon + 1))) {
+            https_url.clear();
+            return false;
+        }
+    }
+    if (host.empty()) {
+        https_url.clear();
+        return false;
+    }
+
+    for (char value : input) {
+        auto byte = static_cast<unsigned char>(value);
+        if (byte <= 0x20 || byte == 0x7f) {
+            https_url.clear();
+            return false;
+        }
+    }
+    return true;
+}
+
+bool
+XrdClHttp::ParseTokenRequest(std::string_view input, TokenRequest &request,
+                             std::string &error)
+{
+    error.clear();
+    request = TokenRequest{};
+
+    auto parsed = nlohmann::json::parse(input.begin(), input.end(), nullptr,
+                                        false);
+    if (parsed.is_discarded() || !parsed.is_object()) {
+        error = "Token query must be a valid JSON object";
+        return false;
+    }
+
+    auto path = parsed.find("path");
+    if (path == parsed.end() || !path->is_string() ||
+        path->get_ref<const std::string &>().empty() ||
+        path->get_ref<const std::string &>().front() != '/') {
+        error = "Token query requires a non-empty absolute string 'path'";
+        return false;
+    }
+    request.path = path->get<std::string>();
+
+    auto issuer = parsed.find("issuer");
+    if (issuer != parsed.end()) {
+        if (!issuer->is_string() ||
+            issuer->get_ref<const std::string &>().empty()) {
+            error = "Token query 'issuer' must be a non-empty string";
+            return false;
+        }
+        request.issuer = issuer->get<std::string>();
+    }
+
+    auto validity = parsed.find("validity");
+    if (validity != parsed.end()) {
+        if (!validity->is_number_integer()) {
+            error = "Token query 'validity' must be a nonnegative integer";
+            return false;
+        }
+        if (validity->is_number_unsigned()) {
+            request.validity = validity->get<std::uint64_t>();
+        } else {
+            auto signed_validity = validity->get<std::int64_t>();
+            if (signed_validity < 0) {
+                error = "Token query 'validity' must be a nonnegative integer";
+                return false;
+            }
+            request.validity = static_cast<std::uint64_t>(signed_validity);
+        }
+    }
+
+    auto write = parsed.find("write");
+    if (write != parsed.end()) {
+        if (!write->is_boolean()) {
+            error = "Token query 'write' must be a boolean";
+            return false;
+        }
+        request.write = write->get<bool>();
+    }
+
+    auto activities = parsed.find("activities");
+    if (activities != parsed.end()) {
+        if (!activities->is_array()) {
+            error = "Token query 'activities' must be an array of strings";
+            return false;
+        }
+        for (const auto &activity : *activities) {
+            if (!activity.is_string() ||
+                activity.get_ref<const std::string &>().empty()) {
+                error = "Token query 'activities' must contain non-empty strings";
+                return false;
+            }
+            request.activities.emplace_back(activity.get<std::string>());
+        }
+    }
+
+    if (request.activities.empty()) {
+        request.activities = DefaultActivities(request.write);
+    }
+    return true;
+}
+
+bool
+XrdClHttp::BuildOAuthAuthorizationServerUrl(std::string_view issuer,
+                                            std::string &url)
+{
+    url.clear();
+    std::string authority;
+    std::string path;
+    if (!ParseIssuerUrl(issuer, authority, path)) return false;
+
+    url = authority + "/.well-known/oauth-authorization-server";
+    if (!path.empty() && path != "/") url += path;
+    return true;
+}
+
+bool
+XrdClHttp::BuildOpenIdConfigurationUrl(std::string_view issuer,
+                                       std::string &url)
+{
+    url.clear();
+    std::string authority;
+    std::string path;
+    if (!ParseIssuerUrl(issuer, authority, path)) return false;
+
+    if (path.empty()) path = "/";
+    if (path.back() != '/') path += '/';
+    url = authority + path + ".well-known/openid-configuration";
+    return true;
+}
+
+std::string
+XrdClHttp::BuildMacaroonRequest(
+    std::uint64_t validity, const std::vector<std::string> &activities)
+{
+    std::string caveat = "activity:";
+    bool first = true;
+    for (const auto &activity : activities) {
+        if (!first) caveat += ',';
+        caveat += activity;
+        first = false;
+    }
+
+    // Use the JSON serializer for the user-provided caveat while retaining the
+    // exact whitespace and member order used by gfal2.
+    return "{\"caveats\": [" + nlohmann::json(caveat).dump() +
+        "], \"validity\": \"PT" + std::to_string(validity) + "M\"}";
+}
+
+std::string
+XrdClHttp::BuildSciTokensRequest()
+{
+    return "grant_type=client_credentials";
+}
+
+bool
+XrdClHttp::BuildOAuthMacaroonRequest(
+    std::string_view path, std::uint64_t validity,
+    const std::vector<std::string> &activities, std::string &body,
+    std::string &error)
+{
+    body.clear();
+    error.clear();
+
+    auto path_end = path.find_first_of("?#");
+    auto scope_path = path.substr(0, path_end);
+    if (scope_path.empty() || scope_path.front() != '/') {
+        error = "OAuth macaroon scope requires an absolute path";
+        return false;
+    }
+    if (validity > std::numeric_limits<std::uint64_t>::max() / 60) {
+        error = "Token validity is too large to convert to seconds";
+        return false;
+    }
+
+    std::string scopes;
+    bool first = true;
+    for (const auto &activity : activities) {
+        if (!first) scopes += ' ';
+        scopes += activity;
+        scopes += ':';
+        scopes.append(scope_path);
+        first = false;
+    }
+
+    body = "grant_type=client_credentials&expire_in=" +
+        std::to_string(validity * 60) + "&scopes=" + PercentEncode(scopes);
+    return true;
+}
+
+bool
+XrdClHttp::ParseJsonStringResponse(std::string_view input,
+                                   std::string_view key, std::string &value,
+                                   std::string &error)
+{
+    value.clear();
+    error.clear();
+    if (input.size() >= kMaxTokenResponseSize) {
+        error = "Token response exceeds maximum size";
+        return false;
+    }
+    if (input.empty()) {
+        error = "Token response contained no data";
+        return false;
+    }
+    if (key.empty()) {
+        error = "Token response key must not be empty";
+        return false;
+    }
+
+    auto parsed = nlohmann::json::parse(input.begin(), input.end(), nullptr,
+                                        false);
+    if (parsed.is_discarded() || !parsed.is_object()) {
+        error = "Token response was not valid JSON";
+        return false;
+    }
+
+    auto member = parsed.find(std::string(key));
+    if (member == parsed.end() || !member->is_string() ||
+        member->get_ref<const std::string &>().empty()) {
+        error = "Token response did not include a non-empty string '" +
+            std::string(key) + "'";
+        return false;
+    }
+    value = member->get<std::string>();
+    return true;
+}
+
+bool
+XrdClHttp::ParseMacaroonResponse(std::string_view input, std::string &token,
+                                 std::string &error)
+{
+    return ParseJsonStringResponse(input, "macaroon", token, error);
+}

--- a/src/XrdClHttp/XrdClHttpToken.hh
+++ b/src/XrdClHttp/XrdClHttpToken.hh
@@ -1,0 +1,78 @@
+/******************************************************************************/
+/* Copyright (C) 2026 by European Organization for Nuclear Research (CERN)   */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/******************************************************************************/
+
+#ifndef XRDCLHTTP_TOKEN_HH
+#define XRDCLHTTP_TOKEN_HH
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace XrdClHttp {
+
+constexpr std::size_t kMaxTokenResponseSize = 1024 * 1024;
+
+struct TokenRequest {
+    std::string path;
+    std::string issuer;
+    std::uint64_t validity{60};
+    bool write{false};
+    std::vector<std::string> activities;
+};
+
+// Accept HTTPS and DAVS URLs only, normalizing DAVS to HTTPS.
+bool NormalizeTokenUrl(std::string_view input, std::string &https_url);
+
+// Parse the QueryCode::Visa argument and apply the default activities when the
+// caller did not provide any.
+bool ParseTokenRequest(std::string_view input, TokenRequest &request,
+                       std::string &error);
+
+// Construct the RFC 8414 and OpenID Connect discovery URLs for an HTTPS
+// issuer. DAVS issuers are normalized to HTTPS, query and fragment components
+// are omitted, and issuer URLs containing credentials are rejected.
+bool BuildOAuthAuthorizationServerUrl(std::string_view issuer,
+                                      std::string &url);
+bool BuildOpenIdConfigurationUrl(std::string_view issuer, std::string &url);
+
+// Construct the byte-for-byte request format emitted by gfal2 for a direct
+// storage-element macaroon request.
+std::string BuildMacaroonRequest(
+    std::uint64_t validity, const std::vector<std::string> &activities);
+
+// Construct the form bodies used by SciTokens and OAuth-style macaroon token
+// endpoints. The OAuth helper rejects validity values which cannot be safely
+// converted from minutes to seconds.
+std::string BuildSciTokensRequest();
+bool BuildOAuthMacaroonRequest(
+    std::string_view path, std::uint64_t validity,
+    const std::vector<std::string> &activities, std::string &body,
+    std::string &error);
+
+// Extract a non-empty string member from a bounded JSON response without
+// exposing response contents in diagnostics.
+bool ParseJsonStringResponse(std::string_view input, std::string_view key,
+                             std::string &value, std::string &error);
+
+// Extract a macaroon without exposing the response contents in diagnostics.
+bool ParseMacaroonResponse(std::string_view input, std::string &token,
+                           std::string &error);
+
+} // namespace XrdClHttp
+
+#endif // XRDCLHTTP_TOKEN_HH

--- a/src/XrdClHttp/XrdClHttpUtil.cc
+++ b/src/XrdClHttp/XrdClHttpUtil.cc
@@ -922,6 +922,46 @@ HandlerQueue::Produce(std::shared_ptr<CurlOperation> handler)
     m_ops_produced.fetch_add(1, std::memory_order_relaxed);
 }
 
+bool
+HandlerQueue::TryProduce(std::shared_ptr<CurlOperation> handler)
+{
+    const auto handler_expiry = handler->GetOperationExpiry();
+    std::unique_lock<std::mutex> lk{m_mutex};
+    if (m_shutdown || m_ops.size() >= m_max_pending_ops ||
+        std::chrono::steady_clock::now() > handler_expiry) {
+        m_ops_rejected.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    try {
+        m_ops.push_back(std::move(handler));
+    } catch (...) {
+        m_ops_rejected.fetch_add(1, std::memory_order_relaxed);
+        return false;
+    }
+
+    char ready[] = "1";
+    while (true) {
+        auto result = write(m_write_fd, ready, 1);
+        if (result == -1) {
+            if (errno == EINTR) {
+                continue;
+            }
+            if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                m_ops.pop_back();
+                m_ops_rejected.fetch_add(1, std::memory_order_relaxed);
+                return false;
+            }
+        }
+        break;
+    }
+
+    lk.unlock();
+    m_consumer_cv.notify_one();
+    m_ops_produced.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
 std::shared_ptr<CurlOperation>
 HandlerQueue::Consume(std::chrono::steady_clock::duration dur)
 {

--- a/src/XrdClHttp/XrdClHttpUtil.hh
+++ b/src/XrdClHttp/XrdClHttpUtil.hh
@@ -194,6 +194,11 @@ public:
 
     void Produce(std::shared_ptr<CurlOperation> handler);
 
+    // Enqueue without waiting for capacity.  This is intended for operations
+    // submitted by a curl worker callback, where waiting for another worker to
+    // drain a full queue can stall the entire worker pool.
+    bool TryProduce(std::shared_ptr<CurlOperation> handler);
+
     std::shared_ptr<CurlOperation> Consume(std::chrono::steady_clock::duration);
     std::shared_ptr<CurlOperation> TryConsume();
 

--- a/src/XrdMacaroons/XrdMacaroonsHandler.cc
+++ b/src/XrdMacaroons/XrdMacaroonsHandler.cc
@@ -30,7 +30,7 @@ char *unquote(const char *str) {
 
     if (str[i] == '%') {
       char savec[3];
-      if (l <= i + 3) {
+      if (l < i + 3) {
         free(r);
         return nullptr;
       }
@@ -220,7 +220,7 @@ int Handler::ProcessTokenRequest(XrdHttpExtReq &req)
             if ((validity = std::strtoll(value.c_str(), nullptr, 10)) <= 0)
                 return req.SendSimpleResp(400, nullptr, nullptr, "Expiration request has invalid value.", 0);
         }
-        else if (key == "scope")
+        else if (key == "scope" || key == "scopes")
         {
             char *value_raw = unquote(value.c_str());
             if (value_raw == nullptr)

--- a/tests/XRootD/macaroons.sh
+++ b/tests/XRootD/macaroons.sh
@@ -3,11 +3,27 @@
 X509_CERT_DIR="${BINARY_DIR}/tests/tls"
 X509_USER_KEY="${X509_CERT_DIR}/client.key"
 X509_USER_CERT="${X509_CERT_DIR}/client.crt"
+XRD_HTTPCLIENTKEYFILE="${X509_USER_KEY}"
+XRD_HTTPCLIENTCERTFILE="${X509_USER_CERT}"
+MACAROONS_PLUGINCONFDIR="${PWD}/macaroons/client.plugins.d"
+TOKEN_ISSUER_PORT=15044
+TOKEN_ISSUER_HOST="https://localhost:${TOKEN_ISSUER_PORT}"
+TOKEN_ISSUER_DAVS_HOST="davs://localhost:${TOKEN_ISSUER_PORT}"
+TOKEN_ISSUER_TRACE="${PWD}/macaroons/token-issuer-trace.jsonl"
+TOKEN_ISSUER_LOG="${PWD}/macaroons/token-issuer.log"
 
 export XrdSecPROTOCOL X509_CERT_DIR X509_USER_KEY X509_USER_CERT
+export XRD_HTTPCLIENTKEYFILE XRD_HTTPCLIENTCERTFILE
 
 function setup_macaroons() {
-	require_commands curl jq openssl
+	require_commands curl jq openssl python3
+
+	mkdir -p "${MACAROONS_PLUGINCONFDIR}"
+	cat >| "${MACAROONS_PLUGINCONFDIR}/http.conf" <<-EOF
+	url = http://*;https://*;dav://*;davs://*
+	lib = libXrdClHttp.so
+	enable = true
+	EOF
 
 	cat >| macaroons.authdb <<-EOF
 	u client /rw a
@@ -29,10 +45,148 @@ function setup_macaroons() {
 	mkdir "${REMOTE_DIR}/rw"
 
 	openssl rand -base64 -out macaroons.secret 64
+
+	: > "${TOKEN_ISSUER_TRACE}"
+	python3 "${SOURCE_DIR}/token_issuer_mock.py" \
+		--bind 127.0.0.1 --port "${TOKEN_ISSUER_PORT}" \
+		--cert "${X509_CERT_DIR}/host.pem" \
+		--key "${X509_CERT_DIR}/host.key" \
+		--trace-file "${TOKEN_ISSUER_TRACE}" \
+		> "${TOKEN_ISSUER_LOG}" 2>&1 &
+	echo "$!" > "${PWD}/macaroons/token-issuer.pid"
+
+	local attempt
+	for ((attempt = 0; attempt < 50; ++attempt)); do
+		if curl -sf --capath "${X509_CERT_DIR}" \
+			"${TOKEN_ISSUER_HOST}/healthz" >/dev/null; then
+			return
+		fi
+		if ! kill -0 "$(cat "${PWD}/macaroons/token-issuer.pid")" 2>/dev/null; then
+			break
+		fi
+		sleep 0.1
+	done
+
+	cat "${TOKEN_ISSUER_LOG}" >&2
+	error "token issuer mock did not become ready"
 }
 
 function teardown_macaroons() {
 	rm macaroons.{authdb,gridmap,secret}
+	rm -f "${MACAROONS_PLUGINCONFDIR}/http.conf"
+	rmdir "${MACAROONS_PLUGINCONFDIR}"
+}
+
+function reset_token_issuer_trace() {
+	: > "${TOKEN_ISSUER_TRACE}"
+}
+
+function assert_token_issuer_trace() {
+	local expected="$1"
+	local actual
+	actual=$(jq -cs \
+		'map({method, url, content_type, accept, body})' \
+		"${TOKEN_ISSUER_TRACE}") || \
+		error "failed to parse token issuer trace"
+
+	if [[ "${actual}" != "${expected}" ]]; then
+		echo "expected token issuer trace: ${expected}" >&2
+		echo "actual token issuer trace:   ${actual}" >&2
+		error "token issuer workflow did not make the expected requests"
+	fi
+}
+
+function test_token_issuer_workflows() {
+	local response expected
+
+	# A successful SciTokens endpoint completes after one discovery request and
+	# one scope-free client-credentials POST.
+	reset_token_issuer_trace
+	response=$(xrdfs token --issuer "${TOKEN_ISSUER_HOST}/sci-success" \
+		"${TOKEN_ISSUER_HOST}/storage/sci-object")
+	assert_eq "sci-token" "${response}" \
+		"SciTokens issuer returned an unexpected token"
+	expected='['
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/sci-success","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/token/sci-success","content_type":"application/x-www-form-urlencoded","accept":"application/json","body":"grant_type=client_credentials"}'
+	expected+=']'
+	assert_token_issuer_trace "${expected}"
+
+	# If the SciTokens POST fails, gfal2 repeats RFC 8414 discovery before
+	# making the scoped OAuth macaroon request. Use DAVS for the issuer to also
+	# verify that it is normalized to HTTPS.
+	reset_token_issuer_trace
+	response=$(xrdfs token --issuer \
+		"${TOKEN_ISSUER_DAVS_HOST}/oauth-success" --validity 2 \
+		"${TOKEN_ISSUER_HOST}/storage/oauth-object?opaque=ignored")
+	assert_eq "oauth-token" "${response}" \
+		"OAuth macaroon issuer returned an unexpected token"
+	expected='['
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/oauth-success","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/token/oauth-success","content_type":"application/x-www-form-urlencoded","accept":"application/json","body":"grant_type=client_credentials"},'
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/oauth-success","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/token/oauth-success","content_type":"application/x-www-form-urlencoded","accept":"application/json","body":"grant_type=client_credentials&expire_in=120&scopes=LIST%3A%2Fstorage%2Foauth-object%20DOWNLOAD%3A%2Fstorage%2Foauth-object"}'
+	expected+=']'
+	assert_token_issuer_trace "${expected}"
+
+	# Both RFC 8414 attempts fail here. The OpenID discovery URL succeeds and
+	# its endpoint receives the OAuth macaroon request.
+	reset_token_issuer_trace
+	response=$(xrdfs token --issuer \
+		"${TOKEN_ISSUER_HOST}/openid-success" \
+		"${TOKEN_ISSUER_HOST}/storage/openid-object")
+	assert_eq "openid-token" "${response}" \
+		"OpenID fallback returned an unexpected token"
+	expected='['
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/openid-success","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/openid-success","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"GET","url":"https://localhost:15044/openid-success/.well-known/openid-configuration","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/token/openid-success","content_type":"application/x-www-form-urlencoded","accept":"application/json","body":"grant_type=client_credentials&expire_in=3600&scopes=LIST%3A%2Fstorage%2Fopenid-object%20DOWNLOAD%3A%2Fstorage%2Fopenid-object"}'
+	expected+=']'
+	assert_token_issuer_trace "${expected}"
+
+	# Direct storage issuance is attempted only after both RFC 8414 requests
+	# and OpenID discovery fail.
+	reset_token_issuer_trace
+	response=$(xrdfs token --issuer \
+		"${TOKEN_ISSUER_HOST}/direct-fallback" \
+		"${TOKEN_ISSUER_HOST}/storage/direct-object?opaque=ignored")
+	assert_eq "direct-token" "${response}" \
+		"direct issuer fallback returned an unexpected token"
+	expected='['
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/direct-fallback","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/direct-fallback","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"GET","url":"https://localhost:15044/direct-fallback/.well-known/openid-configuration","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/storage/direct-object?opaque=ignored","content_type":"application/macaroon-request","accept":"*/*","body":"{\"caveats\": [\"activity:LIST,DOWNLOAD\"], \"validity\": \"PT60M\"}"}'
+	expected+=']'
+	assert_token_issuer_trace "${expected}"
+
+	# Once discovery returns a usable OAuth endpoint, failure of its scoped POST
+	# is terminal. In particular, the target storage URL must not be contacted.
+	reset_token_issuer_trace
+	assert_failure xrdfs token --issuer \
+		"${TOKEN_ISSUER_HOST}/oauth-failure" \
+		"${TOKEN_ISSUER_HOST}/storage/must-not-be-called"
+	expected='['
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/oauth-failure","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/token/oauth-failure","content_type":"application/x-www-form-urlencoded","accept":"application/json","body":"grant_type=client_credentials"},'
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/oauth-failure","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"POST","url":"https://localhost:15044/token/oauth-failure","content_type":"application/x-www-form-urlencoded","accept":"application/json","body":"grant_type=client_credentials&expire_in=3600&scopes=LIST%3A%2Fstorage%2Fmust-not-be-called%20DOWNLOAD%3A%2Fstorage%2Fmust-not-be-called"}'
+	expected+=']'
+	assert_token_issuer_trace "${expected}"
+
+	# The request timeout is one deadline for the entire issuer workflow, not a
+	# fresh timeout for each fallback stage. Each discovery response arrives
+	# within one second, but the two together exceed the operation deadline.
+	reset_token_issuer_trace
+	assert_failure env XRD_REQUESTTIMEOUT=1 xrdfs token --issuer \
+		"${TOKEN_ISSUER_HOST}/slow-deadline" \
+		"${TOKEN_ISSUER_HOST}/storage/deadline-object"
+	expected='['
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/slow-deadline","content_type":"","accept":"*/*","body":""},'
+	expected+='{"method":"GET","url":"https://localhost:15044/.well-known/oauth-authorization-server/slow-deadline","content_type":"","accept":"*/*","body":""}'
+	expected+=']'
+	assert_token_issuer_trace "${expected}"
 }
 
 # Obtain a macaroon for $1 (path, default "/") with an optional JSON caveats
@@ -68,10 +222,95 @@ function get_macaroon() {
 
 function test_macaroons() {
 	HOST="https://localhost:15043"
+	export XRD_PLUGINCONFDIR="${MACAROONS_PLUGINCONFDIR}"
 
-	local response
+	local response xrdfs_macaroon
 
 	# Issuance tests
+
+	# xrdfs uses the same local HTTPS macaroon endpoint as gfal-token.
+	xrdfs_macaroon=$(xrdfs token "${HOST}/")
+	[[ -n "${xrdfs_macaroon}" ]] || error "xrdfs returned an empty macaroon"
+
+	# Tokens and request bodies must only be returned to the caller, not copied
+	# into the XrdCl client log.
+	if grep -Fq "${xrdfs_macaroon}" "${XRD_LOGFILE}"; then
+		error "xrdfs logged the issued macaroon"
+	fi
+	if grep -Fq '"caveats"' "${XRD_LOGFILE}"; then
+		error "xrdfs logged the macaroon request body"
+	fi
+
+	# The write defaults and explicit activity list are both accepted by the
+	# local issuer; these requests do not perform a remote write.
+	response=$(xrdfs token --write --validity 15 "${HOST}/rw")
+	[[ -n "${response}" ]] || error "xrdfs returned an empty write macaroon"
+	response=$(xrdfs token --validity 5 "${HOST}/" DOWNLOAD LIST)
+	[[ -n "${response}" ]] || error "xrdfs returned an empty custom macaroon"
+	response=$(xrdfs "${HOST}" token --validity 1 /)
+	[[ -n "${response}" ]] || error "legacy xrdfs syntax returned an empty macaroon"
+
+	test_token_issuer_workflows
+
+	# A same-host issuer first receives the SciTokens client-credentials
+	# request, which this macaroon endpoint rejects because it has no scope.
+	# xrdfs must then repeat discovery and complete the OAuth macaroon flow.
+	response=$(xrdfs token --issuer "${HOST}" --validity 5 "${HOST}/")
+	[[ -n "${response}" ]] || error "issuer workflow returned an empty token"
+	if grep -Fq "${response}" "${XRD_LOGFILE}"; then
+		error "xrdfs logged the issuer-provided token"
+	fi
+
+	# Discovery below an unknown issuer path fails at both RFC 8414 and OIDC
+	# endpoints, so the workflow falls back to direct storage issuance.
+	response=$(xrdfs token --issuer "${HOST}/missing-issuer" "${HOST}/")
+	[[ -n "${response}" ]] || error "issuer fallback returned an empty token"
+	if grep -Fq "${response}" "${XRD_LOGFILE}"; then
+		error "xrdfs logged the direct-fallback token"
+	fi
+
+	# Keep the OAuth endpoint compatible with both the standard singular
+	# spelling and the plural spelling emitted by gfal-token.
+	response=$(curl -sf \
+		--capath "${X509_CERT_DIR}" --cert "${X509_USER_CERT}" --key "${X509_USER_KEY}" \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		-X POST -d 'grant_type=client_credentials&expire_in=300&scope=DOWNLOAD%3A%2F' \
+		"${HOST}/.oauth2/token")
+	response=$(echo "${response}" | jq -er \
+		'.access_token | select(type == "string" and length > 0)')
+	[[ -n "${response}" ]] || error "singular OAuth scope returned an empty macaroon"
+
+	response=$(curl -sf \
+		--capath "${X509_CERT_DIR}" --cert "${X509_USER_CERT}" --key "${X509_USER_KEY}" \
+		-H 'Content-Type: application/x-www-form-urlencoded' \
+		-X POST -d 'grant_type=client_credentials&expire_in=300&scopes=LIST%3A%2F%20DOWNLOAD%3A%2F' \
+		"${HOST}/.oauth2/token")
+	response=$(echo "${response}" | jq -er \
+		'.access_token | select(type == "string" and length > 0)')
+	[[ -n "${response}" ]] || error "plural OAuth scopes returned an empty macaroon"
+
+	# Exercise direct curl handle reuse in one process: the GET following the
+	# token POST must remain a GET after the easy handle returns to the pool.
+	response=$(printf 'token /\ncat /hello.txt\nexit\n' | xrdfs "${HOST}")
+	[[ "${response}" == *"Hello, macaroons!"* ]] || \
+		error "a read following direct token issuance did not return the file"
+
+	# Exercise all issuer stages and handle reuse in one process as well: the
+	# file GET following discovery and token POSTs must remain a GET after the
+	# easy handles return to the pool.
+	response=$(printf 'token --issuer %s /\ncat /hello.txt\nexit\n' "${HOST}" | \
+		xrdfs "${HOST}")
+	[[ "${response}" == *"Hello, macaroons!"* ]] || \
+		error "a read following issuer token issuance did not return the file"
+
+	# Reject insecure storage and issuer endpoints before making a token request.
+	assert_failure xrdfs token "http://localhost:15043/"
+	assert_failure xrdfs token --issuer http://localhost:15043 "${HOST}/"
+	assert_failure xrdfs token --issuer \
+		"https://client@localhost:15043" "${HOST}/"
+	assert_failure xrdfs token --issuer= "${HOST}/"
+	assert_failure xrdfs token --validity -1 "${HOST}/"
+	assert_failure xrdfs token --val 5 "${HOST}/"
 
 	# can obtain a macaroon via HTTPS POST
 	get_macaroon /

--- a/tests/XRootD/token_issuer_mock.py
+++ b/tests/XRootD/token_issuer_mock.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+
+"""Deterministic HTTPS token issuer used by the XRootD macaroon tests."""
+
+import argparse
+import json
+import ssl
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    """Threaded HTTP server compatible with Python 3.6 and newer."""
+
+    daemon_threads = True
+
+
+SCI_BODY = "grant_type=client_credentials"
+
+
+class TokenIssuerServer(ThreadingHTTPServer):
+    """HTTP server carrying the trace location and advertised endpoint URL."""
+
+    allow_reuse_address = True
+    daemon_threads = True
+
+    def __init__(self, address, handler, trace_file, advertised_url):
+        super().__init__(address, handler)
+        self.trace_file = trace_file
+        self.advertised_url = advertised_url
+        self.trace_lock = threading.Lock()
+
+    def trace(self, entry):
+        with self.trace_lock:
+            with open(self.trace_file, "a", encoding="utf-8") as stream:
+                json.dump(entry, stream, separators=(",", ":"))
+                stream.write("\n")
+
+
+class TokenIssuerHandler(BaseHTTPRequestHandler):
+    """Serve fixed issuer scenarios and record every non-health request."""
+
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, format_string, *args):
+        message = format_string % args
+        print("{} - {}".format(self.address_string(), message), flush=True)
+
+    def send_json(self, status, payload):
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError, ssl.SSLEOFError):
+            pass
+
+    def read_body(self):
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except ValueError:
+            length = 0
+        return self.rfile.read(length).decode("utf-8", errors="replace")
+
+    def record(self, body=""):
+        host = self.headers.get("Host", "")
+        self.server.trace(
+            {
+                "method": self.command,
+                "url": "https://{}{}".format(host, self.path),
+                "content_type": self.headers.get("Content-Type", ""),
+                "accept": self.headers.get("Accept", ""),
+                "body": body,
+            }
+        )
+
+    def token_endpoint(self, scenario):
+        return "{}/token/{}".format(self.server.advertised_url, scenario)
+
+    def do_GET(self):
+        if self.path == "/healthz":
+            self.send_json(200, {"status": "ok"})
+            return
+
+        self.record()
+        metadata_prefix = "/.well-known/oauth-authorization-server/"
+        if self.path.startswith(metadata_prefix):
+            scenario = self.path[len(metadata_prefix):]
+            if scenario == "slow-deadline":
+                time.sleep(0.75)
+                self.send_json(404, {"error": "metadata unavailable"})
+                return
+            if scenario in ("sci-success", "oauth-success", "oauth-failure"):
+                self.send_json(
+                    200, {"token_endpoint": self.token_endpoint(scenario)}
+                )
+                return
+            self.send_json(404, {"error": "metadata unavailable"})
+            return
+
+        if self.path == "/openid-success/.well-known/openid-configuration":
+            self.send_json(
+                200, {"token_endpoint": self.token_endpoint("openid-success")}
+            )
+            return
+
+        self.send_json(404, {"error": "openid metadata unavailable"})
+
+    def do_POST(self):
+        body = self.read_body()
+        self.record(body)
+
+        if self.path == "/token/sci-success":
+            if body == SCI_BODY:
+                self.send_json(200, {"access_token": "sci-token"})
+            else:
+                self.send_json(400, {"error": "unexpected SciTokens body"})
+            return
+
+        if self.path == "/token/oauth-success":
+            if body == SCI_BODY:
+                self.send_json(400, {"error": "OAuth scope required"})
+            elif "&scopes=" in body:
+                self.send_json(200, {"access_token": "oauth-token"})
+            else:
+                self.send_json(400, {"error": "unexpected OAuth body"})
+            return
+
+        if self.path == "/token/openid-success":
+            if "&scopes=" in body:
+                self.send_json(200, {"access_token": "openid-token"})
+            else:
+                self.send_json(400, {"error": "unexpected OAuth body"})
+            return
+
+        if self.path == "/token/oauth-failure":
+            if body == SCI_BODY:
+                self.send_json(400, {"error": "OAuth scope required"})
+            else:
+                self.send_json(403, {"error": "OAuth request rejected"})
+            return
+
+        if self.path.startswith("/storage/direct-object"):
+            self.send_json(200, {"macaroon": "direct-token"})
+            return
+
+        if self.path.startswith("/storage/must-not-be-called"):
+            self.send_json(200, {"macaroon": "unexpected-direct-token"})
+            return
+
+        if self.path.startswith("/storage/deadline-object"):
+            self.send_json(200, {"macaroon": "unexpected-deadline-token"})
+            return
+
+        self.send_json(404, {"error": "unknown token endpoint"})
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bind", default="127.0.0.1")
+    parser.add_argument("--port", required=True, type=int)
+    parser.add_argument("--cert", required=True)
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--trace-file", required=True)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    advertised_url = "https://localhost:{}".format(args.port)
+    server = TokenIssuerServer(
+        (args.bind, args.port),
+        TokenIssuerHandler,
+        args.trace_file,
+        advertised_url,
+    )
+    tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    tls_context.load_cert_chain(args.cert, args.key)
+    server.socket = tls_context.wrap_socket(server.socket, server_side=True)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/XrdClHttp/CMakeLists.txt
+++ b/tests/XrdClHttp/CMakeLists.txt
@@ -1,3 +1,20 @@
+include(GoogleTest)
+
+# Token request and response parsing has no authentication fixture dependency.
+add_executable(xrdcl-http-token-unit-tests
+  TokenTest.cc
+  ${PROJECT_SOURCE_DIR}/src/XrdClHttp/XrdClHttpToken.cc
+)
+
+target_link_libraries(xrdcl-http-token-unit-tests
+  GTest::gtest_main
+)
+
+gtest_discover_tests(xrdcl-http-token-unit-tests
+  TEST_PREFIX XrdClHttp::
+  PROPERTIES DISCOVERY_TIMEOUT 10
+)
+
 # The final shared library has its symbols stripped; we need the symbols available
 # to allow unit tests to access them.  Rather than build the objects twice, we
 # create an internal object library and just link twice -- once stripping the symbols,
@@ -6,8 +23,6 @@ find_package(CURL REQUIRED)
 
 add_library(XrdClHttpTesting SHARED)
 target_link_libraries(XrdClHttpTesting PRIVATE XrdClHttpObj)
-
-include(GoogleTest)
 
 add_executable(xrdcl-http-unit-tests
   HeaderParserTest.cc
@@ -27,7 +42,6 @@ gtest_discover_tests(xrdcl-http-unit-tests TEST_PREFIX XrdClHttp::
 if(NOT BUILD_SCITOKENS)
   return()
 endif()
-
 find_program(OPENSSL_BIN openssl REQUIRED)
 
 # All tests that only depend on the pure XrdCl interfaces and
@@ -43,6 +57,7 @@ add_executable(xrdcl-test
 # Tests depending on XrdClHttp linkage
 add_executable(xrdcl-http-test
   CopyTest.cc
+  HandlerQueueTest.cc
   VectorReadTest.cc
 )
 

--- a/tests/XrdClHttp/HandlerQueueTest.cc
+++ b/tests/XrdClHttp/HandlerQueueTest.cc
@@ -1,0 +1,64 @@
+/******************************************************************************/
+/* Copyright (C) 2026 by European Organization for Nuclear Research (CERN)   */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpOps.hh"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+
+namespace {
+
+class QueueTestOperation final : public XrdClHttp::CurlOperation {
+public:
+    explicit QueueTestOperation(
+        std::chrono::steady_clock::time_point expiry)
+        : CurlOperation(nullptr, "https://queue.example/", expiry, nullptr,
+                        nullptr, nullptr)
+    {}
+
+    void Success() override {}
+
+    HttpVerb GetVerb() const override { return HttpVerb::GET; }
+};
+
+} // anonymous namespace
+
+TEST(HandlerQueue, TryProduceRejectsWithoutWaiting)
+{
+    using namespace std::chrono_literals;
+
+    XrdClHttp::HandlerQueue queue(1);
+    const auto future = std::chrono::steady_clock::now() + 1min;
+    auto first = std::make_shared<QueueTestOperation>(future);
+    auto second = std::make_shared<QueueTestOperation>(future);
+
+    ASSERT_TRUE(queue.TryProduce(first));
+    EXPECT_FALSE(queue.TryProduce(second));
+
+    EXPECT_EQ(queue.TryConsume(), first);
+    EXPECT_TRUE(queue.TryProduce(second));
+    EXPECT_EQ(queue.TryConsume(), second);
+
+    auto expired = std::make_shared<QueueTestOperation>(
+        std::chrono::steady_clock::now() - 1s);
+    EXPECT_FALSE(queue.TryProduce(expired));
+
+    queue.Shutdown();
+    auto after_shutdown = std::make_shared<QueueTestOperation>(future);
+    EXPECT_FALSE(queue.TryProduce(after_shutdown));
+}

--- a/tests/XrdClHttp/TokenTest.cc
+++ b/tests/XrdClHttp/TokenTest.cc
@@ -1,0 +1,439 @@
+/******************************************************************************/
+/* Copyright (C) 2026 by European Organization for Nuclear Research (CERN)   */
+/*                                                                            */
+/* This file is part of the XrdClHttp client plugin for XRootD.               */
+/*                                                                            */
+/* XRootD is free software: you can redistribute it and/or modify it under    */
+/* the terms of the GNU Lesser General Public License as published by the     */
+/* Free Software Foundation, either version 3 of the License, or (at your     */
+/* option) any later version.                                                 */
+/*                                                                            */
+/* XRootD is distributed in the hope that it will be useful, but WITHOUT      */
+/* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or      */
+/* FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public       */
+/* License for more details.                                                  */
+/******************************************************************************/
+
+#include "XrdClHttp/XrdClHttpToken.hh"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string MacaroonResponseOfSize(std::size_t size)
+{
+    const std::string prefix = "{\"macaroon\":\"";
+    const std::string suffix = "\"}";
+    if (size <= prefix.size() + suffix.size()) return {};
+    return prefix +
+        std::string(size - prefix.size() - suffix.size(), 'x') + suffix;
+}
+
+} // namespace
+
+TEST(HttpToken, AcceptsHttpsUrl)
+{
+    std::string normalized;
+    EXPECT_TRUE(XrdClHttp::NormalizeTokenUrl(
+        "https://storage.example/eos/file?opaque=value", normalized));
+    EXPECT_EQ(normalized,
+              "https://storage.example/eos/file?opaque=value");
+}
+
+TEST(HttpToken, NormalizesDavsUrlToHttps)
+{
+    std::string normalized;
+    EXPECT_TRUE(XrdClHttp::NormalizeTokenUrl(
+        "davs://storage.example:8443/eos/file", normalized));
+    EXPECT_EQ(normalized, "https://storage.example:8443/eos/file");
+
+    EXPECT_TRUE(XrdClHttp::NormalizeTokenUrl(
+        "HTTPS://storage.example/eos/file", normalized));
+    EXPECT_EQ(normalized, "https://storage.example/eos/file");
+}
+
+TEST(HttpToken, RejectsInsecureOrMalformedUrl)
+{
+    const std::vector<std::string> invalid = {
+        "http://storage.example/eos/file",
+        "dav://storage.example/eos/file",
+        "root://storage.example//eos/file",
+        "file:///tmp/file",
+        "https:///missing-host",
+        "https://:8443/missing-host",
+        "https://storage.example:/empty-port",
+        "https://storage.example:abc/non-numeric-port",
+        "https://storage.example:65536/out-of-range-port",
+        "https://[::1]suffix/malformed-bracket-suffix",
+        "https://[::1]:abc/non-numeric-ipv6-port",
+        "https://::1/unbracketed-ipv6",
+        "https://storage.example/path with space",
+        "https://storage.example/path\nhttp://redirect.example/"
+    };
+
+    for (const auto &input : invalid) {
+        std::string normalized = "stale-url";
+        EXPECT_FALSE(XrdClHttp::NormalizeTokenUrl(input, normalized))
+            << input;
+        EXPECT_TRUE(normalized.empty()) << input;
+    }
+}
+
+TEST(HttpToken, ParsesReadDefaults)
+{
+    XrdClHttp::TokenRequest request;
+    std::string error;
+
+    ASSERT_TRUE(XrdClHttp::ParseTokenRequest(
+        R"({"path":"/store/file","validity":60,"write":false,"activities":[]})",
+        request, error)) << error;
+    EXPECT_EQ(request.path, "/store/file");
+    EXPECT_EQ(request.validity, 60U);
+    EXPECT_FALSE(request.write);
+    EXPECT_EQ(request.activities,
+              (std::vector<std::string>{"LIST", "DOWNLOAD"}));
+}
+
+TEST(HttpToken, ParsesWriteDefaults)
+{
+    XrdClHttp::TokenRequest request;
+    std::string error;
+
+    ASSERT_TRUE(XrdClHttp::ParseTokenRequest(
+        R"({"path":"/rw","validity":15,"write":true,"activities":[]})",
+        request, error)) << error;
+    EXPECT_EQ(request.path, "/rw");
+    EXPECT_EQ(request.validity, 15U);
+    EXPECT_TRUE(request.write);
+    EXPECT_EQ(request.activities,
+              (std::vector<std::string>{
+                  "LIST", "DOWNLOAD", "MANAGE", "UPLOAD", "DELETE"}));
+}
+
+TEST(HttpToken, PreservesCustomActivities)
+{
+    XrdClHttp::TokenRequest request;
+    std::string error;
+
+    ASSERT_TRUE(XrdClHttp::ParseTokenRequest(
+        R"({"path":"/custom?opaque=value","validity":5,"write":true,"activities":["READ_METADATA","LIST"]})",
+        request, error)) << error;
+    EXPECT_EQ(request.path, "/custom?opaque=value");
+    EXPECT_EQ(request.activities,
+              (std::vector<std::string>{"READ_METADATA", "LIST"}));
+}
+
+TEST(HttpToken, ParsesIssuer)
+{
+    XrdClHttp::TokenRequest request;
+    std::string error;
+
+    ASSERT_TRUE(XrdClHttp::ParseTokenRequest(
+        R"({"path":"/file","issuer":"https://issuer.example/base"})",
+        request, error)) << error;
+    EXPECT_EQ(request.issuer, "https://issuer.example/base");
+
+    ASSERT_TRUE(XrdClHttp::ParseTokenRequest(
+        R"({"path":"/file"})", request, error)) << error;
+    EXPECT_TRUE(request.issuer.empty());
+}
+
+TEST(HttpToken, RejectsInvalidQueryFields)
+{
+    const std::vector<std::string> invalid = {
+        R"({})",
+        R"({"path":""})",
+        R"({"path":"relative/file"})",
+        R"({"path":42})",
+        R"({"path":"/file","validity":-1})",
+        R"({"path":"/file","validity":"60"})",
+        R"({"path":"/file","issuer":""})",
+        R"({"path":"/file","issuer":42})",
+        R"({"path":"/file","write":"yes"})",
+        R"({"path":"/file","activities":"LIST"})",
+        R"({"path":"/file","activities":[""]})",
+        R"({"path":"/file","activities":["LIST",7]})"
+    };
+
+    for (const auto &input : invalid) {
+        XrdClHttp::TokenRequest request;
+        std::string error;
+        EXPECT_FALSE(XrdClHttp::ParseTokenRequest(input, request, error))
+            << input;
+        EXPECT_FALSE(error.empty()) << input;
+    }
+}
+
+TEST(HttpToken, BuildsIssuerDiscoveryUrls)
+{
+    std::string url;
+
+    ASSERT_TRUE(XrdClHttp::BuildOAuthAuthorizationServerUrl(
+        "https://issuer.example", url));
+    EXPECT_EQ(url,
+              "https://issuer.example/.well-known/oauth-authorization-server");
+
+    ASSERT_TRUE(XrdClHttp::BuildOAuthAuthorizationServerUrl(
+        "https://issuer.example/tenant/one", url));
+    EXPECT_EQ(url,
+              "https://issuer.example/.well-known/"
+              "oauth-authorization-server/tenant/one");
+
+    ASSERT_TRUE(XrdClHttp::BuildOpenIdConfigurationUrl(
+        "https://issuer.example", url));
+    EXPECT_EQ(url,
+              "https://issuer.example/.well-known/openid-configuration");
+
+    ASSERT_TRUE(XrdClHttp::BuildOpenIdConfigurationUrl(
+        "davs://issuer.example:8443/tenant/one/", url));
+    EXPECT_EQ(url,
+              "https://issuer.example:8443/tenant/one/"
+              ".well-known/openid-configuration");
+
+    ASSERT_TRUE(XrdClHttp::BuildOAuthAuthorizationServerUrl(
+        "https://issuer.example/tenant?ignored=yes#fragment", url));
+    EXPECT_EQ(url,
+              "https://issuer.example/.well-known/"
+              "oauth-authorization-server/tenant");
+
+    ASSERT_TRUE(XrdClHttp::BuildOpenIdConfigurationUrl(
+        "https://issuer.example?ignored=yes#fragment", url));
+    EXPECT_EQ(url,
+              "https://issuer.example/.well-known/openid-configuration");
+}
+
+TEST(HttpToken, RejectsInsecureIssuerDiscoveryUrls)
+{
+    const std::vector<std::string> invalid = {
+        "http://issuer.example",
+        "root://issuer.example",
+        "https:///missing-host",
+        "https://user:password@issuer.example"
+    };
+
+    for (const auto &issuer : invalid) {
+        std::string url = "stale-url";
+        EXPECT_FALSE(XrdClHttp::BuildOAuthAuthorizationServerUrl(issuer, url))
+            << issuer;
+        EXPECT_TRUE(url.empty()) << issuer;
+        url = "stale-url";
+        EXPECT_FALSE(XrdClHttp::BuildOpenIdConfigurationUrl(issuer, url))
+            << issuer;
+        EXPECT_TRUE(url.empty()) << issuer;
+    }
+}
+
+TEST(HttpToken, BuildsGfalCompatibleReadRequest)
+{
+    EXPECT_EQ(XrdClHttp::BuildMacaroonRequest(
+                  60, {"LIST", "DOWNLOAD"}),
+              "{\"caveats\": [\"activity:LIST,DOWNLOAD\"], "
+              "\"validity\": \"PT60M\"}");
+}
+
+TEST(HttpToken, BuildsGfalCompatibleWriteRequest)
+{
+    EXPECT_EQ(XrdClHttp::BuildMacaroonRequest(
+                  10, {"LIST", "DOWNLOAD", "MANAGE", "UPLOAD", "DELETE"}),
+              "{\"caveats\": "
+              "[\"activity:LIST,DOWNLOAD,MANAGE,UPLOAD,DELETE\"], "
+              "\"validity\": \"PT10M\"}");
+}
+
+TEST(HttpToken, BuildsGfalCompatibleCustomRequest)
+{
+    EXPECT_EQ(XrdClHttp::BuildMacaroonRequest(
+                  5, {"READ_METADATA", "LIST"}),
+              "{\"caveats\": [\"activity:READ_METADATA,LIST\"], "
+              "\"validity\": \"PT5M\"}");
+}
+
+TEST(HttpToken, EscapesCustomActivitiesInJson)
+{
+    EXPECT_EQ(XrdClHttp::BuildMacaroonRequest(1, {"LIST\"INJECT"}),
+              "{\"caveats\": [\"activity:LIST\\\"INJECT\"], "
+              "\"validity\": \"PT1M\"}");
+}
+
+TEST(HttpToken, BuildsSciTokensRequest)
+{
+    EXPECT_EQ(XrdClHttp::BuildSciTokensRequest(),
+              "grant_type=client_credentials");
+}
+
+TEST(HttpToken, BuildsGfalCompatibleOAuthMacaroonRequest)
+{
+    std::string body;
+    std::string error;
+    ASSERT_TRUE(XrdClHttp::BuildOAuthMacaroonRequest(
+        "/eos/pilot/file", 5, {"LIST", "DOWNLOAD"}, body, error))
+        << error;
+    EXPECT_EQ(body,
+              "grant_type=client_credentials&expire_in=300&scopes="
+              "LIST%3A%2Feos%2Fpilot%2Ffile%20"
+              "DOWNLOAD%3A%2Feos%2Fpilot%2Ffile");
+    EXPECT_TRUE(error.empty());
+}
+
+TEST(HttpToken, PercentEncodesOAuthMacaroonScopes)
+{
+    std::string body;
+    std::string error;
+    ASSERT_TRUE(XrdClHttp::BuildOAuthMacaroonRequest(
+        "/eos/a b+~%?opaque=ignored", 0, {"READ_METADATA"}, body,
+        error)) << error;
+    EXPECT_EQ(body,
+              "grant_type=client_credentials&expire_in=0&scopes="
+              "READ_METADATA%3A%2Feos%2Fa%20b%2B~%25");
+
+    ASSERT_TRUE(XrdClHttp::BuildOAuthMacaroonRequest(
+        "/eos/fragment-only#ignored", 1, {"LIST"}, body, error))
+        << error;
+    EXPECT_EQ(body,
+              "grant_type=client_credentials&expire_in=60&scopes="
+              "LIST%3A%2Feos%2Ffragment-only");
+}
+
+TEST(HttpToken, RejectsOAuthMacaroonValidityOverflow)
+{
+    const auto maximum_minutes =
+        std::numeric_limits<std::uint64_t>::max() / 60;
+    std::string body;
+    std::string error;
+
+    ASSERT_TRUE(XrdClHttp::BuildOAuthMacaroonRequest(
+        "/file", maximum_minutes, {"LIST"}, body, error)) << error;
+    EXPECT_NE(body.find("expire_in=" +
+                        std::to_string(maximum_minutes * 60)),
+              std::string::npos);
+
+    body = "stale-body";
+    EXPECT_FALSE(XrdClHttp::BuildOAuthMacaroonRequest(
+        "/file", maximum_minutes + 1, {"LIST"}, body, error));
+    EXPECT_TRUE(body.empty());
+    EXPECT_NE(error.find("too large"), std::string::npos);
+}
+
+TEST(HttpToken, RejectsRelativeOAuthMacaroonScopePath)
+{
+    std::string body = "stale-body";
+    std::string error;
+    EXPECT_FALSE(XrdClHttp::BuildOAuthMacaroonRequest(
+        "relative/file", 5, {"LIST"}, body, error));
+    EXPECT_TRUE(body.empty());
+    EXPECT_FALSE(error.empty());
+}
+
+TEST(HttpToken, ParsesGenericJsonStringResponse)
+{
+    std::string value;
+    std::string error;
+    ASSERT_TRUE(XrdClHttp::ParseJsonStringResponse(
+        R"({"token_endpoint":"https://issuer.example/token"})",
+        "token_endpoint", value, error)) << error;
+    EXPECT_EQ(value, "https://issuer.example/token");
+
+    ASSERT_TRUE(XrdClHttp::ParseJsonStringResponse(
+        R"({"access_token":"issued-token"})", "access_token", value,
+        error)) << error;
+    EXPECT_EQ(value, "issued-token");
+}
+
+TEST(HttpToken, RejectsInvalidGenericJsonStringResponse)
+{
+    const std::vector<std::string> invalid = {
+        R"({})",
+        R"({"access_token":""})",
+        R"({"access_token":null})",
+        R"({"access_token":42})",
+        "not-json",
+        ""
+    };
+
+    for (const auto &input : invalid) {
+        std::string value = "stale-value";
+        std::string error;
+        EXPECT_FALSE(XrdClHttp::ParseJsonStringResponse(
+            input, "access_token", value, error)) << input;
+        EXPECT_TRUE(value.empty()) << input;
+        EXPECT_FALSE(error.empty()) << input;
+        if (!input.empty()) {
+            EXPECT_EQ(error.find(input), std::string::npos) << input;
+        }
+    }
+}
+
+TEST(HttpToken, ParsesMacaroonResponse)
+{
+    std::string token;
+    std::string error;
+    ASSERT_TRUE(XrdClHttp::ParseMacaroonResponse(
+        R"({"expires_in":3600,"macaroon":"issued-token"})", token,
+        error)) << error;
+    EXPECT_EQ(token, "issued-token");
+    EXPECT_TRUE(error.empty());
+}
+
+TEST(HttpToken, RejectsMissingOrEmptyMacaroon)
+{
+    const std::vector<std::string> invalid = {
+        R"({})",
+        R"({"macaroon":""})",
+        R"({"macaroon":null})",
+        R"({"macaroon":42})",
+        ""
+    };
+
+    for (const auto &input : invalid) {
+        std::string token = "stale-token";
+        std::string error;
+        EXPECT_FALSE(XrdClHttp::ParseMacaroonResponse(input, token, error))
+            << input;
+        EXPECT_TRUE(token.empty()) << input;
+        EXPECT_FALSE(error.empty()) << input;
+    }
+}
+
+TEST(HttpToken, AcceptsResponseJustBelowMaximumSize)
+{
+    const std::string response = MacaroonResponseOfSize(
+        XrdClHttp::kMaxTokenResponseSize - 1);
+    ASSERT_EQ(response.size(), XrdClHttp::kMaxTokenResponseSize - 1);
+
+    std::string token;
+    std::string error;
+    ASSERT_TRUE(XrdClHttp::ParseMacaroonResponse(response, token, error))
+        << error;
+    EXPECT_FALSE(token.empty());
+}
+
+TEST(HttpToken, RejectsResponseAtMaximumSize)
+{
+    const std::string response = MacaroonResponseOfSize(
+        XrdClHttp::kMaxTokenResponseSize);
+    ASSERT_EQ(response.size(), XrdClHttp::kMaxTokenResponseSize);
+
+    std::string token;
+    std::string error;
+    EXPECT_FALSE(XrdClHttp::ParseMacaroonResponse(response, token, error));
+    EXPECT_TRUE(token.empty());
+    EXPECT_NE(error.find("maximum size"), std::string::npos);
+}
+
+TEST(HttpToken, DoesNotIncludeResponseBodyInErrors)
+{
+    const std::string marker = "sensitive-response-body";
+    std::string token;
+    std::string error;
+
+    EXPECT_FALSE(XrdClHttp::ParseMacaroonResponse(marker, token, error));
+    EXPECT_EQ(error.find(marker), std::string::npos);
+
+    EXPECT_FALSE(XrdClHttp::ParseMacaroonResponse(
+        "{\"secret\":\"" + marker + "\"}", token, error));
+    EXPECT_EQ(error.find(marker), std::string::npos);
+}


### PR DESCRIPTION
## Summary

Add `xrdfs token` for direct storage-issued and issuer-directed access-token requests over HTTPS and DAVS.

- request storage-issued macaroons with read/write defaults, explicit activities, and configurable validity
- discover issuer metadata through RFC 8414 and OpenID Connect
- support SciTokens client credentials and scoped OAuth macaroon flows
- fall back to direct storage issuance when issuer discovery is unavailable
- keep one deadline across the workflow, restrict redirects to HTTPS, bound response parsing, and avoid exposing secrets in diagnostics
- accept `scope` and `scopes` in XrdMacaroons requests

The implementation includes focused unit tests for URL handling, token responses, queueing, issuer discovery, and macaroon scope parsing, plus end-to-end command coverage.

## Motivation

This extracts the token work from draft #2868 into a standalone pull request so its API and protocol behavior can be reviewed independently from the CLI-option, WebDAV, Python, Tape, and removal work in that aggregate PR. This pull request is opened as a draft while that review is in progress.

This work implements the token workflow tracked in #2863. It is independent of the separate `xrdfs` option changes.

## Validation

- [Full GitHub Actions CI matrix](https://github.com/lobis/xrootd/actions/runs/33719277195)
- [ABI check](https://github.com/lobis/xrootd/actions/runs/33719277262)
- Unit and end-to-end coverage for direct storage, issuer discovery, SciTokens, and macaroon requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `xrdfs token` command for requesting storage access tokens.
  * Supports token requests using SciTokens, OAuth, OpenID Connect, and macaroons.
  * Added issuer discovery, access-mode selection, validity periods, activities, and complete-URL syntax.
  * Added HTTPS/DAVS validation and secure handling of token responses.

* **Bug Fixes**
  * Improved OAuth compatibility for both `scope` and `scopes` parameters.
  * Corrected handling of percent-encoded values at input boundaries.

* **Tests**
  * Added comprehensive coverage for token requests, issuer workflows, validation, timeouts, and queue behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->