### PR TITLE
[XrdHttpTPC] Do not accept Source AND Destination header in COPY

### DIFF
--- a/src/XrdHttpTpc/XrdHttpTpcTPC.cc
+++ b/src/XrdHttpTpc/XrdHttpTpcTPC.cc
@@ -379,9 +379,18 @@ int TPCHandler::ProcessReq(XrdHttpExtReq &req) {
             return req.SendSimpleResp(400, NULL, NULL, "COPY requestd an unsupported Credential type", 0);
         }
     }
-    header = XrdOucTUtils::caseInsensitiveFind(req.headers,"source");
-    if (header != req.headers.end()) {
-        std::string src = PrepareURL(header->second);
+    auto srcHeader = XrdOucTUtils::caseInsensitiveFind(req.headers,"source");
+    auto dstHeader = XrdOucTUtils::caseInsensitiveFind(req.headers,"destination");
+    // A Source header asks for a pull, a Destination header for a push; asking
+    // for both at once is ambiguous, so the request is rejected instead of
+    // arbitrarily honouring one of the two.
+    if (srcHeader != req.headers.end() && dstHeader != req.headers.end()) {
+        const char *error_both = "COPY rejected: both a Source and a Destination header were specified";
+        m_log.Emsg("ProcessReq", error_both);
+        return req.SendSimpleResp(400, NULL, NULL, error_both, 0);
+    }
+    if (srcHeader != req.headers.end()) {
+        std::string src = PrepareURL(srcHeader->second);
         if (!IsAllowedScheme(src)) {
             const char *error_src = "COPY rejected: disallowed scheme in source URL";
             m_log.Emsg("ProcessReq", error_src, src.c_str());
@@ -389,15 +398,14 @@ int TPCHandler::ProcessReq(XrdHttpExtReq &req) {
         }
         return ProcessPullReq(src, req);
     }
-    header = XrdOucTUtils::caseInsensitiveFind(req.headers,"destination");
-    if (header != req.headers.end()) {
-        const std::string& dst = header->second;
+    if (dstHeader != req.headers.end()) {
+        const std::string& dst = dstHeader->second;
         if (!IsAllowedScheme(dst)) {
             const char *error_dst = "COPY rejected: disallowed scheme in destination URL";
             m_log.Emsg("ProcessReq", error_dst, dst.c_str());
             return req.SendSimpleResp(400, NULL, NULL, error_dst, 0);
         }
-        return ProcessPushReq(header->second, req);
+        return ProcessPushReq(dst, req);
     }
     m_log.Emsg("ProcessReq", "COPY verb requested but no source or destination specified.");
     return req.SendSimpleResp(400, NULL, NULL, "No Source or Destination specified", 0);

--- a/tests/TPCTests/test.sh
+++ b/tests/TPCTests/test.sh
@@ -313,6 +313,30 @@ plain_http_tpc() {
     return 0
 }
 
+# A COPY request carrying both a Source and a Destination header is ambiguous:
+# the server cannot tell whether a pull or a push was meant, so it must be
+# rejected instead of silently picking one of the two.
+# $1 is the resource the COPY is sent to, $2 the Source header, $3 the
+# Destination header.
+plain_http_tpc_source_and_destination() {
+    local resource="$1"
+    local src="$2"
+    local dst="$3"
+
+    local http_code
+
+    http_code=$(${CURL} -X COPY -L -s -o >(cat >&2) -w "%{http_code}" \
+        --cacert "${BINARY_DIR}/tests/issuer/tlsca.pem" \
+        -H "Authorization: Bearer ${BEARER_TOKEN}" \
+        -H "TransferHeaderAuthorization: Bearer ${BEARER_TOKEN}" \
+        -H "Source: ${src}" \
+        -H "Destination: ${dst}" \
+        "${resource}")
+
+    echo "$http_code"
+    return 0
+}
+
 download_file() {
     local src=$1
     local dest=$2
@@ -522,6 +546,16 @@ cleanup
 
 assert_eq "400" "$(plain_http_tpc pull "file:///etc/os-release" "$BEARER_TOKEN" "${hosts_http[0]}/${RMTDATADIR}/os-release" "$BEARER_TOKEN")" "Did not reject disallowed protocol"
 assert_eq "400" "$(plain_http_tpc push "${hosts_http[0]}" "$BEARER_TOKEN" "${hosts_http[0]/https/root}/${RMTDATADIR}/fake.root" "$BEARER_TOKEN")" "Did not reject disallowed protocol"
+
+# Both Source and Destination headers in the same COPY request
+
+tpc_src="${hosts_http[0]}/${RMTDATADIR}/${hosts_abbrev[0]}.ref"
+tpc_dst="${hosts_http[1]}/${RMTDATADIR}/${hosts_abbrev[1]}.ref"
+
+assert_eq "400" "$(plain_http_tpc_source_and_destination "${tpc_dst}" "${tpc_src}" "${tpc_dst}")" \
+    "Did not reject a COPY carrying both a Source and a Destination header"
+assert_eq "400" "$(plain_http_tpc_source_and_destination "${tpc_src}" "${tpc_src}" "${tpc_dst}")" \
+    "Did not reject a COPY carrying both a Source and a Destination header"
 
 echo "ALL TESTS PASSED"
 exit 0


### PR DESCRIPTION
Prevents users from submitting a COPY request with both Source and Destination headers.
The server will return 400 Bad Request if that is the case

Fixes #2930
Assisted-By Claude:Opus-5