### PR TITLE
[Tests] Expand XrdPfc (XCache) test coverage

### DIFF
--- a/tests/XRootD/CMakeLists.txt
+++ b/tests/XRootD/CMakeLists.txt
@@ -1,6 +1,22 @@
 
 list(APPEND XROOTD_CONFIGS noauth gsi host unix sss cache posix diglib mirage)
 
+# XCache (XrdPfc) configurations. Each fronts the XRootD::host fixture as its
+# origin and exercises one aspect of the cache; the shared shell helpers are in
+# cachelib.sh.
+list(APPEND XROOTD_CONFIGS cacheevict cacheprefetch cacheblacklist cachespaces cacherestart)
+
+# cachepurge is slow on purpose: the purge check runs on a fixed 60 s cycle and
+# there is no way to trigger one, so the test has to wait for at least one pass.
+list(APPEND XROOTD_CONFIGS cachepurge)
+
+# Range-reading client for the cache tests. xrdcp only does whole files, and
+# the interesting XCache behaviour is block-granular. Threads::Threads because
+# the concurrent-reader mode uses std::thread, which needs pthread linked
+# explicitly on glibc older than 2.34.
+add_executable(xrdpfc-read utils/xrdpfc-read.cc)
+target_link_libraries(xrdpfc-read XrdCl XrdUtils Threads::Threads)
+
 if(ENABLE_FUSE_TESTS)
   list(APPEND XROOTD_CONFIGS fuse)
 endif()
@@ -29,9 +45,11 @@ if(BUILD_SCITOKENS AND HAVE_SCITOKEN_CONFIG_SET_STR)
   list(APPEND httpnoclient_FIXTURES SciTokens)
 endif()
 
-# The cache test requires the XRootD::host fixture to be running to
+# The cache tests require the XRootD::host fixture to be running to
 # act as an origin
-list(APPEND cache_FIXTURES XRootD::host)
+foreach(CACHE_CONFIG cache cacheevict cacheprefetch cacheblacklist cachespaces cacherestart cachepurge)
+  list(APPEND ${CACHE_CONFIG}_FIXTURES XRootD::host)
+endforeach()
 
 list(APPEND gsi_FIXTURES TLS)
 
@@ -81,3 +99,6 @@ if(BUILD_SCITOKENS AND HAVE_SCITOKEN_CONFIG_SET_STR)
       FIXTURES_REQUIRED SciTokens
   )
 endif()
+
+# Waiting out purge cycles, see cachepurge.sh.
+set_tests_properties(XRootD::cachepurge::test PROPERTIES TIMEOUT 600 LABELS slow)

--- a/tests/XRootD/cache.cfg
+++ b/tests/XRootD/cache.cfg
@@ -21,4 +21,23 @@ pss.cachelib libXrdPfc.so
 pss.setopt DebugLevel 4
 pss.origin localhost:5094
 
+# Cache parameters, pinned down rather than left to the defaults because
+# cache.sh asserts on them. The block size fixes how many blocks a file of a
+# given size has; prefetching is off so that the cold read fetches only what the
+# client asked for and b_prefetch stays a fixed 0. Keep PFC_BLOCKSIZE in
+# cache.sh in step with pfc.blocksize.
+
+pfc.blocksize 128k
+pfc.prefetch 0
+
+# Publish the pfc g-stream, which cache.sh reads. b_todisk (bytes fetched from
+# the origin and written to disk) and b_prefetch are only reported here -- they
+# are not in the cinfo -- and b_todisk is the only exact statement of how much
+# came over the network, since the b_hit/b_miss split depends on request
+# granularity. 'json insthdr' makes the datagram JSON throughout, with no
+# binary header to unpack. Keep the port in step with PFC_GSTREAM_PORT in
+# cache.sh.
+
+xrootd.mongstream pfc use flush 1s maxlen 24000 send json insthdr localhost:7097
+
 continue $src/common.cfg

--- a/tests/XRootD/cache.sh
+++ b/tests/XRootD/cache.sh
@@ -1,18 +1,46 @@
 #!/usr/bin/env bash
+#
+# Core XCache read path: whole-file mode, prefetching off, one origin.
+# What this asserts is where the bytes came from, not just that they arrived --
+# returning the right bytes is what a plain proxy would also do.
 
 export XrdSecPROTOCOL=host
 
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+# Must match pfc.blocksize in cache.cfg.
+PFC_BLOCKSIZE=$((128 * 1024))
+
+# Must match the destination port of the xrootd.mongstream line in cache.cfg.
+PFC_GSTREAM_PORT=7097
+
+# Test file size, in whole cache blocks.
+PFC_NBLOCKS=32
+
 function setup_cache() {
 	require_commands diff
+	cache_setup
+}
+
+# Size reported by xrdfs stat for $2 on server $1.
+function stat_size() {
+	xrdfs "$1" stat "$2" 2>/dev/null | sed -n 's/^Size:[[:space:]]*\([0-9]*\).*/\1/p'
 }
 
 function test_cache() {
+	ensure_gstream_collector
+
 	echo
 	echo "client: XRootD $(xrdcp --version 2>&1)"
 	echo "server: XRootD $(xrdfs "${HOST}" query config version 2>&1)"
 	echo
 
-	ORIGIN_HOST="root://localhost:5094"
+	local size=$((PFC_BLOCKSIZE * PFC_NBLOCKS))
+
+	#---------------------------------------------------------------------------
+	echo "--- a file read through the cache is byte-identical to the origin"
+	#---------------------------------------------------------------------------
 
 	assert xrdcp -f "${SOURCE_DIR}"/cache.cfg "${ORIGIN_HOST}//cache.cfg"
 	assert xrdcp -f "${ORIGIN_HOST}"//cache.cfg cache.origin.cfg
@@ -20,4 +48,183 @@ function test_cache() {
 
 	assert xrdcp -f "${HOST}"//cache.cfg host.cache.cfg
 	assert diff -u "${SOURCE_DIR}"/cache.cfg host.cache.cfg
+
+	#---------------------------------------------------------------------------
+	echo "--- cold read fetches the whole file, warm read touches no origin"
+	#---------------------------------------------------------------------------
+
+	local lfn=pfc-hitmiss.dat
+	local cinfo rec hit miss bypass
+	cinfo="$(cinfo_path ${lfn})"
+
+	make_origin_file hitmiss.dat "${lfn}" "${PFC_NBLOCKS}"
+
+	if [[ -e "${cinfo}" ]]; then
+		error "cache already holds ${lfn} before the cold read"
+	fi
+
+	assert xrdcp -f "${HOST}//${lfn}" cold.dat
+	assert cmp hitmiss.dat cold.dat
+
+	rec="$(wait_for_gstream_close "${lfn}" 1)"
+	assert_eq "${size}" "$(json_int "${rec}" b_todisk)" \
+		"cold read should fetch the whole file from the origin"
+	assert_eq "0" "$(json_int "${rec}" b_prefetch)" \
+		"cold read should fetch nothing speculatively, pfc.prefetch is 0"
+	assert_eq "${PFC_NBLOCKS}" "$(json_int "${rec}" n_blks_done)" \
+		"cold read should leave every block downloaded"
+
+	wait_for_access_record "${cinfo}" 1
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${cinfo}")" \
+		"cold read should leave the file complete in the cache"
+
+	# B_hit/B_miss cannot carry "came over the network" -- see the note at the
+	# top of cachelib.sh -- but they do have to add up and account for
+	# everything, with nothing slipping past the cache.
+	read -r hit miss bypass <<< "$(cinfo_access "${cinfo}" 1)"
+	assert_eq "${size}" "$((hit + miss))" "cold read: hit plus miss should be the file size"
+	assert_eq "0" "${bypass}" "cold read should not bypass the cache"
+
+	assert xrdcp -f "${HOST}//${lfn}" warm.dat
+	assert cmp hitmiss.dat warm.dat
+
+	assert_fetched "${lfn}" 2 0 "warm read should not fetch anything from the origin"
+
+	wait_for_access_record "${cinfo}" 2
+	assert_eq "${size} 0 0" "$(cinfo_access "${cinfo}" 2)" \
+		"warm read should be all hit (B_hit B_miss B_bypass)"
+
+	#---------------------------------------------------------------------------
+	echo "--- a small read pulls one whole block, and only once"
+	#---------------------------------------------------------------------------
+
+	# The cache is block-granular: a 4 kB read of an uncached file has to fetch
+	# the whole block it falls in, and nothing more. Reading the same 4 kB again
+	# must then go nowhere near the origin.
+
+	local plfn=pfc-partial.dat
+	local pcinfo
+	pcinfo="$(cinfo_path ${plfn})"
+
+	make_origin_file partial.dat "${plfn}" "${PFC_NBLOCKS}"
+
+	assert xrdpfc-read read "${HOST}//${plfn}" part1.dat 0:4096
+	assert dd if=partial.dat of=part1.ref bs=4096 count=1 status=none
+	assert cmp part1.dat part1.ref
+
+	assert_fetched "${plfn}" 1 "${PFC_BLOCKSIZE}" \
+		"a 4 kB read should pull exactly the one block it falls in"
+
+	wait_for_access_record "${pcinfo}" 1
+	assert_eq "${PFC_NBLOCKS} 1 incomplete" "$(cinfo_blocks "${pcinfo}")" \
+		"after a 4 kB read the file should be one block in and incomplete"
+
+	assert xrdpfc-read read "${HOST}//${plfn}" part2.dat 0:4096
+	assert cmp part2.dat part1.ref
+	assert_fetched "${plfn}" 2 0 "re-reading a cached block should not reach the origin"
+
+	#---------------------------------------------------------------------------
+	echo "--- a vector read fetches only the blocks its chunks land in"
+	#---------------------------------------------------------------------------
+
+	# Scattered reads are the case XCache exists for. Three 4 kB chunks in
+	# blocks 0, 8 and 24: block 0 is already cached from above, so exactly two
+	# blocks should come over the network, and the returned bytes must be the
+	# three ranges concatenated in order.
+
+	local b8=$((PFC_BLOCKSIZE * 8))
+	local b24=$((PFC_BLOCKSIZE * 24))
+
+	assert xrdpfc-read readv "${HOST}//${plfn}" vec.dat 0:4096 "${b8}":4096 "${b24}":4096
+
+	assert dd if=partial.dat of=vec.ref bs=4096 count=1 status=none
+	dd if=partial.dat bs=4096 skip=$((b8 / 4096)) count=1 status=none >> vec.ref
+	dd if=partial.dat bs=4096 skip=$((b24 / 4096)) count=1 status=none >> vec.ref
+	assert cmp vec.dat vec.ref
+
+	assert_fetched "${plfn}" 3 $((2 * PFC_BLOCKSIZE)) \
+		"a vector read should fetch only the blocks it has chunks in"
+
+	wait_for_access_record "${pcinfo}" 3
+	assert_eq "${PFC_NBLOCKS} 3 incomplete" "$(cinfo_blocks "${pcinfo}")" \
+		"the vector read should have added two blocks"
+
+	# Which blocks, not just how many.
+	local expected_map
+	expected_map="$(python3 -c "
+m = ['.'] * ${PFC_NBLOCKS}
+for i in (0, 8, 24): m[i] = 'x'
+print(''.join(m))")"
+	assert_eq "${expected_map}" "$(cinfo_block_map "${pcinfo}")" \
+		"only the blocks the chunks landed in should be present"
+
+	#---------------------------------------------------------------------------
+	echo "--- concurrent readers of the same block fetch it once between them"
+	#---------------------------------------------------------------------------
+
+	# Four readers opening the same uncached file at once and reading the same
+	# two blocks. They share one File object, so the origin should see those
+	# two blocks once, not four times, and every reader must get the same bytes.
+
+	local clfn=pfc-concurrent.dat
+	local cbytes=$((PFC_BLOCKSIZE * 2))
+
+	make_origin_file concurrent.dat "${clfn}" "${PFC_NBLOCKS}"
+
+	assert xrdpfc-read multi "${HOST}//${clfn}" conc.dat 4 "${cbytes}"
+	assert dd if=concurrent.dat of=conc.ref bs="${PFC_BLOCKSIZE}" count=2 status=none
+	assert cmp conc.dat conc.ref
+
+	assert_eq "${cbytes}" "$(sum_gstream_todisk "${clfn}")" \
+		"four concurrent readers of the same two blocks should fetch them once"
+
+	#---------------------------------------------------------------------------
+	echo "--- stat reports the origin's size even when little of the file is cached"
+	#---------------------------------------------------------------------------
+
+	# pfc-partial.dat is three blocks of thirty-two on disk at this point. The
+	# cache must still report the real length: a client that believed the size
+	# of the local sparse copy would read a truncated file.
+
+	local origin_size cache_size
+	origin_size="$(stat_size "${ORIGIN_HOST}" "/${plfn}")"
+	cache_size="$(stat_size "${HOST}" "/${plfn}")"
+
+	assert_eq "${size}" "${origin_size}" "the origin should report the full size"
+	assert_eq "${origin_size}" "${cache_size}" \
+		"stat through the cache should report the origin's size, not what is on disk"
+
+	# And it is still incomplete, so this was not a full copy in disguise.
+	assert_eq "${PFC_NBLOCKS} 3 incomplete" "$(cinfo_blocks "${pcinfo}")" \
+		"the partially cached file should still be partial"
+
+	#---------------------------------------------------------------------------
+	echo "--- writing through the cache is refused, cleanly"
+	#---------------------------------------------------------------------------
+
+	# The proxy is read-only. A write has to fail outright rather than land in
+	# the cache, or worse, half-land and be served later as if it were real.
+
+	assert dd if=/dev/urandom of=upload.dat bs=4096 count=1 status=none
+	assert_failure xrdcp -f upload.dat "${HOST}//pfc-uploaded.dat"
+
+	if [[ -e "$(cache_store)/pfc-uploaded.dat" ]] ||
+	   [[ -e "$(cinfo_path pfc-uploaded.dat)" ]]; then
+		error "a refused write left state in the cache"
+	fi
+	assert_failure xrdfs "${ORIGIN_HOST}" stat /pfc-uploaded.dat
+
+	#---------------------------------------------------------------------------
+	echo "--- a missing file fails and leaves nothing behind in the cache"
+	#---------------------------------------------------------------------------
+
+	# The cache must pass the origin's error through and not create state for a
+	# file that does not exist.
+
+	assert_failure xrdcp -f "${HOST}//pfc-does-not-exist.dat" missing.dat
+
+	if [[ -e "$(cache_store)/pfc-does-not-exist.dat" ]] ||
+	   [[ -e "$(cinfo_path pfc-does-not-exist.dat)" ]]; then
+		error "cache created state for a file that does not exist on the origin"
+	fi
 }

--- a/tests/XRootD/cacheblacklist.cfg
+++ b/tests/XRootD/cacheblacklist.cfg
@@ -1,0 +1,24 @@
+set name = cacheblacklist
+set port = 7104
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+pfc.trace info
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin localhost:5094
+
+pfc.blocksize 128k
+pfc.prefetch 0
+
+# Paths matching a line in the blacklist are proxied straight through and never
+# cached. The list is written by setup_cacheblacklist, since it needs a path
+# only known at run time. Entries are fnmatch patterns.
+pfc.decisionlib libXrdBlacklistDecision.so $pwd/cacheblacklist/blacklist.txt
+
+# cacheblacklist.sh reads this to find out what the cache actually fetched.
+xrootd.mongstream pfc use flush 1s maxlen 24000 send json insthdr localhost:7105
+
+continue $src/common.cfg

--- a/tests/XRootD/cacheblacklist.sh
+++ b/tests/XRootD/cacheblacklist.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# pfc.decisionlib: the cache asks a plugin whether a file should be cached at
+# all. A refusal has to proxy the data through untouched and leave no state
+# behind -- the bypass path, which is otherwise not exercised anywhere.
+
+export XrdSecPROTOCOL=host
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+PFC_BLOCKSIZE=$((128 * 1024))
+PFC_GSTREAM_PORT=7105
+PFC_NBLOCKS=8
+
+function setup_cacheblacklist() {
+	cache_setup
+
+	# The blacklist path is baked into cacheblacklist.cfg. Entries are fnmatch
+	# patterns against the LFN.
+	cat > "${PWD}/${NAME}/blacklist.txt" <<-LIST
+	/nocache/*
+	LIST
+}
+
+function test_cacheblacklist() {
+	ensure_gstream_collector
+
+	local size=$((PFC_BLOCKSIZE * PFC_NBLOCKS))
+
+	#---------------------------------------------------------------------------
+	echo "--- a blacklisted file is served correctly but never cached"
+	#---------------------------------------------------------------------------
+
+	local blocked=nocache/blocked.dat
+
+	assert xrdfs "${ORIGIN_HOST}" mkdir -p /nocache
+	make_origin_file blocked.dat "${blocked}" "${PFC_NBLOCKS}"
+
+	assert xrdcp -f "${HOST}//${blocked}" blocked-out.dat
+	assert cmp blocked.dat blocked-out.dat
+
+	# Read it twice: a cache that quietly stored it the first time would show
+	# up as a changed byte count on the second read.
+	assert xrdcp -f "${HOST}//${blocked}" blocked-out2.dat
+	assert cmp blocked.dat blocked-out2.dat
+
+	if [[ -e "$(cinfo_path ${blocked})" ]] || [[ -e "$(cache_store)/${blocked}" ]]; then
+		error "a blacklisted file was written into the cache"
+	fi
+
+	#---------------------------------------------------------------------------
+	echo "--- a file outside the blacklist is cached as usual"
+	#---------------------------------------------------------------------------
+
+	# Guards against the plugin being wired up as a blanket refusal. Doing it
+	# before checking the g-stream also gives the absence check below
+	# something to synchronise on: once this file's record has been seen, the
+	# stream has been flushed past the reads above.
+	local allowed=pfc-allowed.dat
+	local acinfo
+	acinfo="$(cinfo_path ${allowed})"
+
+	make_origin_file allowed.dat "${allowed}" "${PFC_NBLOCKS}"
+
+	assert xrdcp -f "${HOST}//${allowed}" allowed-out.dat
+	assert cmp allowed.dat allowed-out.dat
+
+	assert_fetched "${allowed}" 1 "${size}" \
+		"a file outside the blacklist should be fetched and cached"
+
+	#---------------------------------------------------------------------------
+	echo "--- the blacklisted file never became a cache file at all"
+	#---------------------------------------------------------------------------
+
+	# A refused decision makes Cache::Attach hand back the upstream IO
+	# unchanged, so no File object is ever constructed and there is nothing to
+	# report on close. The missing record is the positive evidence that the
+	# read was proxied rather than cached and then hidden.
+	assert_no_gstream_close "${blocked}"
+
+	wait_for_access_record "${acinfo}" 1
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${acinfo}")" \
+		"a file outside the blacklist should be complete in the cache"
+
+	assert xrdcp -f "${HOST}//${allowed}" allowed-out2.dat
+	assert cmp allowed.dat allowed-out2.dat
+	assert_fetched "${allowed}" 2 0 "the second read of an allowed file should be served from disk"
+}

--- a/tests/XRootD/cacheevict.cfg
+++ b/tests/XRootD/cacheevict.cfg
@@ -1,0 +1,23 @@
+set name = cacheevict
+set port = 7100
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+pfc.trace info
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin localhost:5094
+
+pfc.blocksize 128k
+pfc.prefetch 0
+
+# Defaults, spelled out because cacheevict.sh depends on them: a file counts as
+# cached for only-if-cached purposes only when all of it is on disk.
+pfc.onlyifcached minsize 1m minfrac 1.0
+
+# cacheevict.sh reads this to find out what the cache actually fetched.
+xrootd.mongstream pfc use flush 1s maxlen 24000 send json insthdr localhost:7101
+
+continue $src/common.cfg

--- a/tests/XRootD/cacheevict.sh
+++ b/tests/XRootD/cacheevict.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# only-if-cached and eviction: the two ways a client asks the cache about, or
+# changes, what it is holding, without going to the origin for the answer.
+
+export XrdSecPROTOCOL=host
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+PFC_BLOCKSIZE=$((128 * 1024))
+PFC_GSTREAM_PORT=7101
+PFC_NBLOCKS=32
+
+function setup_cacheevict() {
+	cache_setup
+}
+
+function test_cacheevict() {
+	ensure_gstream_collector
+
+	local lfn=pfc-evict.dat
+	local size=$((PFC_BLOCKSIZE * PFC_NBLOCKS))
+	local cinfo
+	cinfo="$(cinfo_path ${lfn})"
+
+	make_origin_file evict.dat "${lfn}" "${PFC_NBLOCKS}"
+
+	#---------------------------------------------------------------------------
+	echo "--- only-if-cached refuses a file the cache does not hold"
+	#---------------------------------------------------------------------------
+
+	# The open must fail rather than silently falling back to the origin --
+	# that is the entire point of the flag for a client that is trying to
+	# avoid a WAN transfer.
+	assert_failure xrdcp -f "${HOST}//${lfn}?only-if-cached" oic-cold.dat
+
+	if [[ -e "${cinfo}" ]]; then
+		error "a refused only-if-cached open should not have created cache state"
+	fi
+
+	#---------------------------------------------------------------------------
+	echo "--- a partly cached file still does not count as cached"
+	#---------------------------------------------------------------------------
+
+	# pfc.onlyifcached minfrac 1.0: one block present is not enough.
+	assert xrdpfc-read read "${HOST}//${lfn}" evict-part.dat 0:4096
+	wait_for_access_record "${cinfo}" 1
+	assert_eq "${PFC_NBLOCKS} 1 incomplete" "$(cinfo_blocks "${cinfo}")" \
+		"the 4 kB read should have left the file incomplete"
+
+	assert_failure xrdcp -f "${HOST}//${lfn}?only-if-cached" oic-part.dat
+
+	#---------------------------------------------------------------------------
+	echo "--- once fully cached it is served, without touching the origin"
+	#---------------------------------------------------------------------------
+
+	assert xrdcp -f "${HOST}//${lfn}" evict-full.dat
+	assert cmp evict.dat evict-full.dat
+	wait_for_access_record "${cinfo}" 2
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${cinfo}")" \
+		"the full read should have completed the file"
+
+	assert xrdcp -f "${HOST}//${lfn}?only-if-cached" oic-warm.dat
+	assert cmp evict.dat oic-warm.dat
+
+	# Assert on the running total rather than on a numbered record. Between
+	# them the reads above have pulled the file exactly once; if the
+	# only-if-cached read had gone to the origin the total would have grown.
+	# A read that never constructs a File emits no record at all, and the
+	# refused only-if-cached opens may or may not have bumped the access count
+	# depending on whether the file was still active, so neither the record
+	# count nor its position in the log can be pinned down.
+	assert_eq "${size}" "$(sum_gstream_todisk "${lfn}")" \
+		"an only-if-cached read should never reach the origin"
+
+	#---------------------------------------------------------------------------
+	echo "--- evict removes both the data file and its cinfo"
+	#---------------------------------------------------------------------------
+
+	assert xrdfs "${HOST}" cache evict "/${lfn}"
+
+	for _ in $(seq 50); do
+		[[ -e "${cinfo}" ]] || break
+		sleep 0.2
+	done
+
+	if [[ -e "${cinfo}" ]]; then
+		error "evict left the cinfo behind: ${cinfo}"
+	fi
+	if [[ -e "$(cache_store)/${lfn}" ]]; then
+		error "evict left the data file behind: $(cache_store)/${lfn}"
+	fi
+
+	# Evicting must not have touched the origin's copy.
+	assert xrdcp -f "${ORIGIN_HOST}//${lfn}" evict-origin.dat
+	assert cmp evict.dat evict-origin.dat
+
+	#---------------------------------------------------------------------------
+	echo "--- after eviction the cache is cold again"
+	#---------------------------------------------------------------------------
+
+	assert_failure xrdcp -f "${HOST}//${lfn}?only-if-cached" oic-evicted.dat
+
+	assert xrdcp -f "${HOST}//${lfn}" evict-refetch.dat
+	assert cmp evict.dat evict-refetch.dat
+
+	# The origin has now served the file twice over: once before the eviction
+	# and once after.
+	assert_eq "$((2 * size))" "$(sum_gstream_todisk "${lfn}")" \
+		"the read after eviction should fetch the whole file again"
+}

--- a/tests/XRootD/cachelib.sh
+++ b/tests/XRootD/cachelib.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+#
+# Shared helpers for the XCache (XrdPfc) tests. Sourced by cache*.sh, each of
+# which drives one cache configuration against the XRootD::host fixture.
+#
+# Two independent oracles are available, and they answer different questions:
+#
+#   * the pfc g-stream file_close record -- b_todisk is exactly how many bytes
+#     came over the network on that open, and b_prefetch how much of that was
+#     speculative. Both are counted per block as blocks are written out, so
+#     they do not move with the client's request size.
+#
+#   * the .cinfo file, via xrdpfc_print -- the state left on disk: which blocks
+#     are present, whether the file is complete, and the access history.
+#
+# Do not assert on B_hit/B_miss to mean "came from the network". PFC scores a
+# block as missed only for the request that created it, so a second request
+# landing on the same in-flight block reads as a hit, and with prefetching on a
+# cold read of an uncached file reports 100% hit. That is upstream issue #2366.
+# b_todisk is the field that states it correctly.
+
+# Defaults. A config that differs must set these before calling cache_setup.
+: "${PFC_BLOCKSIZE:=$((128 * 1024))}"
+
+ORIGIN_HOST="root://localhost:5094"
+
+#-------------------------------------------------------------------------------
+# Paths. setup and run are separate processes, so derive rather than export.
+#-------------------------------------------------------------------------------
+
+# Local store of the cache: common.cfg points oss.localroot at what test.sh
+# exports as REMOTE_DIR, so <lfn> and <lfn>.cinfo land there.
+function cache_store() {
+	echo "${REMOTE_DIR}"
+}
+
+function cinfo_path() {
+	echo "$(cache_store)/$1.cinfo"
+}
+
+function gstream_log() {
+	echo "${PWD}/${NAME}/gstream.json"
+}
+
+#-------------------------------------------------------------------------------
+# Setup
+#-------------------------------------------------------------------------------
+
+# Start the g-stream collector. Call from setup_<name> with PFC_GSTREAM_PORT
+# set to the destination port of the xrootd.mongstream line in the config.
+function cache_setup() {
+	require_commands cmp dd python3 xrdpfc-read xrdpfc_print
+
+	# A test that asserts on b_todisk sets PFC_GSTREAM_PORT and gets a
+	# collector; one that only reads the filesystem leaves it unset and does
+	# without, so it needs neither a free UDP port nor a working g-stream.
+	[[ -n "${PFC_GSTREAM_PORT:-}" ]] || return 0
+
+	rm -f "$(gstream_log)"
+	start_gstream_collector
+}
+
+# The helper detaches itself and writes its own pid file: a plain background job
+# would be killed with the rest of this test's process group as soon as ctest
+# reaps the setup step, and one that merely survived would hang the run by
+# holding ctest's output pipe open. It returns once the port is bound, so the
+# server cannot come up before the collector is listening. test.sh's generic
+# teardown kills anything that left a pid file behind.
+function start_gstream_collector() {
+	assert python3 "${SOURCE_DIR}/utils/gstream_recv.py" \
+		"${PFC_GSTREAM_PORT}" "$(gstream_log)" "${PWD}/${NAME}/gstream.pid"
+}
+
+# True while the collector started at setup is still running.
+function gstream_collector_alive() {
+	local pidfile="${PWD}/${NAME}/gstream.pid"
+	[[ -s "${pidfile}" ]] && kill -0 "$(cat "${pidfile}")" 2>/dev/null
+}
+
+# Call at the top of a test body that asserts on the g-stream.
+#
+# The collector starts at setup, but ctest runs every setup first and the test
+# bodies long afterwards -- in a full run that gap is eighty-odd tests and about
+# ten minutes. CI loses one of these idle processes now and then, and since
+# nothing restarts it, every g-stream assertion in that one test fails while the
+# rest of the job is fine; the victim moved between platforms and tests on each
+# run. Starting another one works: a UDP listener that comes back keeps
+# receiving. The server does drop one datagram when it returns, the one whose
+# send reports the ICMP queued from while the port was dead, but nothing is sent
+# between setup and here, so there is none pending.
+function ensure_gstream_collector() {
+	[[ -n "${PFC_GSTREAM_PORT:-}" ]] || return 0
+	gstream_collector_alive && return 0
+
+	echo "g-stream collector is gone, starting another"
+	start_gstream_collector
+}
+
+#-------------------------------------------------------------------------------
+# Test data
+#-------------------------------------------------------------------------------
+
+# Size of a file in bytes. GNU stat -c%s and BSD stat -f%z disagree; wc -c is
+# in POSIX and needs no branch on uname.
+function file_bytes() {
+	wc -c < "$1"
+}
+
+# make_origin_file <local> <lfn> <n_blocks> -- random file of n_blocks whole
+# cache blocks, put on the origin. Whole blocks keep the expected byte counts
+# free of rounding.
+function make_origin_file() {
+	assert dd if=/dev/urandom of="$1" bs="${PFC_BLOCKSIZE}" count="$3" status=none
+	assert xrdcp -fs "$1" "${ORIGIN_HOST}//$2"
+}
+
+#-------------------------------------------------------------------------------
+# The g-stream oracle
+#-------------------------------------------------------------------------------
+
+# Integer field $2 of JSON record $1.
+function json_int() {
+	echo "$1" | sed -n "s/.*\"$2\":\(-\{0,1\}[0-9]\{1,\}\).*/\1/p"
+}
+
+# The file_close record for lfn $1 at access_cnt $2. The record is only emitted
+# when the cache closes the file, which happens after the client has gone, and
+# the g-stream is flushed on a timer on top of that -- so wait, do not race.
+function wait_for_gstream_close() {
+	local rec
+	for _ in $(seq 100); do
+		rec="$(grep '"event":"file_close"' "$(gstream_log)" 2>/dev/null |
+		       grep "\"lfn\":\"/$1\"" | grep "\"access_cnt\":$2," | tail -1)" || true
+		if [[ -n "${rec}" ]]; then
+			echo "${rec}"
+			return 0
+		fi
+		sleep 0.2
+	done
+	# Say whether the log is empty or merely missing this record: the first
+	# means the collector never received anything, the second that the cache
+	# did not close the file when expected. They need different fixes.
+	error "timed out after 20 s waiting for g-stream file_close of /$1" \
+	      "at access_cnt $2; $(gstream_diagnosis)"
+}
+
+# Why might a record be missing? A dead collector and a cache that never closed
+# the file need different fixes, and the bare timeout cannot tell them apart.
+function gstream_diagnosis() {
+	local n_all alive="no"
+	n_all="$(grep -c '"event":"file_close"' "$(gstream_log)" 2>/dev/null || echo 0)"
+	gstream_collector_alive && alive="yes"
+	echo "collector alive: ${alive}, log holds ${n_all} file_close records"
+}
+
+# Total b_todisk over every file_close record for lfn $1 so far -- the bytes
+# the origin has served for it since the cache started.
+#
+# Cumulative rather than per-record on purpose. Records are emitted when the
+# cache closes a file and are then flushed on a timer, so which record a given
+# read lands in, and when it appears in the log, both move around; a running
+# total does not. Waits for the first record, then lets stragglers land.
+function sum_gstream_todisk() {
+	local rec found=""
+	for _ in $(seq 100); do
+		found="$(grep '"event":"file_close"' "$(gstream_log)" 2>/dev/null |
+		         grep "\"lfn\":\"/$1\"" | head -1)" || true
+		[[ -n "${found}" ]] && break
+		sleep 0.2
+	done
+	if [[ -z "${found}" ]]; then
+		error "timed out after 20 s waiting for any g-stream file_close of /$1;" \
+		      "$(gstream_diagnosis)"
+	fi
+	sleep 3
+
+	local total=0
+	while read -r rec; do
+		[[ -n "${rec}" ]] || continue
+		total=$((total + $(json_int "${rec}" b_todisk)))
+	done < <(grep '"event":"file_close"' "$(gstream_log)" 2>/dev/null |
+	         grep "\"lfn\":\"/$1\"" || true)
+
+	echo "${total}"
+}
+
+# assert_fetched <lfn> <access_cnt> <expected b_todisk> <message>
+function assert_fetched() {
+	local rec
+	rec="$(wait_for_gstream_close "$1" "$2")"
+	assert_eq "$3" "$(json_int "${rec}" b_todisk)" "$4"
+}
+
+#-------------------------------------------------------------------------------
+# The cinfo oracle
+#-------------------------------------------------------------------------------
+
+# "<n_blocks> <n_downloaded> <state>"
+function cinfo_blocks() {
+	xrdpfc_print -u B "$1" |
+	sed -n 's/^file_size .*n_blocks \([0-9]*\), n_downloaded \([0-9]*\), state \([a-z]*\).*/\1 \2 \3/p'
+}
+
+function cinfo_n_acc() {
+	xrdpfc_print -u B "$1" | sed -n 's/^Access records (N_acc_total=\([0-9]*\)).*/\1/p'
+}
+
+# "<B_hit> <B_miss> <B_bypass>" of access record $2, in bytes.
+function cinfo_access() {
+	xrdpfc_print -u B "$1" | awk -v rec="$2" '$1 == rec { print $(NF-2), $(NF-1), $NF; exit }'
+}
+
+# The block presence map as a string of x and . , one char per block.
+function cinfo_block_map() {
+	xrdpfc_print -u B -v "$1" |
+	sed -n '/^printing /,/^Access records/p' | sed -n 's/^ *[0-9]\{1,\} \([x.]\{1,\}\)$/\1/p' | tr -d '\n'
+}
+
+function wait_for_access_record() {
+	for _ in $(seq 100); do
+		if [[ -f "$1" ]] && [[ "$(cinfo_n_acc "$1")" == "$2" ]]; then
+			return 0
+		fi
+		sleep 0.2
+	done
+	error "timed out after 20 s waiting for access record $2 of $1"
+}

--- a/tests/XRootD/cacheprefetch.cfg
+++ b/tests/XRootD/cacheprefetch.cfg
@@ -1,0 +1,19 @@
+set name = cacheprefetch
+set port = 7102
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+pfc.trace info
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin localhost:5094
+
+pfc.blocksize 128k
+pfc.prefetch 8
+
+# cacheprefetch.sh reads this to find out what the cache actually fetched.
+xrootd.mongstream pfc use flush 1s maxlen 24000 send json insthdr localhost:7103
+
+continue $src/common.cfg

--- a/tests/XRootD/cacheprefetch.sh
+++ b/tests/XRootD/cacheprefetch.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Prefetching. The prefetcher is what makes a cache useful for sequential
+# reading, and it is also what makes the b_hit/b_miss pair unusable as a
+# measure of network traffic -- see the note in cachelib.sh.
+
+export XrdSecPROTOCOL=host
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+PFC_BLOCKSIZE=$((128 * 1024))
+PFC_GSTREAM_PORT=7103
+PFC_NBLOCKS=32
+
+function setup_cacheprefetch() {
+	cache_setup
+}
+
+function test_cacheprefetch() {
+	ensure_gstream_collector
+
+	local lfn=pfc-prefetch.dat
+	local size=$((PFC_BLOCKSIZE * PFC_NBLOCKS))
+	local cinfo rec todisk prefetched
+	cinfo="$(cinfo_path ${lfn})"
+
+	make_origin_file prefetch.dat "${lfn}" "${PFC_NBLOCKS}"
+
+	#---------------------------------------------------------------------------
+	echo "--- a small read pulls more than it asked for, and it is prefetch"
+	#---------------------------------------------------------------------------
+
+	# With pfc.prefetch 8 a 4 kB read should drag further blocks in behind it.
+	# Without prefetching the same read fetches exactly one block -- that is
+	# asserted in cache.sh, so the two tests bracket the behaviour.
+
+	assert xrdpfc-read read "${HOST}//${lfn}" pf-small.dat 0:4096
+	assert dd if=prefetch.dat of=pf-small.ref bs=4096 count=1 status=none
+	assert cmp pf-small.dat pf-small.ref
+
+	rec="$(wait_for_gstream_close "${lfn}" 1)"
+	todisk="$(json_int "${rec}" b_todisk)"
+	prefetched="$(json_int "${rec}" b_prefetch)"
+
+	if [[ "${todisk}" -le "${PFC_BLOCKSIZE}" ]]; then
+		error "prefetch is on but a 4 kB read fetched only ${todisk} bytes;" \
+		      "expected more than one ${PFC_BLOCKSIZE} byte block"
+	fi
+	if [[ "${prefetched}" -le 0 ]]; then
+		error "prefetch is on but b_prefetch is ${prefetched}"
+	fi
+	if [[ "${prefetched}" -gt "${todisk}" ]]; then
+		error "b_prefetch ${prefetched} exceeds b_todisk ${todisk};" \
+		      "prefetched bytes are a subset of what was fetched"
+	fi
+
+	#---------------------------------------------------------------------------
+	echo "--- prefetch never fetches past the end of the file"
+	#---------------------------------------------------------------------------
+
+	# Read the whole file. However eagerly the prefetcher ran, the origin
+	# cannot have been asked for more than the file holds, and every block has
+	# to end up present exactly once.
+
+	local pfull=pfc-prefetch-full.dat
+	local pfcinfo
+	pfcinfo="$(cinfo_path ${pfull})"
+
+	make_origin_file prefetch-full.dat "${pfull}" "${PFC_NBLOCKS}"
+
+	assert xrdcp -f "${HOST}//${pfull}" pf-full.dat
+	assert cmp prefetch-full.dat pf-full.dat
+
+	assert_fetched "${pfull}" 1 "${size}" \
+		"a full read with prefetching should fetch the file exactly once"
+
+	wait_for_access_record "${pfcinfo}" 1
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${pfcinfo}")" \
+		"the file should be complete after a full read"
+
+	#---------------------------------------------------------------------------
+	echo "--- a re-read of a fully prefetched file goes nowhere"
+	#---------------------------------------------------------------------------
+
+	assert xrdcp -f "${HOST}//${pfull}" pf-full2.dat
+	assert cmp prefetch-full.dat pf-full2.dat
+	assert_fetched "${pfull}" 2 0 "re-reading a complete file should not reach the origin"
+}

--- a/tests/XRootD/cachepurge.cfg
+++ b/tests/XRootD/cachepurge.cfg
@@ -1,0 +1,22 @@
+set name = cachepurge
+set port = 7110
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+pfc.trace info
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin localhost:5094
+
+pfc.blocksize 128k
+pfc.prefetch 0
+
+# A file-usage budget small enough to overrun from a test. When these are set
+# they drive purging instead of the filesystem watermarks, which makes the test
+# independent of how full the developer's disk happens to be. Purge frees down
+# to nominal once usage passes max.
+pfc.diskusage 0.90 0.95 files 2m 3m 4m
+
+continue $src/common.cfg

--- a/tests/XRootD/cachepurge.sh
+++ b/tests/XRootD/cachepurge.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Purging. This is the code that deletes cached data, so what has to be pinned
+# down is not only that it frees space but that it frees the right files: least
+# recently accessed first.
+#
+# Slow by construction. The resource monitor checks for a required purge on a
+# fixed 60 s cycle, and files that were open recently are purge-protected, so
+# reaching the target usually takes more than one cycle. There is no way to ask
+# for a purge on demand.
+
+export XrdSecPROTOCOL=host
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+PFC_BLOCKSIZE=$((128 * 1024))
+
+# No PFC_GSTREAM_PORT: every assertion here reads the cache directory, so this
+# test does not need a g-stream collector.
+
+# Must match the "files <baseline> <nominal> <max>" budget in cachepurge.cfg.
+PFC_FILES_MAX=$((4 * 1024 * 1024))
+
+# Two groups of files, read a couple of seconds apart so their access times
+# fall either side of a clear boundary. Together they overrun the budget.
+PFC_GROUP=4
+PFC_FILE_MB=1
+
+function setup_cachepurge() {
+	cache_setup
+}
+
+function cached_file() {
+	echo "$(cache_store)/pfc-purge-$1.dat"
+}
+
+# Total bytes of cached data files, ignoring cinfo and the stats directory.
+function cached_bytes() {
+	local total=0 f
+	for f in "$(cache_store)"/pfc-purge-*.dat; do
+		[[ -f "${f}" ]] || continue
+		total=$((total + $(file_bytes "${f}")))
+	done
+	echo "${total}"
+}
+
+# Space-separated indices of the files still cached, in order.
+function cached_indices() {
+	local i out=()
+	for i in $(seq 1 $((2 * PFC_GROUP))); do
+		[[ -f "$(cached_file ${i})" ]] && out+=("${i}")
+	done
+	echo "${out[*]}"
+}
+
+function test_cachepurge() {
+	local i n_total=$((2 * PFC_GROUP))
+
+	#---------------------------------------------------------------------------
+	echo "--- fill the cache past its file-usage budget"
+	#---------------------------------------------------------------------------
+
+	assert dd if=/dev/urandom of=purge-src.dat bs=1048576 count="${PFC_FILE_MB}" status=none
+	for i in $(seq 1 ${n_total}); do
+		assert xrdcp -fs purge-src.dat "${ORIGIN_HOST}//pfc-purge-${i}.dat"
+	done
+
+	# Group A first, then a pause, then group B, so that every file in B is
+	# strictly more recently accessed than every file in A.
+	for i in $(seq 1 ${PFC_GROUP}); do
+		assert xrdcp -fs "${HOST}//pfc-purge-${i}.dat" "purge-out-${i}.dat"
+	done
+	sleep 3
+	for i in $(seq $((PFC_GROUP + 1)) ${n_total}); do
+		assert xrdcp -fs "${HOST}//pfc-purge-${i}.dat" "purge-out-${i}.dat"
+	done
+
+	local filled
+	filled="$(cached_bytes)"
+	if [[ "${filled}" -le "${PFC_FILES_MAX}" ]]; then
+		error "test did not overrun the budget: cached ${filled} B, max is ${PFC_FILES_MAX} B"
+	fi
+	# Build the expected list the same way cached_indices does. Not
+	# "seq -s' '": BSD seq puts the separator after the last number too, so
+	# the two sides differed by a trailing space on macOS.
+	local expected=()
+	for i in $(seq 1 ${n_total}); do
+		expected+=("${i}")
+	done
+	assert_eq "${expected[*]}" "$(cached_indices)" \
+		"all files should be cached before purging"
+
+	#---------------------------------------------------------------------------
+	echo "--- wait for the purge to bring usage back under the budget"
+	#---------------------------------------------------------------------------
+
+	# The check runs once a minute and purge protection on recently used files
+	# means it can take more than one pass to converge. Wait for usage to fall
+	# to the max, not to the nominal it aims for: how far a single pass gets
+	# depends on what was protected at the time, and a run that stops at the
+	# max has still enforced the budget.
+	local now
+	for _ in $(seq 300); do
+		now="$(cached_bytes)"
+		[[ "${now}" -le "${PFC_FILES_MAX}" ]] && break
+		sleep 1
+	done
+
+	now="$(cached_bytes)"
+	if [[ "${now}" -gt "${PFC_FILES_MAX}" ]]; then
+		error "purge did not bring usage down: ${now} B still cached," \
+		      "the limit is ${PFC_FILES_MAX} B"
+	fi
+	echo "cached bytes: ${filled} before, ${now} after"
+
+	#---------------------------------------------------------------------------
+	echo "--- the files it removed are the least recently used ones"
+	#---------------------------------------------------------------------------
+
+	# The exact number purged is not fixed -- it depends on how many passes ran
+	# and on what was purge-protected at the time -- but the ordering is the
+	# contract: a recently read file must not be dropped while an older one is
+	# kept.
+	local survivors
+	survivors="$(cached_indices)"
+	echo "survivors: ${survivors:-none}"
+
+	local oldest_survivor=0 newest_purged=0
+	for i in $(seq 1 ${n_total}); do
+		if [[ -f "$(cached_file ${i})" ]]; then
+			[[ "${oldest_survivor}" -eq 0 ]] && oldest_survivor="${i}"
+		else
+			newest_purged="${i}"
+		fi
+	done
+
+	if [[ "${newest_purged}" -eq 0 ]]; then
+		error "nothing was purged even though usage came down; the test is not testing purge"
+	fi
+	if [[ "${oldest_survivor}" -ne 0 ]] && [[ "${newest_purged}" -gt "${oldest_survivor}" ]]; then
+		error "purge kept file ${oldest_survivor} but dropped the more recently read" \
+		      "file ${newest_purged}; survivors were: ${survivors}"
+	fi
+
+	#---------------------------------------------------------------------------
+	echo "--- a purged file is gone from the cache, not just hidden"
+	#---------------------------------------------------------------------------
+
+	local victim="pfc-purge-${newest_purged}.dat"
+
+	if [[ -e "$(cinfo_path ${victim})" ]]; then
+		error "purge removed the data file but left the cinfo: $(cinfo_path ${victim})"
+	fi
+
+	# It still reads correctly, and reading it puts it back in the cache --
+	# which it could only do by going to the origin, since the cinfo above is
+	# gone. Asserted through the cinfo rather than the g-stream so that this
+	# long test depends on nothing but the filesystem.
+	assert xrdcp -f "${HOST}//${victim}" purge-refetch.dat
+	assert cmp purge-src.dat purge-refetch.dat
+
+	wait_for_access_record "$(cinfo_path ${victim})" 1
+	local n_blocks=$((PFC_FILE_MB * 1024 * 1024 / PFC_BLOCKSIZE))
+	assert_eq "${n_blocks} ${n_blocks} complete" "$(cinfo_blocks "$(cinfo_path ${victim})")" \
+		"a purged file should be fetched from the origin again"
+}

--- a/tests/XRootD/cacherestart.cfg
+++ b/tests/XRootD/cacherestart.cfg
@@ -1,0 +1,19 @@
+set name = cacherestart
+set port = 7108
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+pfc.trace info
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin localhost:5094
+
+pfc.blocksize 128k
+pfc.prefetch 0
+
+# cacherestart.sh reads this to find out what the cache actually fetched.
+xrootd.mongstream pfc use flush 1s maxlen 24000 send json insthdr localhost:7109
+
+continue $src/common.cfg

--- a/tests/XRootD/cacherestart.sh
+++ b/tests/XRootD/cacherestart.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Cache content has to survive a restart of the server. That means the cinfo
+# written on close is readable again, and the resource monitor's startup scan
+# picks up what is already on disk instead of ignoring or discarding it.
+
+export XrdSecPROTOCOL=host
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+PFC_BLOCKSIZE=$((128 * 1024))
+PFC_GSTREAM_PORT=7109
+PFC_NBLOCKS=32
+
+function setup_cacherestart() {
+	cache_setup
+}
+
+# Is the cache server answering? XRD_CONNECTIONRETRY=0 so that a probe against
+# a server that is already gone fails at once instead of working through the
+# client's reconnect window.
+function server_is_up() {
+	XRD_CONNECTIONRETRY=0 xrdfs "${HOST}" query config version >/dev/null 2>&1
+}
+
+# Stop and start the server with the same configuration and the same data
+# directory. Deliberately not test.sh's setup(), which wipes the store -- the
+# whole point here is that the store outlives the process.
+function restart_server() {
+	local pidfile="${PWD}/${NAME}/xrootd.pid"
+	local pid
+	pid="$(cat "${pidfile}")"
+
+	kill -s TERM "${pid}"
+
+	# Wait for the server to stop answering, rather than for its pid to
+	# disappear. Watching the pid is what the first version did and it hung
+	# for the full timeout on every CI platform: a pid is not a reliable
+	# handle here, it can be recycled by another process in a busy container
+	# and "ps <pid>" is not portable in that form anyway. Not answering is
+	# also the condition that actually matters, since it is what releases the
+	# port for the next server.
+	for _ in $(seq 240); do
+		server_is_up || break
+		sleep 0.5
+	done
+	if server_is_up; then
+		error "cache server ${pid} still answering 120 s after SIGTERM"
+	fi
+
+	assert xrootd -b -l xrootd.log -s xrootd.pid -c "${CONF}" -n "${NAME}"
+
+	for _ in $(seq 240); do
+		if server_is_up; then
+			return 0
+		fi
+		sleep 0.5
+	done
+	error "cache server did not come back up after restart"
+}
+
+function test_cacherestart() {
+	ensure_gstream_collector
+
+	local complete=pfc-restart-full.dat
+	local partial=pfc-restart-part.dat
+	local size=$((PFC_BLOCKSIZE * PFC_NBLOCKS))
+	local ccinfo pcinfo
+	ccinfo="$(cinfo_path ${complete})"
+	pcinfo="$(cinfo_path ${partial})"
+
+	make_origin_file restart-full.dat "${complete}" "${PFC_NBLOCKS}"
+	make_origin_file restart-part.dat "${partial}" "${PFC_NBLOCKS}"
+
+	#---------------------------------------------------------------------------
+	echo "--- populate the cache: one file complete, one deliberately partial"
+	#---------------------------------------------------------------------------
+
+	assert xrdcp -f "${HOST}//${complete}" restart-c1.dat
+	assert cmp restart-full.dat restart-c1.dat
+	assert_fetched "${complete}" 1 "${size}" "cold read should fetch the whole file"
+
+	# Two chunks, in blocks 0 and 8, so the surviving state is a specific
+	# pattern rather than just a count.
+	local b8=$((PFC_BLOCKSIZE * 8))
+	assert xrdpfc-read read "${HOST}//${partial}" restart-p1.dat 0:4096 "${b8}":4096
+	assert_fetched "${partial}" 1 $((2 * PFC_BLOCKSIZE)) \
+		"the partial read should have fetched two blocks"
+
+	wait_for_access_record "${ccinfo}" 1
+	wait_for_access_record "${pcinfo}" 1
+
+	local expected_map
+	expected_map="$(python3 -c "
+m = ['.'] * ${PFC_NBLOCKS}
+for i in (0, 8): m[i] = 'x'
+print(''.join(m))")"
+	assert_eq "${expected_map}" "$(cinfo_block_map "${pcinfo}")" \
+		"blocks 0 and 8 should be the ones present before the restart"
+
+	#---------------------------------------------------------------------------
+	echo "--- restart the cache server"
+	#---------------------------------------------------------------------------
+
+	restart_server
+
+	# On-disk state must be untouched by the restart itself.
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${ccinfo}")" \
+		"the complete file should still be complete after the restart"
+	assert_eq "${expected_map}" "$(cinfo_block_map "${pcinfo}")" \
+		"the partial file should still hold exactly blocks 0 and 8"
+
+	#---------------------------------------------------------------------------
+	echo "--- the complete file is served from disk by the new process"
+	#---------------------------------------------------------------------------
+
+	assert xrdcp -f "${HOST}//${complete}" restart-c2.dat
+	assert cmp restart-full.dat restart-c2.dat
+	assert_fetched "${complete}" 2 0 \
+		"after a restart a complete file should still be served without the origin"
+
+	#---------------------------------------------------------------------------
+	echo "--- the partial file keeps its blocks and only fetches what is missing"
+	#---------------------------------------------------------------------------
+
+	# Re-reading the two surviving blocks must cost nothing; the cache would
+	# have to have forgotten them to go back to the origin.
+	assert xrdpfc-read read "${HOST}//${partial}" restart-p2.dat 0:4096 "${b8}":4096
+	assert cmp restart-p1.dat restart-p2.dat
+	assert_fetched "${partial}" 2 0 \
+		"blocks cached before the restart should still be on disk after it"
+
+	# Reading the whole file now must fetch exactly the blocks that were
+	# missing, not the whole file again.
+	assert xrdcp -f "${HOST}//${partial}" restart-p3.dat
+	assert cmp restart-part.dat restart-p3.dat
+	assert_fetched "${partial}" 3 $(((PFC_NBLOCKS - 2) * PFC_BLOCKSIZE)) \
+		"completing the file should fetch only the blocks that were missing"
+
+	wait_for_access_record "${pcinfo}" 3
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${pcinfo}")" \
+		"the file should now be complete"
+}

--- a/tests/XRootD/cachespaces.cfg
+++ b/tests/XRootD/cachespaces.cfg
@@ -1,0 +1,26 @@
+set name = cachespaces
+set port = 7106
+
+set src = $SOURCE_DIR
+set pwd = $PWD
+
+pfc.trace info
+
+ofs.osslib libXrdPss.so
+pss.cachelib libXrdPfc.so
+pss.origin localhost:5094
+
+pfc.blocksize 128k
+pfc.prefetch 0
+
+# Split data files and cinfo files across two OSS spaces. The directories are
+# created by setup_cachespaces; PFC refuses to start if either has less than
+# 10 MB available.
+oss.space data $pwd/cachespaces/space-data
+oss.space meta $pwd/cachespaces/space-meta
+pfc.spaces data meta
+
+# cachespaces.sh reads this to find out what the cache actually fetched.
+xrootd.mongstream pfc use flush 1s maxlen 24000 send json insthdr localhost:7107
+
+continue $src/common.cfg

--- a/tests/XRootD/cachespaces.sh
+++ b/tests/XRootD/cachespaces.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+#
+# pfc.spaces: data files and their cinfo metadata go to two different OSS
+# spaces, so a deployment can put the metadata on faster storage. Both halves
+# have to end up in the right place and the file still has to read back.
+
+export XrdSecPROTOCOL=host
+
+# shellcheck source=/dev/null
+source "$(dirname "${BASH_SOURCE[0]}")/cachelib.sh"
+
+PFC_BLOCKSIZE=$((128 * 1024))
+PFC_GSTREAM_PORT=7107
+PFC_NBLOCKS=16
+
+function space_dir() {
+	echo "${PWD}/${NAME}/space-$1"
+}
+
+function setup_cachespaces() {
+	cache_setup
+
+	# Paths must match the oss.space lines in cachespaces.cfg, and must exist
+	# before the server starts: PFC stats each space at config time and
+	# refuses to come up if one has less than 10 MB free.
+	mkdir -p "$(space_dir data)" "$(space_dir meta)"
+}
+
+function teardown_cachespaces() {
+	rm -rf "$(space_dir data)" "$(space_dir meta)"
+}
+
+# Literal target of a symlink, not the resolved path: the comparison below is
+# against the space directory as spelled in the config.
+function link_target() {
+	readlink "$1" 2>/dev/null || true
+}
+
+function test_cachespaces() {
+	ensure_gstream_collector
+
+	local lfn=pfc-spaces.dat
+	local size=$((PFC_BLOCKSIZE * PFC_NBLOCKS))
+	local data_link meta_link data_target meta_target
+
+	make_origin_file spaces.dat "${lfn}" "${PFC_NBLOCKS}"
+
+	#---------------------------------------------------------------------------
+	echo "--- the file reads back correctly with data and meta split"
+	#---------------------------------------------------------------------------
+
+	assert xrdcp -f "${HOST}//${lfn}" spaces-out.dat
+	assert cmp spaces.dat spaces-out.dat
+
+	assert_fetched "${lfn}" 1 "${size}" "cold read should fetch the whole file"
+
+	#---------------------------------------------------------------------------
+	echo "--- the data file lands in the data space, the cinfo in the meta space"
+	#---------------------------------------------------------------------------
+
+	# With spaces configured the cache store holds symlinks, and the real
+	# files live under the space directories with OSS-assigned names. What
+	# matters is which space each symlink points into.
+
+	data_link="$(cache_store)/${lfn}"
+	meta_link="$(cinfo_path ${lfn})"
+
+	wait_for_access_record "${meta_link}" 1
+
+	if [[ ! -L "${data_link}" ]]; then
+		error "expected ${data_link} to be a symlink into a space"
+	fi
+	if [[ ! -L "${meta_link}" ]]; then
+		error "expected ${meta_link} to be a symlink into a space"
+	fi
+
+	data_target="$(link_target "${data_link}")"
+	meta_target="$(link_target "${meta_link}")"
+
+	if [[ "${data_target}" != "$(space_dir data)"/* ]]; then
+		error "data file is not in the data space: ${data_target}"
+	fi
+	if [[ "${meta_target}" != "$(space_dir meta)"/* ]]; then
+		error "cinfo is not in the meta space: ${meta_target}"
+	fi
+
+	# Not a dangling link, and the real bytes are there.
+	if [[ ! -f "${data_target}" ]]; then
+		error "data symlink does not resolve to a file: ${data_target}"
+	fi
+	assert cmp spaces.dat "${data_target}"
+
+	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${meta_link}")" \
+		"the cinfo in the meta space should show the file complete"
+
+	#---------------------------------------------------------------------------
+	echo "--- neither space holds the other one's half"
+	#---------------------------------------------------------------------------
+
+	# The whole point of the split, checked by size rather than by name since
+	# the OSS chooses the names. Sizes come from wc -c in a loop: find's -size
+	# is not dependable across the find implementations in CI.
+	local f n_data_sized=0
+	while read -r f; do
+		[[ -n "${f}" ]] || continue
+		[[ "$(file_bytes "${f}")" -eq "${size}" ]] && n_data_sized=$((n_data_sized + 1))
+	done < <(find "$(space_dir data)" -type f)
+
+	if [[ "${n_data_sized}" -eq 0 ]]; then
+		error "no file of the data file's size under the data space"
+	fi
+
+	while read -r f; do
+		[[ -n "${f}" ]] || continue
+		if [[ "$(file_bytes "${f}")" -eq "${size}" ]]; then
+			error "a full-size data file was written into the meta space: ${f}"
+		fi
+	done < <(find "$(space_dir meta)" -type f)
+
+	#---------------------------------------------------------------------------
+	echo "--- and the split copy serves a warm read"
+	#---------------------------------------------------------------------------
+
+	assert xrdcp -f "${HOST}//${lfn}" spaces-out2.dat
+	assert cmp spaces.dat spaces-out2.dat
+	assert_fetched "${lfn}" 2 0 "warm read should be served from the data space"
+}

--- a/tests/XRootD/utils/gstream_recv.py
+++ b/tests/XRootD/utils/gstream_recv.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Append xrootd 'g' monitoring stream datagrams to a file, one record per line.
+
+Used by cache.sh to read the pfc g-stream, which is the only place b_todisk and
+b_prefetch are published -- the cinfo does not carry them.
+
+With 'send json' the datagram is JSON all the way through: an envelope record
+followed by newline-separated event records, the last one null-terminated. That
+is unlike the binary 'dflthdr' form, which puts an XrdXrootdMonHeader and an
+XrdXrootdMonGS in front and would need unpacking here.
+
+Detaches into its own session and writes its pid to <pidfile>, which test.sh
+picks up for teardown. Without the detach ctest kills it along with the rest of
+the setup test's process group, and nothing is left listening. The socket is
+bound before forking, so once this command returns the port is already up and
+the caller can start the server without racing it.
+
+Usage: gstream_recv.py <port> <outfile> <pidfile>
+"""
+
+import os
+import socket
+import sys
+
+port, outfile, pidfile = sys.argv[1], sys.argv[2], sys.argv[3]
+
+# Bind dual-stack: the config names the destination as localhost, which
+# resolves to ::1 here and to 127.0.0.1 elsewhere.
+sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 0)
+sock.bind(("::", int(port)))
+
+if os.fork() != 0:
+    os._exit(0)
+
+os.setsid()
+
+# Detach from the caller's stdin/stdout/stderr as well as from its session:
+# ctest reads a test's output pipe until every holder closes it, so merely
+# surviving the process group is not enough -- holding the inherited fd would
+# hang the run long after the test script itself has finished.
+devnull = os.open(os.devnull, os.O_RDWR)
+for fd in (0, 1, 2):
+    os.dup2(devnull, fd)
+if devnull > 2:
+    os.close(devnull)
+
+with open(pidfile, "w") as f:
+    f.write("%d\n" % os.getpid())
+
+with open(outfile, "a", buffering=1) as out:
+    while True:
+        data, _ = sock.recvfrom(65536)
+        text = data.rstrip(b"\x00").decode("utf-8", "replace")
+        out.write(text.rstrip("\n") + "\n")

--- a/tests/XRootD/utils/xrdpfc-read.cc
+++ b/tests/XRootD/utils/xrdpfc-read.cc
@@ -1,0 +1,227 @@
+//------------------------------------------------------------------------------
+// Range-reading client used by the XCache tests.
+//
+// xrdcp can only fetch whole files, which is not enough to exercise the cache:
+// the interesting behaviour is block-granular. This reads exactly the ranges it
+// is told to, so a test can leave a file deliberately incomplete, come back for
+// the rest, drive the ReadV path, or have several readers land on the same
+// blocks at once.
+//
+// Data is written to <outfile> in the order the ranges were given, so the test
+// can rebuild the same bytes locally with dd and cmp the two.
+//------------------------------------------------------------------------------
+
+#include "XrdCl/XrdClFile.hh"
+#include "XrdCl/XrdClXRootDResponses.hh"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace
+{
+
+struct Range { uint64_t offset; uint32_t length; };
+
+int fail(const std::string &what, const XrdCl::XRootDStatus &st)
+{
+   fprintf(stderr, "xrdpfc-read: %s failed: %s\n", what.c_str(), st.ToStr().c_str());
+   return 1;
+}
+
+// "<offset>:<length>"
+bool parse_range(const char *s, Range &r)
+{
+   char *end = nullptr;
+   r.offset = strtoull(s, &end, 0);
+   if (end == s || *end != ':') return false;
+   const char *l = end + 1;
+   r.length = (uint32_t) strtoul(l, &end, 0);
+   return end != l && *end == '\0' && r.length > 0;
+}
+
+bool write_out(const char *path, const std::vector<char> &buf, size_t n)
+{
+   FILE *f = fopen(path, "wb");
+   if ( ! f) { perror("xrdpfc-read: fopen"); return false; }
+   bool ok = fwrite(buf.data(), 1, n, f) == n;
+   if (fclose(f) != 0) ok = false;
+   if ( ! ok) fprintf(stderr, "xrdpfc-read: short write to %s\n", path);
+   return ok;
+}
+
+int cmd_read(const std::vector<std::string> &args)
+{
+   // read <url> <outfile> <off:len> [<off:len> ...]
+   // Each range is a separate Read() on one open file.
+   if (args.size() < 3) return 2;
+
+   std::vector<Range> ranges;
+   size_t total = 0;
+   for (size_t i = 2; i < args.size(); ++i)
+   {
+      Range r;
+      if ( ! parse_range(args[i].c_str(), r))
+      {
+         fprintf(stderr, "xrdpfc-read: bad range '%s'\n", args[i].c_str());
+         return 2;
+      }
+      ranges.push_back(r);
+      total += r.length;
+   }
+
+   XrdCl::File f;
+   XrdCl::XRootDStatus st = f.Open(args[0], XrdCl::OpenFlags::Read);
+   if ( ! st.IsOK()) return fail("open", st);
+
+   std::vector<char> buf(total);
+   size_t pos = 0;
+   for (const Range &r : ranges)
+   {
+      uint32_t got = 0;
+      st = f.Read(r.offset, r.length, buf.data() + pos, got);
+      if ( ! st.IsOK()) return fail("read", st);
+      if (got != r.length)
+      {
+         fprintf(stderr, "xrdpfc-read: short read at %llu: wanted %u got %u\n",
+                 (unsigned long long) r.offset, r.length, got);
+         return 1;
+      }
+      pos += got;
+   }
+
+   st = f.Close();
+   if ( ! st.IsOK()) return fail("close", st);
+
+   return write_out(args[1].c_str(), buf, pos) ? 0 : 1;
+}
+
+int cmd_readv(const std::vector<std::string> &args)
+{
+   // readv <url> <outfile> <off:len> [<off:len> ...]
+   // All ranges in a single VectorRead(), which is the path a scattered
+   // analysis read takes and which the cache coalesces into block runs.
+   if (args.size() < 3) return 2;
+
+   std::vector<Range> ranges;
+   size_t total = 0;
+   for (size_t i = 2; i < args.size(); ++i)
+   {
+      Range r;
+      if ( ! parse_range(args[i].c_str(), r))
+      {
+         fprintf(stderr, "xrdpfc-read: bad range '%s'\n", args[i].c_str());
+         return 2;
+      }
+      ranges.push_back(r);
+      total += r.length;
+   }
+
+   XrdCl::File f;
+   XrdCl::XRootDStatus st = f.Open(args[0], XrdCl::OpenFlags::Read);
+   if ( ! st.IsOK()) return fail("open", st);
+
+   std::vector<char> buf(total);
+   XrdCl::ChunkList chunks;
+   size_t pos = 0;
+   for (const Range &r : ranges)
+   {
+      chunks.push_back(XrdCl::ChunkInfo(r.offset, r.length, buf.data() + pos));
+      pos += r.length;
+   }
+
+   XrdCl::VectorReadInfo *vinfo = nullptr;
+   st = f.VectorRead(chunks, nullptr, vinfo);
+   if ( ! st.IsOK()) { delete vinfo; return fail("vectorread", st); }
+
+   uint32_t got = vinfo ? vinfo->GetSize() : 0;
+   delete vinfo;
+   if (got != total)
+   {
+      fprintf(stderr, "xrdpfc-read: short vector read: wanted %zu got %u\n", total, got);
+      return 1;
+   }
+
+   st = f.Close();
+   if ( ! st.IsOK()) return fail("close", st);
+
+   return write_out(args[1].c_str(), buf, pos) ? 0 : 1;
+}
+
+int cmd_multi(const std::vector<std::string> &args)
+{
+   // multi <url> <outfile> <nreaders> <length>
+   // nreaders independent opens reading the same first <length> bytes at the
+   // same time, so they contend for the same blocks. Every reader must return
+   // identical data; the cache should fetch those bytes from the origin once.
+   if (args.size() != 4) return 2;
+
+   const std::string url = args[0];
+   const int      nread  = atoi(args[2].c_str());
+   const uint32_t length = (uint32_t) strtoul(args[3].c_str(), nullptr, 0);
+   if (nread < 1 || length < 1) return 2;
+
+   std::vector<std::vector<char>> bufs(nread, std::vector<char>(length));
+   std::vector<int> rc(nread, 0);
+   std::vector<std::thread> threads;
+
+   for (int i = 0; i < nread; ++i)
+   {
+      threads.emplace_back([&, i]() {
+         XrdCl::File f;
+         XrdCl::XRootDStatus st = f.Open(url, XrdCl::OpenFlags::Read);
+         if ( ! st.IsOK()) { rc[i] = fail("open", st); return; }
+         uint32_t got = 0;
+         st = f.Read(0, length, bufs[i].data(), got);
+         if ( ! st.IsOK()) { rc[i] = fail("read", st); return; }
+         if (got != length)
+         {
+            fprintf(stderr, "xrdpfc-read: reader %d short read: %u of %u\n", i, got, length);
+            rc[i] = 1;
+            return;
+         }
+         st = f.Close();
+         if ( ! st.IsOK()) rc[i] = fail("close", st);
+      });
+   }
+   for (auto &t : threads) t.join();
+
+   for (int i = 0; i < nread; ++i)
+      if (rc[i]) return rc[i];
+
+   for (int i = 1; i < nread; ++i)
+      if (memcmp(bufs[0].data(), bufs[i].data(), length) != 0)
+      {
+         fprintf(stderr, "xrdpfc-read: reader %d returned different data than reader 0\n", i);
+         return 1;
+      }
+
+   return write_out(args[1].c_str(), bufs[0], length) ? 0 : 1;
+}
+
+const char *usage =
+   "Usage: xrdpfc-read read  <url> <outfile> <off:len> [<off:len> ...]\n"
+   "       xrdpfc-read readv <url> <outfile> <off:len> [<off:len> ...]\n"
+   "       xrdpfc-read multi <url> <outfile> <nreaders> <length>\n";
+
+}
+
+int main(int argc, char *argv[])
+{
+   if (argc < 2) { fputs(usage, stderr); return 2; }
+
+   const std::string cmd = argv[1];
+   std::vector<std::string> args(argv + 2, argv + argc);
+
+   int rc;
+   if      (cmd == "read")  rc = cmd_read(args);
+   else if (cmd == "readv") rc = cmd_readv(args);
+   else if (cmd == "multi") rc = cmd_multi(args);
+   else { fputs(usage, stderr); return 2; }
+
+   if (rc == 2) fputs(usage, stderr);
+   return rc;
+}

--- a/tests/XrdPfcTests/CMakeLists.txt
+++ b/tests/XrdPfcTests/CMakeLists.txt
@@ -1,6 +1,12 @@
-add_executable(xrdpfc-unit-tests XrdPfcTests.cc)
+# XrdPfcInfo.cc is compiled in rather than linked from the plugin: the cinfo
+# reader has no dependency on the Cache singleton (xrdpfc_print builds it the
+# same way), so the format can be tested without standing up a cache.
+add_executable(xrdpfc-unit-tests
+  XrdPfcTests.cc
+  XrdPfcInfoTests.cc
+  ${CMAKE_SOURCE_DIR}/src/XrdPfc/XrdPfcInfo.cc)
 
-target_link_libraries(xrdpfc-unit-tests GTest::gtest GTest::gtest_main)
+target_link_libraries(xrdpfc-unit-tests XrdServer XrdUtils GTest::gtest GTest::gtest_main)
 
 gtest_discover_tests(xrdpfc-unit-tests
   PROPERTIES DISCOVERY_TIMEOUT 10)

--- a/tests/XrdPfcTests/XrdPfcInfoTests.cc
+++ b/tests/XrdPfcTests/XrdPfcInfoTests.cc
@@ -1,0 +1,469 @@
+//------------------------------------------------------------------------------
+// Tests for XrdPfc::Info -- the .cinfo file.
+//
+// The cinfo is read from caches populated by older releases, so its layout and
+// its two checksums are a compatibility surface: a change that silently alters
+// either turns a populated production cache into a cold one, or worse, into a
+// cache that trusts a bit vector it should not. These tests pin down the round
+// trip, what happens to damaged files, and the block-accounting arithmetic.
+//
+// Info reads and writes through an XrdOssDF, and calls nothing on it but
+// Read(buf, off, len) and Write(buf, off, len). A vector standing in for the
+// file is therefore enough, and it lets a test damage the bytes in ways a real
+// filesystem makes awkward.
+//------------------------------------------------------------------------------
+
+#include "XrdPfc/XrdPfcInfo.hh"
+#include "XrdPfc/XrdPfcStats.hh"
+
+#include "XrdOss/XrdOss.hh"
+#include "XrdSys/XrdSysTrace.hh"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace XrdPfc;
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+// An XrdOssDF backed by a byte vector.
+//------------------------------------------------------------------------------
+
+class MemFile : public XrdOssDF
+{
+public:
+   std::vector<char> m_bytes;
+
+   ssize_t Read(void *buffer, off_t offset, size_t size)
+   {
+      if (offset < 0) return -EINVAL;
+      if ((size_t) offset >= m_bytes.size()) return 0;
+      size_t n = std::min(size, m_bytes.size() - (size_t) offset);
+      memcpy(buffer, m_bytes.data() + offset, n);
+      return (ssize_t) n;
+   }
+
+   // The only pure virtual in XrdOssDF; Info never calls it.
+   int Close(long long *retsz = 0) { (void) retsz; return 0; }
+
+   ssize_t Write(const void *buffer, off_t offset, size_t size)
+   {
+      if (offset < 0) return -EINVAL;
+      if (m_bytes.size() < (size_t) offset + size)
+         m_bytes.resize((size_t) offset + size);
+      memcpy(m_bytes.data() + offset, buffer, size);
+      return (ssize_t) size;
+   }
+};
+
+const long long BSIZE = 128 * 1024;
+
+class InfoTest : public ::testing::Test
+{
+protected:
+   XrdSysTrace trace { "PfcInfoTest" };
+   size_t      m_saved_max_access = 0;
+
+   void SetUp() override    { m_saved_max_access = Info::s_maxNumAccess; }
+   void TearDown() override { Info::s_maxNumAccess = m_saved_max_access; }
+
+   // An Info for a file of n_blocks whole blocks plus tail_bytes.
+   //
+   // By pointer, never by value: Info owns three malloc'd bit vectors and an
+   // XrdCksCalc, but declares no copy or move constructor, so the implicit
+   // shallow copy would double free. Returning one by value only appears to
+   // work because NRVO elides the copy; it double frees under
+   // -fno-elide-constructors, and did so on a CI compiler.
+   std::unique_ptr<Info> make(long long n_blocks, long long tail_bytes = 0)
+   {
+      auto info = std::make_unique<Info>(&trace);
+      info->SetBufferSizeFileSizeAndCreationTime(BSIZE, n_blocks * BSIZE + tail_bytes);
+      return info;
+   }
+
+   // Mark a block present the way File does: written drives the in-memory
+   // completeness bookkeeping, synced is what Write() actually persists.
+   static void mark(Info &info, int block)
+   {
+      info.SetBitWritten(block);
+      info.SetBitSynced(block);
+   }
+};
+
+//==============================================================================
+// Block accounting
+//==============================================================================
+
+TEST_F(InfoTest, BlockCountRoundsUpForPartialLastBlock)
+{
+   // A file that does not end on a block boundary still needs a bit for the
+   // tail, otherwise the last bytes could never be recorded as present.
+   EXPECT_EQ(make(4)->GetNBlocks(), 4);
+   EXPECT_EQ(make(4, 1)->GetNBlocks(), 5);
+   EXPECT_EQ(make(4, BSIZE - 1)->GetNBlocks(), 5);
+   EXPECT_EQ(make(0, 1)->GetNBlocks(), 1);
+
+   // One byte of bit vector per eight blocks, rounded up.
+   EXPECT_EQ(make(8)->GetBitvecSizeInBytes(), 1);
+   EXPECT_EQ(make(9)->GetBitvecSizeInBytes(), 2);
+}
+
+TEST_F(InfoTest, CompletenessTracksTheBitVector)
+{
+   auto info = make(9);
+
+   EXPECT_FALSE(info->IsComplete());
+   EXPECT_EQ(info->GetNDownloadedBlocks(), 0);
+
+   for (int i = 0; i < 8; ++i)
+   {
+      mark(*info, i);
+      EXPECT_FALSE(info->IsComplete()) << "still missing block 8 after setting " << i;
+   }
+   EXPECT_EQ(info->GetNDownloadedBlocks(), 8);
+
+   // Crossing the byte boundary of the bit vector is where an off-by-one in
+   // the addressing would show up.
+   EXPECT_FALSE(info->TestBitWritten(8));
+   mark(*info, 8);
+   EXPECT_TRUE(info->TestBitWritten(8));
+   EXPECT_TRUE(info->IsComplete());
+   EXPECT_EQ(info->GetNDownloadedBlocks(), 9);
+}
+
+TEST_F(InfoTest, CountsBlocksMissingInARange)
+{
+   auto info = make(16);
+   for (int i : {0, 1, 2, 8, 15}) mark(*info, i);
+
+   EXPECT_EQ(info->CountBlocksNotWrittenInRng(0, 3), 0);
+   EXPECT_EQ(info->CountBlocksNotWrittenInRng(0, 8), 5);   // 3,4,5,6,7
+   EXPECT_EQ(info->CountBlocksNotWrittenInRng(3, 8), 5);
+   EXPECT_EQ(info->CountBlocksNotWrittenInRng(15, 16), 0);
+}
+
+TEST_F(InfoTest, ExpectedDataFileSizeFollowsTheLastPresentBlock)
+{
+   // The data file is only as long as its last present block, except when that
+   // block is the final one, where it is the real file size -- the tail block
+   // is short. Purge and the disk-usage accounting rely on this.
+   auto info = make(4, 100);            // 5 blocks, last one 100 bytes
+   EXPECT_EQ(info->GetLastDownloadedBlock(), -1);
+
+   mark(*info, 0);
+   EXPECT_EQ(info->GetLastDownloadedBlock(), 0);
+   EXPECT_EQ(info->GetExpectedDataFileSize(), BSIZE);
+
+   mark(*info, 2);
+   EXPECT_EQ(info->GetExpectedDataFileSize(), 3 * BSIZE);
+
+   mark(*info, 4);
+   EXPECT_EQ(info->GetExpectedDataFileSize(), 4 * BSIZE + 100);
+}
+
+//==============================================================================
+// The on-disk round trip
+//==============================================================================
+
+TEST_F(InfoTest, RoundTripPreservesStateAndAccessHistory)
+{
+   MemFile f;
+   Stats   s;
+   s.m_NumIos        = 3;
+   s.m_Duration      = 42;
+   s.m_BytesHit      = 1000;
+   s.m_BytesMissed   = 2000;
+   s.m_BytesBypassed = 30;
+
+   const std::vector<int> present { 0, 1, 5, 12 };
+
+   {
+      auto info = make(16);
+      for (int i : present) mark(*info, i);
+      info->SetCkSumState(CSChk_Cache);
+
+      info->WriteIOStatAttach();
+      info->WriteIOStatDetach(s);
+
+      ASSERT_TRUE(info->Write(&f, "/mem", "test.cinfo"));
+   }
+
+   Info back(&trace);
+   ASSERT_TRUE(back.Read(&f, "/mem", "test.cinfo"));
+
+   EXPECT_EQ(back.GetVersion(), 4);
+   EXPECT_EQ(back.GetFileSize(), 16 * BSIZE);
+   EXPECT_EQ(back.GetBufferSize(), BSIZE);
+   EXPECT_EQ(back.GetNBlocks(), 16);
+   EXPECT_EQ(back.GetCkSumState(), CSChk_Cache);
+
+   // Write() persists the synced vector and Read() copies it into the written
+   // one, so exactly the marked blocks must come back present.
+   for (int i = 0; i < 16; ++i)
+   {
+      bool want = std::find(present.begin(), present.end(), i) != present.end();
+      EXPECT_EQ(back.TestBitWritten(i), want) << "block " << i;
+   }
+   EXPECT_EQ(back.GetNDownloadedBlocks(), (int) present.size());
+   EXPECT_FALSE(back.IsComplete());
+
+   ASSERT_EQ(back.GetAccessCnt(), 1u);
+   ASSERT_EQ(back.RefAStats().size(), 1u);
+
+   const Info::AStat &a = back.RefAStats()[0];
+   EXPECT_EQ(a.NumIos, 3);
+   EXPECT_EQ(a.Duration, 42);
+   EXPECT_EQ(a.BytesHit, 1000);
+   EXPECT_EQ(a.BytesMissed, 2000);
+   EXPECT_EQ(a.BytesBypassed, 30);
+   EXPECT_NE(a.DetachTime, 0);
+}
+
+TEST_F(InfoTest, RoundTripOfACompleteFileStaysComplete)
+{
+   MemFile f;
+   {
+      auto info = make(8);
+      for (int i = 0; i < 8; ++i) mark(*info, i);
+      ASSERT_TRUE(info->IsComplete());
+      ASSERT_TRUE(info->Write(&f, "/mem"));
+   }
+
+   Info back(&trace);
+   ASSERT_TRUE(back.Read(&f, "/mem"));
+   EXPECT_TRUE(back.IsComplete());
+   EXPECT_EQ(back.GetNDownloadedBytes(), 8 * BSIZE);
+}
+
+//==============================================================================
+// Damaged files. Every one of these has to be refused: a cinfo that reads back
+// as "fine" when it is not means serving corrupt data as a cache hit.
+//==============================================================================
+
+TEST_F(InfoTest, RefusesAnEmptyOrTruncatedFile)
+{
+   MemFile good;
+   {
+      auto info = make(16);
+      for (int i = 0; i < 16; ++i) mark(*info, i);
+      info->WriteIOStatSingle(1234);
+      ASSERT_TRUE(info->Write(&good, "/mem"));
+   }
+   ASSERT_GT(good.m_bytes.size(), 16u);
+
+   {
+      MemFile empty;
+      Info back(&trace);
+      EXPECT_FALSE(back.Read(&empty, "/mem")) << "an empty cinfo must not read as valid";
+   }
+
+   // Cut at a few points: inside the header, inside the bit vector, and just
+   // short of the trailing checksum.
+   for (size_t cut : { size_t(2), good.m_bytes.size() / 2, good.m_bytes.size() - 1 })
+   {
+      MemFile t;
+      t.m_bytes.assign(good.m_bytes.begin(), good.m_bytes.begin() + cut);
+      Info back(&trace);
+      EXPECT_FALSE(back.Read(&t, "/mem")) << "truncated to " << cut << " bytes";
+   }
+}
+
+TEST_F(InfoTest, RefusesAnySingleByteCorruption)
+{
+   // Two crc32c checksums cover the file: one over the header struct, one over
+   // the bit vector and the access records. Between them, and the version
+   // check in front, no single byte of a cinfo should be able to change
+   // without the file being refused. Sweeping every position rather than a
+   // couple of hand-picked ones is what makes this a statement about the
+   // format instead of about two offsets.
+   MemFile good;
+   {
+      auto info = make(64);
+      for (int i = 0; i < 64; i += 3) mark(*info, i);
+      info->WriteIOStatSingle(1234, 1000, 1100);
+      info->WriteIOStatSingle(5678, 2000, 2100);
+      info->SetCkSumState(CSChk_Both);
+      ASSERT_TRUE(info->Write(&good, "/mem"));
+   }
+
+   // The good file really does read back, so a false below means the damage
+   // was caught and not that Read fails on this input anyway.
+   {
+      Info back(&trace);
+      ASSERT_TRUE(back.Read(&good, "/mem"));
+   }
+
+   for (size_t pos = 0; pos < good.m_bytes.size(); ++pos)
+   {
+      MemFile t = good;
+      t.m_bytes[pos] = (char) (t.m_bytes[pos] ^ 0xFF);
+
+      Info back(&trace);
+      EXPECT_FALSE(back.Read(&t, "/mem"))
+         << "corruption at byte " << pos << " of " << good.m_bytes.size()
+         << " was not detected";
+   }
+}
+
+TEST_F(InfoTest, RefusesAnUnknownVersion)
+{
+   MemFile f;
+   {
+      auto info = make(4);
+      mark(*info, 0);
+      ASSERT_TRUE(info->Write(&f, "/mem"));
+   }
+
+   // Versions 2 and 3 have their own read paths; anything else has to be
+   // rejected rather than parsed as the current layout.
+   const int bogus = 99;
+   memcpy(f.m_bytes.data(), &bogus, sizeof(bogus));
+
+   Info back(&trace);
+   EXPECT_FALSE(back.Read(&f, "/mem"));
+}
+
+//==============================================================================
+// Access records
+//==============================================================================
+
+TEST_F(InfoTest, AStatMergeAccumulatesAndKeepsTheLaterDetachTime)
+{
+   Info::AStat a;
+   a.AttachTime = 100; a.DetachTime = 110; a.NumIos = 1; a.Duration = 10;
+   a.BytesHit = 1; a.BytesMissed = 2; a.BytesBypassed = 3;
+
+   Info::AStat b;
+   b.AttachTime = 200; b.DetachTime = 260; b.NumIos = 2; b.Duration = 60;
+   b.BytesHit = 10; b.BytesMissed = 20; b.BytesBypassed = 30;
+
+   a.MergeWith(b);
+
+   EXPECT_EQ(a.AttachTime, 100);     // the earlier access still opens the record
+   EXPECT_EQ(a.DetachTime, 260);     // and the later one closes it
+   EXPECT_EQ(a.NumIos, 3);
+   EXPECT_EQ(a.Duration, 70);
+   EXPECT_EQ(a.NumMerged, 1);
+   EXPECT_EQ(a.BytesHit, 11);
+   EXPECT_EQ(a.BytesMissed, 22);
+   EXPECT_EQ(a.BytesBypassed, 33);
+}
+
+TEST_F(InfoTest, AccessHistoryIsCappedButTotalsAreNotLost)
+{
+   Info::s_maxNumAccess = 4;
+
+   const int n_acc = 20;
+   long long total_hit = 0;
+
+   MemFile f;
+   {
+      auto info = make(4);
+      mark(*info, 0);
+      for (int i = 0; i < n_acc; ++i)
+      {
+         // Distinct times, so compactification has something to choose by.
+         info->WriteIOStatSingle(100 + i, 1000 + 10 * i, 1005 + 10 * i);
+         total_hit += 100 + i;
+      }
+      ASSERT_TRUE(info->Write(&f, "/mem"));
+   }
+
+   Info back(&trace);
+   ASSERT_TRUE(back.Read(&f, "/mem"));
+
+   // The history is bounded so the cinfo cannot grow without limit ...
+   EXPECT_LE(back.RefAStats().size(), Info::s_maxNumAccess);
+   EXPECT_GT(back.RefAStats().size(), 0u);
+
+   // ... but the count of accesses and the bytes they moved must survive the
+   // merging, otherwise usage reporting silently under-reports busy files.
+   EXPECT_EQ(back.GetAccessCnt(), (size_t) n_acc);
+
+   long long kept_hit = 0;
+   int       kept_ios = 0;
+   for (const Info::AStat &a : back.RefAStats())
+   {
+      kept_hit += a.BytesHit;
+      kept_ios += a.NumIos;
+   }
+   EXPECT_EQ(kept_hit, total_hit);
+   EXPECT_EQ(kept_ios, n_acc);
+
+   // Records are kept in time order, and the newest access is still the last.
+   const std::vector<Info::AStat> &v = back.RefAStats();
+   for (size_t i = 1; i < v.size(); ++i)
+      EXPECT_LE(v[i - 1].AttachTime, v[i].AttachTime) << "record " << i;
+   EXPECT_EQ(v.back().DetachTime, 1005 + 10 * (n_acc - 1));
+}
+
+TEST_F(InfoTest, ResetAllAccessStatsClearsTheHistory)
+{
+   auto info = make(4);
+   info->WriteIOStatSingle(10);
+   info->WriteIOStatSingle(20);
+   ASSERT_EQ(info->GetAccessCnt(), 2u);
+
+   info->ResetAllAccessStats();
+
+   EXPECT_EQ(info->GetAccessCnt(), 0u);
+   EXPECT_TRUE(info->RefAStats().empty());
+}
+
+//==============================================================================
+// Checksum state
+//==============================================================================
+
+TEST_F(InfoTest, CkSumStateIsAThreeBitFieldAndDowngradeIntersects)
+{
+   auto info = make(4);
+
+   EXPECT_EQ(info->GetCkSumState(), CSChk_None);
+
+   info->SetCkSumState(CSChk_Both);
+   EXPECT_TRUE(info->IsCkSumBoth());
+   EXPECT_TRUE(info->IsCkSumCache());
+   EXPECT_TRUE(info->IsCkSumNet());
+
+   // Downgrading is an intersection with what the server is now configured
+   // for: a file checksummed both ways is still valid for a cache-only setup,
+   // but must lose the claim it cannot back any more.
+   info->DowngradeCkSumState(CSChk_Cache);
+   EXPECT_EQ(info->GetCkSumState(), CSChk_Cache);
+   EXPECT_FALSE(info->IsCkSumNet());
+
+   info->SetCkSumState(CSChk_Both);
+   info->ResetCkSumNet();
+   EXPECT_FALSE(info->IsCkSumNet());
+   EXPECT_TRUE(info->IsCkSumCache());
+
+   info->SetCkSumState(CSChk_Both);
+   info->ResetCkSumCache();
+   EXPECT_FALSE(info->IsCkSumCache());
+   EXPECT_TRUE(info->IsCkSumNet());
+}
+
+TEST_F(InfoTest, CkSumStateSurvivesTheRoundTrip)
+{
+   for (int cs = CSChk_None; cs <= CSChk_Both; ++cs)
+   {
+      MemFile f;
+      {
+         auto info = make(4);
+         mark(*info, 0);
+         info->SetCkSumState((CkSumCheck_e) cs);
+         ASSERT_TRUE(info->Write(&f, "/mem"));
+      }
+      Info back(&trace);
+      ASSERT_TRUE(back.Read(&f, "/mem"));
+      EXPECT_EQ(back.GetCkSumState(), (CkSumCheck_e) cs) << "state " << cs;
+   }
+}
+
+}


### PR DESCRIPTION
***Disclaimer:*** This is mostly Claudine -- I have only done one small test before so I was a poor advisor to it -- but I did have it scan all other tests and match them in format and style. If things are off, please advise and I'll give it another spin.

Towards #2747. Covers the single-cache-server scenario; the clustered one is not addressed here.

Before this, XrdPfc had two unit tests over the path tokenizer, one integration test that copied a file through a cache and diffed it, and the xcachewithcsi test for `pfc.cschk cache`. The integration test passed equally well against a plain proxy: `cache.cfg` carried no `pfc.*` directives and nothing checked that anything had been cached.

### What the tests assert on

`b_todisk` and `b_prefetch` from the pfc g-stream `file_close` record, which are counted per block as blocks are written out and so are exact and independent of the client's request size, plus the `.cinfo` via `xrdpfc_print` for the state left on disk.

Deliberately *not* `b_hit`/`b_miss`. A block is scored as missed only for the request that created it, so a second request landing on the same in-flight block reads as a hit. Two things make that bite: the client's single large pgread reaches the cache as 64 kB segments, giving an exact 50/50 split at a 128 kB block; and with prefetching on, a cold read of a file that is not in the cache at all reports `b_hit == size, b_miss == 0` -- the symptom of #2366,
still reproducible. `b_todisk` states it correctly in both cases.

### Coverage

Seven ctest configurations under `tests/XRootD/`, each fronting the existing `XRootD::host` fixture as its origin:

| Config | What it pins down |
|---|---|
| `cache` | cold fetch / warm serve; a 4 kB read pulls exactly one block and only once; a vector read fetches only the blocks its chunks land in, checked against the block map; four concurrent readers of the same blocks fetch them once between them; `stat` reports the origin size for a partly cached file; writes refused cleanly; a missing file leaves no state |
| `cacheevict` | only-if-cached on an absent, a partial and a complete file; `xrdfs cache evict` removes data and cinfo and leaves the origin alone |
| `cacheprefetch` | a small read drags in more than its block and the excess is reported as prefetch; prefetch never runs past EOF |
| `cacheblacklist` | a path `pfc.decisionlib` refuses is proxied, never cached, and produces no `file_close` record at all -- `Cache::Attach` returns the upstream IO, so no `File` exists |
| `cachespaces` | `pfc.spaces`: symlink targets land in the right space, neither space holds the other's half |
| `cacherestart` | a complete and a partial file survive a server restart; the partial one keeps exactly its blocks, then fetches only what was missing |
| `cachepurge` | overruns a `files` budget and asserts the LRU ordering of what purge removed, and that a purged file is gone and refetchable |

Unit tests in `tests/XrdPfcTests/XrdPfcInfoTests.cc` cover the `.cinfo` format:
block accounting, the write/read round trip, access-history capping, and refusal of damaged files. The corruption test sweeps every byte position and requires all of them to be caught.

### New test-only helpers

- `tests/XRootD/utils/xrdpfc-read.cc` -- reads exactly the ranges given, as separate reads, one vector read, or from several threads. `xrdcp` only fetches whole files.
- `tests/XRootD/utils/gstream_recv.py` -- collects the pfc g-stream.
- `tests/XRootD/cachelib.sh` -- shared shell helpers over both oracles.

### Notes for reviewers

- `XRootD::cachepurge::test` takes about two minutes and is labelled `slow`.
  The purge check runs on a fixed 60 s cycle, recently opened files are purge-protected, and there is no way to request a purge, so convergence needs more than one pass.
- `pfc.hdfsmode` is not covered: `ConfigXeq` reports it unsupported and fails the config before doing anything.
- `XrdPfcInfo.cc` is compiled into the gtest binary rather than linked from the plugin, the way `xrdpfc_print` already builds it.
- No non-test source is touched.
