### PR TITLE
[XrdPfc] Forced eviction and directory-count drift: two ResourceMonitor memory-safety fixes (#2808, #2934)

### DIFF
--- a/src/XrdPfc/XrdPfcDirState.cc
+++ b/src/XrdPfc/XrdPfcDirState.cc
@@ -177,9 +177,23 @@ void DirState::update_stats_and_usages(bool purge_empty_dirs, unlink_func unlink
       // Note that root will never get purged.
       bool increment_iter = true;
       if (purge_empty_dirs && sub_ds.m_here_stats.m_NDirectoriesRemoved == 0 &&
-          sub_ds.m_here_usage.m_NDirectories == 0 && sub_ds.m_here_usage.m_NFiles == 0)
+          sub_ds.m_here_usage.m_NDirectories == 0 && sub_ds.m_here_usage.m_NFiles == 0 &&
+          sub_ds.m_here_usage.m_NFilesOpen == 0 && sub_ds.m_subdirs.empty())
       {
-         assert(sub_ds.m_subdirs.empty());
+         // m_subdirs.empty() used to be an assert() here -- but it is compiled out
+         // in release builds (-DNDEBUG) and it does trigger: m_NDirectories can be
+         // short of the real child count when a node's creation went unrecorded.
+         // Reaping such a node would erase a whole live subtree while reporting a
+         // single removal, so treat it as a condition instead.
+         //
+         // m_NFilesOpen == 0 is required for memory safety, not just for accounting:
+         // ResourceMonitor::AccessToken holds a bare DirState* from the time the open
+         // record is processed until the close record is, and the close handler
+         // dereferences it (XrdPfcResourceMonitor.cc, m_file_close_q loop). A file
+         // that is evicted or purged while still open (Cache::UnlinkFile ->
+         // File::initiate_emergency_shutdown) takes m_NFiles back to 0 while the
+         // File object is still alive, so without this term the directory would be
+         // reaped and the pending close would write through a dangling pointer.
 
          std::string dir_path;
          dir_path.reserve(1024);

--- a/src/XrdPfc/XrdPfcDirState.hh
+++ b/src/XrdPfc/XrdPfcDirState.hh
@@ -111,6 +111,56 @@ struct DirState : public DirStateBase
 };
 
 
+//------------------------------------------------------------------------------
+//! Record the DirState nodes that a find_path() / find_dirstate_for_lfn() call
+//! has just created, by walking from the node it returned up to -- but not
+//! including -- the deepest one that already existed.
+//!
+//! This has to happen for *every* open, not only for opens of files that are
+//! new: find_path() creates the chain either way, and a node whose creation
+//! goes unrecorded while its eventual removal is recorded drives
+//! m_NDirectories negative, which is issue #2808. When all the directories
+//! already existed, node == last_existing and this does nothing.
+//!
+//! Free function rather than inline code in ResourceMonitor::process_queues()
+//! so that it can be unit-tested: process_queues() needs the Cache singleton,
+//! this does not.
+//------------------------------------------------------------------------------
+
+inline void note_created_dirs(DirState *node, DirState *last_existing)
+{
+   for (DirState *p = node; p != last_existing; )
+   {
+      p = p->get_parent();
+      p->m_here_stats.m_NDirectoriesCreated += 1;
+   }
+}
+
+//------------------------------------------------------------------------------
+//! The whole accounting for one file-open event: the open itself, any DirState
+//! nodes the lookup had to create, and -- only if the data file was not already
+//! on disk -- the file creation.
+//!
+//! @param node           what find_dirstate_for_lfn() returned
+//! @param last_existing  the deepest node on that path that already existed
+//! @param existing_file  File::Open()'s data_existed
+//!
+//! The *directory* accounting is unconditional while the *file* accounting is
+//! not, and conflating the two is issue #2808: node creation used to be
+//! recorded only for new files, so a directory created while opening a file
+//! that was already on disk went unrecorded while its later removal did not,
+//! and the count drifted one lower per reap until it went negative.
+//------------------------------------------------------------------------------
+
+inline void note_file_open(DirState *node, DirState *last_existing, bool existing_file)
+{
+   node->m_here_stats.m_NFilesOpened += 1;
+   note_created_dirs(node, last_existing);
+   if ( ! existing_file)
+      node->m_here_stats.m_NFilesCreated += 1;
+}
+
+
 //==============================================================================
 // DataFsState
 //==============================================================================

--- a/src/XrdPfc/XrdPfcFile.cc
+++ b/src/XrdPfc/XrdPfcFile.cc
@@ -599,6 +599,9 @@ bool File::Open(XrdOucCacheIO *inputIO)
    m_data_file->Fstat(&data_stat);
    m_st_blocks = data_stat.st_blocks;
 
+   // No early return between here and the matching Close(): the token holds a bare
+   // DirState* and m_NFilesOpen > 0 is what keeps that DirState from being reaped
+   // (XrdPfcDirState.cc), so a lost close leaks a permanently unreapable directory.
    m_resmon_token = Cache::ResMon().register_file_open(m_filename, time(0), data_existed);
    constexpr long long MB = 1024 * 1024;
    m_resmon_report_threshold = std::min(std::max(10 * MB, m_file_size / 20), 500 * MB);

--- a/src/XrdPfc/XrdPfcResourceMonitor.cc
+++ b/src/XrdPfc/XrdPfcResourceMonitor.cc
@@ -257,17 +257,10 @@ int ResourceMonitor::process_queues()
       DirState *last_existing_ds = nullptr;
       DirState *ds = m_fs_state.find_dirstate_for_lfn(at.m_filename, &last_existing_ds);
       at.m_dir_state = ds;
-      ds->m_here_stats.m_NFilesOpened += 1;
 
-      // If this is a new file figure out how many new parent dirs got created along the way.
-      if ( ! i.record.m_existing_file) {
-         ds->m_here_stats.m_NFilesCreated += 1;
-         DirState *pp = ds;
-         while (pp != last_existing_ds) {
-            pp = pp->get_parent();
-            pp->m_here_stats.m_NDirectoriesCreated += 1;
-         }
-      }
+      // The directory accounting is unconditional, the file accounting is not.
+      // See note_file_open() in XrdPfcDirState.hh, and issue #2808.
+      note_file_open(ds, last_existing_ds, i.record.m_existing_file);
 
       ds->m_here_usage.m_LastOpenTime = i.record.m_open_time;
    }
@@ -748,12 +741,44 @@ void ResourceMonitor::perform_purge_check(bool purge_cold_files, int tl)
    //     deletion -- eg, by comparing stat time of cinfo + doing the is-active / is-purge-protected.
 
    const DirState &root_ds = *m_fs_state.get_root();
-   const int n_calc_dirs  = 1 + root_ds.m_here_usage.m_NDirectories + root_ds.m_recursive_subdir_usage.m_NDirectories;
-#ifdef RM_DEBUG
+
+   // Count the tree directly -- this is exactly what fill_pshot_vec_children()
+   // will emplace. Deriving it from the usage counters made reserve() throw
+   // std::length_error whenever those had drifted negative (issue #2808), and
+   // reserve() takes an unsigned size_type so -1 became ~1.8e19.
    const int n_pshot_dirs = root_ds.count_dirs_to_level(9999);
+
+   // Now cross-check the incrementally maintained counters against the tree we
+   // just walked. They are two views of the same thing and must agree; a
+   // disagreement means a directory creation or removal is going unrecorded,
+   // which is what #2808 turned out to be. It costs one comparison per purge
+   // check, so it is worth doing in production rather than under RM_DEBUG.
+   //
+   // Reported when the discrepancy appears and whenever it changes, not on
+   // every check: that keeps a persistent fault to a handful of lines while
+   // still showing the *rate* of drift, and a monotonic drift is exactly what
+   // identified #2808 in the first place.
+   const int n_calc_dirs = 1 + root_ds.m_here_usage.m_NDirectories
+                             + root_ds.m_recursive_subdir_usage.m_NDirectories;
    dprintf("purge dir count recursive=%d vs from_usage=%d\n", n_pshot_dirs, n_calc_dirs);
-#endif
-   ps.m_dir_vec.reserve(n_calc_dirs);
+   const int discrepancy = n_calc_dirs - n_pshot_dirs;
+   if (discrepancy != m_dir_count_discrepancy)
+   {
+      if (discrepancy != 0) {
+         TRACE(Error, trc_pfx << "directory accounting inconsistent: usage counters say "
+               << n_calc_dirs << " directories, the tree holds " << n_pshot_dirs
+               << " (off by " << discrepancy << ", previously " << m_dir_count_discrepancy
+               << "). A directory creation or removal is going unrecorded, so dirstats "
+                  "and the purge's view of this cache are both unreliable. This is a bug "
+                  "in XrdPfc -- please report it.");
+      } else {
+         TRACE(Info, trc_pfx << "directory accounting is consistent again ("
+               << n_pshot_dirs << " directories).");
+      }
+      m_dir_count_discrepancy = discrepancy;
+   }
+
+   ps.m_dir_vec.reserve(n_pshot_dirs);
    ps.m_dir_vec.emplace_back( DirPurgeElement(root_ds, root_ds.m_here_usage, root_ds.m_recursive_subdir_usage, -1) );
    fill_pshot_vec_children(root_ds, 0, ps.m_dir_vec, 9999);
 

--- a/src/XrdPfc/XrdPfcResourceMonitor.hh
+++ b/src/XrdPfc/XrdPfcResourceMonitor.hh
@@ -110,6 +110,7 @@ class ResourceMonitor
    // DirPurge queue -- not needed? But we do need last-change timestamp in DirState.
 
    long long    m_current_usage_in_st_blocks = 0;  // aggregate disk usage by files
+   int          m_dir_count_discrepancy = 0;       // last reported usage-vs-tree mismatch
 
    XrdSysMutex  m_queue_mutex;        // mutex shared between queues
    unsigned int m_queue_swap_u1 = 0u; // identifier of current swap cycle

--- a/tests/XRootD/cacheevict.sh
+++ b/tests/XRootD/cacheevict.sh
@@ -57,7 +57,10 @@ function test_cacheevict() {
 
 	assert xrdcp -f "${HOST}//${lfn}" evict-full.dat
 	assert cmp evict.dat evict-full.dat
-	wait_for_access_record "${cinfo}" 2
+	# Not wait_for_access_record 2: the refused only-if-cached open above may or
+	# may not have left a record of its own (see below), so the count here is
+	# either 2 or 3. Wait on the state this assertion is actually about.
+	wait_for_cinfo_complete "${cinfo}"
 	assert_eq "${PFC_NBLOCKS} ${PFC_NBLOCKS} complete" "$(cinfo_blocks "${cinfo}")" \
 		"the full read should have completed the file"
 

--- a/tests/XRootD/cachelib.sh
+++ b/tests/XRootD/cachelib.sh
@@ -216,6 +216,25 @@ function cinfo_block_map() {
 	sed -n '/^printing /,/^Access records/p' | sed -n 's/^ *[0-9]\{1,\} \([x.]\{1,\}\)$/\1/p' | tr -d '\n'
 }
 
+# Dump what a cinfo actually holds. Called when a wait gives up: a bare
+# "timed out" says nothing about whether the value was short, exact or already
+# past the one waited for, and that is the first thing you need to know.
+function report_cinfo_state() {
+	if [[ -f "$1" ]]; then
+		echo "  cinfo $1: n_acc=$(cinfo_n_acc "$1") blocks=$(cinfo_blocks "$1")"
+	else
+		echo "  cinfo $1: does not exist"
+	fi
+}
+
+# Wait for the cinfo to report exactly $2 access records.
+#
+# Use this only where the count is genuinely determined. An access record is
+# appended when a File attaches, and the cinfo is written and synced repeatedly
+# over the File's life -- not once at close -- so the count is live, and an open
+# that is refused after the File was constructed still leaves a record behind.
+# Where that can happen, wait on the final state instead: see
+# wait_for_cinfo_complete().
 function wait_for_access_record() {
 	for _ in $(seq 100); do
 		if [[ -f "$1" ]] && [[ "$(cinfo_n_acc "$1")" == "$2" ]]; then
@@ -223,5 +242,29 @@ function wait_for_access_record() {
 		fi
 		sleep 0.2
 	done
+	echo "timed out after 20 s waiting for access record $2 of $1"
+	report_cinfo_state "$1"
 	error "timed out after 20 s waiting for access record $2 of $1"
+}
+
+# Wait for every block of the file to be on disk.
+#
+# Completeness is monotonic -- a file becomes complete once and stays complete
+# -- so unlike an access count there is nothing to overshoot and no baseline to
+# sample. Prefer this wherever the assertion that follows is about the file
+# being fully cached.
+function wait_for_cinfo_complete() {
+	local nblk ndone state
+	for _ in $(seq 100); do
+		if [[ -f "$1" ]]; then
+			read -r nblk ndone state <<< "$(cinfo_blocks "$1")"
+			if [[ "${state}" == complete ]] && [[ "${nblk}" == "${ndone}" ]]; then
+				return 0
+			fi
+		fi
+		sleep 0.2
+	done
+	echo "timed out after 20 s waiting for $1 to be complete"
+	report_cinfo_state "$1"
+	error "timed out after 20 s waiting for $1 to be complete"
 }

--- a/tests/XrdPfcTests/CMakeLists.txt
+++ b/tests/XrdPfcTests/CMakeLists.txt
@@ -1,10 +1,13 @@
-# XrdPfcInfo.cc is compiled in rather than linked from the plugin: the cinfo
-# reader has no dependency on the Cache singleton (xrdpfc_print builds it the
-# same way), so the format can be tested without standing up a cache.
+# XrdPfcInfo.cc and XrdPfcDirState.cc are compiled in rather than linked from
+# the plugin: neither has a dependency on the Cache singleton (xrdpfc_print
+# builds Info the same way), so the cinfo format and the directory accounting
+# can both be tested without standing up a cache.
 add_executable(xrdpfc-unit-tests
   XrdPfcTests.cc
   XrdPfcInfoTests.cc
-  ${CMAKE_SOURCE_DIR}/src/XrdPfc/XrdPfcInfo.cc)
+  XrdPfcDirStateTests.cc
+  ${CMAKE_SOURCE_DIR}/src/XrdPfc/XrdPfcInfo.cc
+  ${CMAKE_SOURCE_DIR}/src/XrdPfc/XrdPfcDirState.cc)
 
 target_link_libraries(xrdpfc-unit-tests XrdServer XrdUtils GTest::gtest GTest::gtest_main)
 

--- a/tests/XrdPfcTests/XrdPfcDirStateTests.cc
+++ b/tests/XrdPfcTests/XrdPfcDirStateTests.cc
@@ -1,0 +1,346 @@
+//------------------------------------------------------------------------------
+// Tests for XrdPfc::DirState -- the per-directory usage accounting tree.
+//
+// The tree is maintained incrementally: every change is reported as a delta
+// (DirStats) and folded into a running level (DirUsage), so a single unreported
+// change is never corrected -- it drifts, forever, and propagates to every
+// ancestor. Two consequences were live bugs:
+//
+//  - the directory count could drift negative, and
+//    ResourceMonitor::perform_purge_check() passes it to vector::reserve(),
+//    whose size_type is unsigned, so -1 became ~1.8e19 and threw
+//    std::length_error, killing the resource-monitor thread (issue #2808);
+//  - the empty-leaf reap could free a DirState that a pending file-close still
+//    held a pointer to, which is reachable from the outside with
+//    "xrdfs <cache> cache fevict" on a file that is still open.
+//
+// DirState has no dependency on the Cache singleton, so it is compiled in here
+// the same way XrdPfcInfo.cc is.
+//
+// The event application below deliberately mirrors
+// ResourceMonitor::process_queues(): that is the only producer of these deltas,
+// and a test that invented its own accounting would pass while the real one
+// drifted. If process_queues() changes, these helpers must change with it.
+//------------------------------------------------------------------------------
+
+#include "XrdPfc/XrdPfcDirState.hh"
+
+#include <gtest/gtest.h>
+
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace XrdPfc;
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+// A stand-in for the cache namespace, so unlink_foo() can behave like
+// XrdOssSys::Unlink() does on a directory -- rmdir(), which refuses a
+// non-empty one. Several of the bugs below were masked in production by
+// exactly that refusal, so a test that let every unlink succeed would be
+// testing the wrong thing.
+//------------------------------------------------------------------------------
+
+class FakeNamespace
+{
+public:
+   std::set<std::string> m_files;
+
+   void create(const std::string &lfn) { m_files.insert(lfn); }
+   void remove(const std::string &lfn) { m_files.erase(lfn); }
+
+   int rmdir(const std::string &dir) const
+   {
+      const std::string pfx = dir + "/";
+      for (const auto &f : m_files)
+         if (f.compare(0, pfx.size(), pfx) == 0)
+            return -ENOTEMPTY;
+      return 0;
+   }
+
+   unlink_func unlinker() { return [this](const std::string &d) { return rmdir(d); }; }
+};
+
+//------------------------------------------------------------------------------
+// The accounting ResourceMonitor::process_queues() performs, and nothing more.
+//------------------------------------------------------------------------------
+
+class Accounting
+{
+public:
+   DataFsState    m_fs;
+   FakeNamespace  m_ns;
+   time_t         m_now = 1000;
+
+   //! Mirrors the m_file_open_q loop. existing_file is File::Open()'s
+   //! data_existed, i.e. whether the data file was already on disk.
+   void open(const std::string &lfn, bool existing_file)
+   {
+      DirState *last_existing = nullptr;
+      DirState *ds = m_fs.find_dirstate_for_lfn(lfn, &last_existing);
+      // The production accounting, called rather than re-implemented: a test
+      // that copied this logic would pass while the real one drifted.
+      note_file_open(ds, last_existing, existing_file);
+      ds->m_here_usage.m_LastOpenTime = m_now;
+   }
+
+   //! Mirrors the m_file_close_q loop.
+   void close(const std::string &lfn)
+   {
+      DirState *ds = m_fs.find_dirstate_for_lfn(lfn);
+      ds->m_here_stats.m_NFilesClosed += 1;
+      ds->m_here_usage.m_LastCloseTime = m_now;
+   }
+
+   //! Mirrors the m_file_purge_q3 loop, which does not create missing nodes.
+   void purge(const std::string &lfn, long long st_blocks)
+   {
+      DirState *ds = m_fs.get_root()->find_path(lfn, -1, true, false);
+      if ( ! ds) return;
+      ds->m_here_stats.m_StBlocksRemoved += st_blocks;
+      ds->m_here_stats.m_NFilesRemoved   += 1;
+   }
+
+   void add_blocks(const std::string &lfn, long long st_blocks)
+   {
+      m_fs.find_dirstate_for_lfn(lfn)->m_here_stats.m_StBlocksAdded += st_blocks;
+   }
+
+   //! One heart_beat() secondary-activity cycle.
+   void beat(bool reap_empty_dirs)
+   {
+      ++m_now;
+      m_fs.update_stats_and_usages(m_now, reap_empty_dirs, m_ns.unlinker());
+      m_fs.reset_stats(m_now);
+   }
+
+   //! Cache a file the ordinary way: it appears, is opened, written, closed.
+   void cache_file(const std::string &lfn, long long st_blocks)
+   {
+      m_ns.create(lfn);
+      open(lfn, false);
+      add_blocks(lfn, st_blocks);
+      close(lfn);
+   }
+
+   DirState& root() { return *m_fs.get_root(); }
+
+   //! The quantity perform_purge_check() reserves the purge-shot vector with.
+   int n_dirs_from_usage()
+   {
+      return 1 + root().m_here_usage.m_NDirectories
+               + root().m_recursive_subdir_usage.m_NDirectories;
+   }
+   //! The same count taken from the tree itself.
+   int n_dirs_in_tree() { return root().count_dirs_to_level(9999); }
+
+   DirState* find(const std::string &dir_path)
+   {
+      return root().find_path(dir_path, -1, false, false);
+   }
+};
+
+} // namespace
+
+//==============================================================================
+// The directory count must agree with the tree (issue #2808)
+//==============================================================================
+
+TEST(DirStateCount, MatchesTreeAfterOrdinaryUse)
+{
+   Accounting a;
+   a.cache_file("/a/b/c/f1", 8);
+   a.cache_file("/a/b/f2", 8);
+   a.cache_file("/d/f3", 8);
+   a.beat(false);
+
+   EXPECT_EQ(a.n_dirs_from_usage(), a.n_dirs_in_tree());
+   EXPECT_EQ(a.n_dirs_in_tree(), 5);   // root, a, a/b, a/b/c, d
+}
+
+TEST(DirStateCount, MatchesTreeThroughReapOfAWholeChain)
+{
+   Accounting a;
+   a.cache_file("/a/b/c/f1", 8);
+   a.beat(false);
+   ASSERT_EQ(a.n_dirs_from_usage(), a.n_dirs_in_tree());
+
+   a.m_ns.remove("/a/b/c/f1");
+   a.purge("/a/b/c/f1", 8);
+
+   // The reap takes one level per cycle, so run enough of them to unwind the
+   // chain, checking the invariant at every step.
+   for (int i = 0; i < 5; ++i) {
+      a.beat(true);
+      EXPECT_EQ(a.n_dirs_from_usage(), a.n_dirs_in_tree()) << "after reap cycle " << i;
+   }
+   EXPECT_EQ(a.n_dirs_in_tree(), 1);   // back to the root alone
+}
+
+// The regression behind #2808: find_dirstate_for_lfn() creates the DirState
+// chain whether or not the *file* is new, so an open of a file that already
+// exists -- in a directory the tree has never seen, because the initial scan
+// could not enter it -- used to create nodes with no matching
+// m_NDirectoriesCreated. Their eventual removal was still recorded, so the
+// count went one lower every reap and eventually negative.
+TEST(DirStateCount, CountsNodesCreatedForAnAlreadyExistingFile)
+{
+   Accounting a;
+   a.cache_file("/scanned/f1", 8);
+   a.beat(false);
+   ASSERT_EQ(a.n_dirs_from_usage(), a.n_dirs_in_tree());
+
+   // A file already on disk, in a directory the tree does not know about.
+   a.m_ns.create("/unscanned/sub/f2");
+   a.open("/unscanned/sub/f2", true);
+   a.close("/unscanned/sub/f2");
+   a.beat(false);
+
+   EXPECT_EQ(a.n_dirs_from_usage(), a.n_dirs_in_tree());
+   EXPECT_EQ(a.n_dirs_in_tree(), 4);   // root, scanned, unscanned, unscanned/sub
+}
+
+TEST(DirStateCount, NeverGoesNegativeAcrossRepeatedUnscannedDirs)
+{
+   Accounting a;
+   a.cache_file("/base/anchor", 8);
+   a.beat(false);
+
+   for (int i = 0; i < 8; ++i) {
+      char lfn[64];
+      snprintf(lfn, sizeof(lfn), "/base/d%d/f", i);
+      a.m_ns.create(lfn);
+      a.open(lfn, true);          // already on disk, node is new
+      a.close(lfn);
+      a.beat(false);
+      a.m_ns.remove(lfn);
+      a.purge(lfn, 0);
+      a.beat(true);
+      a.beat(true);
+
+      EXPECT_EQ(a.n_dirs_from_usage(), a.n_dirs_in_tree()) << "iteration " << i;
+      EXPECT_GE(a.n_dirs_from_usage(), 1) << "iteration " << i;
+   }
+}
+
+//==============================================================================
+// What the empty-leaf reap must not remove
+//==============================================================================
+
+TEST(DirStateReap, RemovesAGenuinelyEmptyLeaf)
+{
+   Accounting a;
+   a.cache_file("/a/b/f1", 8);
+   a.beat(false);
+   ASSERT_NE(a.find("/a/b"), nullptr);
+
+   a.m_ns.remove("/a/b/f1");
+   a.purge("/a/b/f1", 8);
+   a.beat(true);
+
+   EXPECT_EQ(a.find("/a/b"), nullptr) << "an empty leaf should be reaped";
+}
+
+// The use-after-free. ResourceMonitor::AccessToken holds a bare DirState* from
+// the time a file's open record is processed until its close record is, and the
+// close handler dereferences it. Removing a file while it is still open --
+// "xrdfs <cache> cache fevict", or a purge racing a client -- takes m_NFiles
+// back to 0 while the File is alive, so the directory must stay put until the
+// close has been accounted for.
+TEST(DirStateReap, KeepsADirectoryWhoseFileIsStillOpen)
+{
+   Accounting a;
+   a.m_ns.create("/a/b/f1");
+   a.open("/a/b/f1", false);
+   a.add_blocks("/a/b/f1", 8);
+   a.beat(false);
+   ASSERT_NE(a.find("/a/b"), nullptr);
+   ASSERT_EQ(a.find("/a/b")->m_here_usage.m_NFilesOpen, 1);
+
+   // Evicted underneath the open file: the data is gone, so rmdir would now
+   // succeed and only the accounting can protect the node.
+   a.m_ns.remove("/a/b/f1");
+   a.purge("/a/b/f1", 8);
+   a.beat(true);
+
+   // Check survival *before* dereferencing: without the fix this node is gone,
+   // and a test for a use-after-free should report that as a failure rather
+   // than crash on its own null pointer.
+   ASSERT_NE(a.find("/a/b"), nullptr)
+      << "reaped a directory that a pending close still points at";
+   EXPECT_EQ(a.find("/a/b")->m_here_usage.m_NFiles, 0)     << "the file is gone";
+   EXPECT_EQ(a.find("/a/b")->m_here_usage.m_NFilesOpen, 1) << "but still counted open";
+
+   // Account for the close without reaping, so the open count can be observed
+   // reaching zero.
+   a.close("/a/b/f1");
+   a.beat(false);
+   ASSERT_NE(a.find("/a/b"), nullptr);
+   EXPECT_EQ(a.find("/a/b")->m_here_usage.m_NFilesOpen, 0);
+
+   // Now it may go.
+   a.beat(true);
+   EXPECT_EQ(a.find("/a/b"), nullptr) << "should be reaped once nothing is open";
+}
+
+TEST(DirStateReap, KeepsADirectoryThatStillHasChildren)
+{
+   Accounting a;
+   a.cache_file("/a/b/c/f1", 8);
+   a.beat(false);
+
+   // Drive m_NDirectories to 0 while a child node is still present, which is
+   // the state m_subdirs.empty() has to catch. It was an assert() before, and
+   // asserts are compiled out of release builds.
+   // Remove the file from the namespace too, so rmdir() would succeed and the
+   // m_subdirs.empty() clause is the only thing left protecting the node. With
+   // the file still present, rmdir refusing would mask a missing guard.
+   a.m_ns.remove("/a/b/c/f1");
+
+   DirState *b = a.find("/a/b");
+   ASSERT_NE(b, nullptr);
+   ASSERT_FALSE(b->m_subdirs.empty());
+   b->m_here_usage.m_NDirectories = 0;
+   b->m_here_usage.m_NFiles       = 0;
+   b->m_here_usage.m_NFilesOpen   = 0;
+
+   a.beat(true);
+
+   EXPECT_NE(a.find("/a/b"), nullptr) << "reaped a node that still had children";
+   EXPECT_NE(a.find("/a/b/c"), nullptr) << "and took a live subtree with it";
+}
+
+TEST(DirStateReap, TakesOneLevelPerCycle)
+{
+   Accounting a;
+   a.cache_file("/a/b/c/f1", 8);
+   a.beat(false);
+   a.m_ns.remove("/a/b/c/f1");
+   a.purge("/a/b/c/f1", 8);
+
+   a.beat(true);
+   EXPECT_EQ(a.find("/a/b/c"), nullptr) << "the leaf goes first";
+   EXPECT_NE(a.find("/a/b"), nullptr)   << "its parent waits for the next cycle";
+
+   a.beat(true);
+   EXPECT_EQ(a.find("/a/b"), nullptr);
+   EXPECT_NE(a.find("/a"), nullptr);
+}
+
+// rmdir() refusing a non-empty directory is the backstop that kept several of
+// these bugs from doing damage in production. Make sure the reap honours it.
+TEST(DirStateReap, HonoursAFailedUnlink)
+{
+   Accounting a;
+   a.cache_file("/a/b/f1", 8);
+   a.beat(false);
+
+   // The accounting believes the directory is empty, the namespace disagrees.
+   a.purge("/a/b/f1", 8);       // note: the file is NOT removed from m_ns
+   a.beat(true);
+
+   EXPECT_NE(a.find("/a/b"), nullptr) << "reaped despite rmdir refusing";
+}


### PR DESCRIPTION
Two memory-safety fixes in the XrdPfc resource monitor, plus unit tests for both. The first aborts the server; the second corrupts the heap quietly.

A follow-up PR with the DirState accounting fixes is stacked on this one and will be opened once this merges; it touches the same files, so please take them in order.

### 1. Negative directory count, `std::length_error` from `reserve()` (#2808)

`perform_purge_check()` sized the purge snapshot vector from the directory *usage* counters. Those counters can drift negative, and `reserve()` takes an unsigned `size_type`, so `-1` became ~1.8e19 and threw.

The count now comes from walking the tree — `count_dirs_to_level()` — which is exactly what `fill_pshot_vec_children()` then emplaces, so the two can no longer disagree. The usage counters are still compared against the walk on every purge check, and a drift is reported when it first appears and again whenever it changes; a monotonic drift of that kind is what identified #2808 in the first place.

The underlying miscount is also fixed: directories created on the path to an already-existing file were not being recorded.

Fixes #2808

### 2. Use-after-free: reaping a DirState a pending close still points at

The empty-directory reap in `DirState::update_stats_and_usages()` had two preconditions that were not actually enforced.

`m_subdirs.empty()` was an `assert()`, compiled out under `-DNDEBUG`, and it does trigger — reaping such a node erases a live subtree while reporting one removal. It is now a condition.

`m_NFilesOpen == 0` was not checked at all, and this one is memory safety rather than accounting: `ResourceMonitor::AccessToken` holds a bare `DirState*` from the open record to the close record, and a file removed while still open takes the directory's file count to 0 with the `File` still alive. Reachable from a client via `xrdfs <cache> cache fevict <url>`; see the linked issue for the trace.

Fixes #2934

### Tests

Nine gtest cases in `tests/XrdPfcTests/XrdPfcDirStateTests.cc`, covering the directory-count invariant and the reap preconditions. Four of the nine fail without the fixes they cover: two against the previous reap guard directly, and two if the node accounting is put back inside the "new file" branch, which is the #2808 bug. The other five pin down behaviour that was already correct.

The tests drive `note_file_open()` and `note_created_dirs()` rather than re-implementing them — an earlier draft copied the logic instead, and consequently passed against the unfixed code.

### Backport to v5.9.x

Both bugs are present on `v5.9.x`, and #2808 was in fact reported against 5.9.5. The four PFC files this PR touches are byte-identical between `v5.9.x` and `master`, so there is nothing to adapt: both code commits cherry-pick cleanly onto `v5.9.x` (verified).

The test commit does **not** apply cleanly — it conflicts in `tests/XrdPfcTests/CMakeLists.txt`, because the gtest scaffolding it extends arrived on master with #2932 and is not on `v5.9.x`. Backporting can be done with some trimming.
